### PR TITLE
Proposal: Figma tokens (colors and dimensions) including different themes are added to tailwind directly

### DIFF
--- a/apps/storybook/.storybook/preview.js
+++ b/apps/storybook/.storybook/preview.js
@@ -25,10 +25,16 @@ const preview = {
   decorators: [
     withThemeByClassName({
       themes: {
-        light: '',
+        "Harness Open Source: Light": 'harness-open-source-light',
+        "Harness Open Source: Dark": 'harness-open-source-dark',
+        "Harness Theme: Light": 'harness-theme-light',
+        "Harness Theme: Dark": 'harness-theme-dark',
+        "UI core: Light": 'ui-core-light',
+        "UI core: Dark": 'ui-core-dark',
+        light: 'light',
         dark: 'dark'
       },
-      defaultTheme: 'dark'
+      defaultTheme: "Harness Open Source: Light"
     })
   ]
 }

--- a/packages/canary/postcss.config.js
+++ b/packages/canary/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {},
-  },
+    autoprefixer: {}
+  }
 }

--- a/packages/canary/src/style-tokens/colors.ts
+++ b/packages/canary/src/style-tokens/colors.ts
@@ -1,563 +1,363 @@
 module.exports = {
-  'figma-background-backdrop': 'hsla(var(--figma___background-backdrop));', // ✦ Theme/Background/Backdrop
-  'figma-background-cards-and-rows-default': 'hsla(var(--figma___background-cards-and-rows-default));', // ✦ Theme/Background/Cards and Rows/Default
-  'figma-background-cards-and-rows-hover': 'hsla(var(--figma___background-cards-and-rows-hover));', // ✦ Theme/Background/Cards and Rows/Hover
-  'figma-background-cards-and-rows-primary-blue-selected':
-    'hsla(var(--figma___background-cards-and-rows-primary-blue-selected));', // ✦ Theme/Background/Cards and Rows/Primary-blue-selected
-  'figma-background-cards-and-rows-selected': 'hsla(var(--figma___background-cards-and-rows-selected));', // ✦ Theme/Background/Cards and Rows/Selected
-  'figma-background-header-page-header': 'hsla(var(--figma___background-header-page-header));', // ✦ Theme/Background/Header/Page Header
-  'figma-background-header-table-header': 'hsla(var(--figma___background-header-table-header));', // ✦ Theme/Background/Header/Table Header
-  'figma-background-paper': 'hsla(var(--figma___background-paper));', // ✦ Theme/Background/Paper
-  'figma-background-primary': 'hsla(var(--figma___background-primary));', // ✦ Theme/Background/Primary
-  'figma-background-solid': 'hsla(var(--figma___background-solid));', // ✦ Theme/Background/Solid
-  'figma-badges-soft-amber-background': 'hsla(var(--figma___badges-soft-amber-background));', // ✦ Theme/Badges/Soft/Amber/background
-  'figma-badges-soft-amber-text': 'hsla(var(--figma___badges-soft-amber-text));', // ✦ Theme/Badges/Soft/Amber/text
-  'figma-badges-soft-blue-background': 'hsla(var(--figma___badges-soft-blue-background));', // ✦ Theme/Badges/Soft/Blue/background
-  'figma-badges-soft-blue-text': 'hsla(var(--figma___badges-soft-blue-text));', // ✦ Theme/Badges/Soft/Blue/text
-  'figma-badges-soft-bronze-background': 'hsla(var(--figma___badges-soft-bronze-background));', // ✦ Theme/Badges/Soft/Bronze/background
-  'figma-badges-soft-bronze-text': 'hsla(var(--figma___badges-soft-bronze-text));', // ✦ Theme/Badges/Soft/Bronze/text
-  'figma-badges-soft-brown-background': 'hsla(var(--figma___badges-soft-brown-background));', // ✦ Theme/Badges/Soft/Brown/background
-  'figma-badges-soft-brown-text': 'hsla(var(--figma___badges-soft-brown-text));', // ✦ Theme/Badges/Soft/Brown/text
-  'figma-badges-soft-crimson-background': 'hsla(var(--figma___badges-soft-crimson-background));', // ✦ Theme/Badges/Soft/Crimson/background
-  'figma-badges-soft-crimson-text': 'hsla(var(--figma___badges-soft-crimson-text));', // ✦ Theme/Badges/Soft/Crimson/text
-  'figma-badges-soft-cyan-background': 'hsla(var(--figma___badges-soft-cyan-background));', // ✦ Theme/Badges/Soft/Cyan/background
-  'figma-badges-soft-cyan-text': 'hsla(var(--figma___badges-soft-cyan-text));', // ✦ Theme/Badges/Soft/Cyan/text
-  'figma-badges-soft-gold-background': 'hsla(var(--figma___badges-soft-gold-background));', // ✦ Theme/Badges/Soft/Gold/background
-  'figma-badges-soft-gold-text': 'hsla(var(--figma___badges-soft-gold-text));', // ✦ Theme/Badges/Soft/Gold/text
-  'figma-badges-soft-grass-background': 'hsla(var(--figma___badges-soft-grass-background));', // ✦ Theme/Badges/Soft/Grass/background
-  'figma-badges-soft-grass-text': 'hsla(var(--figma___badges-soft-grass-text));', // ✦ Theme/Badges/Soft/Grass/text
-  'figma-badges-soft-green-background': 'hsla(var(--figma___badges-soft-green-background));', // ✦ Theme/Badges/Soft/Green/background
-  'figma-badges-soft-green-text': 'hsla(var(--figma___badges-soft-green-text));', // ✦ Theme/Badges/Soft/Green/text
-  'figma-badges-soft-indigo-background': 'hsla(var(--figma___badges-soft-indigo-background));', // ✦ Theme/Badges/Soft/Indigo/background
-  'figma-badges-soft-indigo-text': 'hsla(var(--figma___badges-soft-indigo-text));', // ✦ Theme/Badges/Soft/Indigo/text
-  'figma-badges-soft-iris-background': 'hsla(var(--figma___badges-soft-iris-background));', // ✦ Theme/Badges/Soft/Iris/background
-  'figma-badges-soft-iris-text': 'hsla(var(--figma___badges-soft-iris-text));', // ✦ Theme/Badges/Soft/Iris/text
-  'figma-badges-soft-jade-background': 'hsla(var(--figma___badges-soft-jade-background));', // ✦ Theme/Badges/Soft/Jade/background
-  'figma-badges-soft-jade-text': 'hsla(var(--figma___badges-soft-jade-text));', // ✦ Theme/Badges/Soft/Jade/text
-  'figma-badges-soft-lime-background': 'hsla(var(--figma___badges-soft-lime-background));', // ✦ Theme/Badges/Soft/Lime/background
-  'figma-badges-soft-lime-text': 'hsla(var(--figma___badges-soft-lime-text));', // ✦ Theme/Badges/Soft/Lime/text
-  'figma-badges-soft-mint-background': 'hsla(var(--figma___badges-soft-mint-background));', // ✦ Theme/Badges/Soft/Mint/background
-  'figma-badges-soft-mint-text': 'hsla(var(--figma___badges-soft-mint-text));', // ✦ Theme/Badges/Soft/Mint/text
-  'figma-badges-soft-orange-background': 'hsla(var(--figma___badges-soft-orange-background));', // ✦ Theme/Badges/Soft/Orange/background
-  'figma-badges-soft-orange-text': 'hsla(var(--figma___badges-soft-orange-text));', // ✦ Theme/Badges/Soft/Orange/text
-  'figma-badges-soft-pink-background': 'hsla(var(--figma___badges-soft-pink-background));', // ✦ Theme/Badges/Soft/Pink/background
-  'figma-badges-soft-pink-text': 'hsla(var(--figma___badges-soft-pink-text));', // ✦ Theme/Badges/Soft/Pink/text
-  'figma-badges-soft-plum-background': 'hsla(var(--figma___badges-soft-plum-background));', // ✦ Theme/Badges/Soft/Plum/background
-  'figma-badges-soft-plum-text': 'hsla(var(--figma___badges-soft-plum-text));', // ✦ Theme/Badges/Soft/Plum/text
-  'figma-badges-soft-purple-background': 'hsla(var(--figma___badges-soft-purple-background));', // ✦ Theme/Badges/Soft/Purple/background
-  'figma-badges-soft-purple-text': 'hsla(var(--figma___badges-soft-purple-text));', // ✦ Theme/Badges/Soft/Purple/text
-  'figma-badges-soft-red-background': 'hsla(var(--figma___badges-soft-red-background));', // ✦ Theme/Badges/Soft/Red/background
-  'figma-badges-soft-red-text': 'hsla(var(--figma___badges-soft-red-text));', // ✦ Theme/Badges/Soft/Red/text
-  'figma-badges-soft-ruby-background': 'hsla(var(--figma___badges-soft-ruby-background));', // ✦ Theme/Badges/Soft/Ruby/background
-  'figma-badges-soft-ruby-text': 'hsla(var(--figma___badges-soft-ruby-text));', // ✦ Theme/Badges/Soft/Ruby/text
-  'figma-badges-soft-sky-background': 'hsla(var(--figma___badges-soft-sky-background));', // ✦ Theme/Badges/Soft/Sky/background
-  'figma-badges-soft-sky-text': 'hsla(var(--figma___badges-soft-sky-text));', // ✦ Theme/Badges/Soft/Sky/text
-  'figma-badges-soft-teal-background': 'hsla(var(--figma___badges-soft-teal-background));', // ✦ Theme/Badges/Soft/Teal/background
-  'figma-badges-soft-teal-text': 'hsla(var(--figma___badges-soft-teal-text));', // ✦ Theme/Badges/Soft/Teal/text
-  'figma-badges-soft-violet-background': 'hsla(var(--figma___badges-soft-violet-background));', // ✦ Theme/Badges/Soft/Violet/background
-  'figma-badges-soft-violet-text': 'hsla(var(--figma___badges-soft-violet-text));', // ✦ Theme/Badges/Soft/Violet/text
-  'figma-badges-soft-yellow-background': 'hsla(var(--figma___badges-soft-yellow-background));', // ✦ Theme/Badges/Soft/Yellow/background
-  'figma-badges-soft-yellow-text': 'hsla(var(--figma___badges-soft-yellow-text));', // ✦ Theme/Badges/Soft/Yellow/text
-  'figma-badges-soft-accent-background': 'hsla(var(--figma___badges-soft-accent-background));', // ✦ Theme/Badges/Soft/accent/background
-  'figma-badges-soft-accent-text': 'hsla(var(--figma___badges-soft-accent-text));', // ✦ Theme/Badges/Soft/accent/text
-  'figma-badges-soft-error-background': 'hsla(var(--figma___badges-soft-error-background));', // ✦ Theme/Badges/Soft/error/background
-  'figma-badges-soft-error-text': 'hsla(var(--figma___badges-soft-error-text));', // ✦ Theme/Badges/Soft/error/text
-  'figma-badges-soft-info-background': 'hsla(var(--figma___badges-soft-info-background));', // ✦ Theme/Badges/Soft/info/background
-  'figma-badges-soft-info-text': 'hsla(var(--figma___badges-soft-info-text));', // ✦ Theme/Badges/Soft/info/text
-  'figma-badges-soft-success-background': 'hsla(var(--figma___badges-soft-success-background));', // ✦ Theme/Badges/Soft/success/background
-  'figma-badges-soft-success-text': 'hsla(var(--figma___badges-soft-success-text));', // ✦ Theme/Badges/Soft/success/text
-  'figma-badges-soft-warning-background': 'hsla(var(--figma___badges-soft-warning-background));', // ✦ Theme/Badges/Soft/warning/background
-  'figma-badges-soft-warning-text': 'hsla(var(--figma___badges-soft-warning-text));', // ✦ Theme/Badges/Soft/warning/text
-  'figma-badges-solid-amber-background': 'hsla(var(--figma___badges-solid-amber-background));', // ✦ Theme/Badges/Solid/Amber/background
-  'figma-badges-solid-amber-text': 'hsla(var(--figma___badges-solid-amber-text));', // ✦ Theme/Badges/Solid/Amber/text
-  'figma-badges-solid-blue-background': 'hsla(var(--figma___badges-solid-blue-background));', // ✦ Theme/Badges/Solid/Blue/background
-  'figma-badges-solid-blue-text': 'hsla(var(--figma___badges-solid-blue-text));', // ✦ Theme/Badges/Solid/Blue/text
-  'figma-badges-solid-bronze-background': 'hsla(var(--figma___badges-solid-bronze-background));', // ✦ Theme/Badges/Solid/Bronze/background
-  'figma-badges-solid-bronze-text': 'hsla(var(--figma___badges-solid-bronze-text));', // ✦ Theme/Badges/Solid/Bronze/text
-  'figma-badges-solid-brown-background': 'hsla(var(--figma___badges-solid-brown-background));', // ✦ Theme/Badges/Solid/Brown/background
-  'figma-badges-solid-brown-text': 'hsla(var(--figma___badges-solid-brown-text));', // ✦ Theme/Badges/Solid/Brown/text
-  'figma-badges-solid-crimson-background': 'hsla(var(--figma___badges-solid-crimson-background));', // ✦ Theme/Badges/Solid/Crimson/background
-  'figma-badges-solid-crimson-text': 'hsla(var(--figma___badges-solid-crimson-text));', // ✦ Theme/Badges/Solid/Crimson/text
-  'figma-badges-solid-cyan-background': 'hsla(var(--figma___badges-solid-cyan-background));', // ✦ Theme/Badges/Solid/Cyan/background
-  'figma-badges-solid-cyan-text': 'hsla(var(--figma___badges-solid-cyan-text));', // ✦ Theme/Badges/Solid/Cyan/text
-  'figma-badges-solid-gold-background': 'hsla(var(--figma___badges-solid-gold-background));', // ✦ Theme/Badges/Solid/Gold/background
-  'figma-badges-solid-gold-text': 'hsla(var(--figma___badges-solid-gold-text));', // ✦ Theme/Badges/Solid/Gold/text
-  'figma-badges-solid-grass-background': 'hsla(var(--figma___badges-solid-grass-background));', // ✦ Theme/Badges/Solid/Grass/background
-  'figma-badges-solid-grass-text': 'hsla(var(--figma___badges-solid-grass-text));', // ✦ Theme/Badges/Solid/Grass/text
-  'figma-badges-solid-green-background': 'hsla(var(--figma___badges-solid-green-background));', // ✦ Theme/Badges/Solid/Green/background
-  'figma-badges-solid-green-text': 'hsla(var(--figma___badges-solid-green-text));', // ✦ Theme/Badges/Solid/Green/text
-  'figma-badges-solid-indigo-background': 'hsla(var(--figma___badges-solid-indigo-background));', // ✦ Theme/Badges/Solid/Indigo/background
-  'figma-badges-solid-indigo-text': 'hsla(var(--figma___badges-solid-indigo-text));', // ✦ Theme/Badges/Solid/Indigo/text
-  'figma-badges-solid-iris-background': 'hsla(var(--figma___badges-solid-iris-background));', // ✦ Theme/Badges/Solid/Iris/background
-  'figma-badges-solid-iris-text': 'hsla(var(--figma___badges-solid-iris-text));', // ✦ Theme/Badges/Solid/Iris/text
-  'figma-badges-solid-jade-background': 'hsla(var(--figma___badges-solid-jade-background));', // ✦ Theme/Badges/Solid/Jade/background
-  'figma-badges-solid-jade-text': 'hsla(var(--figma___badges-solid-jade-text));', // ✦ Theme/Badges/Solid/Jade/text
-  'figma-badges-solid-lime-background': 'hsla(var(--figma___badges-solid-lime-background));', // ✦ Theme/Badges/Solid/Lime/background
-  'figma-badges-solid-lime-text': 'hsla(var(--figma___badges-solid-lime-text));', // ✦ Theme/Badges/Solid/Lime/text
-  'figma-badges-solid-mint-background': 'hsla(var(--figma___badges-solid-mint-background));', // ✦ Theme/Badges/Solid/Mint/background
-  'figma-badges-solid-mint-text': 'hsla(var(--figma___badges-solid-mint-text));', // ✦ Theme/Badges/Solid/Mint/text
-  'figma-badges-solid-orange-background': 'hsla(var(--figma___badges-solid-orange-background));', // ✦ Theme/Badges/Solid/Orange/background
-  'figma-badges-solid-orange-text': 'hsla(var(--figma___badges-solid-orange-text));', // ✦ Theme/Badges/Solid/Orange/text
-  'figma-badges-solid-pink-background': 'hsla(var(--figma___badges-solid-pink-background));', // ✦ Theme/Badges/Solid/Pink/background
-  'figma-badges-solid-pink-text': 'hsla(var(--figma___badges-solid-pink-text));', // ✦ Theme/Badges/Solid/Pink/text
-  'figma-badges-solid-plum-background': 'hsla(var(--figma___badges-solid-plum-background));', // ✦ Theme/Badges/Solid/Plum/background
-  'figma-badges-solid-plum-text': 'hsla(var(--figma___badges-solid-plum-text));', // ✦ Theme/Badges/Solid/Plum/text
-  'figma-badges-solid-purple-background': 'hsla(var(--figma___badges-solid-purple-background));', // ✦ Theme/Badges/Solid/Purple/background
-  'figma-badges-solid-purple-text': 'hsla(var(--figma___badges-solid-purple-text));', // ✦ Theme/Badges/Solid/Purple/text
-  'figma-badges-solid-red-background': 'hsla(var(--figma___badges-solid-red-background));', // ✦ Theme/Badges/Solid/Red/background
-  'figma-badges-solid-red-text': 'hsla(var(--figma___badges-solid-red-text));', // ✦ Theme/Badges/Solid/Red/text
-  'figma-badges-solid-ruby-background': 'hsla(var(--figma___badges-solid-ruby-background));', // ✦ Theme/Badges/Solid/Ruby/background
-  'figma-badges-solid-ruby-text': 'hsla(var(--figma___badges-solid-ruby-text));', // ✦ Theme/Badges/Solid/Ruby/text
-  'figma-badges-solid-sky-background': 'hsla(var(--figma___badges-solid-sky-background));', // ✦ Theme/Badges/Solid/Sky/background
-  'figma-badges-solid-sky-text': 'hsla(var(--figma___badges-solid-sky-text));', // ✦ Theme/Badges/Solid/Sky/text
-  'figma-badges-solid-success-background': 'hsla(var(--figma___badges-solid-success-background));', // ✦ Theme/Badges/Solid/Success/background
-  'figma-badges-solid-success-text': 'hsla(var(--figma___badges-solid-success-text));', // ✦ Theme/Badges/Solid/Success/text
-  'figma-badges-solid-teal-background': 'hsla(var(--figma___badges-solid-teal-background));', // ✦ Theme/Badges/Solid/Teal/background
-  'figma-badges-solid-teal-text': 'hsla(var(--figma___badges-solid-teal-text));', // ✦ Theme/Badges/Solid/Teal/text
-  'figma-badges-solid-violet-background': 'hsla(var(--figma___badges-solid-violet-background));', // ✦ Theme/Badges/Solid/Violet/background
-  'figma-badges-solid-violet-text': 'hsla(var(--figma___badges-solid-violet-text));', // ✦ Theme/Badges/Solid/Violet/text
-  'figma-badges-solid-yellow-background': 'hsla(var(--figma___badges-solid-yellow-background));', // ✦ Theme/Badges/Solid/Yellow/background
-  'figma-badges-solid-yellow-text': 'hsla(var(--figma___badges-solid-yellow-text));', // ✦ Theme/Badges/Solid/Yellow/text
-  'figma-badges-solid-accent-background': 'hsla(var(--figma___badges-solid-accent-background));', // ✦ Theme/Badges/Solid/accent/background
-  'figma-badges-solid-accent-text': 'hsla(var(--figma___badges-solid-accent-text));', // ✦ Theme/Badges/Solid/accent/text
-  'figma-badges-solid-info-background': 'hsla(var(--figma___badges-solid-info-background));', // ✦ Theme/Badges/Solid/info/background
-  'figma-badges-solid-info-text': 'hsla(var(--figma___badges-solid-info-text));', // ✦ Theme/Badges/Solid/info/text
-  'figma-badges-solid-warning-background': 'hsla(var(--figma___badges-solid-warning-background));', // ✦ Theme/Badges/Solid/warning/background
-  'figma-badges-solid-warning-text': 'hsla(var(--figma___badges-solid-warning-text));', // ✦ Theme/Badges/Solid/warning/text
-  'figma-badges-surface-amber-background': 'hsla(var(--figma___badges-surface-amber-background));', // ✦ Theme/Badges/Surface/Amber/background
-  'figma-badges-surface-amber-border': 'hsla(var(--figma___badges-surface-amber-border));', // ✦ Theme/Badges/Surface/Amber/border
-  'figma-badges-surface-amber-text': 'hsla(var(--figma___badges-surface-amber-text));', // ✦ Theme/Badges/Surface/Amber/text
-  'figma-badges-surface-blue-background': 'hsla(var(--figma___badges-surface-blue-background));', // ✦ Theme/Badges/Surface/Blue/background
-  'figma-badges-surface-blue-border': 'hsla(var(--figma___badges-surface-blue-border));', // ✦ Theme/Badges/Surface/Blue/border
-  'figma-badges-surface-blue-text': 'hsla(var(--figma___badges-surface-blue-text));', // ✦ Theme/Badges/Surface/Blue/text
-  'figma-badges-surface-bronze-background': 'hsla(var(--figma___badges-surface-bronze-background));', // ✦ Theme/Badges/Surface/Bronze/background
-  'figma-badges-surface-bronze-border': 'hsla(var(--figma___badges-surface-bronze-border));', // ✦ Theme/Badges/Surface/Bronze/border
-  'figma-badges-surface-bronze-text': 'hsla(var(--figma___badges-surface-bronze-text));', // ✦ Theme/Badges/Surface/Bronze/text
-  'figma-badges-surface-brown-background': 'hsla(var(--figma___badges-surface-brown-background));', // ✦ Theme/Badges/Surface/Brown/background
-  'figma-badges-surface-brown-border': 'hsla(var(--figma___badges-surface-brown-border));', // ✦ Theme/Badges/Surface/Brown/border
-  'figma-badges-surface-brown-text': 'hsla(var(--figma___badges-surface-brown-text));', // ✦ Theme/Badges/Surface/Brown/text
-  'figma-badges-surface-crimson-border': 'hsla(var(--figma___badges-surface-crimson-border));', // ✦ Theme/Badges/Surface/Crimson/Border
-  'figma-badges-surface-crimson-background': 'hsla(var(--figma___badges-surface-crimson-background));', // ✦ Theme/Badges/Surface/Crimson/background
-  'figma-badges-surface-crimson-text': 'hsla(var(--figma___badges-surface-crimson-text));', // ✦ Theme/Badges/Surface/Crimson/text
-  'figma-badges-surface-cyan-border': 'hsla(var(--figma___badges-surface-cyan-border));', // ✦ Theme/Badges/Surface/Cyan/Border
-  'figma-badges-surface-cyan-background': 'hsla(var(--figma___badges-surface-cyan-background));', // ✦ Theme/Badges/Surface/Cyan/background
-  'figma-badges-surface-cyan-text': 'hsla(var(--figma___badges-surface-cyan-text));', // ✦ Theme/Badges/Surface/Cyan/text
-  'figma-badges-surface-gold-border': 'hsla(var(--figma___badges-surface-gold-border));', // ✦ Theme/Badges/Surface/Gold/Border
-  'figma-badges-surface-gold-background': 'hsla(var(--figma___badges-surface-gold-background));', // ✦ Theme/Badges/Surface/Gold/background
-  'figma-badges-surface-gold-text': 'hsla(var(--figma___badges-surface-gold-text));', // ✦ Theme/Badges/Surface/Gold/text
-  'figma-badges-surface-grass-border': 'hsla(var(--figma___badges-surface-grass-border));', // ✦ Theme/Badges/Surface/Grass/Border
-  'figma-badges-surface-grass-background': 'hsla(var(--figma___badges-surface-grass-background));', // ✦ Theme/Badges/Surface/Grass/background
-  'figma-badges-surface-grass-text': 'hsla(var(--figma___badges-surface-grass-text));', // ✦ Theme/Badges/Surface/Grass/text
-  'figma-badges-surface-green-background': 'hsla(var(--figma___badges-surface-green-background));', // ✦ Theme/Badges/Surface/Green/background
-  'figma-badges-surface-green-border': 'hsla(var(--figma___badges-surface-green-border));', // ✦ Theme/Badges/Surface/Green/border
-  'figma-badges-surface-green-text': 'hsla(var(--figma___badges-surface-green-text));', // ✦ Theme/Badges/Surface/Green/text
-  'figma-badges-surface-indigo-background': 'hsla(var(--figma___badges-surface-indigo-background));', // ✦ Theme/Badges/Surface/Indigo/background
-  'figma-badges-surface-indigo-border': 'hsla(var(--figma___badges-surface-indigo-border));', // ✦ Theme/Badges/Surface/Indigo/border
-  'figma-badges-surface-indigo-text': 'hsla(var(--figma___badges-surface-indigo-text));', // ✦ Theme/Badges/Surface/Indigo/text
-  'figma-badges-surface-iris-border': 'hsla(var(--figma___badges-surface-iris-border));', // ✦ Theme/Badges/Surface/Iris/Border
-  'figma-badges-surface-iris-background': 'hsla(var(--figma___badges-surface-iris-background));', // ✦ Theme/Badges/Surface/Iris/background
-  'figma-badges-surface-iris-text': 'hsla(var(--figma___badges-surface-iris-text));', // ✦ Theme/Badges/Surface/Iris/text
-  'figma-badges-surface-jade-border': 'hsla(var(--figma___badges-surface-jade-border));', // ✦ Theme/Badges/Surface/Jade/Border
-  'figma-badges-surface-jade-background': 'hsla(var(--figma___badges-surface-jade-background));', // ✦ Theme/Badges/Surface/Jade/background
-  'figma-badges-surface-jade-text': 'hsla(var(--figma___badges-surface-jade-text));', // ✦ Theme/Badges/Surface/Jade/text
-  'figma-badges-surface-lime-border': 'hsla(var(--figma___badges-surface-lime-border));', // ✦ Theme/Badges/Surface/Lime/Border
-  'figma-badges-surface-lime-background': 'hsla(var(--figma___badges-surface-lime-background));', // ✦ Theme/Badges/Surface/Lime/background
-  'figma-badges-surface-lime-text': 'hsla(var(--figma___badges-surface-lime-text));', // ✦ Theme/Badges/Surface/Lime/text
-  'figma-badges-surface-mint-background': 'hsla(var(--figma___badges-surface-mint-background));', // ✦ Theme/Badges/Surface/Mint/background
-  'figma-badges-surface-mint-border': 'hsla(var(--figma___badges-surface-mint-border));', // ✦ Theme/Badges/Surface/Mint/border
-  'figma-badges-surface-mint-text': 'hsla(var(--figma___badges-surface-mint-text));', // ✦ Theme/Badges/Surface/Mint/text
-  'figma-badges-surface-orange-background': 'hsla(var(--figma___badges-surface-orange-background));', // ✦ Theme/Badges/Surface/Orange/background
-  'figma-badges-surface-orange-border': 'hsla(var(--figma___badges-surface-orange-border));', // ✦ Theme/Badges/Surface/Orange/border
-  'figma-badges-surface-orange-text': 'hsla(var(--figma___badges-surface-orange-text));', // ✦ Theme/Badges/Surface/Orange/text
-  'figma-badges-surface-pink-background': 'hsla(var(--figma___badges-surface-pink-background));', // ✦ Theme/Badges/Surface/Pink/background
-  'figma-badges-surface-pink-border': 'hsla(var(--figma___badges-surface-pink-border));', // ✦ Theme/Badges/Surface/Pink/border
-  'figma-badges-surface-pink-text': 'hsla(var(--figma___badges-surface-pink-text));', // ✦ Theme/Badges/Surface/Pink/text
-  'figma-badges-surface-plum-background': 'hsla(var(--figma___badges-surface-plum-background));', // ✦ Theme/Badges/Surface/Plum/background
-  'figma-badges-surface-plum-border': 'hsla(var(--figma___badges-surface-plum-border));', // ✦ Theme/Badges/Surface/Plum/border
-  'figma-badges-surface-plum-text': 'hsla(var(--figma___badges-surface-plum-text));', // ✦ Theme/Badges/Surface/Plum/text
-  'figma-badges-surface-purple-background': 'hsla(var(--figma___badges-surface-purple-background));', // ✦ Theme/Badges/Surface/Purple/background
-  'figma-badges-surface-purple-border': 'hsla(var(--figma___badges-surface-purple-border));', // ✦ Theme/Badges/Surface/Purple/border
-  'figma-badges-surface-purple-text': 'hsla(var(--figma___badges-surface-purple-text));', // ✦ Theme/Badges/Surface/Purple/text
-  'figma-badges-surface-red-background': 'hsla(var(--figma___badges-surface-red-background));', // ✦ Theme/Badges/Surface/Red/background
-  'figma-badges-surface-red-border': 'hsla(var(--figma___badges-surface-red-border));', // ✦ Theme/Badges/Surface/Red/border
-  'figma-badges-surface-red-text': 'hsla(var(--figma___badges-surface-red-text));', // ✦ Theme/Badges/Surface/Red/text
-  'figma-badges-surface-ruby-background': 'hsla(var(--figma___badges-surface-ruby-background));', // ✦ Theme/Badges/Surface/Ruby/background
-  'figma-badges-surface-ruby-border': 'hsla(var(--figma___badges-surface-ruby-border));', // ✦ Theme/Badges/Surface/Ruby/border
-  'figma-badges-surface-ruby-text': 'hsla(var(--figma___badges-surface-ruby-text));', // ✦ Theme/Badges/Surface/Ruby/text
-  'figma-badges-surface-sky-background': 'hsla(var(--figma___badges-surface-sky-background));', // ✦ Theme/Badges/Surface/Sky/background
-  'figma-badges-surface-sky-border': 'hsla(var(--figma___badges-surface-sky-border));', // ✦ Theme/Badges/Surface/Sky/border
-  'figma-badges-surface-sky-text': 'hsla(var(--figma___badges-surface-sky-text));', // ✦ Theme/Badges/Surface/Sky/text
-  'figma-badges-surface-teal-background': 'hsla(var(--figma___badges-surface-teal-background));', // ✦ Theme/Badges/Surface/Teal/background
-  'figma-badges-surface-teal-border': 'hsla(var(--figma___badges-surface-teal-border));', // ✦ Theme/Badges/Surface/Teal/border
-  'figma-badges-surface-teal-text': 'hsla(var(--figma___badges-surface-teal-text));', // ✦ Theme/Badges/Surface/Teal/text
-  'figma-badges-surface-violet-background': 'hsla(var(--figma___badges-surface-violet-background));', // ✦ Theme/Badges/Surface/Violet/background
-  'figma-badges-surface-violet-border': 'hsla(var(--figma___badges-surface-violet-border));', // ✦ Theme/Badges/Surface/Violet/border
-  'figma-badges-surface-violet-text': 'hsla(var(--figma___badges-surface-violet-text));', // ✦ Theme/Badges/Surface/Violet/text
-  'figma-badges-surface-yellow-background': 'hsla(var(--figma___badges-surface-yellow-background));', // ✦ Theme/Badges/Surface/Yellow/background
-  'figma-badges-surface-yellow-border': 'hsla(var(--figma___badges-surface-yellow-border));', // ✦ Theme/Badges/Surface/Yellow/border
-  'figma-badges-surface-yellow-text': 'hsla(var(--figma___badges-surface-yellow-text));', // ✦ Theme/Badges/Surface/Yellow/text
-  'figma-badges-surface-accent-background': 'hsla(var(--figma___badges-surface-accent-background));', // ✦ Theme/Badges/Surface/accent/background
-  'figma-badges-surface-accent-border': 'hsla(var(--figma___badges-surface-accent-border));', // ✦ Theme/Badges/Surface/accent/border
-  'figma-badges-surface-accent-text': 'hsla(var(--figma___badges-surface-accent-text));', // ✦ Theme/Badges/Surface/accent/text
-  'figma-badges-surface-error-background': 'hsla(var(--figma___badges-surface-error-background));', // ✦ Theme/Badges/Surface/error/background
-  'figma-badges-surface-error-border': 'hsla(var(--figma___badges-surface-error-border));', // ✦ Theme/Badges/Surface/error/border
-  'figma-badges-surface-error-text': 'hsla(var(--figma___badges-surface-error-text));', // ✦ Theme/Badges/Surface/error/text
-  'figma-badges-surface-info-background': 'hsla(var(--figma___badges-surface-info-background));', // ✦ Theme/Badges/Surface/info/background
-  'figma-badges-surface-info-border': 'hsla(var(--figma___badges-surface-info-border));', // ✦ Theme/Badges/Surface/info/border
-  'figma-badges-surface-info-text': 'hsla(var(--figma___badges-surface-info-text));', // ✦ Theme/Badges/Surface/info/text
-  'figma-badges-surface-success-background': 'hsla(var(--figma___badges-surface-success-background));', // ✦ Theme/Badges/Surface/success/background
-  'figma-badges-surface-success-border': 'hsla(var(--figma___badges-surface-success-border));', // ✦ Theme/Badges/Surface/success/border
-  'figma-badges-surface-success-text': 'hsla(var(--figma___badges-surface-success-text));', // ✦ Theme/Badges/Surface/success/text
-  'figma-badges-surface-warning-background': 'hsla(var(--figma___badges-surface-warning-background));', // ✦ Theme/Badges/Surface/warning/background
-  'figma-badges-surface-warning-border': 'hsla(var(--figma___badges-surface-warning-border));', // ✦ Theme/Badges/Surface/warning/border
-  'figma-badges-surface-warning-text': 'hsla(var(--figma___badges-surface-warning-text));', // ✦ Theme/Badges/Surface/warning/text
-  'figma-border-disabled': 'hsla(var(--figma___border-disabled));', // ✦ Theme/Border/Disabled
-  'figma-border-hover': 'hsla(var(--figma___border-hover));', // ✦ Theme/Border/Hover
-  'figma-border-primary': 'hsla(var(--figma___border-primary));', // ✦ Theme/Border/Primary
-  'figma-border-secondary': 'hsla(var(--figma___border-secondary));', // ✦ Theme/Border/Secondary
-  'figma-border-selected': 'hsla(var(--figma___border-selected));', // ✦ Theme/Border/Selected
-  'figma-breadcrumbs-current': 'hsla(var(--figma___breadcrumbs-current));', // ✦ Theme/Breadcrumbs/current
-  'figma-breadcrumbs-visited': 'hsla(var(--figma___breadcrumbs-visited));', // ✦ Theme/Breadcrumbs/visited
-  'figma-button-ghost-accent-active': 'hsla(var(--figma___button-ghost-accent-active));', // ✦ Theme/Button/Ghost/Accent/Active
-  'figma-button-ghost-accent-active-text': 'hsla(var(--figma___button-ghost-accent-active-text));', // ✦ Theme/Button/Ghost/Accent/Active text
-  'figma-button-ghost-accent-hover': 'hsla(var(--figma___button-ghost-accent-hover));', // ✦ Theme/Button/Ghost/Accent/Hover
-  'figma-button-ghost-accent-hover-text': 'hsla(var(--figma___button-ghost-accent-hover-text));', // ✦ Theme/Button/Ghost/Accent/Hover text
-  'figma-button-ghost-accent-text-disabled': 'hsla(var(--figma___button-ghost-accent-text-disabled));', // ✦ Theme/Button/Ghost/Accent/Text-disabled
-  'figma-button-ghost-accent-text-primary': 'hsla(var(--figma___button-ghost-accent-text-primary));', // ✦ Theme/Button/Ghost/Accent/Text-primary
-  'figma-button-ghost-error-active': 'hsla(var(--figma___button-ghost-error-active));', // ✦ Theme/Button/Ghost/Error/Active
-  'figma-button-ghost-error-active-text': 'hsla(var(--figma___button-ghost-error-active-text));', // ✦ Theme/Button/Ghost/Error/Active Text
-  'figma-button-ghost-error-hover': 'hsla(var(--figma___button-ghost-error-hover));', // ✦ Theme/Button/Ghost/Error/Hover
-  'figma-button-ghost-error-hover-text': 'hsla(var(--figma___button-ghost-error-hover-text));', // ✦ Theme/Button/Ghost/Error/Hover text
-  'figma-button-ghost-error-text-disabled': 'hsla(var(--figma___button-ghost-error-text-disabled));', // ✦ Theme/Button/Ghost/Error/Text-disabled
-  'figma-button-ghost-error-text-primary': 'hsla(var(--figma___button-ghost-error-text-primary));', // ✦ Theme/Button/Ghost/Error/Text-primary
-  'figma-button-ghost-neutral-active': 'hsla(var(--figma___button-ghost-neutral-active));', // ✦ Theme/Button/Ghost/Neutral/Active
-  'figma-button-ghost-neutral-active-text': 'hsla(var(--figma___button-ghost-neutral-active-text));', // ✦ Theme/Button/Ghost/Neutral/Active Text
-  'figma-button-ghost-neutral-hover': 'hsla(var(--figma___button-ghost-neutral-hover));', // ✦ Theme/Button/Ghost/Neutral/Hover
-  'figma-button-ghost-neutral-hover-text': 'hsla(var(--figma___button-ghost-neutral-hover-text));', // ✦ Theme/Button/Ghost/Neutral/Hover text
-  'figma-button-ghost-neutral-text-disabled': 'hsla(var(--figma___button-ghost-neutral-text-disabled));', // ✦ Theme/Button/Ghost/Neutral/Text-disabled
-  'figma-button-ghost-neutral-text-primary': 'hsla(var(--figma___button-ghost-neutral-text-primary));', // ✦ Theme/Button/Ghost/Neutral/Text-primary
-  'figma-button-ghost-success-active': 'hsla(var(--figma___button-ghost-success-active));', // ✦ Theme/Button/Ghost/Success/Active
-  'figma-button-ghost-success-active-text': 'hsla(var(--figma___button-ghost-success-active-text));', // ✦ Theme/Button/Ghost/Success/Active Text
-  'figma-button-ghost-success-hover': 'hsla(var(--figma___button-ghost-success-hover));', // ✦ Theme/Button/Ghost/Success/Hover
-  'figma-button-ghost-success-hover-text': 'hsla(var(--figma___button-ghost-success-hover-text));', // ✦ Theme/Button/Ghost/Success/Hover text
-  'figma-button-ghost-success-text-disabled': 'hsla(var(--figma___button-ghost-success-text-disabled));', // ✦ Theme/Button/Ghost/Success/Text-disabled
-  'figma-button-ghost-success-text-primary': 'hsla(var(--figma___button-ghost-success-text-primary));', // ✦ Theme/Button/Ghost/Success/Text-primary
-  'figma-button-outline-accent-active': 'hsla(var(--figma___button-outline-accent-active));', // ✦ Theme/Button/Outline/Accent/Active
-  'figma-button-outline-accent-default-border': 'hsla(var(--figma___button-outline-accent-default-border));', // ✦ Theme/Button/Outline/Accent/Default border
-  'figma-button-outline-accent-disabled-border': 'hsla(var(--figma___button-outline-accent-disabled-border));', // ✦ Theme/Button/Outline/Accent/Disabled Border
-  'figma-button-outline-accent-hover': 'hsla(var(--figma___button-outline-accent-hover));', // ✦ Theme/Button/Outline/Accent/Hover
-  'figma-button-outline-accent-text-disabled': 'hsla(var(--figma___button-outline-accent-text-disabled));', // ✦ Theme/Button/Outline/Accent/Text-disabled
-  'figma-button-outline-accent-text-primary': 'hsla(var(--figma___button-outline-accent-text-primary));', // ✦ Theme/Button/Outline/Accent/Text-primary
-  'figma-button-outline-error-active': 'hsla(var(--figma___button-outline-error-active));', // ✦ Theme/Button/Outline/Error/Active
-  'figma-button-outline-error-default-border': 'hsla(var(--figma___button-outline-error-default-border));', // ✦ Theme/Button/Outline/Error/Default - border
-  'figma-button-outline-error-disabled-border': 'hsla(var(--figma___button-outline-error-disabled-border));', // ✦ Theme/Button/Outline/Error/Disabled-border
-  'figma-button-outline-error-hover': 'hsla(var(--figma___button-outline-error-hover));', // ✦ Theme/Button/Outline/Error/Hover
-  'figma-button-outline-error-text-disabled': 'hsla(var(--figma___button-outline-error-text-disabled));', // ✦ Theme/Button/Outline/Error/Text-disabled
-  'figma-button-outline-error-text-primary': 'hsla(var(--figma___button-outline-error-text-primary));', // ✦ Theme/Button/Outline/Error/Text-primary
-  'figma-button-outline-neutral-active': 'hsla(var(--figma___button-outline-neutral-active));', // ✦ Theme/Button/Outline/Neutral/Active
-  'figma-button-outline-neutral-default-border': 'hsla(var(--figma___button-outline-neutral-default-border));', // ✦ Theme/Button/Outline/Neutral/Default - border
-  'figma-button-outline-neutral-disabled-border': 'hsla(var(--figma___button-outline-neutral-disabled-border));', // ✦ Theme/Button/Outline/Neutral/Disabled - border
-  'figma-button-outline-neutral-hover': 'hsla(var(--figma___button-outline-neutral-hover));', // ✦ Theme/Button/Outline/Neutral/Hover
-  'figma-button-outline-neutral-text-disabled': 'hsla(var(--figma___button-outline-neutral-text-disabled));', // ✦ Theme/Button/Outline/Neutral/Text-disabled
-  'figma-button-outline-neutral-text-primary': 'hsla(var(--figma___button-outline-neutral-text-primary));', // ✦ Theme/Button/Outline/Neutral/Text-primary
-  'figma-button-outline-success-active': 'hsla(var(--figma___button-outline-success-active));', // ✦ Theme/Button/Outline/Success/Active
-  'figma-button-outline-success-default-border': 'hsla(var(--figma___button-outline-success-default-border));', // ✦ Theme/Button/Outline/Success/Default-border
-  'figma-button-outline-success-disabled-border': 'hsla(var(--figma___button-outline-success-disabled-border));', // ✦ Theme/Button/Outline/Success/Disabled - border
-  'figma-button-outline-success-hover': 'hsla(var(--figma___button-outline-success-hover));', // ✦ Theme/Button/Outline/Success/Hover
-  'figma-button-outline-success-text-disabled': 'hsla(var(--figma___button-outline-success-text-disabled));', // ✦ Theme/Button/Outline/Success/Text-disabled
-  'figma-button-outline-success-text-primary': 'hsla(var(--figma___button-outline-success-text-primary));', // ✦ Theme/Button/Outline/Success/Text-primary
-  'figma-button-soft-accent-active': 'hsla(var(--figma___button-soft-accent-active));', // ✦ Theme/Button/Soft/Accent/Active
-  'figma-button-soft-accent-disabled': 'hsla(var(--figma___button-soft-accent-disabled));', // ✦ Theme/Button/Soft/Accent/Disabled
-  'figma-button-soft-accent-hover': 'hsla(var(--figma___button-soft-accent-hover));', // ✦ Theme/Button/Soft/Accent/Hover
-  'figma-button-soft-accent-text-disabled': 'hsla(var(--figma___button-soft-accent-text-disabled));', // ✦ Theme/Button/Soft/Accent/Text-disabled
-  'figma-button-soft-accent-text-primary': 'hsla(var(--figma___button-soft-accent-text-primary));', // ✦ Theme/Button/Soft/Accent/Text-primary
-  'figma-button-soft-accent-default': 'hsla(var(--figma___button-soft-accent-default));', // ✦ Theme/Button/Soft/Accent/default
-  'figma-button-soft-error-active': 'hsla(var(--figma___button-soft-error-active));', // ✦ Theme/Button/Soft/Error/Active
-  'figma-button-soft-error-disabled': 'hsla(var(--figma___button-soft-error-disabled));', // ✦ Theme/Button/Soft/Error/Disabled
-  'figma-button-soft-error-hover': 'hsla(var(--figma___button-soft-error-hover));', // ✦ Theme/Button/Soft/Error/Hover
-  'figma-button-soft-error-text-disabled': 'hsla(var(--figma___button-soft-error-text-disabled));', // ✦ Theme/Button/Soft/Error/Text-disabled
-  'figma-button-soft-error-text-primary': 'hsla(var(--figma___button-soft-error-text-primary));', // ✦ Theme/Button/Soft/Error/Text-primary
-  'figma-button-soft-error-default': 'hsla(var(--figma___button-soft-error-default));', // ✦ Theme/Button/Soft/Error/default
-  'figma-button-soft-neutral-active': 'hsla(var(--figma___button-soft-neutral-active));', // ✦ Theme/Button/Soft/Neutral/Active
-  'figma-button-soft-neutral-disabled': 'hsla(var(--figma___button-soft-neutral-disabled));', // ✦ Theme/Button/Soft/Neutral/Disabled
-  'figma-button-soft-neutral-hover': 'hsla(var(--figma___button-soft-neutral-hover));', // ✦ Theme/Button/Soft/Neutral/Hover
-  'figma-button-soft-neutral-text-disabled': 'hsla(var(--figma___button-soft-neutral-text-disabled));', // ✦ Theme/Button/Soft/Neutral/Text-disabled
-  'figma-button-soft-neutral-text-primary': 'hsla(var(--figma___button-soft-neutral-text-primary));', // ✦ Theme/Button/Soft/Neutral/Text-primary
-  'figma-button-soft-neutral-default': 'hsla(var(--figma___button-soft-neutral-default));', // ✦ Theme/Button/Soft/Neutral/default
-  'figma-button-soft-success-active': 'hsla(var(--figma___button-soft-success-active));', // ✦ Theme/Button/Soft/Success/Active
-  'figma-button-soft-success-disabled': 'hsla(var(--figma___button-soft-success-disabled));', // ✦ Theme/Button/Soft/Success/Disabled
-  'figma-button-soft-success-hover': 'hsla(var(--figma___button-soft-success-hover));', // ✦ Theme/Button/Soft/Success/Hover
-  'figma-button-soft-success-text-disabled': 'hsla(var(--figma___button-soft-success-text-disabled));', // ✦ Theme/Button/Soft/Success/Text-disabled
-  'figma-button-soft-success-text-primary': 'hsla(var(--figma___button-soft-success-text-primary));', // ✦ Theme/Button/Soft/Success/Text-primary
-  'figma-button-soft-success-default': 'hsla(var(--figma___button-soft-success-default));', // ✦ Theme/Button/Soft/Success/default
-  'figma-button-solid-accent-active': 'hsla(var(--figma___button-solid-accent-active));', // ✦ Theme/Button/Solid/Accent/Active
-  'figma-button-solid-accent-disabled': 'hsla(var(--figma___button-solid-accent-disabled));', // ✦ Theme/Button/Solid/Accent/Disabled
-  'figma-button-solid-accent-hover': 'hsla(var(--figma___button-solid-accent-hover));', // ✦ Theme/Button/Solid/Accent/Hover
-  'figma-button-solid-accent-text-disabled': 'hsla(var(--figma___button-solid-accent-text-disabled));', // ✦ Theme/Button/Solid/Accent/Text-disabled
-  'figma-button-solid-accent-text-primary': 'hsla(var(--figma___button-solid-accent-text-primary));', // ✦ Theme/Button/Solid/Accent/Text-primary
-  'figma-button-solid-accent-default': 'hsla(var(--figma___button-solid-accent-default));', // ✦ Theme/Button/Solid/Accent/default
-  'figma-button-solid-error-active': 'hsla(var(--figma___button-solid-error-active));', // ✦ Theme/Button/Solid/Error/Active
-  'figma-button-solid-error-disabled': 'hsla(var(--figma___button-solid-error-disabled));', // ✦ Theme/Button/Solid/Error/Disabled
-  'figma-button-solid-error-hover': 'hsla(var(--figma___button-solid-error-hover));', // ✦ Theme/Button/Solid/Error/Hover
-  'figma-button-solid-error-text-disabled': 'hsla(var(--figma___button-solid-error-text-disabled));', // ✦ Theme/Button/Solid/Error/Text-disabled
-  'figma-button-solid-error-text-primary': 'hsla(var(--figma___button-solid-error-text-primary));', // ✦ Theme/Button/Solid/Error/Text-primary
-  'figma-button-solid-error-default': 'hsla(var(--figma___button-solid-error-default));', // ✦ Theme/Button/Solid/Error/default
-  'figma-button-solid-neutral-active': 'hsla(var(--figma___button-solid-neutral-active));', // ✦ Theme/Button/Solid/Neutral/Active
-  'figma-button-solid-neutral-disabled': 'hsla(var(--figma___button-solid-neutral-disabled));', // ✦ Theme/Button/Solid/Neutral/Disabled
-  'figma-button-solid-neutral-hover': 'hsla(var(--figma___button-solid-neutral-hover));', // ✦ Theme/Button/Solid/Neutral/Hover
-  'figma-button-solid-neutral-text-disabled': 'hsla(var(--figma___button-solid-neutral-text-disabled));', // ✦ Theme/Button/Solid/Neutral/Text-disabled
-  'figma-button-solid-neutral-text-primary': 'hsla(var(--figma___button-solid-neutral-text-primary));', // ✦ Theme/Button/Solid/Neutral/Text-primary
-  'figma-button-solid-neutral-default': 'hsla(var(--figma___button-solid-neutral-default));', // ✦ Theme/Button/Solid/Neutral/default
-  'figma-button-solid-success-active': 'hsla(var(--figma___button-solid-success-active));', // ✦ Theme/Button/Solid/Success/Active
-  'figma-button-solid-success-disabled': 'hsla(var(--figma___button-solid-success-disabled));', // ✦ Theme/Button/Solid/Success/Disabled
-  'figma-button-solid-success-hover': 'hsla(var(--figma___button-solid-success-hover));', // ✦ Theme/Button/Solid/Success/Hover
-  'figma-button-solid-success-text-disabled': 'hsla(var(--figma___button-solid-success-text-disabled));', // ✦ Theme/Button/Solid/Success/Text-disabled
-  'figma-button-solid-success-text-primary': 'hsla(var(--figma___button-solid-success-text-primary));', // ✦ Theme/Button/Solid/Success/Text-primary
-  'figma-button-solid-success-default': 'hsla(var(--figma___button-solid-success-default));', // ✦ Theme/Button/Solid/Success/default
-  'figma-button-surface-accent-active': 'hsla(var(--figma___button-surface-accent-active));', // ✦ Theme/Button/Surface/Accent/Active
-  'figma-button-surface-accent-active-border': 'hsla(var(--figma___button-surface-accent-active-border));', // ✦ Theme/Button/Surface/Accent/Active border
-  'figma-button-surface-accent-disabled': 'hsla(var(--figma___button-surface-accent-disabled));', // ✦ Theme/Button/Surface/Accent/Disabled
-  'figma-button-surface-accent-hover': 'hsla(var(--figma___button-surface-accent-hover));', // ✦ Theme/Button/Surface/Accent/Hover
-  'figma-button-surface-accent-hover-border': 'hsla(var(--figma___button-surface-accent-hover-border));', // ✦ Theme/Button/Surface/Accent/Hover Border
-  'figma-button-surface-accent-text-disabled': 'hsla(var(--figma___button-surface-accent-text-disabled));', // ✦ Theme/Button/Surface/Accent/Text-disabled
-  'figma-button-surface-accent-text-primary': 'hsla(var(--figma___button-surface-accent-text-primary));', // ✦ Theme/Button/Surface/Accent/Text-primary
-  'figma-button-surface-accent-default': 'hsla(var(--figma___button-surface-accent-default));', // ✦ Theme/Button/Surface/Accent/default
-  'figma-button-surface-accent-default-border': 'hsla(var(--figma___button-surface-accent-default-border));', // ✦ Theme/Button/Surface/Accent/default border
-  'figma-button-surface-error-active': 'hsla(var(--figma___button-surface-error-active));', // ✦ Theme/Button/Surface/Error/Active
-  'figma-button-surface-error-active-border': 'hsla(var(--figma___button-surface-error-active-border));', // ✦ Theme/Button/Surface/Error/Active border
-  'figma-button-surface-error-disabled': 'hsla(var(--figma___button-surface-error-disabled));', // ✦ Theme/Button/Surface/Error/Disabled
-  'figma-button-surface-error-hover': 'hsla(var(--figma___button-surface-error-hover));', // ✦ Theme/Button/Surface/Error/Hover
-  'figma-button-surface-error-hover-border': 'hsla(var(--figma___button-surface-error-hover-border));', // ✦ Theme/Button/Surface/Error/Hover border
-  'figma-button-surface-error-text-disabled': 'hsla(var(--figma___button-surface-error-text-disabled));', // ✦ Theme/Button/Surface/Error/Text-disabled
-  'figma-button-surface-error-text-primary': 'hsla(var(--figma___button-surface-error-text-primary));', // ✦ Theme/Button/Surface/Error/Text-primary
-  'figma-button-surface-error-border': 'hsla(var(--figma___button-surface-error-border));', // ✦ Theme/Button/Surface/Error/border
-  'figma-button-surface-error-default': 'hsla(var(--figma___button-surface-error-default));', // ✦ Theme/Button/Surface/Error/default
-  'figma-button-surface-neutral-active': 'hsla(var(--figma___button-surface-neutral-active));', // ✦ Theme/Button/Surface/Neutral/Active
-  'figma-button-surface-neutral-disabled': 'hsla(var(--figma___button-surface-neutral-disabled));', // ✦ Theme/Button/Surface/Neutral/Disabled
-  'figma-button-surface-neutral-hover': 'hsla(var(--figma___button-surface-neutral-hover));', // ✦ Theme/Button/Surface/Neutral/Hover
-  'figma-button-surface-neutral-text-disabled': 'hsla(var(--figma___button-surface-neutral-text-disabled));', // ✦ Theme/Button/Surface/Neutral/Text-disabled
-  'figma-button-surface-neutral-text-primary': 'hsla(var(--figma___button-surface-neutral-text-primary));', // ✦ Theme/Button/Surface/Neutral/Text-primary
-  'figma-button-surface-neutral-border': 'hsla(var(--figma___button-surface-neutral-border));', // ✦ Theme/Button/Surface/Neutral/border
-  'figma-button-surface-neutral-default': 'hsla(var(--figma___button-surface-neutral-default));', // ✦ Theme/Button/Surface/Neutral/default
-  'figma-button-surface-success-active': 'hsla(var(--figma___button-surface-success-active));', // ✦ Theme/Button/Surface/Success/Active
-  'figma-button-surface-success-disabled': 'hsla(var(--figma___button-surface-success-disabled));', // ✦ Theme/Button/Surface/Success/Disabled
-  'figma-button-surface-success-hover': 'hsla(var(--figma___button-surface-success-hover));', // ✦ Theme/Button/Surface/Success/Hover
-  'figma-button-surface-success-hover-border': 'hsla(var(--figma___button-surface-success-hover-border));', // ✦ Theme/Button/Surface/Success/Hover border
-  'figma-button-surface-success-text-disabled': 'hsla(var(--figma___button-surface-success-text-disabled));', // ✦ Theme/Button/Surface/Success/Text-disabled
-  'figma-button-surface-success-text-primary': 'hsla(var(--figma___button-surface-success-text-primary));', // ✦ Theme/Button/Surface/Success/Text-primary
-  'figma-button-surface-success-active-border': 'hsla(var(--figma___button-surface-success-active-border));', // ✦ Theme/Button/Surface/Success/active border
-  'figma-button-surface-success-default': 'hsla(var(--figma___button-surface-success-default));', // ✦ Theme/Button/Surface/Success/default
-  'figma-button-surface-success-default-border': 'hsla(var(--figma___button-surface-success-default-border));', // ✦ Theme/Button/Surface/Success/default border
-  'figma-calendar-background': 'hsla(var(--figma___calendar-background));', // ✦ Theme/Calendar/Background
-  'figma-calendar-selected-date-background': 'hsla(var(--figma___calendar-selected-date-background));', // ✦ Theme/Calendar/Selected Date/Background
-  'figma-calendar-selected-date-text': 'hsla(var(--figma___calendar-selected-date-text));', // ✦ Theme/Calendar/Selected Date/Text
-  'figma-calendar-selected-range-background': 'hsla(var(--figma___calendar-selected-range-background));', // ✦ Theme/Calendar/Selected Range/Background
-  'figma-calendar-selected-range-text': 'hsla(var(--figma___calendar-selected-range-text));', // ✦ Theme/Calendar/Selected Range/Text
-  'figma-checkbox-background': 'hsla(var(--figma___checkbox-background));', // ✦ Theme/Checkbox/Background
-  'figma-checkbox-paper': 'hsla(var(--figma___checkbox-paper));', // ✦ Theme/Checkbox/Paper
-  'figma-checkbox-surface-checked-active-active': 'hsla(var(--figma___checkbox-surface-checked-active-active));', // ✦ Theme/Checkbox/Surface/Checked/Active/Active
-  'figma-checkbox-surface-checked-active-check': 'hsla(var(--figma___checkbox-surface-checked-active-check));', // ✦ Theme/Checkbox/Surface/Checked/Active/Check
-  'figma-checkbox-surface-checked-active-hover': 'hsla(var(--figma___checkbox-surface-checked-active-hover));', // ✦ Theme/Checkbox/Surface/Checked/Active/Hover
-  'figma-checkbox-surface-checked-active-default-background':
-    'hsla(var(--figma___checkbox-surface-checked-active-default-background));', // ✦ Theme/Checkbox/Surface/Checked/Active/default background
-  'figma-checkbox-surface-checked-disabled-check': 'hsla(var(--figma___checkbox-surface-checked-disabled-check));', // ✦ Theme/Checkbox/Surface/Checked/Disabled/Check
-  'figma-checkbox-surface-checked-disabled-disabled':
-    'hsla(var(--figma___checkbox-surface-checked-disabled-disabled));', // ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled
-  'figma-checkbox-surface-checked-disabled-border': 'hsla(var(--figma___checkbox-surface-checked-disabled-border));', // ✦ Theme/Checkbox/Surface/Checked/Disabled/border
-  'figma-checkbox-surface-intermediate-active-active-border':
-    'hsla(var(--figma___checkbox-surface-intermediate-active-active-border));', // ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border
-  'figma-checkbox-surface-intermediate-active-check':
-    'hsla(var(--figma___checkbox-surface-intermediate-active-check));', // ✦ Theme/Checkbox/Surface/Intermediate/Active/Check
-  'figma-checkbox-surface-intermediate-active-hover-border':
-    'hsla(var(--figma___checkbox-surface-intermediate-active-hover-border));', // ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border
-  'figma-checkbox-surface-intermediate-active-default-background':
-    'hsla(var(--figma___checkbox-surface-intermediate-active-default-background));', // ✦ Theme/Checkbox/Surface/Intermediate/Active/default background
-  'figma-checkbox-surface-intermediate-active-default-border':
-    'hsla(var(--figma___checkbox-surface-intermediate-active-default-border));', // ✦ Theme/Checkbox/Surface/Intermediate/Active/default border
-  'figma-checkbox-surface-intermediate-disabled-check':
-    'hsla(var(--figma___checkbox-surface-intermediate-disabled-check));', // ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check
-  'figma-checkbox-surface-intermediate-disabled-disabled':
-    'hsla(var(--figma___checkbox-surface-intermediate-disabled-disabled));', // ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled
-  'figma-checkbox-surface-intermediate-disabled-border':
-    'hsla(var(--figma___checkbox-surface-intermediate-disabled-border));', // ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border
-  'figma-checkbox-surface-unchecked-active-active-border':
-    'hsla(var(--figma___checkbox-surface-unchecked-active-active-border));', // ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border
-  'figma-checkbox-surface-unchecked-active-hover-border':
-    'hsla(var(--figma___checkbox-surface-unchecked-active-hover-border));', // ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border
-  'figma-checkbox-surface-unchecked-active-default-background':
-    'hsla(var(--figma___checkbox-surface-unchecked-active-default-background));', // ✦ Theme/Checkbox/Surface/Unchecked/Active/default background
-  'figma-checkbox-surface-unchecked-active-default-border':
-    'hsla(var(--figma___checkbox-surface-unchecked-active-default-border));', // ✦ Theme/Checkbox/Surface/Unchecked/Active/default border
-  'figma-checkbox-surface-unchecked-disabled-disabled':
-    'hsla(var(--figma___checkbox-surface-unchecked-disabled-disabled));', // ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled
-  'figma-checkbox-surface-unchecked-disabled-border':
-    'hsla(var(--figma___checkbox-surface-unchecked-disabled-border));', // ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border
-  'figma-checkbox-border': 'hsla(var(--figma___checkbox-border));', // ✦ Theme/Checkbox/border
-  'figma-default-colors-black': 'hsla(var(--figma___default-colors-black));', // ✦ Theme/Default colors/black
-  'figma-default-colors-dark-to-white': 'hsla(var(--figma___default-colors-dark-to-white));', // ✦ Theme/Default colors/dark-to-white
-  'figma-default-colors-white': 'hsla(var(--figma___default-colors-white));', // ✦ Theme/Default colors/white
-  'figma-default-colors-white-to-dark': 'hsla(var(--figma___default-colors-white-to-dark));', // ✦ Theme/Default colors/white-to-dark
-  'figma-dropdown-dropdown-item-default': 'hsla(var(--figma___dropdown-dropdown-item-default));', // ✦ Theme/Dropdown/Dropdown Item/Default
-  'figma-dropdown-dropdown-item-hover': 'hsla(var(--figma___dropdown-dropdown-item-hover));', // ✦ Theme/Dropdown/Dropdown Item/Hover
-  'figma-dropdown-dropdown-item-selected': 'hsla(var(--figma___dropdown-dropdown-item-selected));', // ✦ Theme/Dropdown/Dropdown Item/Selected
-  'figma-dropdown-text-shortcut-text-selected': 'hsla(var(--figma___dropdown-text-shortcut-text-selected));', // ✦ Theme/Dropdown/Text/Shortcut text selected
-  'figma-dropdown-text-text-selected': 'hsla(var(--figma___dropdown-text-text-selected));', // ✦ Theme/Dropdown/Text/Text Selected
-  'figma-dropdown-text-hover': 'hsla(var(--figma___dropdown-text-hover));', // ✦ Theme/Dropdown/Text/hover
-  'figma-dropdown-background': 'hsla(var(--figma___dropdown-background));', // ✦ Theme/Dropdown/background
-  'figma-dropdown-border': 'hsla(var(--figma___dropdown-border));', // ✦ Theme/Dropdown/border
-  'figma-dropdown-separator': 'hsla(var(--figma___dropdown-separator));', // ✦ Theme/Dropdown/separator
-  'figma-filter-active': 'hsla(var(--figma___filter-active));', // ✦ Theme/Filter/Active
-  'figma-filter-default': 'hsla(var(--figma___filter-default));', // ✦ Theme/Filter/Default
-  'figma-filter-hover': 'hsla(var(--figma___filter-hover));', // ✦ Theme/Filter/Hover
-  'figma-inline-alert-banner-customisable': 'hsla(var(--figma___inline-alert-banner-customisable));', // ✦ Theme/Inline Alert Banner/Customisable
-  'figma-inline-alert-banner-error': 'hsla(var(--figma___inline-alert-banner-error));', // ✦ Theme/Inline Alert Banner/Error
-  'figma-inline-alert-banner-info': 'hsla(var(--figma___inline-alert-banner-info));', // ✦ Theme/Inline Alert Banner/Info
-  'figma-inline-alert-banner-reminder': 'hsla(var(--figma___inline-alert-banner-reminder));', // ✦ Theme/Inline Alert Banner/Reminder
-  'figma-inline-alert-banner-success': 'hsla(var(--figma___inline-alert-banner-success));', // ✦ Theme/Inline Alert Banner/Success
-  'figma-inline-alert-banner-warning': 'hsla(var(--figma___inline-alert-banner-warning));', // ✦ Theme/Inline Alert Banner/Warning
-  'figma-modal-background': 'hsla(var(--figma___modal-background));', // ✦ Theme/Modal/Background
-  'figma-modal-paper': 'hsla(var(--figma___modal-paper));', // ✦ Theme/Modal/Paper
-  'figma-modal-border': 'hsla(var(--figma___modal-border));', // ✦ Theme/Modal/border
-  'figma-neutral-color-gray-1': 'hsla(var(--figma___neutral-color-gray-1));', // ✦ Theme/Neutral color/Gray/1
-  'figma-neutral-color-gray-2': 'hsla(var(--figma___neutral-color-gray-2));', // ✦ Theme/Neutral color/Gray/2
-  'figma-neutral-color-gray-3': 'hsla(var(--figma___neutral-color-gray-3));', // ✦ Theme/Neutral color/Gray/3
-  'figma-neutral-color-gray-4': 'hsla(var(--figma___neutral-color-gray-4));', // ✦ Theme/Neutral color/Gray/4
-  'figma-neutral-color-gray-5': 'hsla(var(--figma___neutral-color-gray-5));', // ✦ Theme/Neutral color/Gray/5
-  'figma-neutral-color-gray-6': 'hsla(var(--figma___neutral-color-gray-6));', // ✦ Theme/Neutral color/Gray/6
-  'figma-neutral-color-gray-7': 'hsla(var(--figma___neutral-color-gray-7));', // ✦ Theme/Neutral color/Gray/7
-  'figma-neutral-color-gray-8': 'hsla(var(--figma___neutral-color-gray-8));', // ✦ Theme/Neutral color/Gray/8
-  'figma-neutral-color-gray-9': 'hsla(var(--figma___neutral-color-gray-9));', // ✦ Theme/Neutral color/Gray/9
-  'figma-neutral-color-gray-10': 'hsla(var(--figma___neutral-color-gray-10));', // ✦ Theme/Neutral color/Gray/10
-  'figma-neutral-color-gray-alpha-1': 'hsla(var(--figma___neutral-color-gray-alpha-1));', // ✦ Theme/Neutral color/Gray Alpha/1
-  'figma-neutral-color-gray-alpha-2': 'hsla(var(--figma___neutral-color-gray-alpha-2));', // ✦ Theme/Neutral color/Gray Alpha/2
-  'figma-neutral-color-gray-alpha-3': 'hsla(var(--figma___neutral-color-gray-alpha-3));', // ✦ Theme/Neutral color/Gray Alpha/3
-  'figma-neutral-color-gray-alpha-4': 'hsla(var(--figma___neutral-color-gray-alpha-4));', // ✦ Theme/Neutral color/Gray Alpha/4
-  'figma-neutral-color-gray-alpha-5': 'hsla(var(--figma___neutral-color-gray-alpha-5));', // ✦ Theme/Neutral color/Gray Alpha/5
-  'figma-neutral-color-gray-alpha-6': 'hsla(var(--figma___neutral-color-gray-alpha-6));', // ✦ Theme/Neutral color/Gray Alpha/6
-  'figma-neutral-color-gray-alpha-7': 'hsla(var(--figma___neutral-color-gray-alpha-7));', // ✦ Theme/Neutral color/Gray Alpha/7
-  'figma-neutral-color-gray-alpha-8': 'hsla(var(--figma___neutral-color-gray-alpha-8));', // ✦ Theme/Neutral color/Gray Alpha/8
-  'figma-neutral-color-gray-alpha-9': 'hsla(var(--figma___neutral-color-gray-alpha-9));', // ✦ Theme/Neutral color/Gray Alpha/9
-  'figma-neutral-color-gray-alpha-10': 'hsla(var(--figma___neutral-color-gray-alpha-10));', // ✦ Theme/Neutral color/Gray Alpha/10
-  'figma-other-colors-ai-violet-1': 'hsla(var(--figma___other-colors-ai-violet-1));', // ✦ Theme/Other Colors/AI Violet/1
-  'figma-other-colors-ai-violet-2': 'hsla(var(--figma___other-colors-ai-violet-2));', // ✦ Theme/Other Colors/AI Violet/2
-  'figma-other-colors-ai-violet-3': 'hsla(var(--figma___other-colors-ai-violet-3));', // ✦ Theme/Other Colors/AI Violet/3
-  'figma-other-colors-ai-violet-4': 'hsla(var(--figma___other-colors-ai-violet-4));', // ✦ Theme/Other Colors/AI Violet/4
-  'figma-other-colors-ai-violet-5': 'hsla(var(--figma___other-colors-ai-violet-5));', // ✦ Theme/Other Colors/AI Violet/5
-  'figma-other-colors-ai-violet-6': 'hsla(var(--figma___other-colors-ai-violet-6));', // ✦ Theme/Other Colors/AI Violet/6
-  'figma-other-colors-ai-violet-7': 'hsla(var(--figma___other-colors-ai-violet-7));', // ✦ Theme/Other Colors/AI Violet/7
-  'figma-other-colors-ai-violet-8': 'hsla(var(--figma___other-colors-ai-violet-8));', // ✦ Theme/Other Colors/AI Violet/8
-  'figma-other-colors-ai-violet-9': 'hsla(var(--figma___other-colors-ai-violet-9));', // ✦ Theme/Other Colors/AI Violet/9
-  'figma-other-colors-ai-violet-10': 'hsla(var(--figma___other-colors-ai-violet-10));', // ✦ Theme/Other Colors/AI Violet/10
-  'figma-other-colors-ai-violet-alpha-1': 'hsla(var(--figma___other-colors-ai-violet-alpha-1));', // ✦ Theme/Other Colors/AI Violet Alpha/1
-  'figma-other-colors-ai-violet-alpha-2': 'hsla(var(--figma___other-colors-ai-violet-alpha-2));', // ✦ Theme/Other Colors/AI Violet Alpha/2
-  'figma-other-colors-ai-violet-alpha-3': 'hsla(var(--figma___other-colors-ai-violet-alpha-3));', // ✦ Theme/Other Colors/AI Violet Alpha/3
-  'figma-other-colors-ai-violet-alpha-4': 'hsla(var(--figma___other-colors-ai-violet-alpha-4));', // ✦ Theme/Other Colors/AI Violet Alpha/4
-  'figma-other-colors-ai-violet-alpha-5': 'hsla(var(--figma___other-colors-ai-violet-alpha-5));', // ✦ Theme/Other Colors/AI Violet Alpha/5
-  'figma-other-colors-ai-violet-alpha-6': 'hsla(var(--figma___other-colors-ai-violet-alpha-6));', // ✦ Theme/Other Colors/AI Violet Alpha/6
-  'figma-other-colors-ai-violet-alpha-7': 'hsla(var(--figma___other-colors-ai-violet-alpha-7));', // ✦ Theme/Other Colors/AI Violet Alpha/7
-  'figma-other-colors-ai-violet-alpha-8': 'hsla(var(--figma___other-colors-ai-violet-alpha-8));', // ✦ Theme/Other Colors/AI Violet Alpha/8
-  'figma-other-colors-ai-violet-alpha-9': 'hsla(var(--figma___other-colors-ai-violet-alpha-9));', // ✦ Theme/Other Colors/AI Violet Alpha/9
-  'figma-other-colors-ai-violet-alpha-10': 'hsla(var(--figma___other-colors-ai-violet-alpha-10));', // ✦ Theme/Other Colors/AI Violet Alpha/10
-  'figma-other-colors-blue-1': 'hsla(var(--figma___other-colors-blue-1));', // ✦ Theme/Other Colors/Blue/1
-  'figma-other-colors-blue-2': 'hsla(var(--figma___other-colors-blue-2));', // ✦ Theme/Other Colors/Blue/2
-  'figma-other-colors-blue-3': 'hsla(var(--figma___other-colors-blue-3));', // ✦ Theme/Other Colors/Blue/3
-  'figma-other-colors-blue-4': 'hsla(var(--figma___other-colors-blue-4));', // ✦ Theme/Other Colors/Blue/4
-  'figma-other-colors-blue-5': 'hsla(var(--figma___other-colors-blue-5));', // ✦ Theme/Other Colors/Blue/5
-  'figma-other-colors-blue-6': 'hsla(var(--figma___other-colors-blue-6));', // ✦ Theme/Other Colors/Blue/6
-  'figma-other-colors-blue-7': 'hsla(var(--figma___other-colors-blue-7));', // ✦ Theme/Other Colors/Blue/7
-  'figma-other-colors-blue-8': 'hsla(var(--figma___other-colors-blue-8));', // ✦ Theme/Other Colors/Blue/8
-  'figma-other-colors-blue-9': 'hsla(var(--figma___other-colors-blue-9));', // ✦ Theme/Other Colors/Blue/9
-  'figma-other-colors-blue-10': 'hsla(var(--figma___other-colors-blue-10));', // ✦ Theme/Other Colors/Blue/10
-  'figma-other-colors-blue-alpha-1': 'hsla(var(--figma___other-colors-blue-alpha-1));', // ✦ Theme/Other Colors/Blue Alpha/1
-  'figma-other-colors-blue-alpha-2': 'hsla(var(--figma___other-colors-blue-alpha-2));', // ✦ Theme/Other Colors/Blue Alpha/2
-  'figma-other-colors-blue-alpha-3': 'hsla(var(--figma___other-colors-blue-alpha-3));', // ✦ Theme/Other Colors/Blue Alpha/3
-  'figma-other-colors-blue-alpha-4': 'hsla(var(--figma___other-colors-blue-alpha-4));', // ✦ Theme/Other Colors/Blue Alpha/4
-  'figma-other-colors-blue-alpha-5': 'hsla(var(--figma___other-colors-blue-alpha-5));', // ✦ Theme/Other Colors/Blue Alpha/5
-  'figma-other-colors-blue-alpha-6': 'hsla(var(--figma___other-colors-blue-alpha-6));', // ✦ Theme/Other Colors/Blue Alpha/6
-  'figma-other-colors-blue-alpha-7': 'hsla(var(--figma___other-colors-blue-alpha-7));', // ✦ Theme/Other Colors/Blue Alpha/7
-  'figma-other-colors-blue-alpha-8': 'hsla(var(--figma___other-colors-blue-alpha-8));', // ✦ Theme/Other Colors/Blue Alpha/8
-  'figma-other-colors-blue-alpha-9': 'hsla(var(--figma___other-colors-blue-alpha-9));', // ✦ Theme/Other Colors/Blue Alpha/9
-  'figma-other-colors-blue-alpha-10': 'hsla(var(--figma___other-colors-blue-alpha-10));', // ✦ Theme/Other Colors/Blue Alpha/10
-  'figma-other-colors-indigo-1': 'hsla(var(--figma___other-colors-indigo-1));', // ✦ Theme/Other Colors/Indigo/1
-  'figma-other-colors-indigo-2': 'hsla(var(--figma___other-colors-indigo-2));', // ✦ Theme/Other Colors/Indigo/2
-  'figma-other-colors-indigo-3': 'hsla(var(--figma___other-colors-indigo-3));', // ✦ Theme/Other Colors/Indigo/3
-  'figma-other-colors-indigo-4': 'hsla(var(--figma___other-colors-indigo-4));', // ✦ Theme/Other Colors/Indigo/4
-  'figma-other-colors-indigo-5': 'hsla(var(--figma___other-colors-indigo-5));', // ✦ Theme/Other Colors/Indigo/5
-  'figma-other-colors-indigo-6': 'hsla(var(--figma___other-colors-indigo-6));', // ✦ Theme/Other Colors/Indigo/6
-  'figma-other-colors-indigo-7': 'hsla(var(--figma___other-colors-indigo-7));', // ✦ Theme/Other Colors/Indigo/7
-  'figma-other-colors-indigo-8': 'hsla(var(--figma___other-colors-indigo-8));', // ✦ Theme/Other Colors/Indigo/8
-  'figma-other-colors-indigo-9': 'hsla(var(--figma___other-colors-indigo-9));', // ✦ Theme/Other Colors/Indigo/9
-  'figma-other-colors-indigo-10': 'hsla(var(--figma___other-colors-indigo-10));', // ✦ Theme/Other Colors/Indigo/10
-  'figma-other-colors-indigo-alpha-1': 'hsla(var(--figma___other-colors-indigo-alpha-1));', // ✦ Theme/Other Colors/Indigo Alpha/1
-  'figma-other-colors-indigo-alpha-2': 'hsla(var(--figma___other-colors-indigo-alpha-2));', // ✦ Theme/Other Colors/Indigo Alpha/2
-  'figma-other-colors-indigo-alpha-3': 'hsla(var(--figma___other-colors-indigo-alpha-3));', // ✦ Theme/Other Colors/Indigo Alpha/3
-  'figma-other-colors-indigo-alpha-4': 'hsla(var(--figma___other-colors-indigo-alpha-4));', // ✦ Theme/Other Colors/Indigo Alpha/4
-  'figma-other-colors-indigo-alpha-5': 'hsla(var(--figma___other-colors-indigo-alpha-5));', // ✦ Theme/Other Colors/Indigo Alpha/5
-  'figma-other-colors-indigo-alpha-6': 'hsla(var(--figma___other-colors-indigo-alpha-6));', // ✦ Theme/Other Colors/Indigo Alpha/6
-  'figma-other-colors-indigo-alpha-7': 'hsla(var(--figma___other-colors-indigo-alpha-7));', // ✦ Theme/Other Colors/Indigo Alpha/7
-  'figma-other-colors-indigo-alpha-8': 'hsla(var(--figma___other-colors-indigo-alpha-8));', // ✦ Theme/Other Colors/Indigo Alpha/8
-  'figma-other-colors-indigo-alpha-9': 'hsla(var(--figma___other-colors-indigo-alpha-9));', // ✦ Theme/Other Colors/Indigo Alpha/9
-  'figma-other-colors-indigo-alpha-10': 'hsla(var(--figma___other-colors-indigo-alpha-10));', // ✦ Theme/Other Colors/Indigo Alpha/10
-  'figma-other-colors-mint-1': 'hsla(var(--figma___other-colors-mint-1));', // ✦ Theme/Other Colors/Mint/1
-  'figma-other-colors-mint-2': 'hsla(var(--figma___other-colors-mint-2));', // ✦ Theme/Other Colors/Mint/2
-  'figma-other-colors-mint-3': 'hsla(var(--figma___other-colors-mint-3));', // ✦ Theme/Other Colors/Mint/3
-  'figma-other-colors-mint-4': 'hsla(var(--figma___other-colors-mint-4));', // ✦ Theme/Other Colors/Mint/4
-  'figma-other-colors-mint-5': 'hsla(var(--figma___other-colors-mint-5));', // ✦ Theme/Other Colors/Mint/5
-  'figma-other-colors-mint-6': 'hsla(var(--figma___other-colors-mint-6));', // ✦ Theme/Other Colors/Mint/6
-  'figma-other-colors-mint-7': 'hsla(var(--figma___other-colors-mint-7));', // ✦ Theme/Other Colors/Mint/7
-  'figma-other-colors-mint-8': 'hsla(var(--figma___other-colors-mint-8));', // ✦ Theme/Other Colors/Mint/8
-  'figma-other-colors-mint-9': 'hsla(var(--figma___other-colors-mint-9));', // ✦ Theme/Other Colors/Mint/9
-  'figma-other-colors-mint-10': 'hsla(var(--figma___other-colors-mint-10));', // ✦ Theme/Other Colors/Mint/10
-  'figma-other-colors-mint-alpha-1': 'hsla(var(--figma___other-colors-mint-alpha-1));', // ✦ Theme/Other Colors/Mint Alpha/1
-  'figma-other-colors-mint-alpha-2': 'hsla(var(--figma___other-colors-mint-alpha-2));', // ✦ Theme/Other Colors/Mint Alpha/2
-  'figma-other-colors-mint-alpha-3': 'hsla(var(--figma___other-colors-mint-alpha-3));', // ✦ Theme/Other Colors/Mint Alpha/3
-  'figma-other-colors-mint-alpha-4': 'hsla(var(--figma___other-colors-mint-alpha-4));', // ✦ Theme/Other Colors/Mint Alpha/4
-  'figma-other-colors-mint-alpha-5': 'hsla(var(--figma___other-colors-mint-alpha-5));', // ✦ Theme/Other Colors/Mint Alpha/5
-  'figma-other-colors-mint-alpha-6': 'hsla(var(--figma___other-colors-mint-alpha-6));', // ✦ Theme/Other Colors/Mint Alpha/6
-  'figma-other-colors-mint-alpha-7': 'hsla(var(--figma___other-colors-mint-alpha-7));', // ✦ Theme/Other Colors/Mint Alpha/7
-  'figma-other-colors-mint-alpha-8': 'hsla(var(--figma___other-colors-mint-alpha-8));', // ✦ Theme/Other Colors/Mint Alpha/8
-  'figma-other-colors-mint-alpha-9': 'hsla(var(--figma___other-colors-mint-alpha-9));', // ✦ Theme/Other Colors/Mint Alpha/9
-  'figma-other-colors-mint-alpha-10': 'hsla(var(--figma___other-colors-mint-alpha-10));', // ✦ Theme/Other Colors/Mint Alpha/10
-  'figma-other-colors-orange-1': 'hsla(var(--figma___other-colors-orange-1));', // ✦ Theme/Other Colors/Orange/1
-  'figma-other-colors-orange-2': 'hsla(var(--figma___other-colors-orange-2));', // ✦ Theme/Other Colors/Orange/2
-  'figma-other-colors-orange-3': 'hsla(var(--figma___other-colors-orange-3));', // ✦ Theme/Other Colors/Orange/3
-  'figma-other-colors-orange-4': 'hsla(var(--figma___other-colors-orange-4));', // ✦ Theme/Other Colors/Orange/4
-  'figma-other-colors-orange-5': 'hsla(var(--figma___other-colors-orange-5));', // ✦ Theme/Other Colors/Orange/5
-  'figma-other-colors-orange-6': 'hsla(var(--figma___other-colors-orange-6));', // ✦ Theme/Other Colors/Orange/6
-  'figma-other-colors-orange-7': 'hsla(var(--figma___other-colors-orange-7));', // ✦ Theme/Other Colors/Orange/7
-  'figma-other-colors-orange-8': 'hsla(var(--figma___other-colors-orange-8));', // ✦ Theme/Other Colors/Orange/8
-  'figma-other-colors-orange-9': 'hsla(var(--figma___other-colors-orange-9));', // ✦ Theme/Other Colors/Orange/9
-  'figma-other-colors-orange-10': 'hsla(var(--figma___other-colors-orange-10));', // ✦ Theme/Other Colors/Orange/10
-  'figma-other-colors-orange-alpha-1': 'hsla(var(--figma___other-colors-orange-alpha-1));', // ✦ Theme/Other Colors/Orange Alpha/1
-  'figma-other-colors-orange-alpha-2': 'hsla(var(--figma___other-colors-orange-alpha-2));', // ✦ Theme/Other Colors/Orange Alpha/2
-  'figma-other-colors-orange-alpha-3': 'hsla(var(--figma___other-colors-orange-alpha-3));', // ✦ Theme/Other Colors/Orange Alpha/3
-  'figma-other-colors-orange-alpha-4': 'hsla(var(--figma___other-colors-orange-alpha-4));', // ✦ Theme/Other Colors/Orange Alpha/4
-  'figma-other-colors-orange-alpha-5': 'hsla(var(--figma___other-colors-orange-alpha-5));', // ✦ Theme/Other Colors/Orange Alpha/5
-  'figma-other-colors-orange-alpha-6': 'hsla(var(--figma___other-colors-orange-alpha-6));', // ✦ Theme/Other Colors/Orange Alpha/6
-  'figma-other-colors-orange-alpha-7': 'hsla(var(--figma___other-colors-orange-alpha-7));', // ✦ Theme/Other Colors/Orange Alpha/7
-  'figma-other-colors-orange-alpha-8': 'hsla(var(--figma___other-colors-orange-alpha-8));', // ✦ Theme/Other Colors/Orange Alpha/8
-  'figma-other-colors-orange-alpha-9': 'hsla(var(--figma___other-colors-orange-alpha-9));', // ✦ Theme/Other Colors/Orange Alpha/9
-  'figma-other-colors-orange-alpha-10': 'hsla(var(--figma___other-colors-orange-alpha-10));', // ✦ Theme/Other Colors/Orange Alpha/10
-  'figma-other-colors-yellow-1': 'hsla(var(--figma___other-colors-yellow-1));', // ✦ Theme/Other Colors/Yellow/1
-  'figma-other-colors-yellow-2': 'hsla(var(--figma___other-colors-yellow-2));', // ✦ Theme/Other Colors/Yellow/2
-  'figma-other-colors-yellow-3': 'hsla(var(--figma___other-colors-yellow-3));', // ✦ Theme/Other Colors/Yellow/3
-  'figma-other-colors-yellow-4': 'hsla(var(--figma___other-colors-yellow-4));', // ✦ Theme/Other Colors/Yellow/4
-  'figma-other-colors-yellow-5': 'hsla(var(--figma___other-colors-yellow-5));', // ✦ Theme/Other Colors/Yellow/5
-  'figma-other-colors-yellow-6': 'hsla(var(--figma___other-colors-yellow-6));', // ✦ Theme/Other Colors/Yellow/6
-  'figma-other-colors-yellow-7': 'hsla(var(--figma___other-colors-yellow-7));', // ✦ Theme/Other Colors/Yellow/7
-  'figma-other-colors-yellow-8': 'hsla(var(--figma___other-colors-yellow-8));', // ✦ Theme/Other Colors/Yellow/8
-  'figma-other-colors-yellow-9': 'hsla(var(--figma___other-colors-yellow-9));', // ✦ Theme/Other Colors/Yellow/9
-  'figma-other-colors-yellow-10': 'hsla(var(--figma___other-colors-yellow-10));', // ✦ Theme/Other Colors/Yellow/10
-  'figma-other-colors-yellow-alpha-1': 'hsla(var(--figma___other-colors-yellow-alpha-1));', // ✦ Theme/Other Colors/Yellow Alpha/1
-  'figma-other-colors-yellow-alpha-2': 'hsla(var(--figma___other-colors-yellow-alpha-2));', // ✦ Theme/Other Colors/Yellow Alpha/2
-  'figma-other-colors-yellow-alpha-3': 'hsla(var(--figma___other-colors-yellow-alpha-3));', // ✦ Theme/Other Colors/Yellow Alpha/3
-  'figma-other-colors-yellow-alpha-4': 'hsla(var(--figma___other-colors-yellow-alpha-4));', // ✦ Theme/Other Colors/Yellow Alpha/4
-  'figma-other-colors-yellow-alpha-5': 'hsla(var(--figma___other-colors-yellow-alpha-5));', // ✦ Theme/Other Colors/Yellow Alpha/5
-  'figma-other-colors-yellow-alpha-6': 'hsla(var(--figma___other-colors-yellow-alpha-6));', // ✦ Theme/Other Colors/Yellow Alpha/6
-  'figma-other-colors-yellow-alpha-7': 'hsla(var(--figma___other-colors-yellow-alpha-7));', // ✦ Theme/Other Colors/Yellow Alpha/7
-  'figma-other-colors-yellow-alpha-8': 'hsla(var(--figma___other-colors-yellow-alpha-8));', // ✦ Theme/Other Colors/Yellow Alpha/8
-  'figma-other-colors-yellow-alpha-9': 'hsla(var(--figma___other-colors-yellow-alpha-9));', // ✦ Theme/Other Colors/Yellow Alpha/9
-  'figma-other-colors-yellow-alpha-10': 'hsla(var(--figma___other-colors-yellow-alpha-10));', // ✦ Theme/Other Colors/Yellow Alpha/10
+  'figma-colors-alerts-status-error-1': 'hsla(var(--figma___colors-alerts-status-error-1));', // ✦ Theme/Colors/Alerts & Status/Error/1
+  'figma-colors-alerts-status-error-2': 'hsla(var(--figma___colors-alerts-status-error-2));', // ✦ Theme/Colors/Alerts & Status/Error/2
+  'figma-colors-alerts-status-error-3': 'hsla(var(--figma___colors-alerts-status-error-3));', // ✦ Theme/Colors/Alerts & Status/Error/3
+  'figma-colors-alerts-status-error-4': 'hsla(var(--figma___colors-alerts-status-error-4));', // ✦ Theme/Colors/Alerts & Status/Error/4
+  'figma-colors-alerts-status-error-5': 'hsla(var(--figma___colors-alerts-status-error-5));', // ✦ Theme/Colors/Alerts & Status/Error/5
+  'figma-colors-alerts-status-error-6': 'hsla(var(--figma___colors-alerts-status-error-6));', // ✦ Theme/Colors/Alerts & Status/Error/6
+  'figma-colors-alerts-status-error-7': 'hsla(var(--figma___colors-alerts-status-error-7));', // ✦ Theme/Colors/Alerts & Status/Error/7
+  'figma-colors-alerts-status-error-8': 'hsla(var(--figma___colors-alerts-status-error-8));', // ✦ Theme/Colors/Alerts & Status/Error/8
+  'figma-colors-alerts-status-error-9': 'hsla(var(--figma___colors-alerts-status-error-9));', // ✦ Theme/Colors/Alerts & Status/Error/9
+  'figma-colors-alerts-status-error-10': 'hsla(var(--figma___colors-alerts-status-error-10));', // ✦ Theme/Colors/Alerts & Status/Error/10
+  'figma-colors-alerts-status-error-alpha-1': 'hsla(var(--figma___colors-alerts-status-error-alpha-1));', // ✦ Theme/Colors/Alerts & Status/Error Alpha/1
+  'figma-colors-alerts-status-error-alpha-2': 'hsla(var(--figma___colors-alerts-status-error-alpha-2));', // ✦ Theme/Colors/Alerts & Status/Error Alpha/2
+  'figma-colors-alerts-status-error-alpha-3': 'hsla(var(--figma___colors-alerts-status-error-alpha-3));', // ✦ Theme/Colors/Alerts & Status/Error Alpha/3
+  'figma-colors-alerts-status-error-alpha-4': 'hsla(var(--figma___colors-alerts-status-error-alpha-4));', // ✦ Theme/Colors/Alerts & Status/Error Alpha/4
+  'figma-colors-alerts-status-error-alpha-5': 'hsla(var(--figma___colors-alerts-status-error-alpha-5));', // ✦ Theme/Colors/Alerts & Status/Error Alpha/5
+  'figma-colors-alerts-status-error-alpha-6': 'hsla(var(--figma___colors-alerts-status-error-alpha-6));', // ✦ Theme/Colors/Alerts & Status/Error Alpha/6
+  'figma-colors-alerts-status-error-alpha-7': 'hsla(var(--figma___colors-alerts-status-error-alpha-7));', // ✦ Theme/Colors/Alerts & Status/Error Alpha/7
+  'figma-colors-alerts-status-error-alpha-8': 'hsla(var(--figma___colors-alerts-status-error-alpha-8));', // ✦ Theme/Colors/Alerts & Status/Error Alpha/8
+  'figma-colors-alerts-status-error-alpha-9': 'hsla(var(--figma___colors-alerts-status-error-alpha-9));', // ✦ Theme/Colors/Alerts & Status/Error Alpha/9
+  'figma-colors-alerts-status-error-alpha-10': 'hsla(var(--figma___colors-alerts-status-error-alpha-10));', // ✦ Theme/Colors/Alerts & Status/Error Alpha/10
+  'figma-colors-alerts-status-info-1': 'hsla(var(--figma___colors-alerts-status-info-1));', // ✦ Theme/Colors/Alerts & Status/Info/1
+  'figma-colors-alerts-status-info-2': 'hsla(var(--figma___colors-alerts-status-info-2));', // ✦ Theme/Colors/Alerts & Status/Info/2
+  'figma-colors-alerts-status-info-3': 'hsla(var(--figma___colors-alerts-status-info-3));', // ✦ Theme/Colors/Alerts & Status/Info/3
+  'figma-colors-alerts-status-info-4': 'hsla(var(--figma___colors-alerts-status-info-4));', // ✦ Theme/Colors/Alerts & Status/Info/4
+  'figma-colors-alerts-status-info-5': 'hsla(var(--figma___colors-alerts-status-info-5));', // ✦ Theme/Colors/Alerts & Status/Info/5
+  'figma-colors-alerts-status-info-6': 'hsla(var(--figma___colors-alerts-status-info-6));', // ✦ Theme/Colors/Alerts & Status/Info/6
+  'figma-colors-alerts-status-info-7': 'hsla(var(--figma___colors-alerts-status-info-7));', // ✦ Theme/Colors/Alerts & Status/Info/7
+  'figma-colors-alerts-status-info-8': 'hsla(var(--figma___colors-alerts-status-info-8));', // ✦ Theme/Colors/Alerts & Status/Info/8
+  'figma-colors-alerts-status-info-9': 'hsla(var(--figma___colors-alerts-status-info-9));', // ✦ Theme/Colors/Alerts & Status/Info/9
+  'figma-colors-alerts-status-info-10': 'hsla(var(--figma___colors-alerts-status-info-10));', // ✦ Theme/Colors/Alerts & Status/Info/10
+  'figma-colors-alerts-status-info-alpha-1': 'hsla(var(--figma___colors-alerts-status-info-alpha-1));', // ✦ Theme/Colors/Alerts & Status/Info Alpha/1
+  'figma-colors-alerts-status-info-alpha-2': 'hsla(var(--figma___colors-alerts-status-info-alpha-2));', // ✦ Theme/Colors/Alerts & Status/Info Alpha/2
+  'figma-colors-alerts-status-info-alpha-3': 'hsla(var(--figma___colors-alerts-status-info-alpha-3));', // ✦ Theme/Colors/Alerts & Status/Info Alpha/3
+  'figma-colors-alerts-status-info-alpha-4': 'hsla(var(--figma___colors-alerts-status-info-alpha-4));', // ✦ Theme/Colors/Alerts & Status/Info Alpha/4
+  'figma-colors-alerts-status-info-alpha-5': 'hsla(var(--figma___colors-alerts-status-info-alpha-5));', // ✦ Theme/Colors/Alerts & Status/Info Alpha/5
+  'figma-colors-alerts-status-info-alpha-6': 'hsla(var(--figma___colors-alerts-status-info-alpha-6));', // ✦ Theme/Colors/Alerts & Status/Info Alpha/6
+  'figma-colors-alerts-status-info-alpha-7': 'hsla(var(--figma___colors-alerts-status-info-alpha-7));', // ✦ Theme/Colors/Alerts & Status/Info Alpha/7
+  'figma-colors-alerts-status-info-alpha-8': 'hsla(var(--figma___colors-alerts-status-info-alpha-8));', // ✦ Theme/Colors/Alerts & Status/Info Alpha/8
+  'figma-colors-alerts-status-info-alpha-9': 'hsla(var(--figma___colors-alerts-status-info-alpha-9));', // ✦ Theme/Colors/Alerts & Status/Info Alpha/9
+  'figma-colors-alerts-status-info-alpha-10': 'hsla(var(--figma___colors-alerts-status-info-alpha-10));', // ✦ Theme/Colors/Alerts & Status/Info Alpha/10
+  'figma-colors-alerts-status-success-1': 'hsla(var(--figma___colors-alerts-status-success-1));', // ✦ Theme/Colors/Alerts & Status/Success/1
+  'figma-colors-alerts-status-success-2': 'hsla(var(--figma___colors-alerts-status-success-2));', // ✦ Theme/Colors/Alerts & Status/Success/2
+  'figma-colors-alerts-status-success-3': 'hsla(var(--figma___colors-alerts-status-success-3));', // ✦ Theme/Colors/Alerts & Status/Success/3
+  'figma-colors-alerts-status-success-4': 'hsla(var(--figma___colors-alerts-status-success-4));', // ✦ Theme/Colors/Alerts & Status/Success/4
+  'figma-colors-alerts-status-success-5': 'hsla(var(--figma___colors-alerts-status-success-5));', // ✦ Theme/Colors/Alerts & Status/Success/5
+  'figma-colors-alerts-status-success-6': 'hsla(var(--figma___colors-alerts-status-success-6));', // ✦ Theme/Colors/Alerts & Status/Success/6
+  'figma-colors-alerts-status-success-7': 'hsla(var(--figma___colors-alerts-status-success-7));', // ✦ Theme/Colors/Alerts & Status/Success/7
+  'figma-colors-alerts-status-success-8': 'hsla(var(--figma___colors-alerts-status-success-8));', // ✦ Theme/Colors/Alerts & Status/Success/8
+  'figma-colors-alerts-status-success-9': 'hsla(var(--figma___colors-alerts-status-success-9));', // ✦ Theme/Colors/Alerts & Status/Success/9
+  'figma-colors-alerts-status-success-10': 'hsla(var(--figma___colors-alerts-status-success-10));', // ✦ Theme/Colors/Alerts & Status/Success/10
+  'figma-colors-alerts-status-success-alpha-1': 'hsla(var(--figma___colors-alerts-status-success-alpha-1));', // ✦ Theme/Colors/Alerts & Status/Success Alpha/1
+  'figma-colors-alerts-status-success-alpha-2': 'hsla(var(--figma___colors-alerts-status-success-alpha-2));', // ✦ Theme/Colors/Alerts & Status/Success Alpha/2
+  'figma-colors-alerts-status-success-alpha-3': 'hsla(var(--figma___colors-alerts-status-success-alpha-3));', // ✦ Theme/Colors/Alerts & Status/Success Alpha/3
+  'figma-colors-alerts-status-success-alpha-4': 'hsla(var(--figma___colors-alerts-status-success-alpha-4));', // ✦ Theme/Colors/Alerts & Status/Success Alpha/4
+  'figma-colors-alerts-status-success-alpha-5': 'hsla(var(--figma___colors-alerts-status-success-alpha-5));', // ✦ Theme/Colors/Alerts & Status/Success Alpha/5
+  'figma-colors-alerts-status-success-alpha-6': 'hsla(var(--figma___colors-alerts-status-success-alpha-6));', // ✦ Theme/Colors/Alerts & Status/Success Alpha/6
+  'figma-colors-alerts-status-success-alpha-7': 'hsla(var(--figma___colors-alerts-status-success-alpha-7));', // ✦ Theme/Colors/Alerts & Status/Success Alpha/7
+  'figma-colors-alerts-status-success-alpha-8': 'hsla(var(--figma___colors-alerts-status-success-alpha-8));', // ✦ Theme/Colors/Alerts & Status/Success Alpha/8
+  'figma-colors-alerts-status-success-alpha-9': 'hsla(var(--figma___colors-alerts-status-success-alpha-9));', // ✦ Theme/Colors/Alerts & Status/Success Alpha/9
+  'figma-colors-alerts-status-success-alpha-10': 'hsla(var(--figma___colors-alerts-status-success-alpha-10));', // ✦ Theme/Colors/Alerts & Status/Success Alpha/10
+  'figma-colors-alerts-status-warning-1': 'hsla(var(--figma___colors-alerts-status-warning-1));', // ✦ Theme/Colors/Alerts & Status/Warning/1
+  'figma-colors-alerts-status-warning-2': 'hsla(var(--figma___colors-alerts-status-warning-2));', // ✦ Theme/Colors/Alerts & Status/Warning/2
+  'figma-colors-alerts-status-warning-3': 'hsla(var(--figma___colors-alerts-status-warning-3));', // ✦ Theme/Colors/Alerts & Status/Warning/3
+  'figma-colors-alerts-status-warning-4': 'hsla(var(--figma___colors-alerts-status-warning-4));', // ✦ Theme/Colors/Alerts & Status/Warning/4
+  'figma-colors-alerts-status-warning-5': 'hsla(var(--figma___colors-alerts-status-warning-5));', // ✦ Theme/Colors/Alerts & Status/Warning/5
+  'figma-colors-alerts-status-warning-6': 'hsla(var(--figma___colors-alerts-status-warning-6));', // ✦ Theme/Colors/Alerts & Status/Warning/6
+  'figma-colors-alerts-status-warning-7': 'hsla(var(--figma___colors-alerts-status-warning-7));', // ✦ Theme/Colors/Alerts & Status/Warning/7
+  'figma-colors-alerts-status-warning-8': 'hsla(var(--figma___colors-alerts-status-warning-8));', // ✦ Theme/Colors/Alerts & Status/Warning/8
+  'figma-colors-alerts-status-warning-9': 'hsla(var(--figma___colors-alerts-status-warning-9));', // ✦ Theme/Colors/Alerts & Status/Warning/9
+  'figma-colors-alerts-status-warning-10': 'hsla(var(--figma___colors-alerts-status-warning-10));', // ✦ Theme/Colors/Alerts & Status/Warning/10
+  'figma-colors-alerts-status-warning-alpha-1': 'hsla(var(--figma___colors-alerts-status-warning-alpha-1));', // ✦ Theme/Colors/Alerts & Status/Warning Alpha/1
+  'figma-colors-alerts-status-warning-alpha-2': 'hsla(var(--figma___colors-alerts-status-warning-alpha-2));', // ✦ Theme/Colors/Alerts & Status/Warning Alpha/2
+  'figma-colors-alerts-status-warning-alpha-3': 'hsla(var(--figma___colors-alerts-status-warning-alpha-3));', // ✦ Theme/Colors/Alerts & Status/Warning Alpha/3
+  'figma-colors-alerts-status-warning-alpha-4': 'hsla(var(--figma___colors-alerts-status-warning-alpha-4));', // ✦ Theme/Colors/Alerts & Status/Warning Alpha/4
+  'figma-colors-alerts-status-warning-alpha-5': 'hsla(var(--figma___colors-alerts-status-warning-alpha-5));', // ✦ Theme/Colors/Alerts & Status/Warning Alpha/5
+  'figma-colors-alerts-status-warning-alpha-6': 'hsla(var(--figma___colors-alerts-status-warning-alpha-6));', // ✦ Theme/Colors/Alerts & Status/Warning Alpha/6
+  'figma-colors-alerts-status-warning-alpha-7': 'hsla(var(--figma___colors-alerts-status-warning-alpha-7));', // ✦ Theme/Colors/Alerts & Status/Warning Alpha/7
+  'figma-colors-alerts-status-warning-alpha-8': 'hsla(var(--figma___colors-alerts-status-warning-alpha-8));', // ✦ Theme/Colors/Alerts & Status/Warning Alpha/8
+  'figma-colors-alerts-status-warning-alpha-9': 'hsla(var(--figma___colors-alerts-status-warning-alpha-9));', // ✦ Theme/Colors/Alerts & Status/Warning Alpha/9
+  'figma-colors-alerts-status-warning-alpha-10': 'hsla(var(--figma___colors-alerts-status-warning-alpha-10));', // ✦ Theme/Colors/Alerts & Status/Warning Alpha/10
+  'figma-colors-charts-ai-violet-1': 'hsla(var(--figma___colors-charts-ai-violet-1));', // ✦ Theme/Colors/Charts/AI Violet/1
+  'figma-colors-charts-ai-violet-2': 'hsla(var(--figma___colors-charts-ai-violet-2));', // ✦ Theme/Colors/Charts/AI Violet/2
+  'figma-colors-charts-ai-violet-3': 'hsla(var(--figma___colors-charts-ai-violet-3));', // ✦ Theme/Colors/Charts/AI Violet/3
+  'figma-colors-charts-ai-violet-4': 'hsla(var(--figma___colors-charts-ai-violet-4));', // ✦ Theme/Colors/Charts/AI Violet/4
+  'figma-colors-charts-ai-violet-5': 'hsla(var(--figma___colors-charts-ai-violet-5));', // ✦ Theme/Colors/Charts/AI Violet/5
+  'figma-colors-charts-ai-violet-6': 'hsla(var(--figma___colors-charts-ai-violet-6));', // ✦ Theme/Colors/Charts/AI Violet/6
+  'figma-colors-charts-ai-violet-7': 'hsla(var(--figma___colors-charts-ai-violet-7));', // ✦ Theme/Colors/Charts/AI Violet/7
+  'figma-colors-charts-ai-violet-8': 'hsla(var(--figma___colors-charts-ai-violet-8));', // ✦ Theme/Colors/Charts/AI Violet/8
+  'figma-colors-charts-ai-violet-9': 'hsla(var(--figma___colors-charts-ai-violet-9));', // ✦ Theme/Colors/Charts/AI Violet/9
+  'figma-colors-charts-ai-violet-10': 'hsla(var(--figma___colors-charts-ai-violet-10));', // ✦ Theme/Colors/Charts/AI Violet/10
+  'figma-colors-charts-ai-violet-alpha-1': 'hsla(var(--figma___colors-charts-ai-violet-alpha-1));', // ✦ Theme/Colors/Charts/AI Violet Alpha/1
+  'figma-colors-charts-ai-violet-alpha-2': 'hsla(var(--figma___colors-charts-ai-violet-alpha-2));', // ✦ Theme/Colors/Charts/AI Violet Alpha/2
+  'figma-colors-charts-ai-violet-alpha-3': 'hsla(var(--figma___colors-charts-ai-violet-alpha-3));', // ✦ Theme/Colors/Charts/AI Violet Alpha/3
+  'figma-colors-charts-ai-violet-alpha-4': 'hsla(var(--figma___colors-charts-ai-violet-alpha-4));', // ✦ Theme/Colors/Charts/AI Violet Alpha/4
+  'figma-colors-charts-ai-violet-alpha-5': 'hsla(var(--figma___colors-charts-ai-violet-alpha-5));', // ✦ Theme/Colors/Charts/AI Violet Alpha/5
+  'figma-colors-charts-ai-violet-alpha-6': 'hsla(var(--figma___colors-charts-ai-violet-alpha-6));', // ✦ Theme/Colors/Charts/AI Violet Alpha/6
+  'figma-colors-charts-ai-violet-alpha-7': 'hsla(var(--figma___colors-charts-ai-violet-alpha-7));', // ✦ Theme/Colors/Charts/AI Violet Alpha/7
+  'figma-colors-charts-ai-violet-alpha-8': 'hsla(var(--figma___colors-charts-ai-violet-alpha-8));', // ✦ Theme/Colors/Charts/AI Violet Alpha/8
+  'figma-colors-charts-ai-violet-alpha-9': 'hsla(var(--figma___colors-charts-ai-violet-alpha-9));', // ✦ Theme/Colors/Charts/AI Violet Alpha/9
+  'figma-colors-charts-ai-violet-alpha-10': 'hsla(var(--figma___colors-charts-ai-violet-alpha-10));', // ✦ Theme/Colors/Charts/AI Violet Alpha/10
+  'figma-colors-charts-blue-1': 'hsla(var(--figma___colors-charts-blue-1));', // ✦ Theme/Colors/Charts/Blue/1
+  'figma-colors-charts-blue-2': 'hsla(var(--figma___colors-charts-blue-2));', // ✦ Theme/Colors/Charts/Blue/2
+  'figma-colors-charts-blue-3': 'hsla(var(--figma___colors-charts-blue-3));', // ✦ Theme/Colors/Charts/Blue/3
+  'figma-colors-charts-blue-4': 'hsla(var(--figma___colors-charts-blue-4));', // ✦ Theme/Colors/Charts/Blue/4
+  'figma-colors-charts-blue-5': 'hsla(var(--figma___colors-charts-blue-5));', // ✦ Theme/Colors/Charts/Blue/5
+  'figma-colors-charts-blue-6': 'hsla(var(--figma___colors-charts-blue-6));', // ✦ Theme/Colors/Charts/Blue/6
+  'figma-colors-charts-blue-7': 'hsla(var(--figma___colors-charts-blue-7));', // ✦ Theme/Colors/Charts/Blue/7
+  'figma-colors-charts-blue-8': 'hsla(var(--figma___colors-charts-blue-8));', // ✦ Theme/Colors/Charts/Blue/8
+  'figma-colors-charts-blue-9': 'hsla(var(--figma___colors-charts-blue-9));', // ✦ Theme/Colors/Charts/Blue/9
+  'figma-colors-charts-blue-10': 'hsla(var(--figma___colors-charts-blue-10));', // ✦ Theme/Colors/Charts/Blue/10
+  'figma-colors-charts-blue-alpha-1': 'hsla(var(--figma___colors-charts-blue-alpha-1));', // ✦ Theme/Colors/Charts/Blue Alpha/1
+  'figma-colors-charts-blue-alpha-2': 'hsla(var(--figma___colors-charts-blue-alpha-2));', // ✦ Theme/Colors/Charts/Blue Alpha/2
+  'figma-colors-charts-blue-alpha-3': 'hsla(var(--figma___colors-charts-blue-alpha-3));', // ✦ Theme/Colors/Charts/Blue Alpha/3
+  'figma-colors-charts-blue-alpha-4': 'hsla(var(--figma___colors-charts-blue-alpha-4));', // ✦ Theme/Colors/Charts/Blue Alpha/4
+  'figma-colors-charts-blue-alpha-5': 'hsla(var(--figma___colors-charts-blue-alpha-5));', // ✦ Theme/Colors/Charts/Blue Alpha/5
+  'figma-colors-charts-blue-alpha-6': 'hsla(var(--figma___colors-charts-blue-alpha-6));', // ✦ Theme/Colors/Charts/Blue Alpha/6
+  'figma-colors-charts-blue-alpha-7': 'hsla(var(--figma___colors-charts-blue-alpha-7));', // ✦ Theme/Colors/Charts/Blue Alpha/7
+  'figma-colors-charts-blue-alpha-8': 'hsla(var(--figma___colors-charts-blue-alpha-8));', // ✦ Theme/Colors/Charts/Blue Alpha/8
+  'figma-colors-charts-blue-alpha-9': 'hsla(var(--figma___colors-charts-blue-alpha-9));', // ✦ Theme/Colors/Charts/Blue Alpha/9
+  'figma-colors-charts-blue-alpha-10': 'hsla(var(--figma___colors-charts-blue-alpha-10));', // ✦ Theme/Colors/Charts/Blue Alpha/10
+  'figma-colors-charts-indigo-1': 'hsla(var(--figma___colors-charts-indigo-1));', // ✦ Theme/Colors/Charts/Indigo/1
+  'figma-colors-charts-indigo-2': 'hsla(var(--figma___colors-charts-indigo-2));', // ✦ Theme/Colors/Charts/Indigo/2
+  'figma-colors-charts-indigo-3': 'hsla(var(--figma___colors-charts-indigo-3));', // ✦ Theme/Colors/Charts/Indigo/3
+  'figma-colors-charts-indigo-4': 'hsla(var(--figma___colors-charts-indigo-4));', // ✦ Theme/Colors/Charts/Indigo/4
+  'figma-colors-charts-indigo-5': 'hsla(var(--figma___colors-charts-indigo-5));', // ✦ Theme/Colors/Charts/Indigo/5
+  'figma-colors-charts-indigo-6': 'hsla(var(--figma___colors-charts-indigo-6));', // ✦ Theme/Colors/Charts/Indigo/6
+  'figma-colors-charts-indigo-7': 'hsla(var(--figma___colors-charts-indigo-7));', // ✦ Theme/Colors/Charts/Indigo/7
+  'figma-colors-charts-indigo-8': 'hsla(var(--figma___colors-charts-indigo-8));', // ✦ Theme/Colors/Charts/Indigo/8
+  'figma-colors-charts-indigo-9': 'hsla(var(--figma___colors-charts-indigo-9));', // ✦ Theme/Colors/Charts/Indigo/9
+  'figma-colors-charts-indigo-10': 'hsla(var(--figma___colors-charts-indigo-10));', // ✦ Theme/Colors/Charts/Indigo/10
+  'figma-colors-charts-indigo-alpha-1': 'hsla(var(--figma___colors-charts-indigo-alpha-1));', // ✦ Theme/Colors/Charts/Indigo Alpha/1
+  'figma-colors-charts-indigo-alpha-2': 'hsla(var(--figma___colors-charts-indigo-alpha-2));', // ✦ Theme/Colors/Charts/Indigo Alpha/2
+  'figma-colors-charts-indigo-alpha-3': 'hsla(var(--figma___colors-charts-indigo-alpha-3));', // ✦ Theme/Colors/Charts/Indigo Alpha/3
+  'figma-colors-charts-indigo-alpha-4': 'hsla(var(--figma___colors-charts-indigo-alpha-4));', // ✦ Theme/Colors/Charts/Indigo Alpha/4
+  'figma-colors-charts-indigo-alpha-5': 'hsla(var(--figma___colors-charts-indigo-alpha-5));', // ✦ Theme/Colors/Charts/Indigo Alpha/5
+  'figma-colors-charts-indigo-alpha-6': 'hsla(var(--figma___colors-charts-indigo-alpha-6));', // ✦ Theme/Colors/Charts/Indigo Alpha/6
+  'figma-colors-charts-indigo-alpha-7': 'hsla(var(--figma___colors-charts-indigo-alpha-7));', // ✦ Theme/Colors/Charts/Indigo Alpha/7
+  'figma-colors-charts-indigo-alpha-8': 'hsla(var(--figma___colors-charts-indigo-alpha-8));', // ✦ Theme/Colors/Charts/Indigo Alpha/8
+  'figma-colors-charts-indigo-alpha-9': 'hsla(var(--figma___colors-charts-indigo-alpha-9));', // ✦ Theme/Colors/Charts/Indigo Alpha/9
+  'figma-colors-charts-indigo-alpha-10': 'hsla(var(--figma___colors-charts-indigo-alpha-10));', // ✦ Theme/Colors/Charts/Indigo Alpha/10
+  'figma-colors-charts-mint-1': 'hsla(var(--figma___colors-charts-mint-1));', // ✦ Theme/Colors/Charts/Mint/1
+  'figma-colors-charts-mint-2': 'hsla(var(--figma___colors-charts-mint-2));', // ✦ Theme/Colors/Charts/Mint/2
+  'figma-colors-charts-mint-3': 'hsla(var(--figma___colors-charts-mint-3));', // ✦ Theme/Colors/Charts/Mint/3
+  'figma-colors-charts-mint-4': 'hsla(var(--figma___colors-charts-mint-4));', // ✦ Theme/Colors/Charts/Mint/4
+  'figma-colors-charts-mint-5': 'hsla(var(--figma___colors-charts-mint-5));', // ✦ Theme/Colors/Charts/Mint/5
+  'figma-colors-charts-mint-6': 'hsla(var(--figma___colors-charts-mint-6));', // ✦ Theme/Colors/Charts/Mint/6
+  'figma-colors-charts-mint-7': 'hsla(var(--figma___colors-charts-mint-7));', // ✦ Theme/Colors/Charts/Mint/7
+  'figma-colors-charts-mint-8': 'hsla(var(--figma___colors-charts-mint-8));', // ✦ Theme/Colors/Charts/Mint/8
+  'figma-colors-charts-mint-9': 'hsla(var(--figma___colors-charts-mint-9));', // ✦ Theme/Colors/Charts/Mint/9
+  'figma-colors-charts-mint-10': 'hsla(var(--figma___colors-charts-mint-10));', // ✦ Theme/Colors/Charts/Mint/10
+  'figma-colors-charts-mint-alpha-1': 'hsla(var(--figma___colors-charts-mint-alpha-1));', // ✦ Theme/Colors/Charts/Mint Alpha/1
+  'figma-colors-charts-mint-alpha-2': 'hsla(var(--figma___colors-charts-mint-alpha-2));', // ✦ Theme/Colors/Charts/Mint Alpha/2
+  'figma-colors-charts-mint-alpha-3': 'hsla(var(--figma___colors-charts-mint-alpha-3));', // ✦ Theme/Colors/Charts/Mint Alpha/3
+  'figma-colors-charts-mint-alpha-4': 'hsla(var(--figma___colors-charts-mint-alpha-4));', // ✦ Theme/Colors/Charts/Mint Alpha/4
+  'figma-colors-charts-mint-alpha-5': 'hsla(var(--figma___colors-charts-mint-alpha-5));', // ✦ Theme/Colors/Charts/Mint Alpha/5
+  'figma-colors-charts-mint-alpha-6': 'hsla(var(--figma___colors-charts-mint-alpha-6));', // ✦ Theme/Colors/Charts/Mint Alpha/6
+  'figma-colors-charts-mint-alpha-7': 'hsla(var(--figma___colors-charts-mint-alpha-7));', // ✦ Theme/Colors/Charts/Mint Alpha/7
+  'figma-colors-charts-mint-alpha-8': 'hsla(var(--figma___colors-charts-mint-alpha-8));', // ✦ Theme/Colors/Charts/Mint Alpha/8
+  'figma-colors-charts-mint-alpha-9': 'hsla(var(--figma___colors-charts-mint-alpha-9));', // ✦ Theme/Colors/Charts/Mint Alpha/9
+  'figma-colors-charts-mint-alpha-10': 'hsla(var(--figma___colors-charts-mint-alpha-10));', // ✦ Theme/Colors/Charts/Mint Alpha/10
+  'figma-colors-charts-orange-1': 'hsla(var(--figma___colors-charts-orange-1));', // ✦ Theme/Colors/Charts/Orange/1
+  'figma-colors-charts-orange-2': 'hsla(var(--figma___colors-charts-orange-2));', // ✦ Theme/Colors/Charts/Orange/2
+  'figma-colors-charts-orange-3': 'hsla(var(--figma___colors-charts-orange-3));', // ✦ Theme/Colors/Charts/Orange/3
+  'figma-colors-charts-orange-4': 'hsla(var(--figma___colors-charts-orange-4));', // ✦ Theme/Colors/Charts/Orange/4
+  'figma-colors-charts-orange-5': 'hsla(var(--figma___colors-charts-orange-5));', // ✦ Theme/Colors/Charts/Orange/5
+  'figma-colors-charts-orange-6': 'hsla(var(--figma___colors-charts-orange-6));', // ✦ Theme/Colors/Charts/Orange/6
+  'figma-colors-charts-orange-7': 'hsla(var(--figma___colors-charts-orange-7));', // ✦ Theme/Colors/Charts/Orange/7
+  'figma-colors-charts-orange-8': 'hsla(var(--figma___colors-charts-orange-8));', // ✦ Theme/Colors/Charts/Orange/8
+  'figma-colors-charts-orange-9': 'hsla(var(--figma___colors-charts-orange-9));', // ✦ Theme/Colors/Charts/Orange/9
+  'figma-colors-charts-orange-10': 'hsla(var(--figma___colors-charts-orange-10));', // ✦ Theme/Colors/Charts/Orange/10
+  'figma-colors-charts-orange-alpha-1': 'hsla(var(--figma___colors-charts-orange-alpha-1));', // ✦ Theme/Colors/Charts/Orange Alpha/1
+  'figma-colors-charts-orange-alpha-2': 'hsla(var(--figma___colors-charts-orange-alpha-2));', // ✦ Theme/Colors/Charts/Orange Alpha/2
+  'figma-colors-charts-orange-alpha-3': 'hsla(var(--figma___colors-charts-orange-alpha-3));', // ✦ Theme/Colors/Charts/Orange Alpha/3
+  'figma-colors-charts-orange-alpha-4': 'hsla(var(--figma___colors-charts-orange-alpha-4));', // ✦ Theme/Colors/Charts/Orange Alpha/4
+  'figma-colors-charts-orange-alpha-5': 'hsla(var(--figma___colors-charts-orange-alpha-5));', // ✦ Theme/Colors/Charts/Orange Alpha/5
+  'figma-colors-charts-orange-alpha-6': 'hsla(var(--figma___colors-charts-orange-alpha-6));', // ✦ Theme/Colors/Charts/Orange Alpha/6
+  'figma-colors-charts-orange-alpha-7': 'hsla(var(--figma___colors-charts-orange-alpha-7));', // ✦ Theme/Colors/Charts/Orange Alpha/7
+  'figma-colors-charts-orange-alpha-8': 'hsla(var(--figma___colors-charts-orange-alpha-8));', // ✦ Theme/Colors/Charts/Orange Alpha/8
+  'figma-colors-charts-orange-alpha-9': 'hsla(var(--figma___colors-charts-orange-alpha-9));', // ✦ Theme/Colors/Charts/Orange Alpha/9
+  'figma-colors-charts-orange-alpha-10': 'hsla(var(--figma___colors-charts-orange-alpha-10));', // ✦ Theme/Colors/Charts/Orange Alpha/10
+  'figma-colors-charts-yellow-1': 'hsla(var(--figma___colors-charts-yellow-1));', // ✦ Theme/Colors/Charts/Yellow/1
+  'figma-colors-charts-yellow-2': 'hsla(var(--figma___colors-charts-yellow-2));', // ✦ Theme/Colors/Charts/Yellow/2
+  'figma-colors-charts-yellow-3': 'hsla(var(--figma___colors-charts-yellow-3));', // ✦ Theme/Colors/Charts/Yellow/3
+  'figma-colors-charts-yellow-4': 'hsla(var(--figma___colors-charts-yellow-4));', // ✦ Theme/Colors/Charts/Yellow/4
+  'figma-colors-charts-yellow-5': 'hsla(var(--figma___colors-charts-yellow-5));', // ✦ Theme/Colors/Charts/Yellow/5
+  'figma-colors-charts-yellow-6': 'hsla(var(--figma___colors-charts-yellow-6));', // ✦ Theme/Colors/Charts/Yellow/6
+  'figma-colors-charts-yellow-7': 'hsla(var(--figma___colors-charts-yellow-7));', // ✦ Theme/Colors/Charts/Yellow/7
+  'figma-colors-charts-yellow-8': 'hsla(var(--figma___colors-charts-yellow-8));', // ✦ Theme/Colors/Charts/Yellow/8
+  'figma-colors-charts-yellow-9': 'hsla(var(--figma___colors-charts-yellow-9));', // ✦ Theme/Colors/Charts/Yellow/9
+  'figma-colors-charts-yellow-10': 'hsla(var(--figma___colors-charts-yellow-10));', // ✦ Theme/Colors/Charts/Yellow/10
+  'figma-colors-charts-yellow-alpha-1': 'hsla(var(--figma___colors-charts-yellow-alpha-1));', // ✦ Theme/Colors/Charts/Yellow Alpha/1
+  'figma-colors-charts-yellow-alpha-2': 'hsla(var(--figma___colors-charts-yellow-alpha-2));', // ✦ Theme/Colors/Charts/Yellow Alpha/2
+  'figma-colors-charts-yellow-alpha-3': 'hsla(var(--figma___colors-charts-yellow-alpha-3));', // ✦ Theme/Colors/Charts/Yellow Alpha/3
+  'figma-colors-charts-yellow-alpha-4': 'hsla(var(--figma___colors-charts-yellow-alpha-4));', // ✦ Theme/Colors/Charts/Yellow Alpha/4
+  'figma-colors-charts-yellow-alpha-5': 'hsla(var(--figma___colors-charts-yellow-alpha-5));', // ✦ Theme/Colors/Charts/Yellow Alpha/5
+  'figma-colors-charts-yellow-alpha-6': 'hsla(var(--figma___colors-charts-yellow-alpha-6));', // ✦ Theme/Colors/Charts/Yellow Alpha/6
+  'figma-colors-charts-yellow-alpha-7': 'hsla(var(--figma___colors-charts-yellow-alpha-7));', // ✦ Theme/Colors/Charts/Yellow Alpha/7
+  'figma-colors-charts-yellow-alpha-8': 'hsla(var(--figma___colors-charts-yellow-alpha-8));', // ✦ Theme/Colors/Charts/Yellow Alpha/8
+  'figma-colors-charts-yellow-alpha-9': 'hsla(var(--figma___colors-charts-yellow-alpha-9));', // ✦ Theme/Colors/Charts/Yellow Alpha/9
+  'figma-colors-charts-yellow-alpha-10': 'hsla(var(--figma___colors-charts-yellow-alpha-10));', // ✦ Theme/Colors/Charts/Yellow Alpha/10
+  'figma-colors-default-black-fixed': 'hsla(var(--figma___colors-default-black-fixed));', // ✦ Theme/Colors/Default/Black (fixed)
+  'figma-colors-default-brand-color': 'hsla(var(--figma___colors-default-brand-color));', // ✦ Theme/Colors/Default/Brand Color
+  'figma-colors-default-dark-to-white': 'hsla(var(--figma___colors-default-dark-to-white));', // ✦ Theme/Colors/Default/Dark-to-white
+  'figma-colors-default-white-fixed': 'hsla(var(--figma___colors-default-white-fixed));', // ✦ Theme/Colors/Default/White (fixed)
+  'figma-colors-default-white-to-dark': 'hsla(var(--figma___colors-default-white-to-dark));', // ✦ Theme/Colors/Default/White-to-dark
+  'figma-colors-module-ccm-100': 'hsla(var(--figma___colors-module-ccm-100));', // ✦ Theme/Colors/Module/CCM/100
+  'figma-colors-module-ccm-200': 'hsla(var(--figma___colors-module-ccm-200));', // ✦ Theme/Colors/Module/CCM/200
+  'figma-colors-module-ccm-300': 'hsla(var(--figma___colors-module-ccm-300));', // ✦ Theme/Colors/Module/CCM/300
+  'figma-colors-module-cd-100': 'hsla(var(--figma___colors-module-cd-100));', // ✦ Theme/Colors/Module/CD/100
+  'figma-colors-module-cd-200': 'hsla(var(--figma___colors-module-cd-200));', // ✦ Theme/Colors/Module/CD/200
+  'figma-colors-module-cd-300': 'hsla(var(--figma___colors-module-cd-300));', // ✦ Theme/Colors/Module/CD/300
+  'figma-colors-module-ce-100': 'hsla(var(--figma___colors-module-ce-100));', // ✦ Theme/Colors/Module/CE/100
+  'figma-colors-module-ce-200': 'hsla(var(--figma___colors-module-ce-200));', // ✦ Theme/Colors/Module/CE/200
+  'figma-colors-module-ce-300': 'hsla(var(--figma___colors-module-ce-300));', // ✦ Theme/Colors/Module/CE/300
+  'figma-colors-module-ci-100': 'hsla(var(--figma___colors-module-ci-100));', // ✦ Theme/Colors/Module/CI/100
+  'figma-colors-module-ci-200': 'hsla(var(--figma___colors-module-ci-200));', // ✦ Theme/Colors/Module/CI/200
+  'figma-colors-module-ci-300': 'hsla(var(--figma___colors-module-ci-300));', // ✦ Theme/Colors/Module/CI/300
+  'figma-colors-module-ff-100': 'hsla(var(--figma___colors-module-ff-100));', // ✦ Theme/Colors/Module/FF/100
+  'figma-colors-module-ff-200': 'hsla(var(--figma___colors-module-ff-200));', // ✦ Theme/Colors/Module/FF/200
+  'figma-colors-module-ff-300': 'hsla(var(--figma___colors-module-ff-300));', // ✦ Theme/Colors/Module/FF/300
+  'figma-colors-module-srm-100': 'hsla(var(--figma___colors-module-srm-100));', // ✦ Theme/Colors/Module/SRM/100
+  'figma-colors-module-srm-200': 'hsla(var(--figma___colors-module-srm-200));', // ✦ Theme/Colors/Module/SRM/200
+  'figma-colors-module-srm-300': 'hsla(var(--figma___colors-module-srm-300));', // ✦ Theme/Colors/Module/SRM/300
+  'figma-colors-module-ssca-100': 'hsla(var(--figma___colors-module-ssca-100));', // ✦ Theme/Colors/Module/SSCA/100
+  'figma-colors-module-ssca-200': 'hsla(var(--figma___colors-module-ssca-200));', // ✦ Theme/Colors/Module/SSCA/200
+  'figma-colors-module-ssca-300': 'hsla(var(--figma___colors-module-ssca-300));', // ✦ Theme/Colors/Module/SSCA/300
+  'figma-colors-module-sto-100': 'hsla(var(--figma___colors-module-sto-100));', // ✦ Theme/Colors/Module/STO/100
+  'figma-colors-module-sto-200': 'hsla(var(--figma___colors-module-sto-200));', // ✦ Theme/Colors/Module/STO/200
+  'figma-colors-module-sto-300': 'hsla(var(--figma___colors-module-sto-300));', // ✦ Theme/Colors/Module/STO/300
+  'figma-colors-neutral-gray-1': 'hsla(var(--figma___colors-neutral-gray-1));', // ✦ Theme/Colors/Neutral/Gray/1
+  'figma-colors-neutral-gray-2': 'hsla(var(--figma___colors-neutral-gray-2));', // ✦ Theme/Colors/Neutral/Gray/2
+  'figma-colors-neutral-gray-3': 'hsla(var(--figma___colors-neutral-gray-3));', // ✦ Theme/Colors/Neutral/Gray/3
+  'figma-colors-neutral-gray-4': 'hsla(var(--figma___colors-neutral-gray-4));', // ✦ Theme/Colors/Neutral/Gray/4
+  'figma-colors-neutral-gray-5': 'hsla(var(--figma___colors-neutral-gray-5));', // ✦ Theme/Colors/Neutral/Gray/5
+  'figma-colors-neutral-gray-6': 'hsla(var(--figma___colors-neutral-gray-6));', // ✦ Theme/Colors/Neutral/Gray/6
+  'figma-colors-neutral-gray-7': 'hsla(var(--figma___colors-neutral-gray-7));', // ✦ Theme/Colors/Neutral/Gray/7
+  'figma-colors-neutral-gray-8': 'hsla(var(--figma___colors-neutral-gray-8));', // ✦ Theme/Colors/Neutral/Gray/8
+  'figma-colors-neutral-gray-9': 'hsla(var(--figma___colors-neutral-gray-9));', // ✦ Theme/Colors/Neutral/Gray/9
+  'figma-colors-neutral-gray-10': 'hsla(var(--figma___colors-neutral-gray-10));', // ✦ Theme/Colors/Neutral/Gray/10
+  'figma-colors-neutral-gray-alpha-1': 'hsla(var(--figma___colors-neutral-gray-alpha-1));', // ✦ Theme/Colors/Neutral/Gray Alpha/1
+  'figma-colors-neutral-gray-alpha-2': 'hsla(var(--figma___colors-neutral-gray-alpha-2));', // ✦ Theme/Colors/Neutral/Gray Alpha/2
+  'figma-colors-neutral-gray-alpha-3': 'hsla(var(--figma___colors-neutral-gray-alpha-3));', // ✦ Theme/Colors/Neutral/Gray Alpha/3
+  'figma-colors-neutral-gray-alpha-4': 'hsla(var(--figma___colors-neutral-gray-alpha-4));', // ✦ Theme/Colors/Neutral/Gray Alpha/4
+  'figma-colors-neutral-gray-alpha-5': 'hsla(var(--figma___colors-neutral-gray-alpha-5));', // ✦ Theme/Colors/Neutral/Gray Alpha/5
+  'figma-colors-neutral-gray-alpha-6': 'hsla(var(--figma___colors-neutral-gray-alpha-6));', // ✦ Theme/Colors/Neutral/Gray Alpha/6
+  'figma-colors-neutral-gray-alpha-7': 'hsla(var(--figma___colors-neutral-gray-alpha-7));', // ✦ Theme/Colors/Neutral/Gray Alpha/7
+  'figma-colors-neutral-gray-alpha-8': 'hsla(var(--figma___colors-neutral-gray-alpha-8));', // ✦ Theme/Colors/Neutral/Gray Alpha/8
+  'figma-colors-neutral-gray-alpha-9': 'hsla(var(--figma___colors-neutral-gray-alpha-9));', // ✦ Theme/Colors/Neutral/Gray Alpha/9
+  'figma-colors-neutral-gray-alpha-10': 'hsla(var(--figma___colors-neutral-gray-alpha-10));', // ✦ Theme/Colors/Neutral/Gray Alpha/10
+  'figma-colors-primary-primary-accent-1': 'hsla(var(--figma___colors-primary-primary-accent-1));', // ✦ Theme/Colors/Primary/Primary Accent/1
+  'figma-colors-primary-primary-accent-2': 'hsla(var(--figma___colors-primary-primary-accent-2));', // ✦ Theme/Colors/Primary/Primary Accent/2
+  'figma-colors-primary-primary-accent-3': 'hsla(var(--figma___colors-primary-primary-accent-3));', // ✦ Theme/Colors/Primary/Primary Accent/3
+  'figma-colors-primary-primary-accent-4': 'hsla(var(--figma___colors-primary-primary-accent-4));', // ✦ Theme/Colors/Primary/Primary Accent/4
+  'figma-colors-primary-primary-accent-5': 'hsla(var(--figma___colors-primary-primary-accent-5));', // ✦ Theme/Colors/Primary/Primary Accent/5
+  'figma-colors-primary-primary-accent-6': 'hsla(var(--figma___colors-primary-primary-accent-6));', // ✦ Theme/Colors/Primary/Primary Accent/6
+  'figma-colors-primary-primary-accent-7': 'hsla(var(--figma___colors-primary-primary-accent-7));', // ✦ Theme/Colors/Primary/Primary Accent/7
+  'figma-colors-primary-primary-accent-8': 'hsla(var(--figma___colors-primary-primary-accent-8));', // ✦ Theme/Colors/Primary/Primary Accent/8
+  'figma-colors-primary-primary-accent-9': 'hsla(var(--figma___colors-primary-primary-accent-9));', // ✦ Theme/Colors/Primary/Primary Accent/9
+  'figma-colors-primary-primary-accent-10': 'hsla(var(--figma___colors-primary-primary-accent-10));', // ✦ Theme/Colors/Primary/Primary Accent/10
+  'figma-colors-primary-primary-alpha-1': 'hsla(var(--figma___colors-primary-primary-alpha-1));', // ✦ Theme/Colors/Primary/Primary Alpha/1
+  'figma-colors-primary-primary-alpha-2': 'hsla(var(--figma___colors-primary-primary-alpha-2));', // ✦ Theme/Colors/Primary/Primary Alpha/2
+  'figma-colors-primary-primary-alpha-3': 'hsla(var(--figma___colors-primary-primary-alpha-3));', // ✦ Theme/Colors/Primary/Primary Alpha/3
+  'figma-colors-primary-primary-alpha-4': 'hsla(var(--figma___colors-primary-primary-alpha-4));', // ✦ Theme/Colors/Primary/Primary Alpha/4
+  'figma-colors-primary-primary-alpha-5': 'hsla(var(--figma___colors-primary-primary-alpha-5));', // ✦ Theme/Colors/Primary/Primary Alpha/5
+  'figma-colors-primary-primary-alpha-6': 'hsla(var(--figma___colors-primary-primary-alpha-6));', // ✦ Theme/Colors/Primary/Primary Alpha/6
+  'figma-colors-primary-primary-alpha-7': 'hsla(var(--figma___colors-primary-primary-alpha-7));', // ✦ Theme/Colors/Primary/Primary Alpha/7
+  'figma-colors-primary-primary-alpha-8': 'hsla(var(--figma___colors-primary-primary-alpha-8));', // ✦ Theme/Colors/Primary/Primary Alpha/8
+  'figma-colors-primary-primary-alpha-9': 'hsla(var(--figma___colors-primary-primary-alpha-9));', // ✦ Theme/Colors/Primary/Primary Alpha/9
+  'figma-colors-primary-primary-alpha-10': 'hsla(var(--figma___colors-primary-primary-alpha-10));', // ✦ Theme/Colors/Primary/Primary Alpha/10
+  'figma-colors-secondary-crimson-crimson-1': 'hsla(var(--figma___colors-secondary-crimson-crimson-1));', // ✦ Theme/Colors/Secondary/Crimson/Crimson 1
+  'figma-colors-secondary-crimson-crimson-10': 'hsla(var(--figma___colors-secondary-crimson-crimson-10));', // ✦ Theme/Colors/Secondary/Crimson/Crimson 10
+  'figma-colors-secondary-crimson-crimson-2': 'hsla(var(--figma___colors-secondary-crimson-crimson-2));', // ✦ Theme/Colors/Secondary/Crimson/Crimson 2
+  'figma-colors-secondary-crimson-crimson-3': 'hsla(var(--figma___colors-secondary-crimson-crimson-3));', // ✦ Theme/Colors/Secondary/Crimson/Crimson 3
+  'figma-colors-secondary-crimson-crimson-4': 'hsla(var(--figma___colors-secondary-crimson-crimson-4));', // ✦ Theme/Colors/Secondary/Crimson/Crimson 4
+  'figma-colors-secondary-crimson-crimson-5': 'hsla(var(--figma___colors-secondary-crimson-crimson-5));', // ✦ Theme/Colors/Secondary/Crimson/Crimson 5
+  'figma-colors-secondary-crimson-crimson-6': 'hsla(var(--figma___colors-secondary-crimson-crimson-6));', // ✦ Theme/Colors/Secondary/Crimson/Crimson 6
+  'figma-colors-secondary-crimson-crimson-7': 'hsla(var(--figma___colors-secondary-crimson-crimson-7));', // ✦ Theme/Colors/Secondary/Crimson/Crimson 7
+  'figma-colors-secondary-crimson-crimson-8': 'hsla(var(--figma___colors-secondary-crimson-crimson-8));', // ✦ Theme/Colors/Secondary/Crimson/Crimson 8
+  'figma-colors-secondary-crimson-crimson-9': 'hsla(var(--figma___colors-secondary-crimson-crimson-9));', // ✦ Theme/Colors/Secondary/Crimson/Crimson 9
+  'figma-colors-secondary-crimson-alpha-crimson-alpha-1':
+    'hsla(var(--figma___colors-secondary-crimson-alpha-crimson-alpha-1));', // ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 1
+  'figma-colors-secondary-crimson-alpha-crimson-alpha-10':
+    'hsla(var(--figma___colors-secondary-crimson-alpha-crimson-alpha-10));', // ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 10
+  'figma-colors-secondary-crimson-alpha-crimson-alpha-11':
+    'hsla(var(--figma___colors-secondary-crimson-alpha-crimson-alpha-11));', // ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 11
+  'figma-colors-secondary-crimson-alpha-crimson-alpha-2':
+    'hsla(var(--figma___colors-secondary-crimson-alpha-crimson-alpha-2));', // ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 2
+  'figma-colors-secondary-crimson-alpha-crimson-alpha-3':
+    'hsla(var(--figma___colors-secondary-crimson-alpha-crimson-alpha-3));', // ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 3
+  'figma-colors-secondary-crimson-alpha-crimson-alpha-4':
+    'hsla(var(--figma___colors-secondary-crimson-alpha-crimson-alpha-4));', // ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 4
+  'figma-colors-secondary-crimson-alpha-crimson-alpha-5':
+    'hsla(var(--figma___colors-secondary-crimson-alpha-crimson-alpha-5));', // ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 5
+  'figma-colors-secondary-crimson-alpha-crimson-alpha-6':
+    'hsla(var(--figma___colors-secondary-crimson-alpha-crimson-alpha-6));', // ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 6
+  'figma-colors-secondary-crimson-alpha-crimson-alpha-8':
+    'hsla(var(--figma___colors-secondary-crimson-alpha-crimson-alpha-8));', // ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 8
+  'figma-colors-secondary-crimson-alpha-crimson-alpha-9':
+    'hsla(var(--figma___colors-secondary-crimson-alpha-crimson-alpha-9));', // ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 9
+  'figma-colors-secondary-lime-1': 'hsla(var(--figma___colors-secondary-lime-1));', // ✦ Theme/Colors/Secondary/Lime/1
+  'figma-colors-secondary-lime-2': 'hsla(var(--figma___colors-secondary-lime-2));', // ✦ Theme/Colors/Secondary/Lime/2
+  'figma-colors-secondary-lime-3': 'hsla(var(--figma___colors-secondary-lime-3));', // ✦ Theme/Colors/Secondary/Lime/3
+  'figma-colors-secondary-lime-4': 'hsla(var(--figma___colors-secondary-lime-4));', // ✦ Theme/Colors/Secondary/Lime/4
+  'figma-colors-secondary-lime-5': 'hsla(var(--figma___colors-secondary-lime-5));', // ✦ Theme/Colors/Secondary/Lime/5
+  'figma-colors-secondary-lime-6': 'hsla(var(--figma___colors-secondary-lime-6));', // ✦ Theme/Colors/Secondary/Lime/6
+  'figma-colors-secondary-lime-7': 'hsla(var(--figma___colors-secondary-lime-7));', // ✦ Theme/Colors/Secondary/Lime/7
+  'figma-colors-secondary-lime-8': 'hsla(var(--figma___colors-secondary-lime-8));', // ✦ Theme/Colors/Secondary/Lime/8
+  'figma-colors-secondary-lime-9': 'hsla(var(--figma___colors-secondary-lime-9));', // ✦ Theme/Colors/Secondary/Lime/9
+  'figma-colors-secondary-lime-10': 'hsla(var(--figma___colors-secondary-lime-10));', // ✦ Theme/Colors/Secondary/Lime/10
+  'figma-colors-secondary-lime-alpha-1': 'hsla(var(--figma___colors-secondary-lime-alpha-1));', // ✦ Theme/Colors/Secondary/Lime Alpha/1
+  'figma-colors-secondary-lime-alpha-2': 'hsla(var(--figma___colors-secondary-lime-alpha-2));', // ✦ Theme/Colors/Secondary/Lime Alpha/2
+  'figma-colors-secondary-lime-alpha-3': 'hsla(var(--figma___colors-secondary-lime-alpha-3));', // ✦ Theme/Colors/Secondary/Lime Alpha/3
+  'figma-colors-secondary-lime-alpha-4': 'hsla(var(--figma___colors-secondary-lime-alpha-4));', // ✦ Theme/Colors/Secondary/Lime Alpha/4
+  'figma-colors-secondary-lime-alpha-5': 'hsla(var(--figma___colors-secondary-lime-alpha-5));', // ✦ Theme/Colors/Secondary/Lime Alpha/5
+  'figma-colors-secondary-lime-alpha-6': 'hsla(var(--figma___colors-secondary-lime-alpha-6));', // ✦ Theme/Colors/Secondary/Lime Alpha/6
+  'figma-colors-secondary-lime-alpha-7': 'hsla(var(--figma___colors-secondary-lime-alpha-7));', // ✦ Theme/Colors/Secondary/Lime Alpha/7
+  'figma-colors-secondary-lime-alpha-8': 'hsla(var(--figma___colors-secondary-lime-alpha-8));', // ✦ Theme/Colors/Secondary/Lime Alpha/8
+  'figma-colors-secondary-lime-alpha-9': 'hsla(var(--figma___colors-secondary-lime-alpha-9));', // ✦ Theme/Colors/Secondary/Lime Alpha/9
+  'figma-colors-secondary-lime-alpha-10': 'hsla(var(--figma___colors-secondary-lime-alpha-10));', // ✦ Theme/Colors/Secondary/Lime Alpha/10
+  'figma-colors-secondary-purple-1': 'hsla(var(--figma___colors-secondary-purple-1));', // ✦ Theme/Colors/Secondary/Purple/1
+  'figma-colors-secondary-purple-2': 'hsla(var(--figma___colors-secondary-purple-2));', // ✦ Theme/Colors/Secondary/Purple/2
+  'figma-colors-secondary-purple-3': 'hsla(var(--figma___colors-secondary-purple-3));', // ✦ Theme/Colors/Secondary/Purple/3
+  'figma-colors-secondary-purple-4': 'hsla(var(--figma___colors-secondary-purple-4));', // ✦ Theme/Colors/Secondary/Purple/4
+  'figma-colors-secondary-purple-5': 'hsla(var(--figma___colors-secondary-purple-5));', // ✦ Theme/Colors/Secondary/Purple/5
+  'figma-colors-secondary-purple-6': 'hsla(var(--figma___colors-secondary-purple-6));', // ✦ Theme/Colors/Secondary/Purple/6
+  'figma-colors-secondary-purple-7': 'hsla(var(--figma___colors-secondary-purple-7));', // ✦ Theme/Colors/Secondary/Purple/7
+  'figma-colors-secondary-purple-8': 'hsla(var(--figma___colors-secondary-purple-8));', // ✦ Theme/Colors/Secondary/Purple/8
+  'figma-colors-secondary-purple-9': 'hsla(var(--figma___colors-secondary-purple-9));', // ✦ Theme/Colors/Secondary/Purple/9
+  'figma-colors-secondary-purple-10': 'hsla(var(--figma___colors-secondary-purple-10));', // ✦ Theme/Colors/Secondary/Purple/10
+  'figma-colors-secondary-purple-alpha-1': 'hsla(var(--figma___colors-secondary-purple-alpha-1));', // ✦ Theme/Colors/Secondary/Purple Alpha/1
+  'figma-colors-secondary-purple-alpha-2': 'hsla(var(--figma___colors-secondary-purple-alpha-2));', // ✦ Theme/Colors/Secondary/Purple Alpha/2
+  'figma-colors-secondary-purple-alpha-3': 'hsla(var(--figma___colors-secondary-purple-alpha-3));', // ✦ Theme/Colors/Secondary/Purple Alpha/3
+  'figma-colors-secondary-purple-alpha-4': 'hsla(var(--figma___colors-secondary-purple-alpha-4));', // ✦ Theme/Colors/Secondary/Purple Alpha/4
+  'figma-colors-secondary-purple-alpha-5': 'hsla(var(--figma___colors-secondary-purple-alpha-5));', // ✦ Theme/Colors/Secondary/Purple Alpha/5
+  'figma-colors-secondary-purple-alpha-6': 'hsla(var(--figma___colors-secondary-purple-alpha-6));', // ✦ Theme/Colors/Secondary/Purple Alpha/6
+  'figma-colors-secondary-purple-alpha-7': 'hsla(var(--figma___colors-secondary-purple-alpha-7));', // ✦ Theme/Colors/Secondary/Purple Alpha/7
+  'figma-colors-secondary-purple-alpha-8': 'hsla(var(--figma___colors-secondary-purple-alpha-8));', // ✦ Theme/Colors/Secondary/Purple Alpha/8
+  'figma-colors-secondary-purple-alpha-9': 'hsla(var(--figma___colors-secondary-purple-alpha-9));', // ✦ Theme/Colors/Secondary/Purple Alpha/9
+  'figma-colors-secondary-purple-alpha-10': 'hsla(var(--figma___colors-secondary-purple-alpha-10));', // ✦ Theme/Colors/Secondary/Purple Alpha/10
+  'figma-colors-secondary-teal-1': 'hsla(var(--figma___colors-secondary-teal-1));', // ✦ Theme/Colors/Secondary/Teal/1
+  'figma-colors-secondary-teal-2': 'hsla(var(--figma___colors-secondary-teal-2));', // ✦ Theme/Colors/Secondary/Teal/2
+  'figma-colors-secondary-teal-3': 'hsla(var(--figma___colors-secondary-teal-3));', // ✦ Theme/Colors/Secondary/Teal/3
+  'figma-colors-secondary-teal-4': 'hsla(var(--figma___colors-secondary-teal-4));', // ✦ Theme/Colors/Secondary/Teal/4
+  'figma-colors-secondary-teal-5': 'hsla(var(--figma___colors-secondary-teal-5));', // ✦ Theme/Colors/Secondary/Teal/5
+  'figma-colors-secondary-teal-6': 'hsla(var(--figma___colors-secondary-teal-6));', // ✦ Theme/Colors/Secondary/Teal/6
+  'figma-colors-secondary-teal-7': 'hsla(var(--figma___colors-secondary-teal-7));', // ✦ Theme/Colors/Secondary/Teal/7
+  'figma-colors-secondary-teal-8': 'hsla(var(--figma___colors-secondary-teal-8));', // ✦ Theme/Colors/Secondary/Teal/8
+  'figma-colors-secondary-teal-9': 'hsla(var(--figma___colors-secondary-teal-9));', // ✦ Theme/Colors/Secondary/Teal/9
+  'figma-colors-secondary-teal-10': 'hsla(var(--figma___colors-secondary-teal-10));', // ✦ Theme/Colors/Secondary/Teal/10
+  'figma-colors-secondary-teal-alpha-1': 'hsla(var(--figma___colors-secondary-teal-alpha-1));', // ✦ Theme/Colors/Secondary/Teal Alpha/1
+  'figma-colors-secondary-teal-alpha-2': 'hsla(var(--figma___colors-secondary-teal-alpha-2));', // ✦ Theme/Colors/Secondary/Teal Alpha/2
+  'figma-colors-secondary-teal-alpha-3': 'hsla(var(--figma___colors-secondary-teal-alpha-3));', // ✦ Theme/Colors/Secondary/Teal Alpha/3
+  'figma-colors-secondary-teal-alpha-4': 'hsla(var(--figma___colors-secondary-teal-alpha-4));', // ✦ Theme/Colors/Secondary/Teal Alpha/4
+  'figma-colors-secondary-teal-alpha-5': 'hsla(var(--figma___colors-secondary-teal-alpha-5));', // ✦ Theme/Colors/Secondary/Teal Alpha/5
+  'figma-colors-secondary-teal-alpha-6': 'hsla(var(--figma___colors-secondary-teal-alpha-6));', // ✦ Theme/Colors/Secondary/Teal Alpha/6
+  'figma-colors-secondary-teal-alpha-7': 'hsla(var(--figma___colors-secondary-teal-alpha-7));', // ✦ Theme/Colors/Secondary/Teal Alpha/7
+  'figma-colors-secondary-teal-alpha-8': 'hsla(var(--figma___colors-secondary-teal-alpha-8));', // ✦ Theme/Colors/Secondary/Teal Alpha/8
+  'figma-colors-secondary-teal-alpha-9': 'hsla(var(--figma___colors-secondary-teal-alpha-9));', // ✦ Theme/Colors/Secondary/Teal Alpha/9
+  'figma-colors-secondary-teal-alpha-10': 'hsla(var(--figma___colors-secondary-teal-alpha-10));', // ✦ Theme/Colors/Secondary/Teal Alpha/10
   'figma-overlays-black-alpha-1': 'hsla(var(--figma___overlays-black-alpha-1));', // ✦ Theme/Overlays/Black Alpha/1
   'figma-overlays-black-alpha-2': 'hsla(var(--figma___overlays-black-alpha-2));', // ✦ Theme/Overlays/Black Alpha/2
   'figma-overlays-black-alpha-3': 'hsla(var(--figma___overlays-black-alpha-3));', // ✦ Theme/Overlays/Black Alpha/3
@@ -578,376 +378,27 @@ module.exports = {
   'figma-overlays-white-alpha-8': 'hsla(var(--figma___overlays-white-alpha-8));', // ✦ Theme/Overlays/White Alpha/8
   'figma-overlays-white-alpha-9': 'hsla(var(--figma___overlays-white-alpha-9));', // ✦ Theme/Overlays/White Alpha/9
   'figma-overlays-white-alpha-10': 'hsla(var(--figma___overlays-white-alpha-10));', // ✦ Theme/Overlays/White Alpha/10
-  'figma-pagination-active-background': 'hsla(var(--figma___pagination-active-background));', // ✦ Theme/Pagination/Active/Background
-  'figma-pagination-active-border': 'hsla(var(--figma___pagination-active-border));', // ✦ Theme/Pagination/Active/Border
-  'figma-pagination-active-text': 'hsla(var(--figma___pagination-active-text));', // ✦ Theme/Pagination/Active/Text
-  'figma-pagination-background': 'hsla(var(--figma___pagination-background));', // ✦ Theme/Pagination/Background
-  'figma-pagination-default-background': 'hsla(var(--figma___pagination-default-background));', // ✦ Theme/Pagination/Default/Background
-  'figma-pagination-default-border': 'hsla(var(--figma___pagination-default-border));', // ✦ Theme/Pagination/Default/Border
-  'figma-pagination-default-text': 'hsla(var(--figma___pagination-default-text));', // ✦ Theme/Pagination/Default/Text
-  'figma-pagination-hover-background': 'hsla(var(--figma___pagination-hover-background));', // ✦ Theme/Pagination/Hover/Background
-  'figma-pagination-hover-border': 'hsla(var(--figma___pagination-hover-border));', // ✦ Theme/Pagination/Hover/Border
-  'figma-pagination-hover-text': 'hsla(var(--figma___pagination-hover-text));', // ✦ Theme/Pagination/Hover/Text
-  'figma-pagination-pagination-shadow-1': 'hsla(var(--figma___pagination-pagination-shadow-1));', // ✦ Theme/Pagination/Pagination shadow/1
-  'figma-pagination-pagination-shadow-2': 'hsla(var(--figma___pagination-pagination-shadow-2));', // ✦ Theme/Pagination/Pagination shadow/2
-  'figma-primary-color-primary-accent-1': 'hsla(var(--figma___primary-color-primary-accent-1));', // ✦ Theme/Primary Color/Primary Accent/1
-  'figma-primary-color-primary-accent-2': 'hsla(var(--figma___primary-color-primary-accent-2));', // ✦ Theme/Primary Color/Primary Accent/2
-  'figma-primary-color-primary-accent-3': 'hsla(var(--figma___primary-color-primary-accent-3));', // ✦ Theme/Primary Color/Primary Accent/3
-  'figma-primary-color-primary-accent-4': 'hsla(var(--figma___primary-color-primary-accent-4));', // ✦ Theme/Primary Color/Primary Accent/4
-  'figma-primary-color-primary-accent-5': 'hsla(var(--figma___primary-color-primary-accent-5));', // ✦ Theme/Primary Color/Primary Accent/5
-  'figma-primary-color-primary-accent-6': 'hsla(var(--figma___primary-color-primary-accent-6));', // ✦ Theme/Primary Color/Primary Accent/6
-  'figma-primary-color-primary-accent-7': 'hsla(var(--figma___primary-color-primary-accent-7));', // ✦ Theme/Primary Color/Primary Accent/7
-  'figma-primary-color-primary-accent-8': 'hsla(var(--figma___primary-color-primary-accent-8));', // ✦ Theme/Primary Color/Primary Accent/8
-  'figma-primary-color-primary-accent-9': 'hsla(var(--figma___primary-color-primary-accent-9));', // ✦ Theme/Primary Color/Primary Accent/9
-  'figma-primary-color-primary-accent-10': 'hsla(var(--figma___primary-color-primary-accent-10));', // ✦ Theme/Primary Color/Primary Accent/10
-  'figma-primary-color-primary-alpha-1': 'hsla(var(--figma___primary-color-primary-alpha-1));', // ✦ Theme/Primary Color/Primary Alpha/1
-  'figma-primary-color-primary-alpha-2': 'hsla(var(--figma___primary-color-primary-alpha-2));', // ✦ Theme/Primary Color/Primary Alpha/2
-  'figma-primary-color-primary-alpha-3': 'hsla(var(--figma___primary-color-primary-alpha-3));', // ✦ Theme/Primary Color/Primary Alpha/3
-  'figma-primary-color-primary-alpha-4': 'hsla(var(--figma___primary-color-primary-alpha-4));', // ✦ Theme/Primary Color/Primary Alpha/4
-  'figma-primary-color-primary-alpha-5': 'hsla(var(--figma___primary-color-primary-alpha-5));', // ✦ Theme/Primary Color/Primary Alpha/5
-  'figma-primary-color-primary-alpha-6': 'hsla(var(--figma___primary-color-primary-alpha-6));', // ✦ Theme/Primary Color/Primary Alpha/6
-  'figma-primary-color-primary-alpha-7': 'hsla(var(--figma___primary-color-primary-alpha-7));', // ✦ Theme/Primary Color/Primary Alpha/7
-  'figma-primary-color-primary-alpha-8': 'hsla(var(--figma___primary-color-primary-alpha-8));', // ✦ Theme/Primary Color/Primary Alpha/8
-  'figma-primary-color-primary-alpha-9': 'hsla(var(--figma___primary-color-primary-alpha-9));', // ✦ Theme/Primary Color/Primary Alpha/9
-  'figma-primary-color-primary-alpha-10': 'hsla(var(--figma___primary-color-primary-alpha-10));', // ✦ Theme/Primary Color/Primary Alpha/10
-  'figma-radio-button-background': 'hsla(var(--figma___radio-button-background));', // ✦ Theme/Radio button/Background
-  'figma-radio-button-checked-active-active-border': 'hsla(var(--figma___radio-button-checked-active-active-border));', // ✦ Theme/Radio button/Checked/Active/Active Border
-  'figma-radio-button-checked-active-active-background':
-    'hsla(var(--figma___radio-button-checked-active-active-background));', // ✦ Theme/Radio button/Checked/Active/Active background
-  'figma-radio-button-checked-active-dot': 'hsla(var(--figma___radio-button-checked-active-dot));', // ✦ Theme/Radio button/Checked/Active/Dot
-  'figma-radio-button-checked-active-hover-background':
-    'hsla(var(--figma___radio-button-checked-active-hover-background));', // ✦ Theme/Radio button/Checked/Active/Hover background
-  'figma-radio-button-checked-active-hover-border': 'hsla(var(--figma___radio-button-checked-active-hover-border));', // ✦ Theme/Radio button/Checked/Active/Hover border
-  'figma-radio-button-checked-active-default-background':
-    'hsla(var(--figma___radio-button-checked-active-default-background));', // ✦ Theme/Radio button/Checked/Active/default background
-  'figma-radio-button-checked-active-default-border':
-    'hsla(var(--figma___radio-button-checked-active-default-border));', // ✦ Theme/Radio button/Checked/Active/default border
-  'figma-radio-button-checked-disabled-dot': 'hsla(var(--figma___radio-button-checked-disabled-dot));', // ✦ Theme/Radio button/Checked/Disabled/Dot
-  'figma-radio-button-checked-disabled-background': 'hsla(var(--figma___radio-button-checked-disabled-background));', // ✦ Theme/Radio button/Checked/Disabled/background
-  'figma-radio-button-checked-disabled-border': 'hsla(var(--figma___radio-button-checked-disabled-border));', // ✦ Theme/Radio button/Checked/Disabled/border
-  'figma-radio-button-paper': 'hsla(var(--figma___radio-button-paper));', // ✦ Theme/Radio button/Paper
-  'figma-radio-button-unchecked-active-active-border':
-    'hsla(var(--figma___radio-button-unchecked-active-active-border));', // ✦ Theme/Radio button/Unchecked/Active/Active border
-  'figma-radio-button-unchecked-active-hover-border':
-    'hsla(var(--figma___radio-button-unchecked-active-hover-border));', // ✦ Theme/Radio button/Unchecked/Active/Hover border
-  'figma-radio-button-unchecked-active-default-background':
-    'hsla(var(--figma___radio-button-unchecked-active-default-background));', // ✦ Theme/Radio button/Unchecked/Active/default background
-  'figma-radio-button-unchecked-active-default-border':
-    'hsla(var(--figma___radio-button-unchecked-active-default-border));', // ✦ Theme/Radio button/Unchecked/Active/default border
-  'figma-radio-button-unchecked-disabled-background':
-    'hsla(var(--figma___radio-button-unchecked-disabled-background));', // ✦ Theme/Radio button/Unchecked/Disabled/background
-  'figma-radio-button-unchecked-disabled-border': 'hsla(var(--figma___radio-button-unchecked-disabled-border));', // ✦ Theme/Radio button/Unchecked/Disabled/border
-  'figma-radio-button-border': 'hsla(var(--figma___radio-button-border));', // ✦ Theme/Radio button/border
-  'figma-secondary-crimson-crimson-1': 'hsla(var(--figma___secondary-crimson-crimson-1));', // ✦ Theme/Secondary/Crimson/Crimson 1
-  'figma-secondary-crimson-crimson-10': 'hsla(var(--figma___secondary-crimson-crimson-10));', // ✦ Theme/Secondary/Crimson/Crimson 10
-  'figma-secondary-crimson-crimson-2': 'hsla(var(--figma___secondary-crimson-crimson-2));', // ✦ Theme/Secondary/Crimson/Crimson 2
-  'figma-secondary-crimson-crimson-3': 'hsla(var(--figma___secondary-crimson-crimson-3));', // ✦ Theme/Secondary/Crimson/Crimson 3
-  'figma-secondary-crimson-crimson-4': 'hsla(var(--figma___secondary-crimson-crimson-4));', // ✦ Theme/Secondary/Crimson/Crimson 4
-  'figma-secondary-crimson-crimson-5': 'hsla(var(--figma___secondary-crimson-crimson-5));', // ✦ Theme/Secondary/Crimson/Crimson 5
-  'figma-secondary-crimson-crimson-6': 'hsla(var(--figma___secondary-crimson-crimson-6));', // ✦ Theme/Secondary/Crimson/Crimson 6
-  'figma-secondary-crimson-crimson-7': 'hsla(var(--figma___secondary-crimson-crimson-7));', // ✦ Theme/Secondary/Crimson/Crimson 7
-  'figma-secondary-crimson-crimson-8': 'hsla(var(--figma___secondary-crimson-crimson-8));', // ✦ Theme/Secondary/Crimson/Crimson 8
-  'figma-secondary-crimson-crimson-9': 'hsla(var(--figma___secondary-crimson-crimson-9));', // ✦ Theme/Secondary/Crimson/Crimson 9
-  'figma-secondary-crimson-alpha-crimson-alpha-1': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-1));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1
-  'figma-secondary-crimson-alpha-crimson-alpha-10': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-10));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10
-  'figma-secondary-crimson-alpha-crimson-alpha-11': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-11));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11
-  'figma-secondary-crimson-alpha-crimson-alpha-2': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-2));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2
-  'figma-secondary-crimson-alpha-crimson-alpha-3': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-3));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3
-  'figma-secondary-crimson-alpha-crimson-alpha-4': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-4));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4
-  'figma-secondary-crimson-alpha-crimson-alpha-5': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-5));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5
-  'figma-secondary-crimson-alpha-crimson-alpha-6': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-6));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6
-  'figma-secondary-crimson-alpha-crimson-alpha-8': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-8));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8
-  'figma-secondary-crimson-alpha-crimson-alpha-9': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-9));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9
-  'figma-secondary-lime-1': 'hsla(var(--figma___secondary-lime-1));', // ✦ Theme/Secondary/Lime/1
-  'figma-secondary-lime-2': 'hsla(var(--figma___secondary-lime-2));', // ✦ Theme/Secondary/Lime/2
-  'figma-secondary-lime-3': 'hsla(var(--figma___secondary-lime-3));', // ✦ Theme/Secondary/Lime/3
-  'figma-secondary-lime-4': 'hsla(var(--figma___secondary-lime-4));', // ✦ Theme/Secondary/Lime/4
-  'figma-secondary-lime-5': 'hsla(var(--figma___secondary-lime-5));', // ✦ Theme/Secondary/Lime/5
-  'figma-secondary-lime-6': 'hsla(var(--figma___secondary-lime-6));', // ✦ Theme/Secondary/Lime/6
-  'figma-secondary-lime-7': 'hsla(var(--figma___secondary-lime-7));', // ✦ Theme/Secondary/Lime/7
-  'figma-secondary-lime-8': 'hsla(var(--figma___secondary-lime-8));', // ✦ Theme/Secondary/Lime/8
-  'figma-secondary-lime-9': 'hsla(var(--figma___secondary-lime-9));', // ✦ Theme/Secondary/Lime/9
-  'figma-secondary-lime-10': 'hsla(var(--figma___secondary-lime-10));', // ✦ Theme/Secondary/Lime/10
-  'figma-secondary-lime-alpha-1': 'hsla(var(--figma___secondary-lime-alpha-1));', // ✦ Theme/Secondary/Lime Alpha/1
-  'figma-secondary-lime-alpha-2': 'hsla(var(--figma___secondary-lime-alpha-2));', // ✦ Theme/Secondary/Lime Alpha/2
-  'figma-secondary-lime-alpha-3': 'hsla(var(--figma___secondary-lime-alpha-3));', // ✦ Theme/Secondary/Lime Alpha/3
-  'figma-secondary-lime-alpha-4': 'hsla(var(--figma___secondary-lime-alpha-4));', // ✦ Theme/Secondary/Lime Alpha/4
-  'figma-secondary-lime-alpha-5': 'hsla(var(--figma___secondary-lime-alpha-5));', // ✦ Theme/Secondary/Lime Alpha/5
-  'figma-secondary-lime-alpha-6': 'hsla(var(--figma___secondary-lime-alpha-6));', // ✦ Theme/Secondary/Lime Alpha/6
-  'figma-secondary-lime-alpha-7': 'hsla(var(--figma___secondary-lime-alpha-7));', // ✦ Theme/Secondary/Lime Alpha/7
-  'figma-secondary-lime-alpha-8': 'hsla(var(--figma___secondary-lime-alpha-8));', // ✦ Theme/Secondary/Lime Alpha/8
-  'figma-secondary-lime-alpha-9': 'hsla(var(--figma___secondary-lime-alpha-9));', // ✦ Theme/Secondary/Lime Alpha/9
-  'figma-secondary-lime-alpha-10': 'hsla(var(--figma___secondary-lime-alpha-10));', // ✦ Theme/Secondary/Lime Alpha/10
-  'figma-secondary-purple-1': 'hsla(var(--figma___secondary-purple-1));', // ✦ Theme/Secondary/Purple/1
-  'figma-secondary-purple-2': 'hsla(var(--figma___secondary-purple-2));', // ✦ Theme/Secondary/Purple/2
-  'figma-secondary-purple-3': 'hsla(var(--figma___secondary-purple-3));', // ✦ Theme/Secondary/Purple/3
-  'figma-secondary-purple-4': 'hsla(var(--figma___secondary-purple-4));', // ✦ Theme/Secondary/Purple/4
-  'figma-secondary-purple-5': 'hsla(var(--figma___secondary-purple-5));', // ✦ Theme/Secondary/Purple/5
-  'figma-secondary-purple-6': 'hsla(var(--figma___secondary-purple-6));', // ✦ Theme/Secondary/Purple/6
-  'figma-secondary-purple-7': 'hsla(var(--figma___secondary-purple-7));', // ✦ Theme/Secondary/Purple/7
-  'figma-secondary-purple-8': 'hsla(var(--figma___secondary-purple-8));', // ✦ Theme/Secondary/Purple/8
-  'figma-secondary-purple-9': 'hsla(var(--figma___secondary-purple-9));', // ✦ Theme/Secondary/Purple/9
-  'figma-secondary-purple-10': 'hsla(var(--figma___secondary-purple-10));', // ✦ Theme/Secondary/Purple/10
-  'figma-secondary-purple-alpha-1': 'hsla(var(--figma___secondary-purple-alpha-1));', // ✦ Theme/Secondary/Purple Alpha/1
-  'figma-secondary-purple-alpha-2': 'hsla(var(--figma___secondary-purple-alpha-2));', // ✦ Theme/Secondary/Purple Alpha/2
-  'figma-secondary-purple-alpha-3': 'hsla(var(--figma___secondary-purple-alpha-3));', // ✦ Theme/Secondary/Purple Alpha/3
-  'figma-secondary-purple-alpha-4': 'hsla(var(--figma___secondary-purple-alpha-4));', // ✦ Theme/Secondary/Purple Alpha/4
-  'figma-secondary-purple-alpha-5': 'hsla(var(--figma___secondary-purple-alpha-5));', // ✦ Theme/Secondary/Purple Alpha/5
-  'figma-secondary-purple-alpha-6': 'hsla(var(--figma___secondary-purple-alpha-6));', // ✦ Theme/Secondary/Purple Alpha/6
-  'figma-secondary-purple-alpha-7': 'hsla(var(--figma___secondary-purple-alpha-7));', // ✦ Theme/Secondary/Purple Alpha/7
-  'figma-secondary-purple-alpha-8': 'hsla(var(--figma___secondary-purple-alpha-8));', // ✦ Theme/Secondary/Purple Alpha/8
-  'figma-secondary-purple-alpha-9': 'hsla(var(--figma___secondary-purple-alpha-9));', // ✦ Theme/Secondary/Purple Alpha/9
-  'figma-secondary-purple-alpha-10': 'hsla(var(--figma___secondary-purple-alpha-10));', // ✦ Theme/Secondary/Purple Alpha/10
-  'figma-secondary-teal-1': 'hsla(var(--figma___secondary-teal-1));', // ✦ Theme/Secondary/Teal/1
-  'figma-secondary-teal-2': 'hsla(var(--figma___secondary-teal-2));', // ✦ Theme/Secondary/Teal/2
-  'figma-secondary-teal-3': 'hsla(var(--figma___secondary-teal-3));', // ✦ Theme/Secondary/Teal/3
-  'figma-secondary-teal-4': 'hsla(var(--figma___secondary-teal-4));', // ✦ Theme/Secondary/Teal/4
-  'figma-secondary-teal-5': 'hsla(var(--figma___secondary-teal-5));', // ✦ Theme/Secondary/Teal/5
-  'figma-secondary-teal-6': 'hsla(var(--figma___secondary-teal-6));', // ✦ Theme/Secondary/Teal/6
-  'figma-secondary-teal-7': 'hsla(var(--figma___secondary-teal-7));', // ✦ Theme/Secondary/Teal/7
-  'figma-secondary-teal-8': 'hsla(var(--figma___secondary-teal-8));', // ✦ Theme/Secondary/Teal/8
-  'figma-secondary-teal-9': 'hsla(var(--figma___secondary-teal-9));', // ✦ Theme/Secondary/Teal/9
-  'figma-secondary-teal-10': 'hsla(var(--figma___secondary-teal-10));', // ✦ Theme/Secondary/Teal/10
-  'figma-secondary-teal-alpha-1': 'hsla(var(--figma___secondary-teal-alpha-1));', // ✦ Theme/Secondary/Teal Alpha/1
-  'figma-secondary-teal-alpha-2': 'hsla(var(--figma___secondary-teal-alpha-2));', // ✦ Theme/Secondary/Teal Alpha/2
-  'figma-secondary-teal-alpha-3': 'hsla(var(--figma___secondary-teal-alpha-3));', // ✦ Theme/Secondary/Teal Alpha/3
-  'figma-secondary-teal-alpha-4': 'hsla(var(--figma___secondary-teal-alpha-4));', // ✦ Theme/Secondary/Teal Alpha/4
-  'figma-secondary-teal-alpha-5': 'hsla(var(--figma___secondary-teal-alpha-5));', // ✦ Theme/Secondary/Teal Alpha/5
-  'figma-secondary-teal-alpha-6': 'hsla(var(--figma___secondary-teal-alpha-6));', // ✦ Theme/Secondary/Teal Alpha/6
-  'figma-secondary-teal-alpha-7': 'hsla(var(--figma___secondary-teal-alpha-7));', // ✦ Theme/Secondary/Teal Alpha/7
-  'figma-secondary-teal-alpha-8': 'hsla(var(--figma___secondary-teal-alpha-8));', // ✦ Theme/Secondary/Teal Alpha/8
-  'figma-secondary-teal-alpha-9': 'hsla(var(--figma___secondary-teal-alpha-9));', // ✦ Theme/Secondary/Teal Alpha/9
-  'figma-secondary-teal-alpha-10': 'hsla(var(--figma___secondary-teal-alpha-10));', // ✦ Theme/Secondary/Teal Alpha/10
-  'figma-shadow-shadow-button-1': 'hsla(var(--figma___shadow-shadow-button-1));', // ✦ Theme/Shadow/Shadow - button/1
-  'figma-shadow-shadow-button-2': 'hsla(var(--figma___shadow-shadow-button-2));', // ✦ Theme/Shadow/Shadow - button/2
-  'figma-shadow-shadow-button-3': 'hsla(var(--figma___shadow-shadow-button-3));', // ✦ Theme/Shadow/Shadow - button/3
-  'figma-shadow-shadow-button-4': 'hsla(var(--figma___shadow-shadow-button-4));', // ✦ Theme/Shadow/Shadow - button/4
-  'figma-shadow-shadow-1-1': 'hsla(var(--figma___shadow-shadow-1-1));', // ✦ Theme/Shadow/Shadow 1/1
-  'figma-shadow-shadow-2-1': 'hsla(var(--figma___shadow-shadow-2-1));', // ✦ Theme/Shadow/Shadow 2/1
-  'figma-shadow-shadow-2-2': 'hsla(var(--figma___shadow-shadow-2-2));', // ✦ Theme/Shadow/Shadow 2/2
-  'figma-shadow-shadow-2-3': 'hsla(var(--figma___shadow-shadow-2-3));', // ✦ Theme/Shadow/Shadow 2/3
-  'figma-shadow-shadow-3-1': 'hsla(var(--figma___shadow-shadow-3-1));', // ✦ Theme/Shadow/Shadow 3/1
-  'figma-shadow-shadow-3-2': 'hsla(var(--figma___shadow-shadow-3-2));', // ✦ Theme/Shadow/Shadow 3/2
-  'figma-shadow-shadow-3-3': 'hsla(var(--figma___shadow-shadow-3-3));', // ✦ Theme/Shadow/Shadow 3/3
-  'figma-shadow-shadow-4-1': 'hsla(var(--figma___shadow-shadow-4-1));', // ✦ Theme/Shadow/Shadow 4/1
-  'figma-shadow-shadow-4-2': 'hsla(var(--figma___shadow-shadow-4-2));', // ✦ Theme/Shadow/Shadow 4/2
-  'figma-shadow-shadow-5-1': 'hsla(var(--figma___shadow-shadow-5-1));', // ✦ Theme/Shadow/Shadow 5/1
-  'figma-shadow-shadow-5-2': 'hsla(var(--figma___shadow-shadow-5-2));', // ✦ Theme/Shadow/Shadow 5/2
-  'figma-shadow-shadow-6-1': 'hsla(var(--figma___shadow-shadow-6-1));', // ✦ Theme/Shadow/Shadow 6/1
-  'figma-shadow-shadow-6-2': 'hsla(var(--figma___shadow-shadow-6-2));', // ✦ Theme/Shadow/Shadow 6/2
-  'figma-shadow-shadow-button-active-1': 'hsla(var(--figma___shadow-shadow-button-active-1));', // ✦ Theme/Shadow/Shadow-button-active/1
-  'figma-shadow-shadow-button-active-2': 'hsla(var(--figma___shadow-shadow-button-active-2));', // ✦ Theme/Shadow/Shadow-button-active/2
-  'figma-shadow-shadow-button-active-3': 'hsla(var(--figma___shadow-shadow-button-active-3));', // ✦ Theme/Shadow/Shadow-button-active/3
-  'figma-shadow-shadow-button-active-4': 'hsla(var(--figma___shadow-shadow-button-active-4));', // ✦ Theme/Shadow/Shadow-button-active/4
-  'figma-side-nav-container-nav-background': 'hsla(var(--figma___side-nav-container-nav-background));', // ✦ Theme/Side nav/Container/Nav-background
-  'figma-side-nav-container-nav-border': 'hsla(var(--figma___side-nav-container-nav-border));', // ✦ Theme/Side nav/Container/Nav-border
-  'figma-side-nav-module-logo-text': 'hsla(var(--figma___side-nav-module-logo-text));', // ✦ Theme/Side nav/Module Logo Text
-  'figma-side-nav-nav-item-default-icon': 'hsla(var(--figma___side-nav-nav-item-default-icon));', // ✦ Theme/Side nav/Nav-item/Default/Icon
-  'figma-side-nav-nav-item-default-text': 'hsla(var(--figma___side-nav-nav-item-default-text));', // ✦ Theme/Side nav/Nav-item/Default/Text
-  'figma-side-nav-nav-item-default-default': 'hsla(var(--figma___side-nav-nav-item-default-default));', // ✦ Theme/Side nav/Nav-item/Default/default
-  'figma-side-nav-nav-item-hover-background': 'hsla(var(--figma___side-nav-nav-item-hover-background));', // ✦ Theme/Side nav/Nav-item/Hover/Background
-  'figma-side-nav-nav-item-hover-icon': 'hsla(var(--figma___side-nav-nav-item-hover-icon));', // ✦ Theme/Side nav/Nav-item/Hover/Icon
-  'figma-side-nav-nav-item-hover-text': 'hsla(var(--figma___side-nav-nav-item-hover-text));', // ✦ Theme/Side nav/Nav-item/Hover/Text
-  'figma-side-nav-nav-item-selected-background': 'hsla(var(--figma___side-nav-nav-item-selected-background));', // ✦ Theme/Side nav/Nav-item/Selected/Background
-  'figma-side-nav-nav-item-selected-icon': 'hsla(var(--figma___side-nav-nav-item-selected-icon));', // ✦ Theme/Side nav/Nav-item/Selected/Icon
-  'figma-side-nav-nav-item-selected-text': 'hsla(var(--figma___side-nav-nav-item-selected-text));', // ✦ Theme/Side nav/Nav-item/Selected/Text
-  'figma-side-nav-profile-role': 'hsla(var(--figma___side-nav-profile-role));', // ✦ Theme/Side nav/Profile/Role
-  'figma-side-nav-profile-text': 'hsla(var(--figma___side-nav-profile-text));', // ✦ Theme/Side nav/Profile/Text
-  'figma-side-nav-scope-selector-default-border': 'hsla(var(--figma___side-nav-scope-selector-default-border));', // ✦ Theme/Side nav/Scope Selector/Default/Border
-  'figma-side-nav-scope-selector-default-main-text-icon':
-    'hsla(var(--figma___side-nav-scope-selector-default-main-text-icon));', // ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon
-  'figma-side-nav-scope-selector-default-scope-name':
-    'hsla(var(--figma___side-nav-scope-selector-default-scope-name));', // ✦ Theme/Side nav/Scope Selector/Default/Scope Name
-  'figma-side-nav-scope-selector-default-default': 'hsla(var(--figma___side-nav-scope-selector-default-default));', // ✦ Theme/Side nav/Scope Selector/Default/default
-  'figma-side-nav-scope-selector-hover-border': 'hsla(var(--figma___side-nav-scope-selector-hover-border));', // ✦ Theme/Side nav/Scope Selector/Hover/Border
-  'figma-side-nav-scope-selector-hover-main-text-icon':
-    'hsla(var(--figma___side-nav-scope-selector-hover-main-text-icon));', // ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon
-  'figma-side-nav-scope-selector-hover-scope-name': 'hsla(var(--figma___side-nav-scope-selector-hover-scope-name));', // ✦ Theme/Side nav/Scope Selector/Hover/Scope Name
-  'figma-side-nav-scope-selector-hover-default': 'hsla(var(--figma___side-nav-scope-selector-hover-default));', // ✦ Theme/Side nav/Scope Selector/Hover/default
-  'figma-side-nav-scope-selector-selected-border': 'hsla(var(--figma___side-nav-scope-selector-selected-border));', // ✦ Theme/Side nav/Scope Selector/Selected/Border
-  'figma-side-nav-scope-selector-selected-main-text-icon':
-    'hsla(var(--figma___side-nav-scope-selector-selected-main-text-icon));', // ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon
-  'figma-side-nav-scope-selector-selected-scope-name':
-    'hsla(var(--figma___side-nav-scope-selector-selected-scope-name));', // ✦ Theme/Side nav/Scope Selector/Selected/Scope Name
-  'figma-side-nav-scope-selector-selected-background':
-    'hsla(var(--figma___side-nav-scope-selector-selected-background));', // ✦ Theme/Side nav/Scope Selector/Selected/background
-  'figma-side-nav-separator': 'hsla(var(--figma___side-nav-separator));', // ✦ Theme/Side nav/Separator
-  'figma-status-colors-error-1': 'hsla(var(--figma___status-colors-error-1));', // ✦ Theme/Status colors/Error/1
-  'figma-status-colors-error-2': 'hsla(var(--figma___status-colors-error-2));', // ✦ Theme/Status colors/Error/2
-  'figma-status-colors-error-3': 'hsla(var(--figma___status-colors-error-3));', // ✦ Theme/Status colors/Error/3
-  'figma-status-colors-error-4': 'hsla(var(--figma___status-colors-error-4));', // ✦ Theme/Status colors/Error/4
-  'figma-status-colors-error-5': 'hsla(var(--figma___status-colors-error-5));', // ✦ Theme/Status colors/Error/5
-  'figma-status-colors-error-6': 'hsla(var(--figma___status-colors-error-6));', // ✦ Theme/Status colors/Error/6
-  'figma-status-colors-error-7': 'hsla(var(--figma___status-colors-error-7));', // ✦ Theme/Status colors/Error/7
-  'figma-status-colors-error-8': 'hsla(var(--figma___status-colors-error-8));', // ✦ Theme/Status colors/Error/8
-  'figma-status-colors-error-9': 'hsla(var(--figma___status-colors-error-9));', // ✦ Theme/Status colors/Error/9
-  'figma-status-colors-error-10': 'hsla(var(--figma___status-colors-error-10));', // ✦ Theme/Status colors/Error/10
-  'figma-status-colors-error-alpha-1': 'hsla(var(--figma___status-colors-error-alpha-1));', // ✦ Theme/Status colors/Error Alpha/1
-  'figma-status-colors-error-alpha-2': 'hsla(var(--figma___status-colors-error-alpha-2));', // ✦ Theme/Status colors/Error Alpha/2
-  'figma-status-colors-error-alpha-3': 'hsla(var(--figma___status-colors-error-alpha-3));', // ✦ Theme/Status colors/Error Alpha/3
-  'figma-status-colors-error-alpha-4': 'hsla(var(--figma___status-colors-error-alpha-4));', // ✦ Theme/Status colors/Error Alpha/4
-  'figma-status-colors-error-alpha-5': 'hsla(var(--figma___status-colors-error-alpha-5));', // ✦ Theme/Status colors/Error Alpha/5
-  'figma-status-colors-error-alpha-6': 'hsla(var(--figma___status-colors-error-alpha-6));', // ✦ Theme/Status colors/Error Alpha/6
-  'figma-status-colors-error-alpha-7': 'hsla(var(--figma___status-colors-error-alpha-7));', // ✦ Theme/Status colors/Error Alpha/7
-  'figma-status-colors-error-alpha-8': 'hsla(var(--figma___status-colors-error-alpha-8));', // ✦ Theme/Status colors/Error Alpha/8
-  'figma-status-colors-error-alpha-9': 'hsla(var(--figma___status-colors-error-alpha-9));', // ✦ Theme/Status colors/Error Alpha/9
-  'figma-status-colors-error-alpha-10': 'hsla(var(--figma___status-colors-error-alpha-10));', // ✦ Theme/Status colors/Error Alpha/10
-  'figma-status-colors-info-1': 'hsla(var(--figma___status-colors-info-1));', // ✦ Theme/Status colors/Info/1
-  'figma-status-colors-info-2': 'hsla(var(--figma___status-colors-info-2));', // ✦ Theme/Status colors/Info/2
-  'figma-status-colors-info-3': 'hsla(var(--figma___status-colors-info-3));', // ✦ Theme/Status colors/Info/3
-  'figma-status-colors-info-4': 'hsla(var(--figma___status-colors-info-4));', // ✦ Theme/Status colors/Info/4
-  'figma-status-colors-info-5': 'hsla(var(--figma___status-colors-info-5));', // ✦ Theme/Status colors/Info/5
-  'figma-status-colors-info-6': 'hsla(var(--figma___status-colors-info-6));', // ✦ Theme/Status colors/Info/6
-  'figma-status-colors-info-7': 'hsla(var(--figma___status-colors-info-7));', // ✦ Theme/Status colors/Info/7
-  'figma-status-colors-info-8': 'hsla(var(--figma___status-colors-info-8));', // ✦ Theme/Status colors/Info/8
-  'figma-status-colors-info-9': 'hsla(var(--figma___status-colors-info-9));', // ✦ Theme/Status colors/Info/9
-  'figma-status-colors-info-10': 'hsla(var(--figma___status-colors-info-10));', // ✦ Theme/Status colors/Info/10
-  'figma-status-colors-info-alpha-1': 'hsla(var(--figma___status-colors-info-alpha-1));', // ✦ Theme/Status colors/Info Alpha/1
-  'figma-status-colors-info-alpha-2': 'hsla(var(--figma___status-colors-info-alpha-2));', // ✦ Theme/Status colors/Info Alpha/2
-  'figma-status-colors-info-alpha-3': 'hsla(var(--figma___status-colors-info-alpha-3));', // ✦ Theme/Status colors/Info Alpha/3
-  'figma-status-colors-info-alpha-4': 'hsla(var(--figma___status-colors-info-alpha-4));', // ✦ Theme/Status colors/Info Alpha/4
-  'figma-status-colors-info-alpha-5': 'hsla(var(--figma___status-colors-info-alpha-5));', // ✦ Theme/Status colors/Info Alpha/5
-  'figma-status-colors-info-alpha-6': 'hsla(var(--figma___status-colors-info-alpha-6));', // ✦ Theme/Status colors/Info Alpha/6
-  'figma-status-colors-info-alpha-7': 'hsla(var(--figma___status-colors-info-alpha-7));', // ✦ Theme/Status colors/Info Alpha/7
-  'figma-status-colors-info-alpha-8': 'hsla(var(--figma___status-colors-info-alpha-8));', // ✦ Theme/Status colors/Info Alpha/8
-  'figma-status-colors-info-alpha-9': 'hsla(var(--figma___status-colors-info-alpha-9));', // ✦ Theme/Status colors/Info Alpha/9
-  'figma-status-colors-info-alpha-10': 'hsla(var(--figma___status-colors-info-alpha-10));', // ✦ Theme/Status colors/Info Alpha/10
-  'figma-status-colors-success-1': 'hsla(var(--figma___status-colors-success-1));', // ✦ Theme/Status colors/Success/1
-  'figma-status-colors-success-2': 'hsla(var(--figma___status-colors-success-2));', // ✦ Theme/Status colors/Success/2
-  'figma-status-colors-success-3': 'hsla(var(--figma___status-colors-success-3));', // ✦ Theme/Status colors/Success/3
-  'figma-status-colors-success-4': 'hsla(var(--figma___status-colors-success-4));', // ✦ Theme/Status colors/Success/4
-  'figma-status-colors-success-5': 'hsla(var(--figma___status-colors-success-5));', // ✦ Theme/Status colors/Success/5
-  'figma-status-colors-success-6': 'hsla(var(--figma___status-colors-success-6));', // ✦ Theme/Status colors/Success/6
-  'figma-status-colors-success-7': 'hsla(var(--figma___status-colors-success-7));', // ✦ Theme/Status colors/Success/7
-  'figma-status-colors-success-8': 'hsla(var(--figma___status-colors-success-8));', // ✦ Theme/Status colors/Success/8
-  'figma-status-colors-success-9': 'hsla(var(--figma___status-colors-success-9));', // ✦ Theme/Status colors/Success/9
-  'figma-status-colors-success-10': 'hsla(var(--figma___status-colors-success-10));', // ✦ Theme/Status colors/Success/10
-  'figma-status-colors-success-alpha-1': 'hsla(var(--figma___status-colors-success-alpha-1));', // ✦ Theme/Status colors/Success Alpha/1
-  'figma-status-colors-success-alpha-2': 'hsla(var(--figma___status-colors-success-alpha-2));', // ✦ Theme/Status colors/Success Alpha/2
-  'figma-status-colors-success-alpha-3': 'hsla(var(--figma___status-colors-success-alpha-3));', // ✦ Theme/Status colors/Success Alpha/3
-  'figma-status-colors-success-alpha-4': 'hsla(var(--figma___status-colors-success-alpha-4));', // ✦ Theme/Status colors/Success Alpha/4
-  'figma-status-colors-success-alpha-5': 'hsla(var(--figma___status-colors-success-alpha-5));', // ✦ Theme/Status colors/Success Alpha/5
-  'figma-status-colors-success-alpha-6': 'hsla(var(--figma___status-colors-success-alpha-6));', // ✦ Theme/Status colors/Success Alpha/6
-  'figma-status-colors-success-alpha-7': 'hsla(var(--figma___status-colors-success-alpha-7));', // ✦ Theme/Status colors/Success Alpha/7
-  'figma-status-colors-success-alpha-8': 'hsla(var(--figma___status-colors-success-alpha-8));', // ✦ Theme/Status colors/Success Alpha/8
-  'figma-status-colors-success-alpha-9': 'hsla(var(--figma___status-colors-success-alpha-9));', // ✦ Theme/Status colors/Success Alpha/9
-  'figma-status-colors-success-alpha-10': 'hsla(var(--figma___status-colors-success-alpha-10));', // ✦ Theme/Status colors/Success Alpha/10
-  'figma-status-colors-warning-1': 'hsla(var(--figma___status-colors-warning-1));', // ✦ Theme/Status colors/Warning/1
-  'figma-status-colors-warning-2': 'hsla(var(--figma___status-colors-warning-2));', // ✦ Theme/Status colors/Warning/2
-  'figma-status-colors-warning-3': 'hsla(var(--figma___status-colors-warning-3));', // ✦ Theme/Status colors/Warning/3
-  'figma-status-colors-warning-4': 'hsla(var(--figma___status-colors-warning-4));', // ✦ Theme/Status colors/Warning/4
-  'figma-status-colors-warning-5': 'hsla(var(--figma___status-colors-warning-5));', // ✦ Theme/Status colors/Warning/5
-  'figma-status-colors-warning-6': 'hsla(var(--figma___status-colors-warning-6));', // ✦ Theme/Status colors/Warning/6
-  'figma-status-colors-warning-7': 'hsla(var(--figma___status-colors-warning-7));', // ✦ Theme/Status colors/Warning/7
-  'figma-status-colors-warning-8': 'hsla(var(--figma___status-colors-warning-8));', // ✦ Theme/Status colors/Warning/8
-  'figma-status-colors-warning-9': 'hsla(var(--figma___status-colors-warning-9));', // ✦ Theme/Status colors/Warning/9
-  'figma-status-colors-warning-10': 'hsla(var(--figma___status-colors-warning-10));', // ✦ Theme/Status colors/Warning/10
-  'figma-status-colors-warning-alpha-1': 'hsla(var(--figma___status-colors-warning-alpha-1));', // ✦ Theme/Status colors/Warning Alpha/1
-  'figma-status-colors-warning-alpha-2': 'hsla(var(--figma___status-colors-warning-alpha-2));', // ✦ Theme/Status colors/Warning Alpha/2
-  'figma-status-colors-warning-alpha-3': 'hsla(var(--figma___status-colors-warning-alpha-3));', // ✦ Theme/Status colors/Warning Alpha/3
-  'figma-status-colors-warning-alpha-4': 'hsla(var(--figma___status-colors-warning-alpha-4));', // ✦ Theme/Status colors/Warning Alpha/4
-  'figma-status-colors-warning-alpha-5': 'hsla(var(--figma___status-colors-warning-alpha-5));', // ✦ Theme/Status colors/Warning Alpha/5
-  'figma-status-colors-warning-alpha-6': 'hsla(var(--figma___status-colors-warning-alpha-6));', // ✦ Theme/Status colors/Warning Alpha/6
-  'figma-status-colors-warning-alpha-7': 'hsla(var(--figma___status-colors-warning-alpha-7));', // ✦ Theme/Status colors/Warning Alpha/7
-  'figma-status-colors-warning-alpha-8': 'hsla(var(--figma___status-colors-warning-alpha-8));', // ✦ Theme/Status colors/Warning Alpha/8
-  'figma-status-colors-warning-alpha-9': 'hsla(var(--figma___status-colors-warning-alpha-9));', // ✦ Theme/Status colors/Warning Alpha/9
-  'figma-status-colors-warning-alpha-10': 'hsla(var(--figma___status-colors-warning-alpha-10));', // ✦ Theme/Status colors/Warning Alpha/10
-  'figma-switch-background': 'hsla(var(--figma___switch-background));', // ✦ Theme/Switch/Background
-  'figma-switch-checked-active-thumb-thumb-background':
-    'hsla(var(--figma___switch-checked-active-thumb-thumb-background));', // ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background
-  'figma-switch-checked-active-thumb-thumb-border': 'hsla(var(--figma___switch-checked-active-thumb-thumb-border));', // ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border
-  'figma-switch-checked-active-background': 'hsla(var(--figma___switch-checked-active-background));', // ✦ Theme/Switch/Checked/Active/background
-  'figma-switch-checked-active-border': 'hsla(var(--figma___switch-checked-active-border));', // ✦ Theme/Switch/Checked/Active/border
-  'figma-switch-checked-default-thumb-thumb-background':
-    'hsla(var(--figma___switch-checked-default-thumb-thumb-background));', // ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background
-  'figma-switch-checked-default-thumb-thumb-border': 'hsla(var(--figma___switch-checked-default-thumb-thumb-border));', // ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border
-  'figma-switch-checked-default-default-background': 'hsla(var(--figma___switch-checked-default-default-background));', // ✦ Theme/Switch/Checked/Default/default background
-  'figma-switch-checked-default-default-border': 'hsla(var(--figma___switch-checked-default-default-border));', // ✦ Theme/Switch/Checked/Default/default border
-  'figma-switch-checked-disabled-thumb-thumb-background':
-    'hsla(var(--figma___switch-checked-disabled-thumb-thumb-background));', // ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background
-  'figma-switch-checked-disabled-thumb-thumb-border':
-    'hsla(var(--figma___switch-checked-disabled-thumb-thumb-border));', // ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border
-  'figma-switch-checked-disabled-background': 'hsla(var(--figma___switch-checked-disabled-background));', // ✦ Theme/Switch/Checked/Disabled/background
-  'figma-switch-checked-disabled-border': 'hsla(var(--figma___switch-checked-disabled-border));', // ✦ Theme/Switch/Checked/Disabled/border
-  'figma-switch-checked-hover-thumb-thumb-background':
-    'hsla(var(--figma___switch-checked-hover-thumb-thumb-background));', // ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background
-  'figma-switch-checked-hover-thumb-thumb-border': 'hsla(var(--figma___switch-checked-hover-thumb-thumb-border));', // ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border
-  'figma-switch-checked-hover-background': 'hsla(var(--figma___switch-checked-hover-background));', // ✦ Theme/Switch/Checked/Hover/background
-  'figma-switch-checked-hover-border': 'hsla(var(--figma___switch-checked-hover-border));', // ✦ Theme/Switch/Checked/Hover/border
-  'figma-switch-paper': 'hsla(var(--figma___switch-paper));', // ✦ Theme/Switch/Paper
-  'figma-switch-unchecked-active-thumb-thumb-background':
-    'hsla(var(--figma___switch-unchecked-active-thumb-thumb-background));', // ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background
-  'figma-switch-unchecked-active-thumb-thumb-border':
-    'hsla(var(--figma___switch-unchecked-active-thumb-thumb-border));', // ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border
-  'figma-switch-unchecked-active-background': 'hsla(var(--figma___switch-unchecked-active-background));', // ✦ Theme/Switch/Unchecked/Active/background
-  'figma-switch-unchecked-active-border': 'hsla(var(--figma___switch-unchecked-active-border));', // ✦ Theme/Switch/Unchecked/Active/border
-  'figma-switch-unchecked-default-thumb-thumb-background':
-    'hsla(var(--figma___switch-unchecked-default-thumb-thumb-background));', // ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background
-  'figma-switch-unchecked-default-thumb-thumb-border':
-    'hsla(var(--figma___switch-unchecked-default-thumb-thumb-border));', // ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border
-  'figma-switch-unchecked-default-default-background':
-    'hsla(var(--figma___switch-unchecked-default-default-background));', // ✦ Theme/Switch/Unchecked/Default/default background
-  'figma-switch-unchecked-default-default-border': 'hsla(var(--figma___switch-unchecked-default-default-border));', // ✦ Theme/Switch/Unchecked/Default/default border
-  'figma-switch-unchecked-disabled-thumb-thumb-background':
-    'hsla(var(--figma___switch-unchecked-disabled-thumb-thumb-background));', // ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background
-  'figma-switch-unchecked-disabled-thumb-thumb-border':
-    'hsla(var(--figma___switch-unchecked-disabled-thumb-thumb-border));', // ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border
-  'figma-switch-unchecked-disabled-background': 'hsla(var(--figma___switch-unchecked-disabled-background));', // ✦ Theme/Switch/Unchecked/Disabled/background
-  'figma-switch-unchecked-disabled-border': 'hsla(var(--figma___switch-unchecked-disabled-border));', // ✦ Theme/Switch/Unchecked/Disabled/border
-  'figma-switch-unchecked-hover-thumb-thumb-background':
-    'hsla(var(--figma___switch-unchecked-hover-thumb-thumb-background));', // ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background
-  'figma-switch-unchecked-hover-thumb-thumb-border': 'hsla(var(--figma___switch-unchecked-hover-thumb-thumb-border));', // ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border
-  'figma-switch-unchecked-hover-background': 'hsla(var(--figma___switch-unchecked-hover-background));', // ✦ Theme/Switch/Unchecked/Hover/background
-  'figma-switch-unchecked-hover-border': 'hsla(var(--figma___switch-unchecked-hover-border));', // ✦ Theme/Switch/Unchecked/Hover/border
-  'figma-switch-border': 'hsla(var(--figma___switch-border));', // ✦ Theme/Switch/border
-  'figma-tabs-number-active-background': 'hsla(var(--figma___tabs-number-active-background));', // ✦ Theme/Tabs/Number/Active/Background
-  'figma-tabs-number-active-text': 'hsla(var(--figma___tabs-number-active-text));', // ✦ Theme/Tabs/Number/Active/text
-  'figma-tabs-number-default-hover-background': 'hsla(var(--figma___tabs-number-default-hover-background));', // ✦ Theme/Tabs/Number/Default & Hover/Background
-  'figma-tabs-number-default-hover-text': 'hsla(var(--figma___tabs-number-default-hover-text));', // ✦ Theme/Tabs/Number/Default & Hover/text
-  'figma-tabs-pills-active-active': 'hsla(var(--figma___tabs-pills-active-active));', // ✦ Theme/Tabs/Pills/Active/Active
-  'figma-tabs-pills-active-text': 'hsla(var(--figma___tabs-pills-active-text));', // ✦ Theme/Tabs/Pills/Active/Text
-  'figma-tabs-pills-active-border-grad-1': 'hsla(var(--figma___tabs-pills-active-border-grad-1));', // ✦ Theme/Tabs/Pills/Active/border grad 1
-  'figma-tabs-pills-active-border-grad-2': 'hsla(var(--figma___tabs-pills-active-border-grad-2));', // ✦ Theme/Tabs/Pills/Active/border grad 2
-  'figma-tabs-pills-backgrounds': 'hsla(var(--figma___tabs-pills-backgrounds));', // ✦ Theme/Tabs/Pills/Backgrounds
-  'figma-tabs-pills-default-background': 'hsla(var(--figma___tabs-pills-default-background));', // ✦ Theme/Tabs/Pills/Default/Background
-  'figma-tabs-pills-default-text': 'hsla(var(--figma___tabs-pills-default-text));', // ✦ Theme/Tabs/Pills/Default/Text
-  'figma-tabs-pills-hover-background': 'hsla(var(--figma___tabs-pills-hover-background));', // ✦ Theme/Tabs/Pills/Hover/Background
-  'figma-tabs-pills-hover-text': 'hsla(var(--figma___tabs-pills-hover-text));', // ✦ Theme/Tabs/Pills/Hover/Text
-  'figma-tabs-pills-number-active-background': 'hsla(var(--figma___tabs-pills-number-active-background));', // ✦ Theme/Tabs/Pills/Number/Active/Background
-  'figma-tabs-pills-number-active-text': 'hsla(var(--figma___tabs-pills-number-active-text));', // ✦ Theme/Tabs/Pills/Number/Active/text
-  'figma-tabs-pills-border-grad-1': 'hsla(var(--figma___tabs-pills-border-grad-1));', // ✦ Theme/Tabs/Pills/border grad 1
-  'figma-tabs-pills-border-grad-2': 'hsla(var(--figma___tabs-pills-border-grad-2));', // ✦ Theme/Tabs/Pills/border grad 2
-  'figma-tabs-primary-active-text': 'hsla(var(--figma___tabs-primary-active-text));', // ✦ Theme/Tabs/Primary/Active/Text
-  'figma-tabs-primary-active-underline': 'hsla(var(--figma___tabs-primary-active-underline));', // ✦ Theme/Tabs/Primary/Active/Underline
-  'figma-tabs-primary-border': 'hsla(var(--figma___tabs-primary-border));', // ✦ Theme/Tabs/Primary/Border
-  'figma-tabs-primary-default-background': 'hsla(var(--figma___tabs-primary-default-background));', // ✦ Theme/Tabs/Primary/Default/Background
-  'figma-tabs-primary-default-text': 'hsla(var(--figma___tabs-primary-default-text));', // ✦ Theme/Tabs/Primary/Default/Text
-  'figma-tabs-primary-hover-background': 'hsla(var(--figma___tabs-primary-hover-background));', // ✦ Theme/Tabs/Primary/Hover/Background
-  'figma-tabs-primary-hover-text': 'hsla(var(--figma___tabs-primary-hover-text));', // ✦ Theme/Tabs/Primary/Hover/Text
-  'figma-tabs-primary-pills-pills': 'hsla(var(--figma___tabs-primary-pills-pills));', // ✦ Theme/Tabs/Primary/Pills/Pills
-  'figma-text-disabled': 'hsla(var(--figma___text-disabled));', // ✦ Theme/Text/Disabled
-  'figma-text-links': 'hsla(var(--figma___text-links));', // ✦ Theme/Text/Links
-  'figma-text-secondary': 'hsla(var(--figma___text-secondary));', // ✦ Theme/Text/Secondary
-  'figma-text-tertiary': 'hsla(var(--figma___text-tertiary));', // ✦ Theme/Text/Tertiary
-  'figma-text-primary': 'hsla(var(--figma___text-primary));', // ✦ Theme/Text/primary
-  'figma-textfield-assistive-text-primary': 'hsla(var(--figma___textfield-assistive-text-primary));', // ✦ Theme/Textfield/Assistive Text/Primary
-  'figma-textfield-background': 'hsla(var(--figma___textfield-background));', // ✦ Theme/Textfield/Background
-  'figma-textfield-input-field-background': 'hsla(var(--figma___textfield-input-field-background));', // ✦ Theme/Textfield/Input Field/Background
-  'figma-textfield-input-field-default': 'hsla(var(--figma___textfield-input-field-default));', // ✦ Theme/Textfield/Input Field/Default
-  'figma-textfield-input-field-error': 'hsla(var(--figma___textfield-input-field-error));', // ✦ Theme/Textfield/Input Field/Error
-  'figma-textfield-input-field-hover': 'hsla(var(--figma___textfield-input-field-hover));', // ✦ Theme/Textfield/Input Field/Hover
-  'figma-textfield-label-info-icon': 'hsla(var(--figma___textfield-label-info-icon));', // ✦ Theme/Textfield/Label/Info Icon
-  'figma-textfield-label-link': 'hsla(var(--figma___textfield-label-link));', // ✦ Theme/Textfield/Label/Link
-  'figma-textfield-label-main': 'hsla(var(--figma___textfield-label-main));', // ✦ Theme/Textfield/Label/Main
-  'figma-textfield-label-optional': 'hsla(var(--figma___textfield-label-optional));', // ✦ Theme/Textfield/Label/Optional
-  'figma-textfield-pin-soft-background': 'hsla(var(--figma___textfield-pin-soft-background));', // ✦ Theme/Textfield/Pin/Soft/Background
-  'figma-textfield-pin-soft-border': 'hsla(var(--figma___textfield-pin-soft-border));', // ✦ Theme/Textfield/Pin/Soft/border
-  'figma-textfield-pin-soft-pin': 'hsla(var(--figma___textfield-pin-soft-pin));', // ✦ Theme/Textfield/Pin/Soft/pin
-  'figma-textfield-pin-surface-background': 'hsla(var(--figma___textfield-pin-surface-background));', // ✦ Theme/Textfield/Pin/Surface/Background
-  'figma-textfield-pin-surface-border': 'hsla(var(--figma___textfield-pin-surface-border));', // ✦ Theme/Textfield/Pin/Surface/border
-  'figma-textfield-pin-surface-pin': 'hsla(var(--figma___textfield-pin-surface-pin));', // ✦ Theme/Textfield/Pin/Surface/pin
-  'figma-tooltip-background': 'hsla(var(--figma___tooltip-background));', // ✦ Theme/Tooltip/Background
-  'figma-tooltip-body-text': 'hsla(var(--figma___tooltip-body-text));', // ✦ Theme/Tooltip/Body Text
-  'figma-tooltip-dismissable-icon': 'hsla(var(--figma___tooltip-dismissable-icon));', // ✦ Theme/Tooltip/Dismissable icon
-  'figma-tooltip-tooltip-title': 'hsla(var(--figma___tooltip-tooltip-title));' // ✦ Theme/Tooltip/Tooltip Title
+  'figma-semantic-background-backdrop': 'hsla(var(--figma___semantic-background-backdrop));', // ✦ Theme/Semantic/Background/Backdrop
+  'figma-semantic-background-cards-and-rows-default':
+    'hsla(var(--figma___semantic-background-cards-and-rows-default));', // ✦ Theme/Semantic/Background/Cards and Rows/Default
+  'figma-semantic-background-cards-and-rows-hover': 'hsla(var(--figma___semantic-background-cards-and-rows-hover));', // ✦ Theme/Semantic/Background/Cards and Rows/Hover
+  'figma-semantic-background-cards-and-rows-primary-blue-selected':
+    'hsla(var(--figma___semantic-background-cards-and-rows-primary-blue-selected));', // ✦ Theme/Semantic/Background/Cards and Rows/Primary-blue-selected
+  'figma-semantic-background-cards-and-rows-selected':
+    'hsla(var(--figma___semantic-background-cards-and-rows-selected));', // ✦ Theme/Semantic/Background/Cards and Rows/Selected
+  'figma-semantic-background-header-page-header': 'hsla(var(--figma___semantic-background-header-page-header));', // ✦ Theme/Semantic/Background/Header/Page Header
+  'figma-semantic-background-header-table-header': 'hsla(var(--figma___semantic-background-header-table-header));', // ✦ Theme/Semantic/Background/Header/Table Header
+  'figma-semantic-background-paper': 'hsla(var(--figma___semantic-background-paper));', // ✦ Theme/Semantic/Background/Paper
+  'figma-semantic-background-primary': 'hsla(var(--figma___semantic-background-primary));', // ✦ Theme/Semantic/Background/Primary
+  'figma-semantic-background-solid': 'hsla(var(--figma___semantic-background-solid));', // ✦ Theme/Semantic/Background/Solid
+  'figma-semantic-border-disabled': 'hsla(var(--figma___semantic-border-disabled));', // ✦ Theme/Semantic/Border/Disabled
+  'figma-semantic-border-hover': 'hsla(var(--figma___semantic-border-hover));', // ✦ Theme/Semantic/Border/Hover
+  'figma-semantic-border-primary': 'hsla(var(--figma___semantic-border-primary));', // ✦ Theme/Semantic/Border/Primary
+  'figma-semantic-border-secondary': 'hsla(var(--figma___semantic-border-secondary));', // ✦ Theme/Semantic/Border/Secondary
+  'figma-semantic-border-selected': 'hsla(var(--figma___semantic-border-selected));', // ✦ Theme/Semantic/Border/Selected
+  'figma-semantic-text-disabled': 'hsla(var(--figma___semantic-text-disabled));', // ✦ Theme/Semantic/Text/Disabled
+  'figma-semantic-text-links': 'hsla(var(--figma___semantic-text-links));', // ✦ Theme/Semantic/Text/Links
+  'figma-semantic-text-secondary': 'hsla(var(--figma___semantic-text-secondary));', // ✦ Theme/Semantic/Text/Secondary
+  'figma-semantic-text-tertiary': 'hsla(var(--figma___semantic-text-tertiary));', // ✦ Theme/Semantic/Text/Tertiary
+  'figma-semantic-text-primary': 'hsla(var(--figma___semantic-text-primary));' // ✦ Theme/Semantic/Text/primary
 }

--- a/packages/canary/src/style-tokens/colors.ts
+++ b/packages/canary/src/style-tokens/colors.ts
@@ -1,0 +1,953 @@
+module.exports = {
+  'figma-background-backdrop': 'hsla(var(--figma___background-backdrop));', // ✦ Theme/Background/Backdrop
+  'figma-background-cards-and-rows-default': 'hsla(var(--figma___background-cards-and-rows-default));', // ✦ Theme/Background/Cards and Rows/Default
+  'figma-background-cards-and-rows-hover': 'hsla(var(--figma___background-cards-and-rows-hover));', // ✦ Theme/Background/Cards and Rows/Hover
+  'figma-background-cards-and-rows-primary-blue-selected':
+    'hsla(var(--figma___background-cards-and-rows-primary-blue-selected));', // ✦ Theme/Background/Cards and Rows/Primary-blue-selected
+  'figma-background-cards-and-rows-selected': 'hsla(var(--figma___background-cards-and-rows-selected));', // ✦ Theme/Background/Cards and Rows/Selected
+  'figma-background-header-page-header': 'hsla(var(--figma___background-header-page-header));', // ✦ Theme/Background/Header/Page Header
+  'figma-background-header-table-header': 'hsla(var(--figma___background-header-table-header));', // ✦ Theme/Background/Header/Table Header
+  'figma-background-paper': 'hsla(var(--figma___background-paper));', // ✦ Theme/Background/Paper
+  'figma-background-primary': 'hsla(var(--figma___background-primary));', // ✦ Theme/Background/Primary
+  'figma-background-solid': 'hsla(var(--figma___background-solid));', // ✦ Theme/Background/Solid
+  'figma-badges-soft-amber-background': 'hsla(var(--figma___badges-soft-amber-background));', // ✦ Theme/Badges/Soft/Amber/background
+  'figma-badges-soft-amber-text': 'hsla(var(--figma___badges-soft-amber-text));', // ✦ Theme/Badges/Soft/Amber/text
+  'figma-badges-soft-blue-background': 'hsla(var(--figma___badges-soft-blue-background));', // ✦ Theme/Badges/Soft/Blue/background
+  'figma-badges-soft-blue-text': 'hsla(var(--figma___badges-soft-blue-text));', // ✦ Theme/Badges/Soft/Blue/text
+  'figma-badges-soft-bronze-background': 'hsla(var(--figma___badges-soft-bronze-background));', // ✦ Theme/Badges/Soft/Bronze/background
+  'figma-badges-soft-bronze-text': 'hsla(var(--figma___badges-soft-bronze-text));', // ✦ Theme/Badges/Soft/Bronze/text
+  'figma-badges-soft-brown-background': 'hsla(var(--figma___badges-soft-brown-background));', // ✦ Theme/Badges/Soft/Brown/background
+  'figma-badges-soft-brown-text': 'hsla(var(--figma___badges-soft-brown-text));', // ✦ Theme/Badges/Soft/Brown/text
+  'figma-badges-soft-crimson-background': 'hsla(var(--figma___badges-soft-crimson-background));', // ✦ Theme/Badges/Soft/Crimson/background
+  'figma-badges-soft-crimson-text': 'hsla(var(--figma___badges-soft-crimson-text));', // ✦ Theme/Badges/Soft/Crimson/text
+  'figma-badges-soft-cyan-background': 'hsla(var(--figma___badges-soft-cyan-background));', // ✦ Theme/Badges/Soft/Cyan/background
+  'figma-badges-soft-cyan-text': 'hsla(var(--figma___badges-soft-cyan-text));', // ✦ Theme/Badges/Soft/Cyan/text
+  'figma-badges-soft-gold-background': 'hsla(var(--figma___badges-soft-gold-background));', // ✦ Theme/Badges/Soft/Gold/background
+  'figma-badges-soft-gold-text': 'hsla(var(--figma___badges-soft-gold-text));', // ✦ Theme/Badges/Soft/Gold/text
+  'figma-badges-soft-grass-background': 'hsla(var(--figma___badges-soft-grass-background));', // ✦ Theme/Badges/Soft/Grass/background
+  'figma-badges-soft-grass-text': 'hsla(var(--figma___badges-soft-grass-text));', // ✦ Theme/Badges/Soft/Grass/text
+  'figma-badges-soft-green-background': 'hsla(var(--figma___badges-soft-green-background));', // ✦ Theme/Badges/Soft/Green/background
+  'figma-badges-soft-green-text': 'hsla(var(--figma___badges-soft-green-text));', // ✦ Theme/Badges/Soft/Green/text
+  'figma-badges-soft-indigo-background': 'hsla(var(--figma___badges-soft-indigo-background));', // ✦ Theme/Badges/Soft/Indigo/background
+  'figma-badges-soft-indigo-text': 'hsla(var(--figma___badges-soft-indigo-text));', // ✦ Theme/Badges/Soft/Indigo/text
+  'figma-badges-soft-iris-background': 'hsla(var(--figma___badges-soft-iris-background));', // ✦ Theme/Badges/Soft/Iris/background
+  'figma-badges-soft-iris-text': 'hsla(var(--figma___badges-soft-iris-text));', // ✦ Theme/Badges/Soft/Iris/text
+  'figma-badges-soft-jade-background': 'hsla(var(--figma___badges-soft-jade-background));', // ✦ Theme/Badges/Soft/Jade/background
+  'figma-badges-soft-jade-text': 'hsla(var(--figma___badges-soft-jade-text));', // ✦ Theme/Badges/Soft/Jade/text
+  'figma-badges-soft-lime-background': 'hsla(var(--figma___badges-soft-lime-background));', // ✦ Theme/Badges/Soft/Lime/background
+  'figma-badges-soft-lime-text': 'hsla(var(--figma___badges-soft-lime-text));', // ✦ Theme/Badges/Soft/Lime/text
+  'figma-badges-soft-mint-background': 'hsla(var(--figma___badges-soft-mint-background));', // ✦ Theme/Badges/Soft/Mint/background
+  'figma-badges-soft-mint-text': 'hsla(var(--figma___badges-soft-mint-text));', // ✦ Theme/Badges/Soft/Mint/text
+  'figma-badges-soft-orange-background': 'hsla(var(--figma___badges-soft-orange-background));', // ✦ Theme/Badges/Soft/Orange/background
+  'figma-badges-soft-orange-text': 'hsla(var(--figma___badges-soft-orange-text));', // ✦ Theme/Badges/Soft/Orange/text
+  'figma-badges-soft-pink-background': 'hsla(var(--figma___badges-soft-pink-background));', // ✦ Theme/Badges/Soft/Pink/background
+  'figma-badges-soft-pink-text': 'hsla(var(--figma___badges-soft-pink-text));', // ✦ Theme/Badges/Soft/Pink/text
+  'figma-badges-soft-plum-background': 'hsla(var(--figma___badges-soft-plum-background));', // ✦ Theme/Badges/Soft/Plum/background
+  'figma-badges-soft-plum-text': 'hsla(var(--figma___badges-soft-plum-text));', // ✦ Theme/Badges/Soft/Plum/text
+  'figma-badges-soft-purple-background': 'hsla(var(--figma___badges-soft-purple-background));', // ✦ Theme/Badges/Soft/Purple/background
+  'figma-badges-soft-purple-text': 'hsla(var(--figma___badges-soft-purple-text));', // ✦ Theme/Badges/Soft/Purple/text
+  'figma-badges-soft-red-background': 'hsla(var(--figma___badges-soft-red-background));', // ✦ Theme/Badges/Soft/Red/background
+  'figma-badges-soft-red-text': 'hsla(var(--figma___badges-soft-red-text));', // ✦ Theme/Badges/Soft/Red/text
+  'figma-badges-soft-ruby-background': 'hsla(var(--figma___badges-soft-ruby-background));', // ✦ Theme/Badges/Soft/Ruby/background
+  'figma-badges-soft-ruby-text': 'hsla(var(--figma___badges-soft-ruby-text));', // ✦ Theme/Badges/Soft/Ruby/text
+  'figma-badges-soft-sky-background': 'hsla(var(--figma___badges-soft-sky-background));', // ✦ Theme/Badges/Soft/Sky/background
+  'figma-badges-soft-sky-text': 'hsla(var(--figma___badges-soft-sky-text));', // ✦ Theme/Badges/Soft/Sky/text
+  'figma-badges-soft-teal-background': 'hsla(var(--figma___badges-soft-teal-background));', // ✦ Theme/Badges/Soft/Teal/background
+  'figma-badges-soft-teal-text': 'hsla(var(--figma___badges-soft-teal-text));', // ✦ Theme/Badges/Soft/Teal/text
+  'figma-badges-soft-violet-background': 'hsla(var(--figma___badges-soft-violet-background));', // ✦ Theme/Badges/Soft/Violet/background
+  'figma-badges-soft-violet-text': 'hsla(var(--figma___badges-soft-violet-text));', // ✦ Theme/Badges/Soft/Violet/text
+  'figma-badges-soft-yellow-background': 'hsla(var(--figma___badges-soft-yellow-background));', // ✦ Theme/Badges/Soft/Yellow/background
+  'figma-badges-soft-yellow-text': 'hsla(var(--figma___badges-soft-yellow-text));', // ✦ Theme/Badges/Soft/Yellow/text
+  'figma-badges-soft-accent-background': 'hsla(var(--figma___badges-soft-accent-background));', // ✦ Theme/Badges/Soft/accent/background
+  'figma-badges-soft-accent-text': 'hsla(var(--figma___badges-soft-accent-text));', // ✦ Theme/Badges/Soft/accent/text
+  'figma-badges-soft-error-background': 'hsla(var(--figma___badges-soft-error-background));', // ✦ Theme/Badges/Soft/error/background
+  'figma-badges-soft-error-text': 'hsla(var(--figma___badges-soft-error-text));', // ✦ Theme/Badges/Soft/error/text
+  'figma-badges-soft-info-background': 'hsla(var(--figma___badges-soft-info-background));', // ✦ Theme/Badges/Soft/info/background
+  'figma-badges-soft-info-text': 'hsla(var(--figma___badges-soft-info-text));', // ✦ Theme/Badges/Soft/info/text
+  'figma-badges-soft-success-background': 'hsla(var(--figma___badges-soft-success-background));', // ✦ Theme/Badges/Soft/success/background
+  'figma-badges-soft-success-text': 'hsla(var(--figma___badges-soft-success-text));', // ✦ Theme/Badges/Soft/success/text
+  'figma-badges-soft-warning-background': 'hsla(var(--figma___badges-soft-warning-background));', // ✦ Theme/Badges/Soft/warning/background
+  'figma-badges-soft-warning-text': 'hsla(var(--figma___badges-soft-warning-text));', // ✦ Theme/Badges/Soft/warning/text
+  'figma-badges-solid-amber-background': 'hsla(var(--figma___badges-solid-amber-background));', // ✦ Theme/Badges/Solid/Amber/background
+  'figma-badges-solid-amber-text': 'hsla(var(--figma___badges-solid-amber-text));', // ✦ Theme/Badges/Solid/Amber/text
+  'figma-badges-solid-blue-background': 'hsla(var(--figma___badges-solid-blue-background));', // ✦ Theme/Badges/Solid/Blue/background
+  'figma-badges-solid-blue-text': 'hsla(var(--figma___badges-solid-blue-text));', // ✦ Theme/Badges/Solid/Blue/text
+  'figma-badges-solid-bronze-background': 'hsla(var(--figma___badges-solid-bronze-background));', // ✦ Theme/Badges/Solid/Bronze/background
+  'figma-badges-solid-bronze-text': 'hsla(var(--figma___badges-solid-bronze-text));', // ✦ Theme/Badges/Solid/Bronze/text
+  'figma-badges-solid-brown-background': 'hsla(var(--figma___badges-solid-brown-background));', // ✦ Theme/Badges/Solid/Brown/background
+  'figma-badges-solid-brown-text': 'hsla(var(--figma___badges-solid-brown-text));', // ✦ Theme/Badges/Solid/Brown/text
+  'figma-badges-solid-crimson-background': 'hsla(var(--figma___badges-solid-crimson-background));', // ✦ Theme/Badges/Solid/Crimson/background
+  'figma-badges-solid-crimson-text': 'hsla(var(--figma___badges-solid-crimson-text));', // ✦ Theme/Badges/Solid/Crimson/text
+  'figma-badges-solid-cyan-background': 'hsla(var(--figma___badges-solid-cyan-background));', // ✦ Theme/Badges/Solid/Cyan/background
+  'figma-badges-solid-cyan-text': 'hsla(var(--figma___badges-solid-cyan-text));', // ✦ Theme/Badges/Solid/Cyan/text
+  'figma-badges-solid-gold-background': 'hsla(var(--figma___badges-solid-gold-background));', // ✦ Theme/Badges/Solid/Gold/background
+  'figma-badges-solid-gold-text': 'hsla(var(--figma___badges-solid-gold-text));', // ✦ Theme/Badges/Solid/Gold/text
+  'figma-badges-solid-grass-background': 'hsla(var(--figma___badges-solid-grass-background));', // ✦ Theme/Badges/Solid/Grass/background
+  'figma-badges-solid-grass-text': 'hsla(var(--figma___badges-solid-grass-text));', // ✦ Theme/Badges/Solid/Grass/text
+  'figma-badges-solid-green-background': 'hsla(var(--figma___badges-solid-green-background));', // ✦ Theme/Badges/Solid/Green/background
+  'figma-badges-solid-green-text': 'hsla(var(--figma___badges-solid-green-text));', // ✦ Theme/Badges/Solid/Green/text
+  'figma-badges-solid-indigo-background': 'hsla(var(--figma___badges-solid-indigo-background));', // ✦ Theme/Badges/Solid/Indigo/background
+  'figma-badges-solid-indigo-text': 'hsla(var(--figma___badges-solid-indigo-text));', // ✦ Theme/Badges/Solid/Indigo/text
+  'figma-badges-solid-iris-background': 'hsla(var(--figma___badges-solid-iris-background));', // ✦ Theme/Badges/Solid/Iris/background
+  'figma-badges-solid-iris-text': 'hsla(var(--figma___badges-solid-iris-text));', // ✦ Theme/Badges/Solid/Iris/text
+  'figma-badges-solid-jade-background': 'hsla(var(--figma___badges-solid-jade-background));', // ✦ Theme/Badges/Solid/Jade/background
+  'figma-badges-solid-jade-text': 'hsla(var(--figma___badges-solid-jade-text));', // ✦ Theme/Badges/Solid/Jade/text
+  'figma-badges-solid-lime-background': 'hsla(var(--figma___badges-solid-lime-background));', // ✦ Theme/Badges/Solid/Lime/background
+  'figma-badges-solid-lime-text': 'hsla(var(--figma___badges-solid-lime-text));', // ✦ Theme/Badges/Solid/Lime/text
+  'figma-badges-solid-mint-background': 'hsla(var(--figma___badges-solid-mint-background));', // ✦ Theme/Badges/Solid/Mint/background
+  'figma-badges-solid-mint-text': 'hsla(var(--figma___badges-solid-mint-text));', // ✦ Theme/Badges/Solid/Mint/text
+  'figma-badges-solid-orange-background': 'hsla(var(--figma___badges-solid-orange-background));', // ✦ Theme/Badges/Solid/Orange/background
+  'figma-badges-solid-orange-text': 'hsla(var(--figma___badges-solid-orange-text));', // ✦ Theme/Badges/Solid/Orange/text
+  'figma-badges-solid-pink-background': 'hsla(var(--figma___badges-solid-pink-background));', // ✦ Theme/Badges/Solid/Pink/background
+  'figma-badges-solid-pink-text': 'hsla(var(--figma___badges-solid-pink-text));', // ✦ Theme/Badges/Solid/Pink/text
+  'figma-badges-solid-plum-background': 'hsla(var(--figma___badges-solid-plum-background));', // ✦ Theme/Badges/Solid/Plum/background
+  'figma-badges-solid-plum-text': 'hsla(var(--figma___badges-solid-plum-text));', // ✦ Theme/Badges/Solid/Plum/text
+  'figma-badges-solid-purple-background': 'hsla(var(--figma___badges-solid-purple-background));', // ✦ Theme/Badges/Solid/Purple/background
+  'figma-badges-solid-purple-text': 'hsla(var(--figma___badges-solid-purple-text));', // ✦ Theme/Badges/Solid/Purple/text
+  'figma-badges-solid-red-background': 'hsla(var(--figma___badges-solid-red-background));', // ✦ Theme/Badges/Solid/Red/background
+  'figma-badges-solid-red-text': 'hsla(var(--figma___badges-solid-red-text));', // ✦ Theme/Badges/Solid/Red/text
+  'figma-badges-solid-ruby-background': 'hsla(var(--figma___badges-solid-ruby-background));', // ✦ Theme/Badges/Solid/Ruby/background
+  'figma-badges-solid-ruby-text': 'hsla(var(--figma___badges-solid-ruby-text));', // ✦ Theme/Badges/Solid/Ruby/text
+  'figma-badges-solid-sky-background': 'hsla(var(--figma___badges-solid-sky-background));', // ✦ Theme/Badges/Solid/Sky/background
+  'figma-badges-solid-sky-text': 'hsla(var(--figma___badges-solid-sky-text));', // ✦ Theme/Badges/Solid/Sky/text
+  'figma-badges-solid-success-background': 'hsla(var(--figma___badges-solid-success-background));', // ✦ Theme/Badges/Solid/Success/background
+  'figma-badges-solid-success-text': 'hsla(var(--figma___badges-solid-success-text));', // ✦ Theme/Badges/Solid/Success/text
+  'figma-badges-solid-teal-background': 'hsla(var(--figma___badges-solid-teal-background));', // ✦ Theme/Badges/Solid/Teal/background
+  'figma-badges-solid-teal-text': 'hsla(var(--figma___badges-solid-teal-text));', // ✦ Theme/Badges/Solid/Teal/text
+  'figma-badges-solid-violet-background': 'hsla(var(--figma___badges-solid-violet-background));', // ✦ Theme/Badges/Solid/Violet/background
+  'figma-badges-solid-violet-text': 'hsla(var(--figma___badges-solid-violet-text));', // ✦ Theme/Badges/Solid/Violet/text
+  'figma-badges-solid-yellow-background': 'hsla(var(--figma___badges-solid-yellow-background));', // ✦ Theme/Badges/Solid/Yellow/background
+  'figma-badges-solid-yellow-text': 'hsla(var(--figma___badges-solid-yellow-text));', // ✦ Theme/Badges/Solid/Yellow/text
+  'figma-badges-solid-accent-background': 'hsla(var(--figma___badges-solid-accent-background));', // ✦ Theme/Badges/Solid/accent/background
+  'figma-badges-solid-accent-text': 'hsla(var(--figma___badges-solid-accent-text));', // ✦ Theme/Badges/Solid/accent/text
+  'figma-badges-solid-info-background': 'hsla(var(--figma___badges-solid-info-background));', // ✦ Theme/Badges/Solid/info/background
+  'figma-badges-solid-info-text': 'hsla(var(--figma___badges-solid-info-text));', // ✦ Theme/Badges/Solid/info/text
+  'figma-badges-solid-warning-background': 'hsla(var(--figma___badges-solid-warning-background));', // ✦ Theme/Badges/Solid/warning/background
+  'figma-badges-solid-warning-text': 'hsla(var(--figma___badges-solid-warning-text));', // ✦ Theme/Badges/Solid/warning/text
+  'figma-badges-surface-amber-background': 'hsla(var(--figma___badges-surface-amber-background));', // ✦ Theme/Badges/Surface/Amber/background
+  'figma-badges-surface-amber-border': 'hsla(var(--figma___badges-surface-amber-border));', // ✦ Theme/Badges/Surface/Amber/border
+  'figma-badges-surface-amber-text': 'hsla(var(--figma___badges-surface-amber-text));', // ✦ Theme/Badges/Surface/Amber/text
+  'figma-badges-surface-blue-background': 'hsla(var(--figma___badges-surface-blue-background));', // ✦ Theme/Badges/Surface/Blue/background
+  'figma-badges-surface-blue-border': 'hsla(var(--figma___badges-surface-blue-border));', // ✦ Theme/Badges/Surface/Blue/border
+  'figma-badges-surface-blue-text': 'hsla(var(--figma___badges-surface-blue-text));', // ✦ Theme/Badges/Surface/Blue/text
+  'figma-badges-surface-bronze-background': 'hsla(var(--figma___badges-surface-bronze-background));', // ✦ Theme/Badges/Surface/Bronze/background
+  'figma-badges-surface-bronze-border': 'hsla(var(--figma___badges-surface-bronze-border));', // ✦ Theme/Badges/Surface/Bronze/border
+  'figma-badges-surface-bronze-text': 'hsla(var(--figma___badges-surface-bronze-text));', // ✦ Theme/Badges/Surface/Bronze/text
+  'figma-badges-surface-brown-background': 'hsla(var(--figma___badges-surface-brown-background));', // ✦ Theme/Badges/Surface/Brown/background
+  'figma-badges-surface-brown-border': 'hsla(var(--figma___badges-surface-brown-border));', // ✦ Theme/Badges/Surface/Brown/border
+  'figma-badges-surface-brown-text': 'hsla(var(--figma___badges-surface-brown-text));', // ✦ Theme/Badges/Surface/Brown/text
+  'figma-badges-surface-crimson-border': 'hsla(var(--figma___badges-surface-crimson-border));', // ✦ Theme/Badges/Surface/Crimson/Border
+  'figma-badges-surface-crimson-background': 'hsla(var(--figma___badges-surface-crimson-background));', // ✦ Theme/Badges/Surface/Crimson/background
+  'figma-badges-surface-crimson-text': 'hsla(var(--figma___badges-surface-crimson-text));', // ✦ Theme/Badges/Surface/Crimson/text
+  'figma-badges-surface-cyan-border': 'hsla(var(--figma___badges-surface-cyan-border));', // ✦ Theme/Badges/Surface/Cyan/Border
+  'figma-badges-surface-cyan-background': 'hsla(var(--figma___badges-surface-cyan-background));', // ✦ Theme/Badges/Surface/Cyan/background
+  'figma-badges-surface-cyan-text': 'hsla(var(--figma___badges-surface-cyan-text));', // ✦ Theme/Badges/Surface/Cyan/text
+  'figma-badges-surface-gold-border': 'hsla(var(--figma___badges-surface-gold-border));', // ✦ Theme/Badges/Surface/Gold/Border
+  'figma-badges-surface-gold-background': 'hsla(var(--figma___badges-surface-gold-background));', // ✦ Theme/Badges/Surface/Gold/background
+  'figma-badges-surface-gold-text': 'hsla(var(--figma___badges-surface-gold-text));', // ✦ Theme/Badges/Surface/Gold/text
+  'figma-badges-surface-grass-border': 'hsla(var(--figma___badges-surface-grass-border));', // ✦ Theme/Badges/Surface/Grass/Border
+  'figma-badges-surface-grass-background': 'hsla(var(--figma___badges-surface-grass-background));', // ✦ Theme/Badges/Surface/Grass/background
+  'figma-badges-surface-grass-text': 'hsla(var(--figma___badges-surface-grass-text));', // ✦ Theme/Badges/Surface/Grass/text
+  'figma-badges-surface-green-background': 'hsla(var(--figma___badges-surface-green-background));', // ✦ Theme/Badges/Surface/Green/background
+  'figma-badges-surface-green-border': 'hsla(var(--figma___badges-surface-green-border));', // ✦ Theme/Badges/Surface/Green/border
+  'figma-badges-surface-green-text': 'hsla(var(--figma___badges-surface-green-text));', // ✦ Theme/Badges/Surface/Green/text
+  'figma-badges-surface-indigo-background': 'hsla(var(--figma___badges-surface-indigo-background));', // ✦ Theme/Badges/Surface/Indigo/background
+  'figma-badges-surface-indigo-border': 'hsla(var(--figma___badges-surface-indigo-border));', // ✦ Theme/Badges/Surface/Indigo/border
+  'figma-badges-surface-indigo-text': 'hsla(var(--figma___badges-surface-indigo-text));', // ✦ Theme/Badges/Surface/Indigo/text
+  'figma-badges-surface-iris-border': 'hsla(var(--figma___badges-surface-iris-border));', // ✦ Theme/Badges/Surface/Iris/Border
+  'figma-badges-surface-iris-background': 'hsla(var(--figma___badges-surface-iris-background));', // ✦ Theme/Badges/Surface/Iris/background
+  'figma-badges-surface-iris-text': 'hsla(var(--figma___badges-surface-iris-text));', // ✦ Theme/Badges/Surface/Iris/text
+  'figma-badges-surface-jade-border': 'hsla(var(--figma___badges-surface-jade-border));', // ✦ Theme/Badges/Surface/Jade/Border
+  'figma-badges-surface-jade-background': 'hsla(var(--figma___badges-surface-jade-background));', // ✦ Theme/Badges/Surface/Jade/background
+  'figma-badges-surface-jade-text': 'hsla(var(--figma___badges-surface-jade-text));', // ✦ Theme/Badges/Surface/Jade/text
+  'figma-badges-surface-lime-border': 'hsla(var(--figma___badges-surface-lime-border));', // ✦ Theme/Badges/Surface/Lime/Border
+  'figma-badges-surface-lime-background': 'hsla(var(--figma___badges-surface-lime-background));', // ✦ Theme/Badges/Surface/Lime/background
+  'figma-badges-surface-lime-text': 'hsla(var(--figma___badges-surface-lime-text));', // ✦ Theme/Badges/Surface/Lime/text
+  'figma-badges-surface-mint-background': 'hsla(var(--figma___badges-surface-mint-background));', // ✦ Theme/Badges/Surface/Mint/background
+  'figma-badges-surface-mint-border': 'hsla(var(--figma___badges-surface-mint-border));', // ✦ Theme/Badges/Surface/Mint/border
+  'figma-badges-surface-mint-text': 'hsla(var(--figma___badges-surface-mint-text));', // ✦ Theme/Badges/Surface/Mint/text
+  'figma-badges-surface-orange-background': 'hsla(var(--figma___badges-surface-orange-background));', // ✦ Theme/Badges/Surface/Orange/background
+  'figma-badges-surface-orange-border': 'hsla(var(--figma___badges-surface-orange-border));', // ✦ Theme/Badges/Surface/Orange/border
+  'figma-badges-surface-orange-text': 'hsla(var(--figma___badges-surface-orange-text));', // ✦ Theme/Badges/Surface/Orange/text
+  'figma-badges-surface-pink-background': 'hsla(var(--figma___badges-surface-pink-background));', // ✦ Theme/Badges/Surface/Pink/background
+  'figma-badges-surface-pink-border': 'hsla(var(--figma___badges-surface-pink-border));', // ✦ Theme/Badges/Surface/Pink/border
+  'figma-badges-surface-pink-text': 'hsla(var(--figma___badges-surface-pink-text));', // ✦ Theme/Badges/Surface/Pink/text
+  'figma-badges-surface-plum-background': 'hsla(var(--figma___badges-surface-plum-background));', // ✦ Theme/Badges/Surface/Plum/background
+  'figma-badges-surface-plum-border': 'hsla(var(--figma___badges-surface-plum-border));', // ✦ Theme/Badges/Surface/Plum/border
+  'figma-badges-surface-plum-text': 'hsla(var(--figma___badges-surface-plum-text));', // ✦ Theme/Badges/Surface/Plum/text
+  'figma-badges-surface-purple-background': 'hsla(var(--figma___badges-surface-purple-background));', // ✦ Theme/Badges/Surface/Purple/background
+  'figma-badges-surface-purple-border': 'hsla(var(--figma___badges-surface-purple-border));', // ✦ Theme/Badges/Surface/Purple/border
+  'figma-badges-surface-purple-text': 'hsla(var(--figma___badges-surface-purple-text));', // ✦ Theme/Badges/Surface/Purple/text
+  'figma-badges-surface-red-background': 'hsla(var(--figma___badges-surface-red-background));', // ✦ Theme/Badges/Surface/Red/background
+  'figma-badges-surface-red-border': 'hsla(var(--figma___badges-surface-red-border));', // ✦ Theme/Badges/Surface/Red/border
+  'figma-badges-surface-red-text': 'hsla(var(--figma___badges-surface-red-text));', // ✦ Theme/Badges/Surface/Red/text
+  'figma-badges-surface-ruby-background': 'hsla(var(--figma___badges-surface-ruby-background));', // ✦ Theme/Badges/Surface/Ruby/background
+  'figma-badges-surface-ruby-border': 'hsla(var(--figma___badges-surface-ruby-border));', // ✦ Theme/Badges/Surface/Ruby/border
+  'figma-badges-surface-ruby-text': 'hsla(var(--figma___badges-surface-ruby-text));', // ✦ Theme/Badges/Surface/Ruby/text
+  'figma-badges-surface-sky-background': 'hsla(var(--figma___badges-surface-sky-background));', // ✦ Theme/Badges/Surface/Sky/background
+  'figma-badges-surface-sky-border': 'hsla(var(--figma___badges-surface-sky-border));', // ✦ Theme/Badges/Surface/Sky/border
+  'figma-badges-surface-sky-text': 'hsla(var(--figma___badges-surface-sky-text));', // ✦ Theme/Badges/Surface/Sky/text
+  'figma-badges-surface-teal-background': 'hsla(var(--figma___badges-surface-teal-background));', // ✦ Theme/Badges/Surface/Teal/background
+  'figma-badges-surface-teal-border': 'hsla(var(--figma___badges-surface-teal-border));', // ✦ Theme/Badges/Surface/Teal/border
+  'figma-badges-surface-teal-text': 'hsla(var(--figma___badges-surface-teal-text));', // ✦ Theme/Badges/Surface/Teal/text
+  'figma-badges-surface-violet-background': 'hsla(var(--figma___badges-surface-violet-background));', // ✦ Theme/Badges/Surface/Violet/background
+  'figma-badges-surface-violet-border': 'hsla(var(--figma___badges-surface-violet-border));', // ✦ Theme/Badges/Surface/Violet/border
+  'figma-badges-surface-violet-text': 'hsla(var(--figma___badges-surface-violet-text));', // ✦ Theme/Badges/Surface/Violet/text
+  'figma-badges-surface-yellow-background': 'hsla(var(--figma___badges-surface-yellow-background));', // ✦ Theme/Badges/Surface/Yellow/background
+  'figma-badges-surface-yellow-border': 'hsla(var(--figma___badges-surface-yellow-border));', // ✦ Theme/Badges/Surface/Yellow/border
+  'figma-badges-surface-yellow-text': 'hsla(var(--figma___badges-surface-yellow-text));', // ✦ Theme/Badges/Surface/Yellow/text
+  'figma-badges-surface-accent-background': 'hsla(var(--figma___badges-surface-accent-background));', // ✦ Theme/Badges/Surface/accent/background
+  'figma-badges-surface-accent-border': 'hsla(var(--figma___badges-surface-accent-border));', // ✦ Theme/Badges/Surface/accent/border
+  'figma-badges-surface-accent-text': 'hsla(var(--figma___badges-surface-accent-text));', // ✦ Theme/Badges/Surface/accent/text
+  'figma-badges-surface-error-background': 'hsla(var(--figma___badges-surface-error-background));', // ✦ Theme/Badges/Surface/error/background
+  'figma-badges-surface-error-border': 'hsla(var(--figma___badges-surface-error-border));', // ✦ Theme/Badges/Surface/error/border
+  'figma-badges-surface-error-text': 'hsla(var(--figma___badges-surface-error-text));', // ✦ Theme/Badges/Surface/error/text
+  'figma-badges-surface-info-background': 'hsla(var(--figma___badges-surface-info-background));', // ✦ Theme/Badges/Surface/info/background
+  'figma-badges-surface-info-border': 'hsla(var(--figma___badges-surface-info-border));', // ✦ Theme/Badges/Surface/info/border
+  'figma-badges-surface-info-text': 'hsla(var(--figma___badges-surface-info-text));', // ✦ Theme/Badges/Surface/info/text
+  'figma-badges-surface-success-background': 'hsla(var(--figma___badges-surface-success-background));', // ✦ Theme/Badges/Surface/success/background
+  'figma-badges-surface-success-border': 'hsla(var(--figma___badges-surface-success-border));', // ✦ Theme/Badges/Surface/success/border
+  'figma-badges-surface-success-text': 'hsla(var(--figma___badges-surface-success-text));', // ✦ Theme/Badges/Surface/success/text
+  'figma-badges-surface-warning-background': 'hsla(var(--figma___badges-surface-warning-background));', // ✦ Theme/Badges/Surface/warning/background
+  'figma-badges-surface-warning-border': 'hsla(var(--figma___badges-surface-warning-border));', // ✦ Theme/Badges/Surface/warning/border
+  'figma-badges-surface-warning-text': 'hsla(var(--figma___badges-surface-warning-text));', // ✦ Theme/Badges/Surface/warning/text
+  'figma-border-disabled': 'hsla(var(--figma___border-disabled));', // ✦ Theme/Border/Disabled
+  'figma-border-hover': 'hsla(var(--figma___border-hover));', // ✦ Theme/Border/Hover
+  'figma-border-primary': 'hsla(var(--figma___border-primary));', // ✦ Theme/Border/Primary
+  'figma-border-secondary': 'hsla(var(--figma___border-secondary));', // ✦ Theme/Border/Secondary
+  'figma-border-selected': 'hsla(var(--figma___border-selected));', // ✦ Theme/Border/Selected
+  'figma-breadcrumbs-current': 'hsla(var(--figma___breadcrumbs-current));', // ✦ Theme/Breadcrumbs/current
+  'figma-breadcrumbs-visited': 'hsla(var(--figma___breadcrumbs-visited));', // ✦ Theme/Breadcrumbs/visited
+  'figma-button-ghost-accent-active': 'hsla(var(--figma___button-ghost-accent-active));', // ✦ Theme/Button/Ghost/Accent/Active
+  'figma-button-ghost-accent-active-text': 'hsla(var(--figma___button-ghost-accent-active-text));', // ✦ Theme/Button/Ghost/Accent/Active text
+  'figma-button-ghost-accent-hover': 'hsla(var(--figma___button-ghost-accent-hover));', // ✦ Theme/Button/Ghost/Accent/Hover
+  'figma-button-ghost-accent-hover-text': 'hsla(var(--figma___button-ghost-accent-hover-text));', // ✦ Theme/Button/Ghost/Accent/Hover text
+  'figma-button-ghost-accent-text-disabled': 'hsla(var(--figma___button-ghost-accent-text-disabled));', // ✦ Theme/Button/Ghost/Accent/Text-disabled
+  'figma-button-ghost-accent-text-primary': 'hsla(var(--figma___button-ghost-accent-text-primary));', // ✦ Theme/Button/Ghost/Accent/Text-primary
+  'figma-button-ghost-error-active': 'hsla(var(--figma___button-ghost-error-active));', // ✦ Theme/Button/Ghost/Error/Active
+  'figma-button-ghost-error-active-text': 'hsla(var(--figma___button-ghost-error-active-text));', // ✦ Theme/Button/Ghost/Error/Active Text
+  'figma-button-ghost-error-hover': 'hsla(var(--figma___button-ghost-error-hover));', // ✦ Theme/Button/Ghost/Error/Hover
+  'figma-button-ghost-error-hover-text': 'hsla(var(--figma___button-ghost-error-hover-text));', // ✦ Theme/Button/Ghost/Error/Hover text
+  'figma-button-ghost-error-text-disabled': 'hsla(var(--figma___button-ghost-error-text-disabled));', // ✦ Theme/Button/Ghost/Error/Text-disabled
+  'figma-button-ghost-error-text-primary': 'hsla(var(--figma___button-ghost-error-text-primary));', // ✦ Theme/Button/Ghost/Error/Text-primary
+  'figma-button-ghost-neutral-active': 'hsla(var(--figma___button-ghost-neutral-active));', // ✦ Theme/Button/Ghost/Neutral/Active
+  'figma-button-ghost-neutral-active-text': 'hsla(var(--figma___button-ghost-neutral-active-text));', // ✦ Theme/Button/Ghost/Neutral/Active Text
+  'figma-button-ghost-neutral-hover': 'hsla(var(--figma___button-ghost-neutral-hover));', // ✦ Theme/Button/Ghost/Neutral/Hover
+  'figma-button-ghost-neutral-hover-text': 'hsla(var(--figma___button-ghost-neutral-hover-text));', // ✦ Theme/Button/Ghost/Neutral/Hover text
+  'figma-button-ghost-neutral-text-disabled': 'hsla(var(--figma___button-ghost-neutral-text-disabled));', // ✦ Theme/Button/Ghost/Neutral/Text-disabled
+  'figma-button-ghost-neutral-text-primary': 'hsla(var(--figma___button-ghost-neutral-text-primary));', // ✦ Theme/Button/Ghost/Neutral/Text-primary
+  'figma-button-ghost-success-active': 'hsla(var(--figma___button-ghost-success-active));', // ✦ Theme/Button/Ghost/Success/Active
+  'figma-button-ghost-success-active-text': 'hsla(var(--figma___button-ghost-success-active-text));', // ✦ Theme/Button/Ghost/Success/Active Text
+  'figma-button-ghost-success-hover': 'hsla(var(--figma___button-ghost-success-hover));', // ✦ Theme/Button/Ghost/Success/Hover
+  'figma-button-ghost-success-hover-text': 'hsla(var(--figma___button-ghost-success-hover-text));', // ✦ Theme/Button/Ghost/Success/Hover text
+  'figma-button-ghost-success-text-disabled': 'hsla(var(--figma___button-ghost-success-text-disabled));', // ✦ Theme/Button/Ghost/Success/Text-disabled
+  'figma-button-ghost-success-text-primary': 'hsla(var(--figma___button-ghost-success-text-primary));', // ✦ Theme/Button/Ghost/Success/Text-primary
+  'figma-button-outline-accent-active': 'hsla(var(--figma___button-outline-accent-active));', // ✦ Theme/Button/Outline/Accent/Active
+  'figma-button-outline-accent-default-border': 'hsla(var(--figma___button-outline-accent-default-border));', // ✦ Theme/Button/Outline/Accent/Default border
+  'figma-button-outline-accent-disabled-border': 'hsla(var(--figma___button-outline-accent-disabled-border));', // ✦ Theme/Button/Outline/Accent/Disabled Border
+  'figma-button-outline-accent-hover': 'hsla(var(--figma___button-outline-accent-hover));', // ✦ Theme/Button/Outline/Accent/Hover
+  'figma-button-outline-accent-text-disabled': 'hsla(var(--figma___button-outline-accent-text-disabled));', // ✦ Theme/Button/Outline/Accent/Text-disabled
+  'figma-button-outline-accent-text-primary': 'hsla(var(--figma___button-outline-accent-text-primary));', // ✦ Theme/Button/Outline/Accent/Text-primary
+  'figma-button-outline-error-active': 'hsla(var(--figma___button-outline-error-active));', // ✦ Theme/Button/Outline/Error/Active
+  'figma-button-outline-error-default-border': 'hsla(var(--figma___button-outline-error-default-border));', // ✦ Theme/Button/Outline/Error/Default - border
+  'figma-button-outline-error-disabled-border': 'hsla(var(--figma___button-outline-error-disabled-border));', // ✦ Theme/Button/Outline/Error/Disabled-border
+  'figma-button-outline-error-hover': 'hsla(var(--figma___button-outline-error-hover));', // ✦ Theme/Button/Outline/Error/Hover
+  'figma-button-outline-error-text-disabled': 'hsla(var(--figma___button-outline-error-text-disabled));', // ✦ Theme/Button/Outline/Error/Text-disabled
+  'figma-button-outline-error-text-primary': 'hsla(var(--figma___button-outline-error-text-primary));', // ✦ Theme/Button/Outline/Error/Text-primary
+  'figma-button-outline-neutral-active': 'hsla(var(--figma___button-outline-neutral-active));', // ✦ Theme/Button/Outline/Neutral/Active
+  'figma-button-outline-neutral-default-border': 'hsla(var(--figma___button-outline-neutral-default-border));', // ✦ Theme/Button/Outline/Neutral/Default - border
+  'figma-button-outline-neutral-disabled-border': 'hsla(var(--figma___button-outline-neutral-disabled-border));', // ✦ Theme/Button/Outline/Neutral/Disabled - border
+  'figma-button-outline-neutral-hover': 'hsla(var(--figma___button-outline-neutral-hover));', // ✦ Theme/Button/Outline/Neutral/Hover
+  'figma-button-outline-neutral-text-disabled': 'hsla(var(--figma___button-outline-neutral-text-disabled));', // ✦ Theme/Button/Outline/Neutral/Text-disabled
+  'figma-button-outline-neutral-text-primary': 'hsla(var(--figma___button-outline-neutral-text-primary));', // ✦ Theme/Button/Outline/Neutral/Text-primary
+  'figma-button-outline-success-active': 'hsla(var(--figma___button-outline-success-active));', // ✦ Theme/Button/Outline/Success/Active
+  'figma-button-outline-success-default-border': 'hsla(var(--figma___button-outline-success-default-border));', // ✦ Theme/Button/Outline/Success/Default-border
+  'figma-button-outline-success-disabled-border': 'hsla(var(--figma___button-outline-success-disabled-border));', // ✦ Theme/Button/Outline/Success/Disabled - border
+  'figma-button-outline-success-hover': 'hsla(var(--figma___button-outline-success-hover));', // ✦ Theme/Button/Outline/Success/Hover
+  'figma-button-outline-success-text-disabled': 'hsla(var(--figma___button-outline-success-text-disabled));', // ✦ Theme/Button/Outline/Success/Text-disabled
+  'figma-button-outline-success-text-primary': 'hsla(var(--figma___button-outline-success-text-primary));', // ✦ Theme/Button/Outline/Success/Text-primary
+  'figma-button-soft-accent-active': 'hsla(var(--figma___button-soft-accent-active));', // ✦ Theme/Button/Soft/Accent/Active
+  'figma-button-soft-accent-disabled': 'hsla(var(--figma___button-soft-accent-disabled));', // ✦ Theme/Button/Soft/Accent/Disabled
+  'figma-button-soft-accent-hover': 'hsla(var(--figma___button-soft-accent-hover));', // ✦ Theme/Button/Soft/Accent/Hover
+  'figma-button-soft-accent-text-disabled': 'hsla(var(--figma___button-soft-accent-text-disabled));', // ✦ Theme/Button/Soft/Accent/Text-disabled
+  'figma-button-soft-accent-text-primary': 'hsla(var(--figma___button-soft-accent-text-primary));', // ✦ Theme/Button/Soft/Accent/Text-primary
+  'figma-button-soft-accent-default': 'hsla(var(--figma___button-soft-accent-default));', // ✦ Theme/Button/Soft/Accent/default
+  'figma-button-soft-error-active': 'hsla(var(--figma___button-soft-error-active));', // ✦ Theme/Button/Soft/Error/Active
+  'figma-button-soft-error-disabled': 'hsla(var(--figma___button-soft-error-disabled));', // ✦ Theme/Button/Soft/Error/Disabled
+  'figma-button-soft-error-hover': 'hsla(var(--figma___button-soft-error-hover));', // ✦ Theme/Button/Soft/Error/Hover
+  'figma-button-soft-error-text-disabled': 'hsla(var(--figma___button-soft-error-text-disabled));', // ✦ Theme/Button/Soft/Error/Text-disabled
+  'figma-button-soft-error-text-primary': 'hsla(var(--figma___button-soft-error-text-primary));', // ✦ Theme/Button/Soft/Error/Text-primary
+  'figma-button-soft-error-default': 'hsla(var(--figma___button-soft-error-default));', // ✦ Theme/Button/Soft/Error/default
+  'figma-button-soft-neutral-active': 'hsla(var(--figma___button-soft-neutral-active));', // ✦ Theme/Button/Soft/Neutral/Active
+  'figma-button-soft-neutral-disabled': 'hsla(var(--figma___button-soft-neutral-disabled));', // ✦ Theme/Button/Soft/Neutral/Disabled
+  'figma-button-soft-neutral-hover': 'hsla(var(--figma___button-soft-neutral-hover));', // ✦ Theme/Button/Soft/Neutral/Hover
+  'figma-button-soft-neutral-text-disabled': 'hsla(var(--figma___button-soft-neutral-text-disabled));', // ✦ Theme/Button/Soft/Neutral/Text-disabled
+  'figma-button-soft-neutral-text-primary': 'hsla(var(--figma___button-soft-neutral-text-primary));', // ✦ Theme/Button/Soft/Neutral/Text-primary
+  'figma-button-soft-neutral-default': 'hsla(var(--figma___button-soft-neutral-default));', // ✦ Theme/Button/Soft/Neutral/default
+  'figma-button-soft-success-active': 'hsla(var(--figma___button-soft-success-active));', // ✦ Theme/Button/Soft/Success/Active
+  'figma-button-soft-success-disabled': 'hsla(var(--figma___button-soft-success-disabled));', // ✦ Theme/Button/Soft/Success/Disabled
+  'figma-button-soft-success-hover': 'hsla(var(--figma___button-soft-success-hover));', // ✦ Theme/Button/Soft/Success/Hover
+  'figma-button-soft-success-text-disabled': 'hsla(var(--figma___button-soft-success-text-disabled));', // ✦ Theme/Button/Soft/Success/Text-disabled
+  'figma-button-soft-success-text-primary': 'hsla(var(--figma___button-soft-success-text-primary));', // ✦ Theme/Button/Soft/Success/Text-primary
+  'figma-button-soft-success-default': 'hsla(var(--figma___button-soft-success-default));', // ✦ Theme/Button/Soft/Success/default
+  'figma-button-solid-accent-active': 'hsla(var(--figma___button-solid-accent-active));', // ✦ Theme/Button/Solid/Accent/Active
+  'figma-button-solid-accent-disabled': 'hsla(var(--figma___button-solid-accent-disabled));', // ✦ Theme/Button/Solid/Accent/Disabled
+  'figma-button-solid-accent-hover': 'hsla(var(--figma___button-solid-accent-hover));', // ✦ Theme/Button/Solid/Accent/Hover
+  'figma-button-solid-accent-text-disabled': 'hsla(var(--figma___button-solid-accent-text-disabled));', // ✦ Theme/Button/Solid/Accent/Text-disabled
+  'figma-button-solid-accent-text-primary': 'hsla(var(--figma___button-solid-accent-text-primary));', // ✦ Theme/Button/Solid/Accent/Text-primary
+  'figma-button-solid-accent-default': 'hsla(var(--figma___button-solid-accent-default));', // ✦ Theme/Button/Solid/Accent/default
+  'figma-button-solid-error-active': 'hsla(var(--figma___button-solid-error-active));', // ✦ Theme/Button/Solid/Error/Active
+  'figma-button-solid-error-disabled': 'hsla(var(--figma___button-solid-error-disabled));', // ✦ Theme/Button/Solid/Error/Disabled
+  'figma-button-solid-error-hover': 'hsla(var(--figma___button-solid-error-hover));', // ✦ Theme/Button/Solid/Error/Hover
+  'figma-button-solid-error-text-disabled': 'hsla(var(--figma___button-solid-error-text-disabled));', // ✦ Theme/Button/Solid/Error/Text-disabled
+  'figma-button-solid-error-text-primary': 'hsla(var(--figma___button-solid-error-text-primary));', // ✦ Theme/Button/Solid/Error/Text-primary
+  'figma-button-solid-error-default': 'hsla(var(--figma___button-solid-error-default));', // ✦ Theme/Button/Solid/Error/default
+  'figma-button-solid-neutral-active': 'hsla(var(--figma___button-solid-neutral-active));', // ✦ Theme/Button/Solid/Neutral/Active
+  'figma-button-solid-neutral-disabled': 'hsla(var(--figma___button-solid-neutral-disabled));', // ✦ Theme/Button/Solid/Neutral/Disabled
+  'figma-button-solid-neutral-hover': 'hsla(var(--figma___button-solid-neutral-hover));', // ✦ Theme/Button/Solid/Neutral/Hover
+  'figma-button-solid-neutral-text-disabled': 'hsla(var(--figma___button-solid-neutral-text-disabled));', // ✦ Theme/Button/Solid/Neutral/Text-disabled
+  'figma-button-solid-neutral-text-primary': 'hsla(var(--figma___button-solid-neutral-text-primary));', // ✦ Theme/Button/Solid/Neutral/Text-primary
+  'figma-button-solid-neutral-default': 'hsla(var(--figma___button-solid-neutral-default));', // ✦ Theme/Button/Solid/Neutral/default
+  'figma-button-solid-success-active': 'hsla(var(--figma___button-solid-success-active));', // ✦ Theme/Button/Solid/Success/Active
+  'figma-button-solid-success-disabled': 'hsla(var(--figma___button-solid-success-disabled));', // ✦ Theme/Button/Solid/Success/Disabled
+  'figma-button-solid-success-hover': 'hsla(var(--figma___button-solid-success-hover));', // ✦ Theme/Button/Solid/Success/Hover
+  'figma-button-solid-success-text-disabled': 'hsla(var(--figma___button-solid-success-text-disabled));', // ✦ Theme/Button/Solid/Success/Text-disabled
+  'figma-button-solid-success-text-primary': 'hsla(var(--figma___button-solid-success-text-primary));', // ✦ Theme/Button/Solid/Success/Text-primary
+  'figma-button-solid-success-default': 'hsla(var(--figma___button-solid-success-default));', // ✦ Theme/Button/Solid/Success/default
+  'figma-button-surface-accent-active': 'hsla(var(--figma___button-surface-accent-active));', // ✦ Theme/Button/Surface/Accent/Active
+  'figma-button-surface-accent-active-border': 'hsla(var(--figma___button-surface-accent-active-border));', // ✦ Theme/Button/Surface/Accent/Active border
+  'figma-button-surface-accent-disabled': 'hsla(var(--figma___button-surface-accent-disabled));', // ✦ Theme/Button/Surface/Accent/Disabled
+  'figma-button-surface-accent-hover': 'hsla(var(--figma___button-surface-accent-hover));', // ✦ Theme/Button/Surface/Accent/Hover
+  'figma-button-surface-accent-hover-border': 'hsla(var(--figma___button-surface-accent-hover-border));', // ✦ Theme/Button/Surface/Accent/Hover Border
+  'figma-button-surface-accent-text-disabled': 'hsla(var(--figma___button-surface-accent-text-disabled));', // ✦ Theme/Button/Surface/Accent/Text-disabled
+  'figma-button-surface-accent-text-primary': 'hsla(var(--figma___button-surface-accent-text-primary));', // ✦ Theme/Button/Surface/Accent/Text-primary
+  'figma-button-surface-accent-default': 'hsla(var(--figma___button-surface-accent-default));', // ✦ Theme/Button/Surface/Accent/default
+  'figma-button-surface-accent-default-border': 'hsla(var(--figma___button-surface-accent-default-border));', // ✦ Theme/Button/Surface/Accent/default border
+  'figma-button-surface-error-active': 'hsla(var(--figma___button-surface-error-active));', // ✦ Theme/Button/Surface/Error/Active
+  'figma-button-surface-error-active-border': 'hsla(var(--figma___button-surface-error-active-border));', // ✦ Theme/Button/Surface/Error/Active border
+  'figma-button-surface-error-disabled': 'hsla(var(--figma___button-surface-error-disabled));', // ✦ Theme/Button/Surface/Error/Disabled
+  'figma-button-surface-error-hover': 'hsla(var(--figma___button-surface-error-hover));', // ✦ Theme/Button/Surface/Error/Hover
+  'figma-button-surface-error-hover-border': 'hsla(var(--figma___button-surface-error-hover-border));', // ✦ Theme/Button/Surface/Error/Hover border
+  'figma-button-surface-error-text-disabled': 'hsla(var(--figma___button-surface-error-text-disabled));', // ✦ Theme/Button/Surface/Error/Text-disabled
+  'figma-button-surface-error-text-primary': 'hsla(var(--figma___button-surface-error-text-primary));', // ✦ Theme/Button/Surface/Error/Text-primary
+  'figma-button-surface-error-border': 'hsla(var(--figma___button-surface-error-border));', // ✦ Theme/Button/Surface/Error/border
+  'figma-button-surface-error-default': 'hsla(var(--figma___button-surface-error-default));', // ✦ Theme/Button/Surface/Error/default
+  'figma-button-surface-neutral-active': 'hsla(var(--figma___button-surface-neutral-active));', // ✦ Theme/Button/Surface/Neutral/Active
+  'figma-button-surface-neutral-disabled': 'hsla(var(--figma___button-surface-neutral-disabled));', // ✦ Theme/Button/Surface/Neutral/Disabled
+  'figma-button-surface-neutral-hover': 'hsla(var(--figma___button-surface-neutral-hover));', // ✦ Theme/Button/Surface/Neutral/Hover
+  'figma-button-surface-neutral-text-disabled': 'hsla(var(--figma___button-surface-neutral-text-disabled));', // ✦ Theme/Button/Surface/Neutral/Text-disabled
+  'figma-button-surface-neutral-text-primary': 'hsla(var(--figma___button-surface-neutral-text-primary));', // ✦ Theme/Button/Surface/Neutral/Text-primary
+  'figma-button-surface-neutral-border': 'hsla(var(--figma___button-surface-neutral-border));', // ✦ Theme/Button/Surface/Neutral/border
+  'figma-button-surface-neutral-default': 'hsla(var(--figma___button-surface-neutral-default));', // ✦ Theme/Button/Surface/Neutral/default
+  'figma-button-surface-success-active': 'hsla(var(--figma___button-surface-success-active));', // ✦ Theme/Button/Surface/Success/Active
+  'figma-button-surface-success-disabled': 'hsla(var(--figma___button-surface-success-disabled));', // ✦ Theme/Button/Surface/Success/Disabled
+  'figma-button-surface-success-hover': 'hsla(var(--figma___button-surface-success-hover));', // ✦ Theme/Button/Surface/Success/Hover
+  'figma-button-surface-success-hover-border': 'hsla(var(--figma___button-surface-success-hover-border));', // ✦ Theme/Button/Surface/Success/Hover border
+  'figma-button-surface-success-text-disabled': 'hsla(var(--figma___button-surface-success-text-disabled));', // ✦ Theme/Button/Surface/Success/Text-disabled
+  'figma-button-surface-success-text-primary': 'hsla(var(--figma___button-surface-success-text-primary));', // ✦ Theme/Button/Surface/Success/Text-primary
+  'figma-button-surface-success-active-border': 'hsla(var(--figma___button-surface-success-active-border));', // ✦ Theme/Button/Surface/Success/active border
+  'figma-button-surface-success-default': 'hsla(var(--figma___button-surface-success-default));', // ✦ Theme/Button/Surface/Success/default
+  'figma-button-surface-success-default-border': 'hsla(var(--figma___button-surface-success-default-border));', // ✦ Theme/Button/Surface/Success/default border
+  'figma-calendar-background': 'hsla(var(--figma___calendar-background));', // ✦ Theme/Calendar/Background
+  'figma-calendar-selected-date-background': 'hsla(var(--figma___calendar-selected-date-background));', // ✦ Theme/Calendar/Selected Date/Background
+  'figma-calendar-selected-date-text': 'hsla(var(--figma___calendar-selected-date-text));', // ✦ Theme/Calendar/Selected Date/Text
+  'figma-calendar-selected-range-background': 'hsla(var(--figma___calendar-selected-range-background));', // ✦ Theme/Calendar/Selected Range/Background
+  'figma-calendar-selected-range-text': 'hsla(var(--figma___calendar-selected-range-text));', // ✦ Theme/Calendar/Selected Range/Text
+  'figma-checkbox-background': 'hsla(var(--figma___checkbox-background));', // ✦ Theme/Checkbox/Background
+  'figma-checkbox-paper': 'hsla(var(--figma___checkbox-paper));', // ✦ Theme/Checkbox/Paper
+  'figma-checkbox-surface-checked-active-active': 'hsla(var(--figma___checkbox-surface-checked-active-active));', // ✦ Theme/Checkbox/Surface/Checked/Active/Active
+  'figma-checkbox-surface-checked-active-check': 'hsla(var(--figma___checkbox-surface-checked-active-check));', // ✦ Theme/Checkbox/Surface/Checked/Active/Check
+  'figma-checkbox-surface-checked-active-hover': 'hsla(var(--figma___checkbox-surface-checked-active-hover));', // ✦ Theme/Checkbox/Surface/Checked/Active/Hover
+  'figma-checkbox-surface-checked-active-default-background':
+    'hsla(var(--figma___checkbox-surface-checked-active-default-background));', // ✦ Theme/Checkbox/Surface/Checked/Active/default background
+  'figma-checkbox-surface-checked-disabled-check': 'hsla(var(--figma___checkbox-surface-checked-disabled-check));', // ✦ Theme/Checkbox/Surface/Checked/Disabled/Check
+  'figma-checkbox-surface-checked-disabled-disabled':
+    'hsla(var(--figma___checkbox-surface-checked-disabled-disabled));', // ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled
+  'figma-checkbox-surface-checked-disabled-border': 'hsla(var(--figma___checkbox-surface-checked-disabled-border));', // ✦ Theme/Checkbox/Surface/Checked/Disabled/border
+  'figma-checkbox-surface-intermediate-active-active-border':
+    'hsla(var(--figma___checkbox-surface-intermediate-active-active-border));', // ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border
+  'figma-checkbox-surface-intermediate-active-check':
+    'hsla(var(--figma___checkbox-surface-intermediate-active-check));', // ✦ Theme/Checkbox/Surface/Intermediate/Active/Check
+  'figma-checkbox-surface-intermediate-active-hover-border':
+    'hsla(var(--figma___checkbox-surface-intermediate-active-hover-border));', // ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border
+  'figma-checkbox-surface-intermediate-active-default-background':
+    'hsla(var(--figma___checkbox-surface-intermediate-active-default-background));', // ✦ Theme/Checkbox/Surface/Intermediate/Active/default background
+  'figma-checkbox-surface-intermediate-active-default-border':
+    'hsla(var(--figma___checkbox-surface-intermediate-active-default-border));', // ✦ Theme/Checkbox/Surface/Intermediate/Active/default border
+  'figma-checkbox-surface-intermediate-disabled-check':
+    'hsla(var(--figma___checkbox-surface-intermediate-disabled-check));', // ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check
+  'figma-checkbox-surface-intermediate-disabled-disabled':
+    'hsla(var(--figma___checkbox-surface-intermediate-disabled-disabled));', // ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled
+  'figma-checkbox-surface-intermediate-disabled-border':
+    'hsla(var(--figma___checkbox-surface-intermediate-disabled-border));', // ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border
+  'figma-checkbox-surface-unchecked-active-active-border':
+    'hsla(var(--figma___checkbox-surface-unchecked-active-active-border));', // ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border
+  'figma-checkbox-surface-unchecked-active-hover-border':
+    'hsla(var(--figma___checkbox-surface-unchecked-active-hover-border));', // ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border
+  'figma-checkbox-surface-unchecked-active-default-background':
+    'hsla(var(--figma___checkbox-surface-unchecked-active-default-background));', // ✦ Theme/Checkbox/Surface/Unchecked/Active/default background
+  'figma-checkbox-surface-unchecked-active-default-border':
+    'hsla(var(--figma___checkbox-surface-unchecked-active-default-border));', // ✦ Theme/Checkbox/Surface/Unchecked/Active/default border
+  'figma-checkbox-surface-unchecked-disabled-disabled':
+    'hsla(var(--figma___checkbox-surface-unchecked-disabled-disabled));', // ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled
+  'figma-checkbox-surface-unchecked-disabled-border':
+    'hsla(var(--figma___checkbox-surface-unchecked-disabled-border));', // ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border
+  'figma-checkbox-border': 'hsla(var(--figma___checkbox-border));', // ✦ Theme/Checkbox/border
+  'figma-default-colors-black': 'hsla(var(--figma___default-colors-black));', // ✦ Theme/Default colors/black
+  'figma-default-colors-dark-to-white': 'hsla(var(--figma___default-colors-dark-to-white));', // ✦ Theme/Default colors/dark-to-white
+  'figma-default-colors-white': 'hsla(var(--figma___default-colors-white));', // ✦ Theme/Default colors/white
+  'figma-default-colors-white-to-dark': 'hsla(var(--figma___default-colors-white-to-dark));', // ✦ Theme/Default colors/white-to-dark
+  'figma-dropdown-dropdown-item-default': 'hsla(var(--figma___dropdown-dropdown-item-default));', // ✦ Theme/Dropdown/Dropdown Item/Default
+  'figma-dropdown-dropdown-item-hover': 'hsla(var(--figma___dropdown-dropdown-item-hover));', // ✦ Theme/Dropdown/Dropdown Item/Hover
+  'figma-dropdown-dropdown-item-selected': 'hsla(var(--figma___dropdown-dropdown-item-selected));', // ✦ Theme/Dropdown/Dropdown Item/Selected
+  'figma-dropdown-text-shortcut-text-selected': 'hsla(var(--figma___dropdown-text-shortcut-text-selected));', // ✦ Theme/Dropdown/Text/Shortcut text selected
+  'figma-dropdown-text-text-selected': 'hsla(var(--figma___dropdown-text-text-selected));', // ✦ Theme/Dropdown/Text/Text Selected
+  'figma-dropdown-text-hover': 'hsla(var(--figma___dropdown-text-hover));', // ✦ Theme/Dropdown/Text/hover
+  'figma-dropdown-background': 'hsla(var(--figma___dropdown-background));', // ✦ Theme/Dropdown/background
+  'figma-dropdown-border': 'hsla(var(--figma___dropdown-border));', // ✦ Theme/Dropdown/border
+  'figma-dropdown-separator': 'hsla(var(--figma___dropdown-separator));', // ✦ Theme/Dropdown/separator
+  'figma-filter-active': 'hsla(var(--figma___filter-active));', // ✦ Theme/Filter/Active
+  'figma-filter-default': 'hsla(var(--figma___filter-default));', // ✦ Theme/Filter/Default
+  'figma-filter-hover': 'hsla(var(--figma___filter-hover));', // ✦ Theme/Filter/Hover
+  'figma-inline-alert-banner-customisable': 'hsla(var(--figma___inline-alert-banner-customisable));', // ✦ Theme/Inline Alert Banner/Customisable
+  'figma-inline-alert-banner-error': 'hsla(var(--figma___inline-alert-banner-error));', // ✦ Theme/Inline Alert Banner/Error
+  'figma-inline-alert-banner-info': 'hsla(var(--figma___inline-alert-banner-info));', // ✦ Theme/Inline Alert Banner/Info
+  'figma-inline-alert-banner-reminder': 'hsla(var(--figma___inline-alert-banner-reminder));', // ✦ Theme/Inline Alert Banner/Reminder
+  'figma-inline-alert-banner-success': 'hsla(var(--figma___inline-alert-banner-success));', // ✦ Theme/Inline Alert Banner/Success
+  'figma-inline-alert-banner-warning': 'hsla(var(--figma___inline-alert-banner-warning));', // ✦ Theme/Inline Alert Banner/Warning
+  'figma-modal-background': 'hsla(var(--figma___modal-background));', // ✦ Theme/Modal/Background
+  'figma-modal-paper': 'hsla(var(--figma___modal-paper));', // ✦ Theme/Modal/Paper
+  'figma-modal-border': 'hsla(var(--figma___modal-border));', // ✦ Theme/Modal/border
+  'figma-neutral-color-gray-1': 'hsla(var(--figma___neutral-color-gray-1));', // ✦ Theme/Neutral color/Gray/1
+  'figma-neutral-color-gray-2': 'hsla(var(--figma___neutral-color-gray-2));', // ✦ Theme/Neutral color/Gray/2
+  'figma-neutral-color-gray-3': 'hsla(var(--figma___neutral-color-gray-3));', // ✦ Theme/Neutral color/Gray/3
+  'figma-neutral-color-gray-4': 'hsla(var(--figma___neutral-color-gray-4));', // ✦ Theme/Neutral color/Gray/4
+  'figma-neutral-color-gray-5': 'hsla(var(--figma___neutral-color-gray-5));', // ✦ Theme/Neutral color/Gray/5
+  'figma-neutral-color-gray-6': 'hsla(var(--figma___neutral-color-gray-6));', // ✦ Theme/Neutral color/Gray/6
+  'figma-neutral-color-gray-7': 'hsla(var(--figma___neutral-color-gray-7));', // ✦ Theme/Neutral color/Gray/7
+  'figma-neutral-color-gray-8': 'hsla(var(--figma___neutral-color-gray-8));', // ✦ Theme/Neutral color/Gray/8
+  'figma-neutral-color-gray-9': 'hsla(var(--figma___neutral-color-gray-9));', // ✦ Theme/Neutral color/Gray/9
+  'figma-neutral-color-gray-10': 'hsla(var(--figma___neutral-color-gray-10));', // ✦ Theme/Neutral color/Gray/10
+  'figma-neutral-color-gray-alpha-1': 'hsla(var(--figma___neutral-color-gray-alpha-1));', // ✦ Theme/Neutral color/Gray Alpha/1
+  'figma-neutral-color-gray-alpha-2': 'hsla(var(--figma___neutral-color-gray-alpha-2));', // ✦ Theme/Neutral color/Gray Alpha/2
+  'figma-neutral-color-gray-alpha-3': 'hsla(var(--figma___neutral-color-gray-alpha-3));', // ✦ Theme/Neutral color/Gray Alpha/3
+  'figma-neutral-color-gray-alpha-4': 'hsla(var(--figma___neutral-color-gray-alpha-4));', // ✦ Theme/Neutral color/Gray Alpha/4
+  'figma-neutral-color-gray-alpha-5': 'hsla(var(--figma___neutral-color-gray-alpha-5));', // ✦ Theme/Neutral color/Gray Alpha/5
+  'figma-neutral-color-gray-alpha-6': 'hsla(var(--figma___neutral-color-gray-alpha-6));', // ✦ Theme/Neutral color/Gray Alpha/6
+  'figma-neutral-color-gray-alpha-7': 'hsla(var(--figma___neutral-color-gray-alpha-7));', // ✦ Theme/Neutral color/Gray Alpha/7
+  'figma-neutral-color-gray-alpha-8': 'hsla(var(--figma___neutral-color-gray-alpha-8));', // ✦ Theme/Neutral color/Gray Alpha/8
+  'figma-neutral-color-gray-alpha-9': 'hsla(var(--figma___neutral-color-gray-alpha-9));', // ✦ Theme/Neutral color/Gray Alpha/9
+  'figma-neutral-color-gray-alpha-10': 'hsla(var(--figma___neutral-color-gray-alpha-10));', // ✦ Theme/Neutral color/Gray Alpha/10
+  'figma-other-colors-ai-violet-1': 'hsla(var(--figma___other-colors-ai-violet-1));', // ✦ Theme/Other Colors/AI Violet/1
+  'figma-other-colors-ai-violet-2': 'hsla(var(--figma___other-colors-ai-violet-2));', // ✦ Theme/Other Colors/AI Violet/2
+  'figma-other-colors-ai-violet-3': 'hsla(var(--figma___other-colors-ai-violet-3));', // ✦ Theme/Other Colors/AI Violet/3
+  'figma-other-colors-ai-violet-4': 'hsla(var(--figma___other-colors-ai-violet-4));', // ✦ Theme/Other Colors/AI Violet/4
+  'figma-other-colors-ai-violet-5': 'hsla(var(--figma___other-colors-ai-violet-5));', // ✦ Theme/Other Colors/AI Violet/5
+  'figma-other-colors-ai-violet-6': 'hsla(var(--figma___other-colors-ai-violet-6));', // ✦ Theme/Other Colors/AI Violet/6
+  'figma-other-colors-ai-violet-7': 'hsla(var(--figma___other-colors-ai-violet-7));', // ✦ Theme/Other Colors/AI Violet/7
+  'figma-other-colors-ai-violet-8': 'hsla(var(--figma___other-colors-ai-violet-8));', // ✦ Theme/Other Colors/AI Violet/8
+  'figma-other-colors-ai-violet-9': 'hsla(var(--figma___other-colors-ai-violet-9));', // ✦ Theme/Other Colors/AI Violet/9
+  'figma-other-colors-ai-violet-10': 'hsla(var(--figma___other-colors-ai-violet-10));', // ✦ Theme/Other Colors/AI Violet/10
+  'figma-other-colors-ai-violet-alpha-1': 'hsla(var(--figma___other-colors-ai-violet-alpha-1));', // ✦ Theme/Other Colors/AI Violet Alpha/1
+  'figma-other-colors-ai-violet-alpha-2': 'hsla(var(--figma___other-colors-ai-violet-alpha-2));', // ✦ Theme/Other Colors/AI Violet Alpha/2
+  'figma-other-colors-ai-violet-alpha-3': 'hsla(var(--figma___other-colors-ai-violet-alpha-3));', // ✦ Theme/Other Colors/AI Violet Alpha/3
+  'figma-other-colors-ai-violet-alpha-4': 'hsla(var(--figma___other-colors-ai-violet-alpha-4));', // ✦ Theme/Other Colors/AI Violet Alpha/4
+  'figma-other-colors-ai-violet-alpha-5': 'hsla(var(--figma___other-colors-ai-violet-alpha-5));', // ✦ Theme/Other Colors/AI Violet Alpha/5
+  'figma-other-colors-ai-violet-alpha-6': 'hsla(var(--figma___other-colors-ai-violet-alpha-6));', // ✦ Theme/Other Colors/AI Violet Alpha/6
+  'figma-other-colors-ai-violet-alpha-7': 'hsla(var(--figma___other-colors-ai-violet-alpha-7));', // ✦ Theme/Other Colors/AI Violet Alpha/7
+  'figma-other-colors-ai-violet-alpha-8': 'hsla(var(--figma___other-colors-ai-violet-alpha-8));', // ✦ Theme/Other Colors/AI Violet Alpha/8
+  'figma-other-colors-ai-violet-alpha-9': 'hsla(var(--figma___other-colors-ai-violet-alpha-9));', // ✦ Theme/Other Colors/AI Violet Alpha/9
+  'figma-other-colors-ai-violet-alpha-10': 'hsla(var(--figma___other-colors-ai-violet-alpha-10));', // ✦ Theme/Other Colors/AI Violet Alpha/10
+  'figma-other-colors-blue-1': 'hsla(var(--figma___other-colors-blue-1));', // ✦ Theme/Other Colors/Blue/1
+  'figma-other-colors-blue-2': 'hsla(var(--figma___other-colors-blue-2));', // ✦ Theme/Other Colors/Blue/2
+  'figma-other-colors-blue-3': 'hsla(var(--figma___other-colors-blue-3));', // ✦ Theme/Other Colors/Blue/3
+  'figma-other-colors-blue-4': 'hsla(var(--figma___other-colors-blue-4));', // ✦ Theme/Other Colors/Blue/4
+  'figma-other-colors-blue-5': 'hsla(var(--figma___other-colors-blue-5));', // ✦ Theme/Other Colors/Blue/5
+  'figma-other-colors-blue-6': 'hsla(var(--figma___other-colors-blue-6));', // ✦ Theme/Other Colors/Blue/6
+  'figma-other-colors-blue-7': 'hsla(var(--figma___other-colors-blue-7));', // ✦ Theme/Other Colors/Blue/7
+  'figma-other-colors-blue-8': 'hsla(var(--figma___other-colors-blue-8));', // ✦ Theme/Other Colors/Blue/8
+  'figma-other-colors-blue-9': 'hsla(var(--figma___other-colors-blue-9));', // ✦ Theme/Other Colors/Blue/9
+  'figma-other-colors-blue-10': 'hsla(var(--figma___other-colors-blue-10));', // ✦ Theme/Other Colors/Blue/10
+  'figma-other-colors-blue-alpha-1': 'hsla(var(--figma___other-colors-blue-alpha-1));', // ✦ Theme/Other Colors/Blue Alpha/1
+  'figma-other-colors-blue-alpha-2': 'hsla(var(--figma___other-colors-blue-alpha-2));', // ✦ Theme/Other Colors/Blue Alpha/2
+  'figma-other-colors-blue-alpha-3': 'hsla(var(--figma___other-colors-blue-alpha-3));', // ✦ Theme/Other Colors/Blue Alpha/3
+  'figma-other-colors-blue-alpha-4': 'hsla(var(--figma___other-colors-blue-alpha-4));', // ✦ Theme/Other Colors/Blue Alpha/4
+  'figma-other-colors-blue-alpha-5': 'hsla(var(--figma___other-colors-blue-alpha-5));', // ✦ Theme/Other Colors/Blue Alpha/5
+  'figma-other-colors-blue-alpha-6': 'hsla(var(--figma___other-colors-blue-alpha-6));', // ✦ Theme/Other Colors/Blue Alpha/6
+  'figma-other-colors-blue-alpha-7': 'hsla(var(--figma___other-colors-blue-alpha-7));', // ✦ Theme/Other Colors/Blue Alpha/7
+  'figma-other-colors-blue-alpha-8': 'hsla(var(--figma___other-colors-blue-alpha-8));', // ✦ Theme/Other Colors/Blue Alpha/8
+  'figma-other-colors-blue-alpha-9': 'hsla(var(--figma___other-colors-blue-alpha-9));', // ✦ Theme/Other Colors/Blue Alpha/9
+  'figma-other-colors-blue-alpha-10': 'hsla(var(--figma___other-colors-blue-alpha-10));', // ✦ Theme/Other Colors/Blue Alpha/10
+  'figma-other-colors-indigo-1': 'hsla(var(--figma___other-colors-indigo-1));', // ✦ Theme/Other Colors/Indigo/1
+  'figma-other-colors-indigo-2': 'hsla(var(--figma___other-colors-indigo-2));', // ✦ Theme/Other Colors/Indigo/2
+  'figma-other-colors-indigo-3': 'hsla(var(--figma___other-colors-indigo-3));', // ✦ Theme/Other Colors/Indigo/3
+  'figma-other-colors-indigo-4': 'hsla(var(--figma___other-colors-indigo-4));', // ✦ Theme/Other Colors/Indigo/4
+  'figma-other-colors-indigo-5': 'hsla(var(--figma___other-colors-indigo-5));', // ✦ Theme/Other Colors/Indigo/5
+  'figma-other-colors-indigo-6': 'hsla(var(--figma___other-colors-indigo-6));', // ✦ Theme/Other Colors/Indigo/6
+  'figma-other-colors-indigo-7': 'hsla(var(--figma___other-colors-indigo-7));', // ✦ Theme/Other Colors/Indigo/7
+  'figma-other-colors-indigo-8': 'hsla(var(--figma___other-colors-indigo-8));', // ✦ Theme/Other Colors/Indigo/8
+  'figma-other-colors-indigo-9': 'hsla(var(--figma___other-colors-indigo-9));', // ✦ Theme/Other Colors/Indigo/9
+  'figma-other-colors-indigo-10': 'hsla(var(--figma___other-colors-indigo-10));', // ✦ Theme/Other Colors/Indigo/10
+  'figma-other-colors-indigo-alpha-1': 'hsla(var(--figma___other-colors-indigo-alpha-1));', // ✦ Theme/Other Colors/Indigo Alpha/1
+  'figma-other-colors-indigo-alpha-2': 'hsla(var(--figma___other-colors-indigo-alpha-2));', // ✦ Theme/Other Colors/Indigo Alpha/2
+  'figma-other-colors-indigo-alpha-3': 'hsla(var(--figma___other-colors-indigo-alpha-3));', // ✦ Theme/Other Colors/Indigo Alpha/3
+  'figma-other-colors-indigo-alpha-4': 'hsla(var(--figma___other-colors-indigo-alpha-4));', // ✦ Theme/Other Colors/Indigo Alpha/4
+  'figma-other-colors-indigo-alpha-5': 'hsla(var(--figma___other-colors-indigo-alpha-5));', // ✦ Theme/Other Colors/Indigo Alpha/5
+  'figma-other-colors-indigo-alpha-6': 'hsla(var(--figma___other-colors-indigo-alpha-6));', // ✦ Theme/Other Colors/Indigo Alpha/6
+  'figma-other-colors-indigo-alpha-7': 'hsla(var(--figma___other-colors-indigo-alpha-7));', // ✦ Theme/Other Colors/Indigo Alpha/7
+  'figma-other-colors-indigo-alpha-8': 'hsla(var(--figma___other-colors-indigo-alpha-8));', // ✦ Theme/Other Colors/Indigo Alpha/8
+  'figma-other-colors-indigo-alpha-9': 'hsla(var(--figma___other-colors-indigo-alpha-9));', // ✦ Theme/Other Colors/Indigo Alpha/9
+  'figma-other-colors-indigo-alpha-10': 'hsla(var(--figma___other-colors-indigo-alpha-10));', // ✦ Theme/Other Colors/Indigo Alpha/10
+  'figma-other-colors-mint-1': 'hsla(var(--figma___other-colors-mint-1));', // ✦ Theme/Other Colors/Mint/1
+  'figma-other-colors-mint-2': 'hsla(var(--figma___other-colors-mint-2));', // ✦ Theme/Other Colors/Mint/2
+  'figma-other-colors-mint-3': 'hsla(var(--figma___other-colors-mint-3));', // ✦ Theme/Other Colors/Mint/3
+  'figma-other-colors-mint-4': 'hsla(var(--figma___other-colors-mint-4));', // ✦ Theme/Other Colors/Mint/4
+  'figma-other-colors-mint-5': 'hsla(var(--figma___other-colors-mint-5));', // ✦ Theme/Other Colors/Mint/5
+  'figma-other-colors-mint-6': 'hsla(var(--figma___other-colors-mint-6));', // ✦ Theme/Other Colors/Mint/6
+  'figma-other-colors-mint-7': 'hsla(var(--figma___other-colors-mint-7));', // ✦ Theme/Other Colors/Mint/7
+  'figma-other-colors-mint-8': 'hsla(var(--figma___other-colors-mint-8));', // ✦ Theme/Other Colors/Mint/8
+  'figma-other-colors-mint-9': 'hsla(var(--figma___other-colors-mint-9));', // ✦ Theme/Other Colors/Mint/9
+  'figma-other-colors-mint-10': 'hsla(var(--figma___other-colors-mint-10));', // ✦ Theme/Other Colors/Mint/10
+  'figma-other-colors-mint-alpha-1': 'hsla(var(--figma___other-colors-mint-alpha-1));', // ✦ Theme/Other Colors/Mint Alpha/1
+  'figma-other-colors-mint-alpha-2': 'hsla(var(--figma___other-colors-mint-alpha-2));', // ✦ Theme/Other Colors/Mint Alpha/2
+  'figma-other-colors-mint-alpha-3': 'hsla(var(--figma___other-colors-mint-alpha-3));', // ✦ Theme/Other Colors/Mint Alpha/3
+  'figma-other-colors-mint-alpha-4': 'hsla(var(--figma___other-colors-mint-alpha-4));', // ✦ Theme/Other Colors/Mint Alpha/4
+  'figma-other-colors-mint-alpha-5': 'hsla(var(--figma___other-colors-mint-alpha-5));', // ✦ Theme/Other Colors/Mint Alpha/5
+  'figma-other-colors-mint-alpha-6': 'hsla(var(--figma___other-colors-mint-alpha-6));', // ✦ Theme/Other Colors/Mint Alpha/6
+  'figma-other-colors-mint-alpha-7': 'hsla(var(--figma___other-colors-mint-alpha-7));', // ✦ Theme/Other Colors/Mint Alpha/7
+  'figma-other-colors-mint-alpha-8': 'hsla(var(--figma___other-colors-mint-alpha-8));', // ✦ Theme/Other Colors/Mint Alpha/8
+  'figma-other-colors-mint-alpha-9': 'hsla(var(--figma___other-colors-mint-alpha-9));', // ✦ Theme/Other Colors/Mint Alpha/9
+  'figma-other-colors-mint-alpha-10': 'hsla(var(--figma___other-colors-mint-alpha-10));', // ✦ Theme/Other Colors/Mint Alpha/10
+  'figma-other-colors-orange-1': 'hsla(var(--figma___other-colors-orange-1));', // ✦ Theme/Other Colors/Orange/1
+  'figma-other-colors-orange-2': 'hsla(var(--figma___other-colors-orange-2));', // ✦ Theme/Other Colors/Orange/2
+  'figma-other-colors-orange-3': 'hsla(var(--figma___other-colors-orange-3));', // ✦ Theme/Other Colors/Orange/3
+  'figma-other-colors-orange-4': 'hsla(var(--figma___other-colors-orange-4));', // ✦ Theme/Other Colors/Orange/4
+  'figma-other-colors-orange-5': 'hsla(var(--figma___other-colors-orange-5));', // ✦ Theme/Other Colors/Orange/5
+  'figma-other-colors-orange-6': 'hsla(var(--figma___other-colors-orange-6));', // ✦ Theme/Other Colors/Orange/6
+  'figma-other-colors-orange-7': 'hsla(var(--figma___other-colors-orange-7));', // ✦ Theme/Other Colors/Orange/7
+  'figma-other-colors-orange-8': 'hsla(var(--figma___other-colors-orange-8));', // ✦ Theme/Other Colors/Orange/8
+  'figma-other-colors-orange-9': 'hsla(var(--figma___other-colors-orange-9));', // ✦ Theme/Other Colors/Orange/9
+  'figma-other-colors-orange-10': 'hsla(var(--figma___other-colors-orange-10));', // ✦ Theme/Other Colors/Orange/10
+  'figma-other-colors-orange-alpha-1': 'hsla(var(--figma___other-colors-orange-alpha-1));', // ✦ Theme/Other Colors/Orange Alpha/1
+  'figma-other-colors-orange-alpha-2': 'hsla(var(--figma___other-colors-orange-alpha-2));', // ✦ Theme/Other Colors/Orange Alpha/2
+  'figma-other-colors-orange-alpha-3': 'hsla(var(--figma___other-colors-orange-alpha-3));', // ✦ Theme/Other Colors/Orange Alpha/3
+  'figma-other-colors-orange-alpha-4': 'hsla(var(--figma___other-colors-orange-alpha-4));', // ✦ Theme/Other Colors/Orange Alpha/4
+  'figma-other-colors-orange-alpha-5': 'hsla(var(--figma___other-colors-orange-alpha-5));', // ✦ Theme/Other Colors/Orange Alpha/5
+  'figma-other-colors-orange-alpha-6': 'hsla(var(--figma___other-colors-orange-alpha-6));', // ✦ Theme/Other Colors/Orange Alpha/6
+  'figma-other-colors-orange-alpha-7': 'hsla(var(--figma___other-colors-orange-alpha-7));', // ✦ Theme/Other Colors/Orange Alpha/7
+  'figma-other-colors-orange-alpha-8': 'hsla(var(--figma___other-colors-orange-alpha-8));', // ✦ Theme/Other Colors/Orange Alpha/8
+  'figma-other-colors-orange-alpha-9': 'hsla(var(--figma___other-colors-orange-alpha-9));', // ✦ Theme/Other Colors/Orange Alpha/9
+  'figma-other-colors-orange-alpha-10': 'hsla(var(--figma___other-colors-orange-alpha-10));', // ✦ Theme/Other Colors/Orange Alpha/10
+  'figma-other-colors-yellow-1': 'hsla(var(--figma___other-colors-yellow-1));', // ✦ Theme/Other Colors/Yellow/1
+  'figma-other-colors-yellow-2': 'hsla(var(--figma___other-colors-yellow-2));', // ✦ Theme/Other Colors/Yellow/2
+  'figma-other-colors-yellow-3': 'hsla(var(--figma___other-colors-yellow-3));', // ✦ Theme/Other Colors/Yellow/3
+  'figma-other-colors-yellow-4': 'hsla(var(--figma___other-colors-yellow-4));', // ✦ Theme/Other Colors/Yellow/4
+  'figma-other-colors-yellow-5': 'hsla(var(--figma___other-colors-yellow-5));', // ✦ Theme/Other Colors/Yellow/5
+  'figma-other-colors-yellow-6': 'hsla(var(--figma___other-colors-yellow-6));', // ✦ Theme/Other Colors/Yellow/6
+  'figma-other-colors-yellow-7': 'hsla(var(--figma___other-colors-yellow-7));', // ✦ Theme/Other Colors/Yellow/7
+  'figma-other-colors-yellow-8': 'hsla(var(--figma___other-colors-yellow-8));', // ✦ Theme/Other Colors/Yellow/8
+  'figma-other-colors-yellow-9': 'hsla(var(--figma___other-colors-yellow-9));', // ✦ Theme/Other Colors/Yellow/9
+  'figma-other-colors-yellow-10': 'hsla(var(--figma___other-colors-yellow-10));', // ✦ Theme/Other Colors/Yellow/10
+  'figma-other-colors-yellow-alpha-1': 'hsla(var(--figma___other-colors-yellow-alpha-1));', // ✦ Theme/Other Colors/Yellow Alpha/1
+  'figma-other-colors-yellow-alpha-2': 'hsla(var(--figma___other-colors-yellow-alpha-2));', // ✦ Theme/Other Colors/Yellow Alpha/2
+  'figma-other-colors-yellow-alpha-3': 'hsla(var(--figma___other-colors-yellow-alpha-3));', // ✦ Theme/Other Colors/Yellow Alpha/3
+  'figma-other-colors-yellow-alpha-4': 'hsla(var(--figma___other-colors-yellow-alpha-4));', // ✦ Theme/Other Colors/Yellow Alpha/4
+  'figma-other-colors-yellow-alpha-5': 'hsla(var(--figma___other-colors-yellow-alpha-5));', // ✦ Theme/Other Colors/Yellow Alpha/5
+  'figma-other-colors-yellow-alpha-6': 'hsla(var(--figma___other-colors-yellow-alpha-6));', // ✦ Theme/Other Colors/Yellow Alpha/6
+  'figma-other-colors-yellow-alpha-7': 'hsla(var(--figma___other-colors-yellow-alpha-7));', // ✦ Theme/Other Colors/Yellow Alpha/7
+  'figma-other-colors-yellow-alpha-8': 'hsla(var(--figma___other-colors-yellow-alpha-8));', // ✦ Theme/Other Colors/Yellow Alpha/8
+  'figma-other-colors-yellow-alpha-9': 'hsla(var(--figma___other-colors-yellow-alpha-9));', // ✦ Theme/Other Colors/Yellow Alpha/9
+  'figma-other-colors-yellow-alpha-10': 'hsla(var(--figma___other-colors-yellow-alpha-10));', // ✦ Theme/Other Colors/Yellow Alpha/10
+  'figma-overlays-black-alpha-1': 'hsla(var(--figma___overlays-black-alpha-1));', // ✦ Theme/Overlays/Black Alpha/1
+  'figma-overlays-black-alpha-2': 'hsla(var(--figma___overlays-black-alpha-2));', // ✦ Theme/Overlays/Black Alpha/2
+  'figma-overlays-black-alpha-3': 'hsla(var(--figma___overlays-black-alpha-3));', // ✦ Theme/Overlays/Black Alpha/3
+  'figma-overlays-black-alpha-4': 'hsla(var(--figma___overlays-black-alpha-4));', // ✦ Theme/Overlays/Black Alpha/4
+  'figma-overlays-black-alpha-5': 'hsla(var(--figma___overlays-black-alpha-5));', // ✦ Theme/Overlays/Black Alpha/5
+  'figma-overlays-black-alpha-6': 'hsla(var(--figma___overlays-black-alpha-6));', // ✦ Theme/Overlays/Black Alpha/6
+  'figma-overlays-black-alpha-7': 'hsla(var(--figma___overlays-black-alpha-7));', // ✦ Theme/Overlays/Black Alpha/7
+  'figma-overlays-black-alpha-8': 'hsla(var(--figma___overlays-black-alpha-8));', // ✦ Theme/Overlays/Black Alpha/8
+  'figma-overlays-black-alpha-9': 'hsla(var(--figma___overlays-black-alpha-9));', // ✦ Theme/Overlays/Black Alpha/9
+  'figma-overlays-black-alpha-10': 'hsla(var(--figma___overlays-black-alpha-10));', // ✦ Theme/Overlays/Black Alpha/10
+  'figma-overlays-white-alpha-1': 'hsla(var(--figma___overlays-white-alpha-1));', // ✦ Theme/Overlays/White Alpha/1
+  'figma-overlays-white-alpha-2': 'hsla(var(--figma___overlays-white-alpha-2));', // ✦ Theme/Overlays/White Alpha/2
+  'figma-overlays-white-alpha-3': 'hsla(var(--figma___overlays-white-alpha-3));', // ✦ Theme/Overlays/White Alpha/3
+  'figma-overlays-white-alpha-4': 'hsla(var(--figma___overlays-white-alpha-4));', // ✦ Theme/Overlays/White Alpha/4
+  'figma-overlays-white-alpha-5': 'hsla(var(--figma___overlays-white-alpha-5));', // ✦ Theme/Overlays/White Alpha/5
+  'figma-overlays-white-alpha-6': 'hsla(var(--figma___overlays-white-alpha-6));', // ✦ Theme/Overlays/White Alpha/6
+  'figma-overlays-white-alpha-7': 'hsla(var(--figma___overlays-white-alpha-7));', // ✦ Theme/Overlays/White Alpha/7
+  'figma-overlays-white-alpha-8': 'hsla(var(--figma___overlays-white-alpha-8));', // ✦ Theme/Overlays/White Alpha/8
+  'figma-overlays-white-alpha-9': 'hsla(var(--figma___overlays-white-alpha-9));', // ✦ Theme/Overlays/White Alpha/9
+  'figma-overlays-white-alpha-10': 'hsla(var(--figma___overlays-white-alpha-10));', // ✦ Theme/Overlays/White Alpha/10
+  'figma-pagination-active-background': 'hsla(var(--figma___pagination-active-background));', // ✦ Theme/Pagination/Active/Background
+  'figma-pagination-active-border': 'hsla(var(--figma___pagination-active-border));', // ✦ Theme/Pagination/Active/Border
+  'figma-pagination-active-text': 'hsla(var(--figma___pagination-active-text));', // ✦ Theme/Pagination/Active/Text
+  'figma-pagination-background': 'hsla(var(--figma___pagination-background));', // ✦ Theme/Pagination/Background
+  'figma-pagination-default-background': 'hsla(var(--figma___pagination-default-background));', // ✦ Theme/Pagination/Default/Background
+  'figma-pagination-default-border': 'hsla(var(--figma___pagination-default-border));', // ✦ Theme/Pagination/Default/Border
+  'figma-pagination-default-text': 'hsla(var(--figma___pagination-default-text));', // ✦ Theme/Pagination/Default/Text
+  'figma-pagination-hover-background': 'hsla(var(--figma___pagination-hover-background));', // ✦ Theme/Pagination/Hover/Background
+  'figma-pagination-hover-border': 'hsla(var(--figma___pagination-hover-border));', // ✦ Theme/Pagination/Hover/Border
+  'figma-pagination-hover-text': 'hsla(var(--figma___pagination-hover-text));', // ✦ Theme/Pagination/Hover/Text
+  'figma-pagination-pagination-shadow-1': 'hsla(var(--figma___pagination-pagination-shadow-1));', // ✦ Theme/Pagination/Pagination shadow/1
+  'figma-pagination-pagination-shadow-2': 'hsla(var(--figma___pagination-pagination-shadow-2));', // ✦ Theme/Pagination/Pagination shadow/2
+  'figma-primary-color-primary-accent-1': 'hsla(var(--figma___primary-color-primary-accent-1));', // ✦ Theme/Primary Color/Primary Accent/1
+  'figma-primary-color-primary-accent-2': 'hsla(var(--figma___primary-color-primary-accent-2));', // ✦ Theme/Primary Color/Primary Accent/2
+  'figma-primary-color-primary-accent-3': 'hsla(var(--figma___primary-color-primary-accent-3));', // ✦ Theme/Primary Color/Primary Accent/3
+  'figma-primary-color-primary-accent-4': 'hsla(var(--figma___primary-color-primary-accent-4));', // ✦ Theme/Primary Color/Primary Accent/4
+  'figma-primary-color-primary-accent-5': 'hsla(var(--figma___primary-color-primary-accent-5));', // ✦ Theme/Primary Color/Primary Accent/5
+  'figma-primary-color-primary-accent-6': 'hsla(var(--figma___primary-color-primary-accent-6));', // ✦ Theme/Primary Color/Primary Accent/6
+  'figma-primary-color-primary-accent-7': 'hsla(var(--figma___primary-color-primary-accent-7));', // ✦ Theme/Primary Color/Primary Accent/7
+  'figma-primary-color-primary-accent-8': 'hsla(var(--figma___primary-color-primary-accent-8));', // ✦ Theme/Primary Color/Primary Accent/8
+  'figma-primary-color-primary-accent-9': 'hsla(var(--figma___primary-color-primary-accent-9));', // ✦ Theme/Primary Color/Primary Accent/9
+  'figma-primary-color-primary-accent-10': 'hsla(var(--figma___primary-color-primary-accent-10));', // ✦ Theme/Primary Color/Primary Accent/10
+  'figma-primary-color-primary-alpha-1': 'hsla(var(--figma___primary-color-primary-alpha-1));', // ✦ Theme/Primary Color/Primary Alpha/1
+  'figma-primary-color-primary-alpha-2': 'hsla(var(--figma___primary-color-primary-alpha-2));', // ✦ Theme/Primary Color/Primary Alpha/2
+  'figma-primary-color-primary-alpha-3': 'hsla(var(--figma___primary-color-primary-alpha-3));', // ✦ Theme/Primary Color/Primary Alpha/3
+  'figma-primary-color-primary-alpha-4': 'hsla(var(--figma___primary-color-primary-alpha-4));', // ✦ Theme/Primary Color/Primary Alpha/4
+  'figma-primary-color-primary-alpha-5': 'hsla(var(--figma___primary-color-primary-alpha-5));', // ✦ Theme/Primary Color/Primary Alpha/5
+  'figma-primary-color-primary-alpha-6': 'hsla(var(--figma___primary-color-primary-alpha-6));', // ✦ Theme/Primary Color/Primary Alpha/6
+  'figma-primary-color-primary-alpha-7': 'hsla(var(--figma___primary-color-primary-alpha-7));', // ✦ Theme/Primary Color/Primary Alpha/7
+  'figma-primary-color-primary-alpha-8': 'hsla(var(--figma___primary-color-primary-alpha-8));', // ✦ Theme/Primary Color/Primary Alpha/8
+  'figma-primary-color-primary-alpha-9': 'hsla(var(--figma___primary-color-primary-alpha-9));', // ✦ Theme/Primary Color/Primary Alpha/9
+  'figma-primary-color-primary-alpha-10': 'hsla(var(--figma___primary-color-primary-alpha-10));', // ✦ Theme/Primary Color/Primary Alpha/10
+  'figma-radio-button-background': 'hsla(var(--figma___radio-button-background));', // ✦ Theme/Radio button/Background
+  'figma-radio-button-checked-active-active-border': 'hsla(var(--figma___radio-button-checked-active-active-border));', // ✦ Theme/Radio button/Checked/Active/Active Border
+  'figma-radio-button-checked-active-active-background':
+    'hsla(var(--figma___radio-button-checked-active-active-background));', // ✦ Theme/Radio button/Checked/Active/Active background
+  'figma-radio-button-checked-active-dot': 'hsla(var(--figma___radio-button-checked-active-dot));', // ✦ Theme/Radio button/Checked/Active/Dot
+  'figma-radio-button-checked-active-hover-background':
+    'hsla(var(--figma___radio-button-checked-active-hover-background));', // ✦ Theme/Radio button/Checked/Active/Hover background
+  'figma-radio-button-checked-active-hover-border': 'hsla(var(--figma___radio-button-checked-active-hover-border));', // ✦ Theme/Radio button/Checked/Active/Hover border
+  'figma-radio-button-checked-active-default-background':
+    'hsla(var(--figma___radio-button-checked-active-default-background));', // ✦ Theme/Radio button/Checked/Active/default background
+  'figma-radio-button-checked-active-default-border':
+    'hsla(var(--figma___radio-button-checked-active-default-border));', // ✦ Theme/Radio button/Checked/Active/default border
+  'figma-radio-button-checked-disabled-dot': 'hsla(var(--figma___radio-button-checked-disabled-dot));', // ✦ Theme/Radio button/Checked/Disabled/Dot
+  'figma-radio-button-checked-disabled-background': 'hsla(var(--figma___radio-button-checked-disabled-background));', // ✦ Theme/Radio button/Checked/Disabled/background
+  'figma-radio-button-checked-disabled-border': 'hsla(var(--figma___radio-button-checked-disabled-border));', // ✦ Theme/Radio button/Checked/Disabled/border
+  'figma-radio-button-paper': 'hsla(var(--figma___radio-button-paper));', // ✦ Theme/Radio button/Paper
+  'figma-radio-button-unchecked-active-active-border':
+    'hsla(var(--figma___radio-button-unchecked-active-active-border));', // ✦ Theme/Radio button/Unchecked/Active/Active border
+  'figma-radio-button-unchecked-active-hover-border':
+    'hsla(var(--figma___radio-button-unchecked-active-hover-border));', // ✦ Theme/Radio button/Unchecked/Active/Hover border
+  'figma-radio-button-unchecked-active-default-background':
+    'hsla(var(--figma___radio-button-unchecked-active-default-background));', // ✦ Theme/Radio button/Unchecked/Active/default background
+  'figma-radio-button-unchecked-active-default-border':
+    'hsla(var(--figma___radio-button-unchecked-active-default-border));', // ✦ Theme/Radio button/Unchecked/Active/default border
+  'figma-radio-button-unchecked-disabled-background':
+    'hsla(var(--figma___radio-button-unchecked-disabled-background));', // ✦ Theme/Radio button/Unchecked/Disabled/background
+  'figma-radio-button-unchecked-disabled-border': 'hsla(var(--figma___radio-button-unchecked-disabled-border));', // ✦ Theme/Radio button/Unchecked/Disabled/border
+  'figma-radio-button-border': 'hsla(var(--figma___radio-button-border));', // ✦ Theme/Radio button/border
+  'figma-secondary-crimson-crimson-1': 'hsla(var(--figma___secondary-crimson-crimson-1));', // ✦ Theme/Secondary/Crimson/Crimson 1
+  'figma-secondary-crimson-crimson-10': 'hsla(var(--figma___secondary-crimson-crimson-10));', // ✦ Theme/Secondary/Crimson/Crimson 10
+  'figma-secondary-crimson-crimson-2': 'hsla(var(--figma___secondary-crimson-crimson-2));', // ✦ Theme/Secondary/Crimson/Crimson 2
+  'figma-secondary-crimson-crimson-3': 'hsla(var(--figma___secondary-crimson-crimson-3));', // ✦ Theme/Secondary/Crimson/Crimson 3
+  'figma-secondary-crimson-crimson-4': 'hsla(var(--figma___secondary-crimson-crimson-4));', // ✦ Theme/Secondary/Crimson/Crimson 4
+  'figma-secondary-crimson-crimson-5': 'hsla(var(--figma___secondary-crimson-crimson-5));', // ✦ Theme/Secondary/Crimson/Crimson 5
+  'figma-secondary-crimson-crimson-6': 'hsla(var(--figma___secondary-crimson-crimson-6));', // ✦ Theme/Secondary/Crimson/Crimson 6
+  'figma-secondary-crimson-crimson-7': 'hsla(var(--figma___secondary-crimson-crimson-7));', // ✦ Theme/Secondary/Crimson/Crimson 7
+  'figma-secondary-crimson-crimson-8': 'hsla(var(--figma___secondary-crimson-crimson-8));', // ✦ Theme/Secondary/Crimson/Crimson 8
+  'figma-secondary-crimson-crimson-9': 'hsla(var(--figma___secondary-crimson-crimson-9));', // ✦ Theme/Secondary/Crimson/Crimson 9
+  'figma-secondary-crimson-alpha-crimson-alpha-1': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-1));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1
+  'figma-secondary-crimson-alpha-crimson-alpha-10': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-10));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10
+  'figma-secondary-crimson-alpha-crimson-alpha-11': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-11));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11
+  'figma-secondary-crimson-alpha-crimson-alpha-2': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-2));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2
+  'figma-secondary-crimson-alpha-crimson-alpha-3': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-3));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3
+  'figma-secondary-crimson-alpha-crimson-alpha-4': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-4));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4
+  'figma-secondary-crimson-alpha-crimson-alpha-5': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-5));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5
+  'figma-secondary-crimson-alpha-crimson-alpha-6': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-6));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6
+  'figma-secondary-crimson-alpha-crimson-alpha-8': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-8));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8
+  'figma-secondary-crimson-alpha-crimson-alpha-9': 'hsla(var(--figma___secondary-crimson-alpha-crimson-alpha-9));', // ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9
+  'figma-secondary-lime-1': 'hsla(var(--figma___secondary-lime-1));', // ✦ Theme/Secondary/Lime/1
+  'figma-secondary-lime-2': 'hsla(var(--figma___secondary-lime-2));', // ✦ Theme/Secondary/Lime/2
+  'figma-secondary-lime-3': 'hsla(var(--figma___secondary-lime-3));', // ✦ Theme/Secondary/Lime/3
+  'figma-secondary-lime-4': 'hsla(var(--figma___secondary-lime-4));', // ✦ Theme/Secondary/Lime/4
+  'figma-secondary-lime-5': 'hsla(var(--figma___secondary-lime-5));', // ✦ Theme/Secondary/Lime/5
+  'figma-secondary-lime-6': 'hsla(var(--figma___secondary-lime-6));', // ✦ Theme/Secondary/Lime/6
+  'figma-secondary-lime-7': 'hsla(var(--figma___secondary-lime-7));', // ✦ Theme/Secondary/Lime/7
+  'figma-secondary-lime-8': 'hsla(var(--figma___secondary-lime-8));', // ✦ Theme/Secondary/Lime/8
+  'figma-secondary-lime-9': 'hsla(var(--figma___secondary-lime-9));', // ✦ Theme/Secondary/Lime/9
+  'figma-secondary-lime-10': 'hsla(var(--figma___secondary-lime-10));', // ✦ Theme/Secondary/Lime/10
+  'figma-secondary-lime-alpha-1': 'hsla(var(--figma___secondary-lime-alpha-1));', // ✦ Theme/Secondary/Lime Alpha/1
+  'figma-secondary-lime-alpha-2': 'hsla(var(--figma___secondary-lime-alpha-2));', // ✦ Theme/Secondary/Lime Alpha/2
+  'figma-secondary-lime-alpha-3': 'hsla(var(--figma___secondary-lime-alpha-3));', // ✦ Theme/Secondary/Lime Alpha/3
+  'figma-secondary-lime-alpha-4': 'hsla(var(--figma___secondary-lime-alpha-4));', // ✦ Theme/Secondary/Lime Alpha/4
+  'figma-secondary-lime-alpha-5': 'hsla(var(--figma___secondary-lime-alpha-5));', // ✦ Theme/Secondary/Lime Alpha/5
+  'figma-secondary-lime-alpha-6': 'hsla(var(--figma___secondary-lime-alpha-6));', // ✦ Theme/Secondary/Lime Alpha/6
+  'figma-secondary-lime-alpha-7': 'hsla(var(--figma___secondary-lime-alpha-7));', // ✦ Theme/Secondary/Lime Alpha/7
+  'figma-secondary-lime-alpha-8': 'hsla(var(--figma___secondary-lime-alpha-8));', // ✦ Theme/Secondary/Lime Alpha/8
+  'figma-secondary-lime-alpha-9': 'hsla(var(--figma___secondary-lime-alpha-9));', // ✦ Theme/Secondary/Lime Alpha/9
+  'figma-secondary-lime-alpha-10': 'hsla(var(--figma___secondary-lime-alpha-10));', // ✦ Theme/Secondary/Lime Alpha/10
+  'figma-secondary-purple-1': 'hsla(var(--figma___secondary-purple-1));', // ✦ Theme/Secondary/Purple/1
+  'figma-secondary-purple-2': 'hsla(var(--figma___secondary-purple-2));', // ✦ Theme/Secondary/Purple/2
+  'figma-secondary-purple-3': 'hsla(var(--figma___secondary-purple-3));', // ✦ Theme/Secondary/Purple/3
+  'figma-secondary-purple-4': 'hsla(var(--figma___secondary-purple-4));', // ✦ Theme/Secondary/Purple/4
+  'figma-secondary-purple-5': 'hsla(var(--figma___secondary-purple-5));', // ✦ Theme/Secondary/Purple/5
+  'figma-secondary-purple-6': 'hsla(var(--figma___secondary-purple-6));', // ✦ Theme/Secondary/Purple/6
+  'figma-secondary-purple-7': 'hsla(var(--figma___secondary-purple-7));', // ✦ Theme/Secondary/Purple/7
+  'figma-secondary-purple-8': 'hsla(var(--figma___secondary-purple-8));', // ✦ Theme/Secondary/Purple/8
+  'figma-secondary-purple-9': 'hsla(var(--figma___secondary-purple-9));', // ✦ Theme/Secondary/Purple/9
+  'figma-secondary-purple-10': 'hsla(var(--figma___secondary-purple-10));', // ✦ Theme/Secondary/Purple/10
+  'figma-secondary-purple-alpha-1': 'hsla(var(--figma___secondary-purple-alpha-1));', // ✦ Theme/Secondary/Purple Alpha/1
+  'figma-secondary-purple-alpha-2': 'hsla(var(--figma___secondary-purple-alpha-2));', // ✦ Theme/Secondary/Purple Alpha/2
+  'figma-secondary-purple-alpha-3': 'hsla(var(--figma___secondary-purple-alpha-3));', // ✦ Theme/Secondary/Purple Alpha/3
+  'figma-secondary-purple-alpha-4': 'hsla(var(--figma___secondary-purple-alpha-4));', // ✦ Theme/Secondary/Purple Alpha/4
+  'figma-secondary-purple-alpha-5': 'hsla(var(--figma___secondary-purple-alpha-5));', // ✦ Theme/Secondary/Purple Alpha/5
+  'figma-secondary-purple-alpha-6': 'hsla(var(--figma___secondary-purple-alpha-6));', // ✦ Theme/Secondary/Purple Alpha/6
+  'figma-secondary-purple-alpha-7': 'hsla(var(--figma___secondary-purple-alpha-7));', // ✦ Theme/Secondary/Purple Alpha/7
+  'figma-secondary-purple-alpha-8': 'hsla(var(--figma___secondary-purple-alpha-8));', // ✦ Theme/Secondary/Purple Alpha/8
+  'figma-secondary-purple-alpha-9': 'hsla(var(--figma___secondary-purple-alpha-9));', // ✦ Theme/Secondary/Purple Alpha/9
+  'figma-secondary-purple-alpha-10': 'hsla(var(--figma___secondary-purple-alpha-10));', // ✦ Theme/Secondary/Purple Alpha/10
+  'figma-secondary-teal-1': 'hsla(var(--figma___secondary-teal-1));', // ✦ Theme/Secondary/Teal/1
+  'figma-secondary-teal-2': 'hsla(var(--figma___secondary-teal-2));', // ✦ Theme/Secondary/Teal/2
+  'figma-secondary-teal-3': 'hsla(var(--figma___secondary-teal-3));', // ✦ Theme/Secondary/Teal/3
+  'figma-secondary-teal-4': 'hsla(var(--figma___secondary-teal-4));', // ✦ Theme/Secondary/Teal/4
+  'figma-secondary-teal-5': 'hsla(var(--figma___secondary-teal-5));', // ✦ Theme/Secondary/Teal/5
+  'figma-secondary-teal-6': 'hsla(var(--figma___secondary-teal-6));', // ✦ Theme/Secondary/Teal/6
+  'figma-secondary-teal-7': 'hsla(var(--figma___secondary-teal-7));', // ✦ Theme/Secondary/Teal/7
+  'figma-secondary-teal-8': 'hsla(var(--figma___secondary-teal-8));', // ✦ Theme/Secondary/Teal/8
+  'figma-secondary-teal-9': 'hsla(var(--figma___secondary-teal-9));', // ✦ Theme/Secondary/Teal/9
+  'figma-secondary-teal-10': 'hsla(var(--figma___secondary-teal-10));', // ✦ Theme/Secondary/Teal/10
+  'figma-secondary-teal-alpha-1': 'hsla(var(--figma___secondary-teal-alpha-1));', // ✦ Theme/Secondary/Teal Alpha/1
+  'figma-secondary-teal-alpha-2': 'hsla(var(--figma___secondary-teal-alpha-2));', // ✦ Theme/Secondary/Teal Alpha/2
+  'figma-secondary-teal-alpha-3': 'hsla(var(--figma___secondary-teal-alpha-3));', // ✦ Theme/Secondary/Teal Alpha/3
+  'figma-secondary-teal-alpha-4': 'hsla(var(--figma___secondary-teal-alpha-4));', // ✦ Theme/Secondary/Teal Alpha/4
+  'figma-secondary-teal-alpha-5': 'hsla(var(--figma___secondary-teal-alpha-5));', // ✦ Theme/Secondary/Teal Alpha/5
+  'figma-secondary-teal-alpha-6': 'hsla(var(--figma___secondary-teal-alpha-6));', // ✦ Theme/Secondary/Teal Alpha/6
+  'figma-secondary-teal-alpha-7': 'hsla(var(--figma___secondary-teal-alpha-7));', // ✦ Theme/Secondary/Teal Alpha/7
+  'figma-secondary-teal-alpha-8': 'hsla(var(--figma___secondary-teal-alpha-8));', // ✦ Theme/Secondary/Teal Alpha/8
+  'figma-secondary-teal-alpha-9': 'hsla(var(--figma___secondary-teal-alpha-9));', // ✦ Theme/Secondary/Teal Alpha/9
+  'figma-secondary-teal-alpha-10': 'hsla(var(--figma___secondary-teal-alpha-10));', // ✦ Theme/Secondary/Teal Alpha/10
+  'figma-shadow-shadow-button-1': 'hsla(var(--figma___shadow-shadow-button-1));', // ✦ Theme/Shadow/Shadow - button/1
+  'figma-shadow-shadow-button-2': 'hsla(var(--figma___shadow-shadow-button-2));', // ✦ Theme/Shadow/Shadow - button/2
+  'figma-shadow-shadow-button-3': 'hsla(var(--figma___shadow-shadow-button-3));', // ✦ Theme/Shadow/Shadow - button/3
+  'figma-shadow-shadow-button-4': 'hsla(var(--figma___shadow-shadow-button-4));', // ✦ Theme/Shadow/Shadow - button/4
+  'figma-shadow-shadow-1-1': 'hsla(var(--figma___shadow-shadow-1-1));', // ✦ Theme/Shadow/Shadow 1/1
+  'figma-shadow-shadow-2-1': 'hsla(var(--figma___shadow-shadow-2-1));', // ✦ Theme/Shadow/Shadow 2/1
+  'figma-shadow-shadow-2-2': 'hsla(var(--figma___shadow-shadow-2-2));', // ✦ Theme/Shadow/Shadow 2/2
+  'figma-shadow-shadow-2-3': 'hsla(var(--figma___shadow-shadow-2-3));', // ✦ Theme/Shadow/Shadow 2/3
+  'figma-shadow-shadow-3-1': 'hsla(var(--figma___shadow-shadow-3-1));', // ✦ Theme/Shadow/Shadow 3/1
+  'figma-shadow-shadow-3-2': 'hsla(var(--figma___shadow-shadow-3-2));', // ✦ Theme/Shadow/Shadow 3/2
+  'figma-shadow-shadow-3-3': 'hsla(var(--figma___shadow-shadow-3-3));', // ✦ Theme/Shadow/Shadow 3/3
+  'figma-shadow-shadow-4-1': 'hsla(var(--figma___shadow-shadow-4-1));', // ✦ Theme/Shadow/Shadow 4/1
+  'figma-shadow-shadow-4-2': 'hsla(var(--figma___shadow-shadow-4-2));', // ✦ Theme/Shadow/Shadow 4/2
+  'figma-shadow-shadow-5-1': 'hsla(var(--figma___shadow-shadow-5-1));', // ✦ Theme/Shadow/Shadow 5/1
+  'figma-shadow-shadow-5-2': 'hsla(var(--figma___shadow-shadow-5-2));', // ✦ Theme/Shadow/Shadow 5/2
+  'figma-shadow-shadow-6-1': 'hsla(var(--figma___shadow-shadow-6-1));', // ✦ Theme/Shadow/Shadow 6/1
+  'figma-shadow-shadow-6-2': 'hsla(var(--figma___shadow-shadow-6-2));', // ✦ Theme/Shadow/Shadow 6/2
+  'figma-shadow-shadow-button-active-1': 'hsla(var(--figma___shadow-shadow-button-active-1));', // ✦ Theme/Shadow/Shadow-button-active/1
+  'figma-shadow-shadow-button-active-2': 'hsla(var(--figma___shadow-shadow-button-active-2));', // ✦ Theme/Shadow/Shadow-button-active/2
+  'figma-shadow-shadow-button-active-3': 'hsla(var(--figma___shadow-shadow-button-active-3));', // ✦ Theme/Shadow/Shadow-button-active/3
+  'figma-shadow-shadow-button-active-4': 'hsla(var(--figma___shadow-shadow-button-active-4));', // ✦ Theme/Shadow/Shadow-button-active/4
+  'figma-side-nav-container-nav-background': 'hsla(var(--figma___side-nav-container-nav-background));', // ✦ Theme/Side nav/Container/Nav-background
+  'figma-side-nav-container-nav-border': 'hsla(var(--figma___side-nav-container-nav-border));', // ✦ Theme/Side nav/Container/Nav-border
+  'figma-side-nav-module-logo-text': 'hsla(var(--figma___side-nav-module-logo-text));', // ✦ Theme/Side nav/Module Logo Text
+  'figma-side-nav-nav-item-default-icon': 'hsla(var(--figma___side-nav-nav-item-default-icon));', // ✦ Theme/Side nav/Nav-item/Default/Icon
+  'figma-side-nav-nav-item-default-text': 'hsla(var(--figma___side-nav-nav-item-default-text));', // ✦ Theme/Side nav/Nav-item/Default/Text
+  'figma-side-nav-nav-item-default-default': 'hsla(var(--figma___side-nav-nav-item-default-default));', // ✦ Theme/Side nav/Nav-item/Default/default
+  'figma-side-nav-nav-item-hover-background': 'hsla(var(--figma___side-nav-nav-item-hover-background));', // ✦ Theme/Side nav/Nav-item/Hover/Background
+  'figma-side-nav-nav-item-hover-icon': 'hsla(var(--figma___side-nav-nav-item-hover-icon));', // ✦ Theme/Side nav/Nav-item/Hover/Icon
+  'figma-side-nav-nav-item-hover-text': 'hsla(var(--figma___side-nav-nav-item-hover-text));', // ✦ Theme/Side nav/Nav-item/Hover/Text
+  'figma-side-nav-nav-item-selected-background': 'hsla(var(--figma___side-nav-nav-item-selected-background));', // ✦ Theme/Side nav/Nav-item/Selected/Background
+  'figma-side-nav-nav-item-selected-icon': 'hsla(var(--figma___side-nav-nav-item-selected-icon));', // ✦ Theme/Side nav/Nav-item/Selected/Icon
+  'figma-side-nav-nav-item-selected-text': 'hsla(var(--figma___side-nav-nav-item-selected-text));', // ✦ Theme/Side nav/Nav-item/Selected/Text
+  'figma-side-nav-profile-role': 'hsla(var(--figma___side-nav-profile-role));', // ✦ Theme/Side nav/Profile/Role
+  'figma-side-nav-profile-text': 'hsla(var(--figma___side-nav-profile-text));', // ✦ Theme/Side nav/Profile/Text
+  'figma-side-nav-scope-selector-default-border': 'hsla(var(--figma___side-nav-scope-selector-default-border));', // ✦ Theme/Side nav/Scope Selector/Default/Border
+  'figma-side-nav-scope-selector-default-main-text-icon':
+    'hsla(var(--figma___side-nav-scope-selector-default-main-text-icon));', // ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon
+  'figma-side-nav-scope-selector-default-scope-name':
+    'hsla(var(--figma___side-nav-scope-selector-default-scope-name));', // ✦ Theme/Side nav/Scope Selector/Default/Scope Name
+  'figma-side-nav-scope-selector-default-default': 'hsla(var(--figma___side-nav-scope-selector-default-default));', // ✦ Theme/Side nav/Scope Selector/Default/default
+  'figma-side-nav-scope-selector-hover-border': 'hsla(var(--figma___side-nav-scope-selector-hover-border));', // ✦ Theme/Side nav/Scope Selector/Hover/Border
+  'figma-side-nav-scope-selector-hover-main-text-icon':
+    'hsla(var(--figma___side-nav-scope-selector-hover-main-text-icon));', // ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon
+  'figma-side-nav-scope-selector-hover-scope-name': 'hsla(var(--figma___side-nav-scope-selector-hover-scope-name));', // ✦ Theme/Side nav/Scope Selector/Hover/Scope Name
+  'figma-side-nav-scope-selector-hover-default': 'hsla(var(--figma___side-nav-scope-selector-hover-default));', // ✦ Theme/Side nav/Scope Selector/Hover/default
+  'figma-side-nav-scope-selector-selected-border': 'hsla(var(--figma___side-nav-scope-selector-selected-border));', // ✦ Theme/Side nav/Scope Selector/Selected/Border
+  'figma-side-nav-scope-selector-selected-main-text-icon':
+    'hsla(var(--figma___side-nav-scope-selector-selected-main-text-icon));', // ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon
+  'figma-side-nav-scope-selector-selected-scope-name':
+    'hsla(var(--figma___side-nav-scope-selector-selected-scope-name));', // ✦ Theme/Side nav/Scope Selector/Selected/Scope Name
+  'figma-side-nav-scope-selector-selected-background':
+    'hsla(var(--figma___side-nav-scope-selector-selected-background));', // ✦ Theme/Side nav/Scope Selector/Selected/background
+  'figma-side-nav-separator': 'hsla(var(--figma___side-nav-separator));', // ✦ Theme/Side nav/Separator
+  'figma-status-colors-error-1': 'hsla(var(--figma___status-colors-error-1));', // ✦ Theme/Status colors/Error/1
+  'figma-status-colors-error-2': 'hsla(var(--figma___status-colors-error-2));', // ✦ Theme/Status colors/Error/2
+  'figma-status-colors-error-3': 'hsla(var(--figma___status-colors-error-3));', // ✦ Theme/Status colors/Error/3
+  'figma-status-colors-error-4': 'hsla(var(--figma___status-colors-error-4));', // ✦ Theme/Status colors/Error/4
+  'figma-status-colors-error-5': 'hsla(var(--figma___status-colors-error-5));', // ✦ Theme/Status colors/Error/5
+  'figma-status-colors-error-6': 'hsla(var(--figma___status-colors-error-6));', // ✦ Theme/Status colors/Error/6
+  'figma-status-colors-error-7': 'hsla(var(--figma___status-colors-error-7));', // ✦ Theme/Status colors/Error/7
+  'figma-status-colors-error-8': 'hsla(var(--figma___status-colors-error-8));', // ✦ Theme/Status colors/Error/8
+  'figma-status-colors-error-9': 'hsla(var(--figma___status-colors-error-9));', // ✦ Theme/Status colors/Error/9
+  'figma-status-colors-error-10': 'hsla(var(--figma___status-colors-error-10));', // ✦ Theme/Status colors/Error/10
+  'figma-status-colors-error-alpha-1': 'hsla(var(--figma___status-colors-error-alpha-1));', // ✦ Theme/Status colors/Error Alpha/1
+  'figma-status-colors-error-alpha-2': 'hsla(var(--figma___status-colors-error-alpha-2));', // ✦ Theme/Status colors/Error Alpha/2
+  'figma-status-colors-error-alpha-3': 'hsla(var(--figma___status-colors-error-alpha-3));', // ✦ Theme/Status colors/Error Alpha/3
+  'figma-status-colors-error-alpha-4': 'hsla(var(--figma___status-colors-error-alpha-4));', // ✦ Theme/Status colors/Error Alpha/4
+  'figma-status-colors-error-alpha-5': 'hsla(var(--figma___status-colors-error-alpha-5));', // ✦ Theme/Status colors/Error Alpha/5
+  'figma-status-colors-error-alpha-6': 'hsla(var(--figma___status-colors-error-alpha-6));', // ✦ Theme/Status colors/Error Alpha/6
+  'figma-status-colors-error-alpha-7': 'hsla(var(--figma___status-colors-error-alpha-7));', // ✦ Theme/Status colors/Error Alpha/7
+  'figma-status-colors-error-alpha-8': 'hsla(var(--figma___status-colors-error-alpha-8));', // ✦ Theme/Status colors/Error Alpha/8
+  'figma-status-colors-error-alpha-9': 'hsla(var(--figma___status-colors-error-alpha-9));', // ✦ Theme/Status colors/Error Alpha/9
+  'figma-status-colors-error-alpha-10': 'hsla(var(--figma___status-colors-error-alpha-10));', // ✦ Theme/Status colors/Error Alpha/10
+  'figma-status-colors-info-1': 'hsla(var(--figma___status-colors-info-1));', // ✦ Theme/Status colors/Info/1
+  'figma-status-colors-info-2': 'hsla(var(--figma___status-colors-info-2));', // ✦ Theme/Status colors/Info/2
+  'figma-status-colors-info-3': 'hsla(var(--figma___status-colors-info-3));', // ✦ Theme/Status colors/Info/3
+  'figma-status-colors-info-4': 'hsla(var(--figma___status-colors-info-4));', // ✦ Theme/Status colors/Info/4
+  'figma-status-colors-info-5': 'hsla(var(--figma___status-colors-info-5));', // ✦ Theme/Status colors/Info/5
+  'figma-status-colors-info-6': 'hsla(var(--figma___status-colors-info-6));', // ✦ Theme/Status colors/Info/6
+  'figma-status-colors-info-7': 'hsla(var(--figma___status-colors-info-7));', // ✦ Theme/Status colors/Info/7
+  'figma-status-colors-info-8': 'hsla(var(--figma___status-colors-info-8));', // ✦ Theme/Status colors/Info/8
+  'figma-status-colors-info-9': 'hsla(var(--figma___status-colors-info-9));', // ✦ Theme/Status colors/Info/9
+  'figma-status-colors-info-10': 'hsla(var(--figma___status-colors-info-10));', // ✦ Theme/Status colors/Info/10
+  'figma-status-colors-info-alpha-1': 'hsla(var(--figma___status-colors-info-alpha-1));', // ✦ Theme/Status colors/Info Alpha/1
+  'figma-status-colors-info-alpha-2': 'hsla(var(--figma___status-colors-info-alpha-2));', // ✦ Theme/Status colors/Info Alpha/2
+  'figma-status-colors-info-alpha-3': 'hsla(var(--figma___status-colors-info-alpha-3));', // ✦ Theme/Status colors/Info Alpha/3
+  'figma-status-colors-info-alpha-4': 'hsla(var(--figma___status-colors-info-alpha-4));', // ✦ Theme/Status colors/Info Alpha/4
+  'figma-status-colors-info-alpha-5': 'hsla(var(--figma___status-colors-info-alpha-5));', // ✦ Theme/Status colors/Info Alpha/5
+  'figma-status-colors-info-alpha-6': 'hsla(var(--figma___status-colors-info-alpha-6));', // ✦ Theme/Status colors/Info Alpha/6
+  'figma-status-colors-info-alpha-7': 'hsla(var(--figma___status-colors-info-alpha-7));', // ✦ Theme/Status colors/Info Alpha/7
+  'figma-status-colors-info-alpha-8': 'hsla(var(--figma___status-colors-info-alpha-8));', // ✦ Theme/Status colors/Info Alpha/8
+  'figma-status-colors-info-alpha-9': 'hsla(var(--figma___status-colors-info-alpha-9));', // ✦ Theme/Status colors/Info Alpha/9
+  'figma-status-colors-info-alpha-10': 'hsla(var(--figma___status-colors-info-alpha-10));', // ✦ Theme/Status colors/Info Alpha/10
+  'figma-status-colors-success-1': 'hsla(var(--figma___status-colors-success-1));', // ✦ Theme/Status colors/Success/1
+  'figma-status-colors-success-2': 'hsla(var(--figma___status-colors-success-2));', // ✦ Theme/Status colors/Success/2
+  'figma-status-colors-success-3': 'hsla(var(--figma___status-colors-success-3));', // ✦ Theme/Status colors/Success/3
+  'figma-status-colors-success-4': 'hsla(var(--figma___status-colors-success-4));', // ✦ Theme/Status colors/Success/4
+  'figma-status-colors-success-5': 'hsla(var(--figma___status-colors-success-5));', // ✦ Theme/Status colors/Success/5
+  'figma-status-colors-success-6': 'hsla(var(--figma___status-colors-success-6));', // ✦ Theme/Status colors/Success/6
+  'figma-status-colors-success-7': 'hsla(var(--figma___status-colors-success-7));', // ✦ Theme/Status colors/Success/7
+  'figma-status-colors-success-8': 'hsla(var(--figma___status-colors-success-8));', // ✦ Theme/Status colors/Success/8
+  'figma-status-colors-success-9': 'hsla(var(--figma___status-colors-success-9));', // ✦ Theme/Status colors/Success/9
+  'figma-status-colors-success-10': 'hsla(var(--figma___status-colors-success-10));', // ✦ Theme/Status colors/Success/10
+  'figma-status-colors-success-alpha-1': 'hsla(var(--figma___status-colors-success-alpha-1));', // ✦ Theme/Status colors/Success Alpha/1
+  'figma-status-colors-success-alpha-2': 'hsla(var(--figma___status-colors-success-alpha-2));', // ✦ Theme/Status colors/Success Alpha/2
+  'figma-status-colors-success-alpha-3': 'hsla(var(--figma___status-colors-success-alpha-3));', // ✦ Theme/Status colors/Success Alpha/3
+  'figma-status-colors-success-alpha-4': 'hsla(var(--figma___status-colors-success-alpha-4));', // ✦ Theme/Status colors/Success Alpha/4
+  'figma-status-colors-success-alpha-5': 'hsla(var(--figma___status-colors-success-alpha-5));', // ✦ Theme/Status colors/Success Alpha/5
+  'figma-status-colors-success-alpha-6': 'hsla(var(--figma___status-colors-success-alpha-6));', // ✦ Theme/Status colors/Success Alpha/6
+  'figma-status-colors-success-alpha-7': 'hsla(var(--figma___status-colors-success-alpha-7));', // ✦ Theme/Status colors/Success Alpha/7
+  'figma-status-colors-success-alpha-8': 'hsla(var(--figma___status-colors-success-alpha-8));', // ✦ Theme/Status colors/Success Alpha/8
+  'figma-status-colors-success-alpha-9': 'hsla(var(--figma___status-colors-success-alpha-9));', // ✦ Theme/Status colors/Success Alpha/9
+  'figma-status-colors-success-alpha-10': 'hsla(var(--figma___status-colors-success-alpha-10));', // ✦ Theme/Status colors/Success Alpha/10
+  'figma-status-colors-warning-1': 'hsla(var(--figma___status-colors-warning-1));', // ✦ Theme/Status colors/Warning/1
+  'figma-status-colors-warning-2': 'hsla(var(--figma___status-colors-warning-2));', // ✦ Theme/Status colors/Warning/2
+  'figma-status-colors-warning-3': 'hsla(var(--figma___status-colors-warning-3));', // ✦ Theme/Status colors/Warning/3
+  'figma-status-colors-warning-4': 'hsla(var(--figma___status-colors-warning-4));', // ✦ Theme/Status colors/Warning/4
+  'figma-status-colors-warning-5': 'hsla(var(--figma___status-colors-warning-5));', // ✦ Theme/Status colors/Warning/5
+  'figma-status-colors-warning-6': 'hsla(var(--figma___status-colors-warning-6));', // ✦ Theme/Status colors/Warning/6
+  'figma-status-colors-warning-7': 'hsla(var(--figma___status-colors-warning-7));', // ✦ Theme/Status colors/Warning/7
+  'figma-status-colors-warning-8': 'hsla(var(--figma___status-colors-warning-8));', // ✦ Theme/Status colors/Warning/8
+  'figma-status-colors-warning-9': 'hsla(var(--figma___status-colors-warning-9));', // ✦ Theme/Status colors/Warning/9
+  'figma-status-colors-warning-10': 'hsla(var(--figma___status-colors-warning-10));', // ✦ Theme/Status colors/Warning/10
+  'figma-status-colors-warning-alpha-1': 'hsla(var(--figma___status-colors-warning-alpha-1));', // ✦ Theme/Status colors/Warning Alpha/1
+  'figma-status-colors-warning-alpha-2': 'hsla(var(--figma___status-colors-warning-alpha-2));', // ✦ Theme/Status colors/Warning Alpha/2
+  'figma-status-colors-warning-alpha-3': 'hsla(var(--figma___status-colors-warning-alpha-3));', // ✦ Theme/Status colors/Warning Alpha/3
+  'figma-status-colors-warning-alpha-4': 'hsla(var(--figma___status-colors-warning-alpha-4));', // ✦ Theme/Status colors/Warning Alpha/4
+  'figma-status-colors-warning-alpha-5': 'hsla(var(--figma___status-colors-warning-alpha-5));', // ✦ Theme/Status colors/Warning Alpha/5
+  'figma-status-colors-warning-alpha-6': 'hsla(var(--figma___status-colors-warning-alpha-6));', // ✦ Theme/Status colors/Warning Alpha/6
+  'figma-status-colors-warning-alpha-7': 'hsla(var(--figma___status-colors-warning-alpha-7));', // ✦ Theme/Status colors/Warning Alpha/7
+  'figma-status-colors-warning-alpha-8': 'hsla(var(--figma___status-colors-warning-alpha-8));', // ✦ Theme/Status colors/Warning Alpha/8
+  'figma-status-colors-warning-alpha-9': 'hsla(var(--figma___status-colors-warning-alpha-9));', // ✦ Theme/Status colors/Warning Alpha/9
+  'figma-status-colors-warning-alpha-10': 'hsla(var(--figma___status-colors-warning-alpha-10));', // ✦ Theme/Status colors/Warning Alpha/10
+  'figma-switch-background': 'hsla(var(--figma___switch-background));', // ✦ Theme/Switch/Background
+  'figma-switch-checked-active-thumb-thumb-background':
+    'hsla(var(--figma___switch-checked-active-thumb-thumb-background));', // ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background
+  'figma-switch-checked-active-thumb-thumb-border': 'hsla(var(--figma___switch-checked-active-thumb-thumb-border));', // ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border
+  'figma-switch-checked-active-background': 'hsla(var(--figma___switch-checked-active-background));', // ✦ Theme/Switch/Checked/Active/background
+  'figma-switch-checked-active-border': 'hsla(var(--figma___switch-checked-active-border));', // ✦ Theme/Switch/Checked/Active/border
+  'figma-switch-checked-default-thumb-thumb-background':
+    'hsla(var(--figma___switch-checked-default-thumb-thumb-background));', // ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background
+  'figma-switch-checked-default-thumb-thumb-border': 'hsla(var(--figma___switch-checked-default-thumb-thumb-border));', // ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border
+  'figma-switch-checked-default-default-background': 'hsla(var(--figma___switch-checked-default-default-background));', // ✦ Theme/Switch/Checked/Default/default background
+  'figma-switch-checked-default-default-border': 'hsla(var(--figma___switch-checked-default-default-border));', // ✦ Theme/Switch/Checked/Default/default border
+  'figma-switch-checked-disabled-thumb-thumb-background':
+    'hsla(var(--figma___switch-checked-disabled-thumb-thumb-background));', // ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background
+  'figma-switch-checked-disabled-thumb-thumb-border':
+    'hsla(var(--figma___switch-checked-disabled-thumb-thumb-border));', // ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border
+  'figma-switch-checked-disabled-background': 'hsla(var(--figma___switch-checked-disabled-background));', // ✦ Theme/Switch/Checked/Disabled/background
+  'figma-switch-checked-disabled-border': 'hsla(var(--figma___switch-checked-disabled-border));', // ✦ Theme/Switch/Checked/Disabled/border
+  'figma-switch-checked-hover-thumb-thumb-background':
+    'hsla(var(--figma___switch-checked-hover-thumb-thumb-background));', // ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background
+  'figma-switch-checked-hover-thumb-thumb-border': 'hsla(var(--figma___switch-checked-hover-thumb-thumb-border));', // ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border
+  'figma-switch-checked-hover-background': 'hsla(var(--figma___switch-checked-hover-background));', // ✦ Theme/Switch/Checked/Hover/background
+  'figma-switch-checked-hover-border': 'hsla(var(--figma___switch-checked-hover-border));', // ✦ Theme/Switch/Checked/Hover/border
+  'figma-switch-paper': 'hsla(var(--figma___switch-paper));', // ✦ Theme/Switch/Paper
+  'figma-switch-unchecked-active-thumb-thumb-background':
+    'hsla(var(--figma___switch-unchecked-active-thumb-thumb-background));', // ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background
+  'figma-switch-unchecked-active-thumb-thumb-border':
+    'hsla(var(--figma___switch-unchecked-active-thumb-thumb-border));', // ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border
+  'figma-switch-unchecked-active-background': 'hsla(var(--figma___switch-unchecked-active-background));', // ✦ Theme/Switch/Unchecked/Active/background
+  'figma-switch-unchecked-active-border': 'hsla(var(--figma___switch-unchecked-active-border));', // ✦ Theme/Switch/Unchecked/Active/border
+  'figma-switch-unchecked-default-thumb-thumb-background':
+    'hsla(var(--figma___switch-unchecked-default-thumb-thumb-background));', // ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background
+  'figma-switch-unchecked-default-thumb-thumb-border':
+    'hsla(var(--figma___switch-unchecked-default-thumb-thumb-border));', // ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border
+  'figma-switch-unchecked-default-default-background':
+    'hsla(var(--figma___switch-unchecked-default-default-background));', // ✦ Theme/Switch/Unchecked/Default/default background
+  'figma-switch-unchecked-default-default-border': 'hsla(var(--figma___switch-unchecked-default-default-border));', // ✦ Theme/Switch/Unchecked/Default/default border
+  'figma-switch-unchecked-disabled-thumb-thumb-background':
+    'hsla(var(--figma___switch-unchecked-disabled-thumb-thumb-background));', // ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background
+  'figma-switch-unchecked-disabled-thumb-thumb-border':
+    'hsla(var(--figma___switch-unchecked-disabled-thumb-thumb-border));', // ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border
+  'figma-switch-unchecked-disabled-background': 'hsla(var(--figma___switch-unchecked-disabled-background));', // ✦ Theme/Switch/Unchecked/Disabled/background
+  'figma-switch-unchecked-disabled-border': 'hsla(var(--figma___switch-unchecked-disabled-border));', // ✦ Theme/Switch/Unchecked/Disabled/border
+  'figma-switch-unchecked-hover-thumb-thumb-background':
+    'hsla(var(--figma___switch-unchecked-hover-thumb-thumb-background));', // ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background
+  'figma-switch-unchecked-hover-thumb-thumb-border': 'hsla(var(--figma___switch-unchecked-hover-thumb-thumb-border));', // ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border
+  'figma-switch-unchecked-hover-background': 'hsla(var(--figma___switch-unchecked-hover-background));', // ✦ Theme/Switch/Unchecked/Hover/background
+  'figma-switch-unchecked-hover-border': 'hsla(var(--figma___switch-unchecked-hover-border));', // ✦ Theme/Switch/Unchecked/Hover/border
+  'figma-switch-border': 'hsla(var(--figma___switch-border));', // ✦ Theme/Switch/border
+  'figma-tabs-number-active-background': 'hsla(var(--figma___tabs-number-active-background));', // ✦ Theme/Tabs/Number/Active/Background
+  'figma-tabs-number-active-text': 'hsla(var(--figma___tabs-number-active-text));', // ✦ Theme/Tabs/Number/Active/text
+  'figma-tabs-number-default-hover-background': 'hsla(var(--figma___tabs-number-default-hover-background));', // ✦ Theme/Tabs/Number/Default & Hover/Background
+  'figma-tabs-number-default-hover-text': 'hsla(var(--figma___tabs-number-default-hover-text));', // ✦ Theme/Tabs/Number/Default & Hover/text
+  'figma-tabs-pills-active-active': 'hsla(var(--figma___tabs-pills-active-active));', // ✦ Theme/Tabs/Pills/Active/Active
+  'figma-tabs-pills-active-text': 'hsla(var(--figma___tabs-pills-active-text));', // ✦ Theme/Tabs/Pills/Active/Text
+  'figma-tabs-pills-active-border-grad-1': 'hsla(var(--figma___tabs-pills-active-border-grad-1));', // ✦ Theme/Tabs/Pills/Active/border grad 1
+  'figma-tabs-pills-active-border-grad-2': 'hsla(var(--figma___tabs-pills-active-border-grad-2));', // ✦ Theme/Tabs/Pills/Active/border grad 2
+  'figma-tabs-pills-backgrounds': 'hsla(var(--figma___tabs-pills-backgrounds));', // ✦ Theme/Tabs/Pills/Backgrounds
+  'figma-tabs-pills-default-background': 'hsla(var(--figma___tabs-pills-default-background));', // ✦ Theme/Tabs/Pills/Default/Background
+  'figma-tabs-pills-default-text': 'hsla(var(--figma___tabs-pills-default-text));', // ✦ Theme/Tabs/Pills/Default/Text
+  'figma-tabs-pills-hover-background': 'hsla(var(--figma___tabs-pills-hover-background));', // ✦ Theme/Tabs/Pills/Hover/Background
+  'figma-tabs-pills-hover-text': 'hsla(var(--figma___tabs-pills-hover-text));', // ✦ Theme/Tabs/Pills/Hover/Text
+  'figma-tabs-pills-number-active-background': 'hsla(var(--figma___tabs-pills-number-active-background));', // ✦ Theme/Tabs/Pills/Number/Active/Background
+  'figma-tabs-pills-number-active-text': 'hsla(var(--figma___tabs-pills-number-active-text));', // ✦ Theme/Tabs/Pills/Number/Active/text
+  'figma-tabs-pills-border-grad-1': 'hsla(var(--figma___tabs-pills-border-grad-1));', // ✦ Theme/Tabs/Pills/border grad 1
+  'figma-tabs-pills-border-grad-2': 'hsla(var(--figma___tabs-pills-border-grad-2));', // ✦ Theme/Tabs/Pills/border grad 2
+  'figma-tabs-primary-active-text': 'hsla(var(--figma___tabs-primary-active-text));', // ✦ Theme/Tabs/Primary/Active/Text
+  'figma-tabs-primary-active-underline': 'hsla(var(--figma___tabs-primary-active-underline));', // ✦ Theme/Tabs/Primary/Active/Underline
+  'figma-tabs-primary-border': 'hsla(var(--figma___tabs-primary-border));', // ✦ Theme/Tabs/Primary/Border
+  'figma-tabs-primary-default-background': 'hsla(var(--figma___tabs-primary-default-background));', // ✦ Theme/Tabs/Primary/Default/Background
+  'figma-tabs-primary-default-text': 'hsla(var(--figma___tabs-primary-default-text));', // ✦ Theme/Tabs/Primary/Default/Text
+  'figma-tabs-primary-hover-background': 'hsla(var(--figma___tabs-primary-hover-background));', // ✦ Theme/Tabs/Primary/Hover/Background
+  'figma-tabs-primary-hover-text': 'hsla(var(--figma___tabs-primary-hover-text));', // ✦ Theme/Tabs/Primary/Hover/Text
+  'figma-tabs-primary-pills-pills': 'hsla(var(--figma___tabs-primary-pills-pills));', // ✦ Theme/Tabs/Primary/Pills/Pills
+  'figma-text-disabled': 'hsla(var(--figma___text-disabled));', // ✦ Theme/Text/Disabled
+  'figma-text-links': 'hsla(var(--figma___text-links));', // ✦ Theme/Text/Links
+  'figma-text-secondary': 'hsla(var(--figma___text-secondary));', // ✦ Theme/Text/Secondary
+  'figma-text-tertiary': 'hsla(var(--figma___text-tertiary));', // ✦ Theme/Text/Tertiary
+  'figma-text-primary': 'hsla(var(--figma___text-primary));', // ✦ Theme/Text/primary
+  'figma-textfield-assistive-text-primary': 'hsla(var(--figma___textfield-assistive-text-primary));', // ✦ Theme/Textfield/Assistive Text/Primary
+  'figma-textfield-background': 'hsla(var(--figma___textfield-background));', // ✦ Theme/Textfield/Background
+  'figma-textfield-input-field-background': 'hsla(var(--figma___textfield-input-field-background));', // ✦ Theme/Textfield/Input Field/Background
+  'figma-textfield-input-field-default': 'hsla(var(--figma___textfield-input-field-default));', // ✦ Theme/Textfield/Input Field/Default
+  'figma-textfield-input-field-error': 'hsla(var(--figma___textfield-input-field-error));', // ✦ Theme/Textfield/Input Field/Error
+  'figma-textfield-input-field-hover': 'hsla(var(--figma___textfield-input-field-hover));', // ✦ Theme/Textfield/Input Field/Hover
+  'figma-textfield-label-info-icon': 'hsla(var(--figma___textfield-label-info-icon));', // ✦ Theme/Textfield/Label/Info Icon
+  'figma-textfield-label-link': 'hsla(var(--figma___textfield-label-link));', // ✦ Theme/Textfield/Label/Link
+  'figma-textfield-label-main': 'hsla(var(--figma___textfield-label-main));', // ✦ Theme/Textfield/Label/Main
+  'figma-textfield-label-optional': 'hsla(var(--figma___textfield-label-optional));', // ✦ Theme/Textfield/Label/Optional
+  'figma-textfield-pin-soft-background': 'hsla(var(--figma___textfield-pin-soft-background));', // ✦ Theme/Textfield/Pin/Soft/Background
+  'figma-textfield-pin-soft-border': 'hsla(var(--figma___textfield-pin-soft-border));', // ✦ Theme/Textfield/Pin/Soft/border
+  'figma-textfield-pin-soft-pin': 'hsla(var(--figma___textfield-pin-soft-pin));', // ✦ Theme/Textfield/Pin/Soft/pin
+  'figma-textfield-pin-surface-background': 'hsla(var(--figma___textfield-pin-surface-background));', // ✦ Theme/Textfield/Pin/Surface/Background
+  'figma-textfield-pin-surface-border': 'hsla(var(--figma___textfield-pin-surface-border));', // ✦ Theme/Textfield/Pin/Surface/border
+  'figma-textfield-pin-surface-pin': 'hsla(var(--figma___textfield-pin-surface-pin));', // ✦ Theme/Textfield/Pin/Surface/pin
+  'figma-tooltip-background': 'hsla(var(--figma___tooltip-background));', // ✦ Theme/Tooltip/Background
+  'figma-tooltip-body-text': 'hsla(var(--figma___tooltip-body-text));', // ✦ Theme/Tooltip/Body Text
+  'figma-tooltip-dismissable-icon': 'hsla(var(--figma___tooltip-dismissable-icon));', // ✦ Theme/Tooltip/Dismissable icon
+  'figma-tooltip-tooltip-title': 'hsla(var(--figma___tooltip-tooltip-title));' // ✦ Theme/Tooltip/Tooltip Title
+}

--- a/packages/canary/src/style-tokens/dimensions.ts
+++ b/packages/canary/src/style-tokens/dimensions.ts
@@ -1,68 +1,17 @@
 module.exports = {
-  'figma-badges-badge-radius': 'var(--figma___badges-badge-radius);', // ✦ Theme/Badges/badge-radius
-  'figma-grids-extra-large-1920-col': 'var(--figma___grids-extra-large-1920-col);', // ✦ Theme/Grids/Extra Large (> 1920)/Col
-  'figma-grids-extra-large-1920-gutters': 'var(--figma___grids-extra-large-1920-gutters);', // ✦ Theme/Grids/Extra Large (> 1920)/Gutters
-  'figma-grids-extra-large-1920-width': 'var(--figma___grids-extra-large-1920-width);', // ✦ Theme/Grids/Extra Large (> 1920)/Width
-  'figma-grids-extra-small-0-to-480-col': 'var(--figma___grids-extra-small-0-to-480-col);', // ✦ Theme/Grids/Extra Small (0 to 480)/Col
-  'figma-grids-extra-small-0-to-480-gutters': 'var(--figma___grids-extra-small-0-to-480-gutters);', // ✦ Theme/Grids/Extra Small (0 to 480)/Gutters
-  'figma-grids-extra-small-0-to-480-margins': 'var(--figma___grids-extra-small-0-to-480-margins);', // ✦ Theme/Grids/Extra Small (0 to 480)/Margins
-  'figma-grids-large-1280-to-1920-col': 'var(--figma___grids-large-1280-to-1920-col);', // ✦ Theme/Grids/Large (1280 to 1920)/Col
-  'figma-grids-large-1280-to-1920-gutters': 'var(--figma___grids-large-1280-to-1920-gutters);', // ✦ Theme/Grids/Large (1280 to 1920)/Gutters
-  'figma-grids-large-1280-to-1920-margins': 'var(--figma___grids-large-1280-to-1920-margins);', // ✦ Theme/Grids/Large (1280 to 1920)/Margins
-  'figma-grids-medium-576-to-1279-col': 'var(--figma___grids-medium-576-to-1279-col);', // ✦ Theme/Grids/Medium (576 to 1279)/Col
-  'figma-grids-medium-576-to-1279-gutters': 'var(--figma___grids-medium-576-to-1279-gutters);', // ✦ Theme/Grids/Medium (576 to 1279)/Gutters
-  'figma-grids-medium-576-to-1279-margins': 'var(--figma___grids-medium-576-to-1279-margins);', // ✦ Theme/Grids/Medium (576 to 1279)/Margins
-  'figma-grids-small-480-to-575-col': 'var(--figma___grids-small-480-to-575-col);', // ✦ Theme/Grids/Small (480 to 575)/Col
-  'figma-grids-small-480-to-575-gutters': 'var(--figma___grids-small-480-to-575-gutters);', // ✦ Theme/Grids/Small (480 to 575)/Gutters
-  'figma-grids-small-480-to-575-margins': 'var(--figma___grids-small-480-to-575-margins);', // ✦ Theme/Grids/Small (480 to 575)/Margins
-  'figma-height-button-height-1': 'var(--figma___height-button-height-1);', // ✦ Theme/Height/button-height-1
-  'figma-height-button-height-2': 'var(--figma___height-button-height-2);', // ✦ Theme/Height/button-height-2
-  'figma-height-button-height-3': 'var(--figma___height-button-height-3);', // ✦ Theme/Height/button-height-3
-  'figma-height-button-height-4': 'var(--figma___height-button-height-4);', // ✦ Theme/Height/button-height-4
-  'figma-height-menu-item-height-1': 'var(--figma___height-menu-item-height-1);', // ✦ Theme/Height/menu-item-height-1
-  'figma-height-menu-item-height-2': 'var(--figma___height-menu-item-height-2);', // ✦ Theme/Height/menu-item-height-2
-  'figma-height-table-cell-min-height-1': 'var(--figma___height-table-cell-min-height-1);', // ✦ Theme/Height/table-cell-min-height-1
-  'figma-height-table-cell-min-height-2': 'var(--figma___height-table-cell-min-height-2);', // ✦ Theme/Height/table-cell-min-height-2
-  'figma-height-table-cell-min-height-3': 'var(--figma___height-table-cell-min-height-3);', // ✦ Theme/Height/table-cell-min-height-3
+  'figma-component-pagination-border-radius': 'var(--figma___component-pagination-border-radius);', // ✦ Theme/Component/Pagination/Border-radius
+  'figma-component-pagination-gap': 'var(--figma___component-pagination-gap);', // ✦ Theme/Component/Pagination/Gap
+  'figma-component-switch-thumb-size-1': 'var(--figma___component-switch-thumb-size-1);', // ✦ Theme/Component/Switch/Thumb Size/1
+  'figma-component-switch-thumb-size-2': 'var(--figma___component-switch-thumb-size-2);', // ✦ Theme/Component/Switch/Thumb Size/2
+  'figma-component-switch-thumb-size-3': 'var(--figma___component-switch-thumb-size-3);', // ✦ Theme/Component/Switch/Thumb Size/3
+  'figma-component-textfield-gap': 'var(--figma___component-textfield-gap);', // ✦ Theme/Component/Textfield/Gap
   'figma-padding-main-content-padding': 'var(--figma___padding-main-content-padding);', // ✦ Theme/Padding/Main content padding
-  'figma-padding-table-cell-padding-1': 'var(--figma___padding-table-cell-padding-1);', // ✦ Theme/Padding/table-cell-padding-1
-  'figma-padding-table-cell-padding-2': 'var(--figma___padding-table-cell-padding-2);', // ✦ Theme/Padding/table-cell-padding-2
-  'figma-padding-table-cell-padding-3': 'var(--figma___padding-table-cell-padding-3);', // ✦ Theme/Padding/table-cell-padding-3
-  'figma-pagination-active-border-radius': 'var(--figma___pagination-active-border-radius);', // ✦ Theme/Pagination/Active/Border-radius
-  'figma-pagination-border-radius': 'var(--figma___pagination-border-radius);', // ✦ Theme/Pagination/Border-radius
-  'figma-pagination-default-border-radius': 'var(--figma___pagination-default-border-radius);', // ✦ Theme/Pagination/Default/Border-radius
-  'figma-pagination-gap': 'var(--figma___pagination-gap);', // ✦ Theme/Pagination/Gap
-  'figma-pagination-hover-border-radius': 'var(--figma___pagination-hover-border-radius);', // ✦ Theme/Pagination/Hover/Border-radius
   'figma-radius-1': 'var(--figma___radius-1);', // ✦ Theme/Radius/1
   'figma-radius-2': 'var(--figma___radius-2);', // ✦ Theme/Radius/2
   'figma-radius-3': 'var(--figma___radius-3);', // ✦ Theme/Radius/3
   'figma-radius-4': 'var(--figma___radius-4);', // ✦ Theme/Radius/4
   'figma-radius-5': 'var(--figma___radius-5);', // ✦ Theme/Radius/5
   'figma-radius-6': 'var(--figma___radius-6);', // ✦ Theme/Radius/6
-  'figma-radius-1-max': 'var(--figma___radius-1-max);', // ✦ Theme/Radius/1-max
-  'figma-radius-2-max': 'var(--figma___radius-2-max);', // ✦ Theme/Radius/2-max
-  'figma-radius-3-max': 'var(--figma___radius-3-max);', // ✦ Theme/Radius/3-max
-  'figma-radius-4-max': 'var(--figma___radius-4-max);', // ✦ Theme/Radius/4-max
-  'figma-radius-5-max': 'var(--figma___radius-5-max);', // ✦ Theme/Radius/5-max
-  'figma-radius-6-max': 'var(--figma___radius-6-max);', // ✦ Theme/Radius/6-max
   'figma-radius-main-content-radius': 'var(--figma___radius-main-content-radius);', // ✦ Theme/Radius/Main content radius
-  'figma-radius-full': 'var(--figma___radius-full);', // ✦ Theme/Radius/full
-  'figma-space-1': 'var(--figma___space-1);', // ✦ Theme/Space/1
-  'figma-space-2': 'var(--figma___space-2);', // ✦ Theme/Space/2
-  'figma-space-3': 'var(--figma___space-3);', // ✦ Theme/Space/3
-  'figma-space-4': 'var(--figma___space-4);', // ✦ Theme/Space/4
-  'figma-space-5': 'var(--figma___space-5);', // ✦ Theme/Space/5
-  'figma-space-6': 'var(--figma___space-6);', // ✦ Theme/Space/6
-  'figma-space-7': 'var(--figma___space-7);', // ✦ Theme/Space/7
-  'figma-space-8': 'var(--figma___space-8);', // ✦ Theme/Space/8
-  'figma-space-9': 'var(--figma___space-9);', // ✦ Theme/Space/9
-  'figma-switch-thumb-size-1': 'var(--figma___switch-thumb-size-1);', // ✦ Theme/Switch/Thumb Size/1
-  'figma-switch-thumb-size-2': 'var(--figma___switch-thumb-size-2);', // ✦ Theme/Switch/Thumb Size/2
-  'figma-switch-thumb-size-3': 'var(--figma___switch-thumb-size-3);', // ✦ Theme/Switch/Thumb Size/3
-  'figma-tabs-pills-border-radius': 'var(--figma___tabs-pills-border-radius);', // ✦ Theme/Tabs/Pills/border-radius
-  'figma-tabs-pills-padding': 'var(--figma___tabs-pills-padding);', // ✦ Theme/Tabs/Pills/padding
-  'figma-tabs-pills-pill-border-radius': 'var(--figma___tabs-pills-pill-border-radius);', // ✦ Theme/Tabs/Pills/pill border radius
-  'figma-textfield-assistive-text-assistive-text': 'var(--figma___textfield-assistive-text-assistive-text);', // ✦ Theme/Textfield/Assistive Text/Assistive Text
-  'figma-textfield-gap': 'var(--figma___textfield-gap);', // ✦ Theme/Textfield/Gap
-  'figma-textfield-input-field-textfield-height': 'var(--figma___textfield-input-field-textfield-height);' // ✦ Theme/Textfield/Input Field/Textfield Height
+  'figma-radius-full': 'var(--figma___radius-full);' // ✦ Theme/Radius/full
 }

--- a/packages/canary/src/style-tokens/dimensions.ts
+++ b/packages/canary/src/style-tokens/dimensions.ts
@@ -1,0 +1,68 @@
+module.exports = {
+  'figma-badges-badge-radius': 'var(--figma___badges-badge-radius);', // ✦ Theme/Badges/badge-radius
+  'figma-grids-extra-large-1920-col': 'var(--figma___grids-extra-large-1920-col);', // ✦ Theme/Grids/Extra Large (> 1920)/Col
+  'figma-grids-extra-large-1920-gutters': 'var(--figma___grids-extra-large-1920-gutters);', // ✦ Theme/Grids/Extra Large (> 1920)/Gutters
+  'figma-grids-extra-large-1920-width': 'var(--figma___grids-extra-large-1920-width);', // ✦ Theme/Grids/Extra Large (> 1920)/Width
+  'figma-grids-extra-small-0-to-480-col': 'var(--figma___grids-extra-small-0-to-480-col);', // ✦ Theme/Grids/Extra Small (0 to 480)/Col
+  'figma-grids-extra-small-0-to-480-gutters': 'var(--figma___grids-extra-small-0-to-480-gutters);', // ✦ Theme/Grids/Extra Small (0 to 480)/Gutters
+  'figma-grids-extra-small-0-to-480-margins': 'var(--figma___grids-extra-small-0-to-480-margins);', // ✦ Theme/Grids/Extra Small (0 to 480)/Margins
+  'figma-grids-large-1280-to-1920-col': 'var(--figma___grids-large-1280-to-1920-col);', // ✦ Theme/Grids/Large (1280 to 1920)/Col
+  'figma-grids-large-1280-to-1920-gutters': 'var(--figma___grids-large-1280-to-1920-gutters);', // ✦ Theme/Grids/Large (1280 to 1920)/Gutters
+  'figma-grids-large-1280-to-1920-margins': 'var(--figma___grids-large-1280-to-1920-margins);', // ✦ Theme/Grids/Large (1280 to 1920)/Margins
+  'figma-grids-medium-576-to-1279-col': 'var(--figma___grids-medium-576-to-1279-col);', // ✦ Theme/Grids/Medium (576 to 1279)/Col
+  'figma-grids-medium-576-to-1279-gutters': 'var(--figma___grids-medium-576-to-1279-gutters);', // ✦ Theme/Grids/Medium (576 to 1279)/Gutters
+  'figma-grids-medium-576-to-1279-margins': 'var(--figma___grids-medium-576-to-1279-margins);', // ✦ Theme/Grids/Medium (576 to 1279)/Margins
+  'figma-grids-small-480-to-575-col': 'var(--figma___grids-small-480-to-575-col);', // ✦ Theme/Grids/Small (480 to 575)/Col
+  'figma-grids-small-480-to-575-gutters': 'var(--figma___grids-small-480-to-575-gutters);', // ✦ Theme/Grids/Small (480 to 575)/Gutters
+  'figma-grids-small-480-to-575-margins': 'var(--figma___grids-small-480-to-575-margins);', // ✦ Theme/Grids/Small (480 to 575)/Margins
+  'figma-height-button-height-1': 'var(--figma___height-button-height-1);', // ✦ Theme/Height/button-height-1
+  'figma-height-button-height-2': 'var(--figma___height-button-height-2);', // ✦ Theme/Height/button-height-2
+  'figma-height-button-height-3': 'var(--figma___height-button-height-3);', // ✦ Theme/Height/button-height-3
+  'figma-height-button-height-4': 'var(--figma___height-button-height-4);', // ✦ Theme/Height/button-height-4
+  'figma-height-menu-item-height-1': 'var(--figma___height-menu-item-height-1);', // ✦ Theme/Height/menu-item-height-1
+  'figma-height-menu-item-height-2': 'var(--figma___height-menu-item-height-2);', // ✦ Theme/Height/menu-item-height-2
+  'figma-height-table-cell-min-height-1': 'var(--figma___height-table-cell-min-height-1);', // ✦ Theme/Height/table-cell-min-height-1
+  'figma-height-table-cell-min-height-2': 'var(--figma___height-table-cell-min-height-2);', // ✦ Theme/Height/table-cell-min-height-2
+  'figma-height-table-cell-min-height-3': 'var(--figma___height-table-cell-min-height-3);', // ✦ Theme/Height/table-cell-min-height-3
+  'figma-padding-main-content-padding': 'var(--figma___padding-main-content-padding);', // ✦ Theme/Padding/Main content padding
+  'figma-padding-table-cell-padding-1': 'var(--figma___padding-table-cell-padding-1);', // ✦ Theme/Padding/table-cell-padding-1
+  'figma-padding-table-cell-padding-2': 'var(--figma___padding-table-cell-padding-2);', // ✦ Theme/Padding/table-cell-padding-2
+  'figma-padding-table-cell-padding-3': 'var(--figma___padding-table-cell-padding-3);', // ✦ Theme/Padding/table-cell-padding-3
+  'figma-pagination-active-border-radius': 'var(--figma___pagination-active-border-radius);', // ✦ Theme/Pagination/Active/Border-radius
+  'figma-pagination-border-radius': 'var(--figma___pagination-border-radius);', // ✦ Theme/Pagination/Border-radius
+  'figma-pagination-default-border-radius': 'var(--figma___pagination-default-border-radius);', // ✦ Theme/Pagination/Default/Border-radius
+  'figma-pagination-gap': 'var(--figma___pagination-gap);', // ✦ Theme/Pagination/Gap
+  'figma-pagination-hover-border-radius': 'var(--figma___pagination-hover-border-radius);', // ✦ Theme/Pagination/Hover/Border-radius
+  'figma-radius-1': 'var(--figma___radius-1);', // ✦ Theme/Radius/1
+  'figma-radius-2': 'var(--figma___radius-2);', // ✦ Theme/Radius/2
+  'figma-radius-3': 'var(--figma___radius-3);', // ✦ Theme/Radius/3
+  'figma-radius-4': 'var(--figma___radius-4);', // ✦ Theme/Radius/4
+  'figma-radius-5': 'var(--figma___radius-5);', // ✦ Theme/Radius/5
+  'figma-radius-6': 'var(--figma___radius-6);', // ✦ Theme/Radius/6
+  'figma-radius-1-max': 'var(--figma___radius-1-max);', // ✦ Theme/Radius/1-max
+  'figma-radius-2-max': 'var(--figma___radius-2-max);', // ✦ Theme/Radius/2-max
+  'figma-radius-3-max': 'var(--figma___radius-3-max);', // ✦ Theme/Radius/3-max
+  'figma-radius-4-max': 'var(--figma___radius-4-max);', // ✦ Theme/Radius/4-max
+  'figma-radius-5-max': 'var(--figma___radius-5-max);', // ✦ Theme/Radius/5-max
+  'figma-radius-6-max': 'var(--figma___radius-6-max);', // ✦ Theme/Radius/6-max
+  'figma-radius-main-content-radius': 'var(--figma___radius-main-content-radius);', // ✦ Theme/Radius/Main content radius
+  'figma-radius-full': 'var(--figma___radius-full);', // ✦ Theme/Radius/full
+  'figma-space-1': 'var(--figma___space-1);', // ✦ Theme/Space/1
+  'figma-space-2': 'var(--figma___space-2);', // ✦ Theme/Space/2
+  'figma-space-3': 'var(--figma___space-3);', // ✦ Theme/Space/3
+  'figma-space-4': 'var(--figma___space-4);', // ✦ Theme/Space/4
+  'figma-space-5': 'var(--figma___space-5);', // ✦ Theme/Space/5
+  'figma-space-6': 'var(--figma___space-6);', // ✦ Theme/Space/6
+  'figma-space-7': 'var(--figma___space-7);', // ✦ Theme/Space/7
+  'figma-space-8': 'var(--figma___space-8);', // ✦ Theme/Space/8
+  'figma-space-9': 'var(--figma___space-9);', // ✦ Theme/Space/9
+  'figma-switch-thumb-size-1': 'var(--figma___switch-thumb-size-1);', // ✦ Theme/Switch/Thumb Size/1
+  'figma-switch-thumb-size-2': 'var(--figma___switch-thumb-size-2);', // ✦ Theme/Switch/Thumb Size/2
+  'figma-switch-thumb-size-3': 'var(--figma___switch-thumb-size-3);', // ✦ Theme/Switch/Thumb Size/3
+  'figma-tabs-pills-border-radius': 'var(--figma___tabs-pills-border-radius);', // ✦ Theme/Tabs/Pills/border-radius
+  'figma-tabs-pills-padding': 'var(--figma___tabs-pills-padding);', // ✦ Theme/Tabs/Pills/padding
+  'figma-tabs-pills-pill-border-radius': 'var(--figma___tabs-pills-pill-border-radius);', // ✦ Theme/Tabs/Pills/pill border radius
+  'figma-textfield-assistive-text-assistive-text': 'var(--figma___textfield-assistive-text-assistive-text);', // ✦ Theme/Textfield/Assistive Text/Assistive Text
+  'figma-textfield-gap': 'var(--figma___textfield-gap);', // ✦ Theme/Textfield/Gap
+  'figma-textfield-input-field-textfield-height': 'var(--figma___textfield-input-field-textfield-height);' // ✦ Theme/Textfield/Input Field/Textfield Height
+}

--- a/packages/canary/src/style-tokens/fonts.ts
+++ b/packages/canary/src/style-tokens/fonts.ts
@@ -1,0 +1,70 @@
+module.exports = {
+	"size-components-1": ["12px", { lineHeight: "16px", fontWeight: "500" }],
+	"size-components-2": ["14px", { lineHeight: "20px", fontWeight: "500" }],
+	"size-components-3": ["16px", { lineHeight: "24px", fontWeight: "500" }],
+	"size-components-4": ["18px", { lineHeight: "26px", fontWeight: "500" }],
+	"typography-body-1-medium": [
+		"14px",
+		{ lineHeight: "20px", fontWeight: "500" },
+	],
+	"typography-body-1-regular": [
+		"14px",
+		{ lineHeight: "20px", fontWeight: "400" },
+	],
+	"typography-body-1-semibold": [
+		"14px",
+		{ lineHeight: "20px", fontWeight: "600" },
+	],
+	"typography-body-2-medium": [
+		"12px",
+		{ lineHeight: "16px", fontWeight: "500" },
+	],
+	"typography-body-2-regular": [
+		"12px",
+		{ lineHeight: "16px", fontWeight: "400" },
+	],
+	"typography-body-2-semibold": [
+		"12px",
+		{ lineHeight: "16px", fontWeight: "600" },
+	],
+	"typography-greeting-text-greeting-text": [
+		"35px",
+		{ lineHeight: "40px", fontWeight: "600" },
+	],
+	"typography-metadata-and-graph-axis-medium": [
+		"10px",
+		{ lineHeight: "12px", fontWeight: "500" },
+	],
+	"typography-metadata-and-graph-axis-regular": [
+		"10px",
+		{ lineHeight: "12px", fontWeight: "400" },
+	],
+	"typography-metadata-and-graph-axis-semibold": [
+		"10px",
+		{ lineHeight: "16px", fontWeight: "600" },
+	],
+	"typography-modal-dialog-header": [
+		"20px",
+		{ lineHeight: "28px", fontWeight: "600" },
+	],
+	"typography-page-header-page-header": [
+		"24px",
+		{ lineHeight: "30px", fontWeight: "600" },
+	],
+	"typography-subtitle-1-medium": [
+		"16px",
+		{ lineHeight: "24px", fontWeight: "500" },
+	],
+	"typography-subtitle-1-regular": [
+		"16px",
+		{ lineHeight: "24px", fontWeight: "400" },
+	],
+	"typography-subtitle-2-medium": [
+		"16px",
+		{ lineHeight: "24px", fontWeight: "500" },
+	],
+	"typography-subtitle-2-semibold": [
+		"16px",
+		{ lineHeight: "24px", fontWeight: "600" },
+	],
+};

--- a/packages/canary/src/style-tokens/themes/harness-open-source.css
+++ b/packages/canary/src/style-tokens/themes/harness-open-source.css
@@ -1,0 +1,3767 @@
+/* Non color variables */
+:root {
+  --figma___badges-badge-radius: 100px;
+  /* ✦ Theme/Badges/badge-radius/Harness Open Source/Mode 1 */
+  --figma___grids-extra-large-1920-col: 12px;
+  /* ✦ Theme/Grids/Extra Large (> 1920)/Col/Harness Open Source/Mode 1 */
+  --figma___grids-extra-large-1920-gutters: 20px;
+  /* ✦ Theme/Grids/Extra Large (> 1920)/Gutters/Harness Open Source/Mode 1 */
+  --figma___grids-extra-large-1920-width: 138px;
+  /* ✦ Theme/Grids/Extra Large (> 1920)/Width/Harness Open Source/Mode 1 */
+  --figma___grids-extra-small-0-to-480-col: 2px;
+  /* ✦ Theme/Grids/Extra Small (0 to 480)/Col/Harness Open Source/Mode 1 */
+  --figma___grids-extra-small-0-to-480-gutters: 16px;
+  /* ✦ Theme/Grids/Extra Small (0 to 480)/Gutters/Harness Open Source/Mode 1 */
+  --figma___grids-extra-small-0-to-480-margins: 16px;
+  /* ✦ Theme/Grids/Extra Small (0 to 480)/Margins/Harness Open Source/Mode 1 */
+  --figma___grids-large-1280-to-1920-col: 12px;
+  /* ✦ Theme/Grids/Large (1280 to 1920)/Col/Harness Open Source/Mode 1 */
+  --figma___grids-large-1280-to-1920-gutters: 20px;
+  /* ✦ Theme/Grids/Large (1280 to 1920)/Gutters/Harness Open Source/Mode 1 */
+  --figma___grids-large-1280-to-1920-margins: 24px;
+  /* ✦ Theme/Grids/Large (1280 to 1920)/Margins/Harness Open Source/Mode 1 */
+  --figma___grids-medium-576-to-1279-col: 8px;
+  /* ✦ Theme/Grids/Medium (576 to 1279)/Col/Harness Open Source/Mode 1 */
+  --figma___grids-medium-576-to-1279-gutters: 16px;
+  /* ✦ Theme/Grids/Medium (576 to 1279)/Gutters/Harness Open Source/Mode 1 */
+  --figma___grids-medium-576-to-1279-margins: 24px;
+  /* ✦ Theme/Grids/Medium (576 to 1279)/Margins/Harness Open Source/Mode 1 */
+  --figma___grids-small-480-to-575-col: 4px;
+  /* ✦ Theme/Grids/Small (480 to 575)/Col/Harness Open Source/Mode 1 */
+  --figma___grids-small-480-to-575-gutters: 16px;
+  /* ✦ Theme/Grids/Small (480 to 575)/Gutters/Harness Open Source/Mode 1 */
+  --figma___grids-small-480-to-575-margins: 24px;
+  /* ✦ Theme/Grids/Small (480 to 575)/Margins/Harness Open Source/Mode 1 */
+  --figma___height-button-height-1: 24px;
+  /* ✦ Theme/Height/button-height-1/Harness Open Source/Mode 1 */
+  --figma___height-button-height-2: 32px;
+  /* ✦ Theme/Height/button-height-2/Harness Open Source/Mode 1 */
+  --figma___height-button-height-3: 40px;
+  /* ✦ Theme/Height/button-height-3/Harness Open Source/Mode 1 */
+  --figma___height-button-height-4: 48px;
+  /* ✦ Theme/Height/button-height-4/Harness Open Source/Mode 1 */
+  --figma___height-menu-item-height-1: 24px;
+  /* ✦ Theme/Height/menu-item-height-1/Harness Open Source/Mode 1 */
+  --figma___height-menu-item-height-2: 32px;
+  /* ✦ Theme/Height/menu-item-height-2/Harness Open Source/Mode 1 */
+  --figma___height-table-cell-min-height-1: 36px;
+  /* ✦ Theme/Height/table-cell-min-height-1/Harness Open Source/Mode 1 */
+  --figma___height-table-cell-min-height-2: 44px;
+  /* ✦ Theme/Height/table-cell-min-height-2/Harness Open Source/Mode 1 */
+  --figma___height-table-cell-min-height-3: 48px;
+  /* ✦ Theme/Height/table-cell-min-height-3/Harness Open Source/Mode 1 */
+  --figma___padding-main-content-padding: 0px;
+  /* ✦ Theme/Padding/Main content padding/Harness Open Source/Mode 1 */
+  --figma___padding-table-cell-padding-1: 8px;
+  /* ✦ Theme/Padding/table-cell-padding-1/Harness Open Source/Mode 1 */
+  --figma___padding-table-cell-padding-2: 12px;
+  /* ✦ Theme/Padding/table-cell-padding-2/Harness Open Source/Mode 1 */
+  --figma___padding-table-cell-padding-3: 16px;
+  /* ✦ Theme/Padding/table-cell-padding-3/Harness Open Source/Mode 1 */
+  --figma___pagination-active-border-radius: 32px;
+  /* ✦ Theme/Pagination/Active/Border-radius/Harness Open Source/Mode 1 */
+  --figma___pagination-border-radius: 0px;
+  /* ✦ Theme/Pagination/Border-radius/Harness Open Source/Mode 1 */
+  --figma___pagination-default-border-radius: 4px;
+  /* ✦ Theme/Pagination/Default/Border-radius/Harness Open Source/Mode 1 */
+  --figma___pagination-gap: 0px;
+  /* ✦ Theme/Pagination/Gap/Harness Open Source/Mode 1 */
+  --figma___pagination-hover-border-radius: 100px;
+  /* ✦ Theme/Pagination/Hover/Border-radius/Harness Open Source/Mode 1 */
+  --figma___radius-1: 3px;
+  /* ✦ Theme/Radius/1/Harness Open Source/Mode 1 */
+  --figma___radius-2: 4px;
+  /* ✦ Theme/Radius/2/Harness Open Source/Mode 1 */
+  --figma___radius-3: 6px;
+  /* ✦ Theme/Radius/3/Harness Open Source/Mode 1 */
+  --figma___radius-4: 8px;
+  /* ✦ Theme/Radius/4/Harness Open Source/Mode 1 */
+  --figma___radius-5: 12px;
+  /* ✦ Theme/Radius/5/Harness Open Source/Mode 1 */
+  --figma___radius-6: 16px;
+  /* ✦ Theme/Radius/6/Harness Open Source/Mode 1 */
+  --figma___radius-1-max: 3px;
+  /* ✦ Theme/Radius/1-max/Harness Open Source/Mode 1 */
+  --figma___radius-2-max: 4px;
+  /* ✦ Theme/Radius/2-max/Harness Open Source/Mode 1 */
+  --figma___radius-3-max: 6px;
+  /* ✦ Theme/Radius/3-max/Harness Open Source/Mode 1 */
+  --figma___radius-4-max: 8px;
+  /* ✦ Theme/Radius/4-max/Harness Open Source/Mode 1 */
+  --figma___radius-5-max: 12px;
+  /* ✦ Theme/Radius/5-max/Harness Open Source/Mode 1 */
+  --figma___radius-6-max: 16px;
+  /* ✦ Theme/Radius/6-max/Harness Open Source/Mode 1 */
+  --figma___radius-main-content-radius: 0px;
+  /* ✦ Theme/Radius/Main content radius/Harness Open Source/Mode 1 */
+  --figma___radius-full: 9999px;
+  /* ✦ Theme/Radius/full/Harness Open Source/Mode 1 */
+  --figma___space-1: 4px;
+  /* ✦ Theme/Space/1/Harness Open Source/Mode 1 */
+  --figma___space-2: 8px;
+  /* ✦ Theme/Space/2/Harness Open Source/Mode 1 */
+  --figma___space-3: 12px;
+  /* ✦ Theme/Space/3/Harness Open Source/Mode 1 */
+  --figma___space-4: 16px;
+  /* ✦ Theme/Space/4/Harness Open Source/Mode 1 */
+  --figma___space-5: 24px;
+  /* ✦ Theme/Space/5/Harness Open Source/Mode 1 */
+  --figma___space-6: 32px;
+  /* ✦ Theme/Space/6/Harness Open Source/Mode 1 */
+  --figma___space-7: 40px;
+  /* ✦ Theme/Space/7/Harness Open Source/Mode 1 */
+  --figma___space-8: 48px;
+  /* ✦ Theme/Space/8/Harness Open Source/Mode 1 */
+  --figma___space-9: 64px;
+  /* ✦ Theme/Space/9/Harness Open Source/Mode 1 */
+  --figma___switch-thumb-size-1: 12px;
+  /* ✦ Theme/Switch/Thumb Size/1/Harness Open Source/Mode 1 */
+  --figma___switch-thumb-size-2: 16px;
+  /* ✦ Theme/Switch/Thumb Size/2/Harness Open Source/Mode 1 */
+  --figma___switch-thumb-size-3: 20px;
+  /* ✦ Theme/Switch/Thumb Size/3/Harness Open Source/Mode 1 */
+  --figma___tabs-pills-border-radius: 6px;
+  /* ✦ Theme/Tabs/Pills/border-radius/Harness Open Source/Mode 1 */
+  --figma___tabs-pills-padding: 4px;
+  /* ✦ Theme/Tabs/Pills/padding/Harness Open Source/Mode 1 */
+  --figma___tabs-pills-pill-border-radius: 4px;
+  /* ✦ Theme/Tabs/Pills/pill border radius/Harness Open Source/Mode 1 */
+  --figma___textfield-assistive-text-assistive-text: 14px;
+  /* ✦ Theme/Textfield/Assistive Text/Assistive Text/Harness Open Source/Mode 1 */
+  --figma___textfield-gap: 8px;
+  /* ✦ Theme/Textfield/Gap/Harness Open Source/Mode 1 */
+  --figma___textfield-input-field-textfield-height: 36px;
+  /* ✦ Theme/Textfield/Input Field/Textfield Height/Harness Open Source/Mode 1 */
+}
+
+/* Color variables - light mode */
+.harness-open-source-light {
+  --figma___background-backdrop: 230 100% 9% / 0.28;
+  /* ✦ Theme/Background/Backdrop/Harness Open Source/Light */
+  --figma___background-cards-and-rows-default: 0 0% 100% / 0;
+  /* ✦ Theme/Background/Cards and Rows/Default/Harness Open Source/Light */
+  --figma___background-cards-and-rows-hover: 0 0% 0% / 0.03;
+  /* ✦ Theme/Background/Cards and Rows/Hover/Harness Open Source/Light */
+  --figma___background-cards-and-rows-primary-blue-selected: 240 100% 12% / 0.05;
+  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/Harness Open Source/Light */
+  --figma___background-cards-and-rows-selected: 0 0% 0% / 0.04;
+  /* ✦ Theme/Background/Cards and Rows/Selected/Harness Open Source/Light */
+  --figma___background-header-page-header: 0 0% 100% / 1;
+  /* ✦ Theme/Background/Header/Page Header/Harness Open Source/Light */
+  --figma___background-header-table-header: 0 0% 98% / 1;
+  /* ✦ Theme/Background/Header/Table Header/Harness Open Source/Light */
+  --figma___background-paper: 0 0% 98% / 1;
+  /* ✦ Theme/Background/Paper/Harness Open Source/Light */
+  --figma___background-primary: 0 0% 98% / 1;
+  /* ✦ Theme/Background/Primary/Harness Open Source/Light */
+  --figma___background-solid: 0 0% 100% / 1;
+  /* ✦ Theme/Background/Solid/Harness Open Source/Light */
+  --figma___badges-soft-amber-background: 45 100% 50% / 0.19;
+  /* ✦ Theme/Badges/Soft/Amber/background/Harness Open Source/Light */
+  --figma___badges-soft-amber-text: 25 100% 24% / 0.81;
+  /* ✦ Theme/Badges/Soft/Amber/text/Harness Open Source/Light */
+  --figma___badges-soft-blue-background: 210 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Soft/Blue/background/Harness Open Source/Light */
+  --figma___badges-soft-blue-text: 211 100% 39% / 0.96;
+  /* ✦ Theme/Badges/Soft/Blue/text/Harness Open Source/Light */
+  --figma___badges-soft-bronze-background: 18 99% 30% / 0.07;
+  /* ✦ Theme/Badges/Soft/Bronze/background/Harness Open Source/Light */
+  --figma___badges-soft-bronze-text: 15 100% 12% / 0.67;
+  /* ✦ Theme/Badges/Soft/Bronze/text/Harness Open Source/Light */
+  --figma___badges-soft-brown-background: 30 98% 34% / 0.08;
+  /* ✦ Theme/Badges/Soft/Brown/background/Harness Open Source/Light */
+  --figma___badges-soft-brown-text: 24 100% 16% / 0.73;
+  /* ✦ Theme/Badges/Soft/Brown/text/Harness Open Source/Light */
+  --figma___badges-soft-crimson-background: 332 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Soft/Crimson/background/Harness Open Source/Light */
+  --figma___badges-soft-crimson-text: 336 100% 38% / 0.89;
+  /* ✦ Theme/Badges/Soft/Crimson/text/Harness Open Source/Light */
+  --figma___badges-soft-cyan-background: 186 98% 42% / 0.09;
+  /* ✦ Theme/Badges/Soft/Cyan/background/Harness Open Source/Light */
+  --figma___badges-soft-cyan-text: 192 100% 28% / 0.95;
+  /* ✦ Theme/Badges/Soft/Cyan/text/Harness Open Source/Light */
+  --figma___badges-soft-gold-background: 45 97% 28% / 0.09;
+  /* ✦ Theme/Badges/Soft/Gold/background/Harness Open Source/Light */
+  --figma___badges-soft-gold-text: 36 100% 11% / 0.71;
+  /* ✦ Theme/Badges/Soft/Gold/text/Harness Open Source/Light */
+  --figma___badges-soft-grass-background: 120 98% 35% / 0.08;
+  /* ✦ Theme/Badges/Soft/Grass/background/Harness Open Source/Light */
+  --figma___badges-soft-grass-text: 133 100% 19% / 0.84;
+  /* ✦ Theme/Badges/Soft/Grass/text/Harness Open Source/Light */
+  --figma___badges-soft-green-background: 139 98% 37% / 0.09;
+  /* ✦ Theme/Badges/Soft/Green/background/Harness Open Source/Light */
+  --figma___badges-soft-green-text: 153 100% 21% / 0.91;
+  /* ✦ Theme/Badges/Soft/Green/text/Harness Open Source/Light */
+  --figma___badges-soft-indigo-background: 224 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Soft/Indigo/background/Harness Open Source/Light */
+  --figma___badges-soft-indigo-text: 226 100% 31% / 0.8;
+  /* ✦ Theme/Badges/Soft/Indigo/text/Harness Open Source/Light */
+  --figma___badges-soft-iris-background: 240 100% 51% / 0.05;
+  /* ✦ Theme/Badges/Soft/Iris/background/Harness Open Source/Light */
+  --figma___badges-soft-iris-text: 240 100% 34% / 0.72;
+  /* ✦ Theme/Badges/Soft/Iris/text/Harness Open Source/Light */
+  --figma___badges-soft-jade-background: 150 100% 41% / 0.11;
+  /* ✦ Theme/Badges/Soft/Jade/background/Harness Open Source/Light */
+  --figma___badges-soft-jade-text: 163 100% 21% / 0.9;
+  /* ✦ Theme/Badges/Soft/Jade/text/Harness Open Source/Light */
+  --figma___badges-soft-lime-background: 84 99% 44% / 0.15;
+  /* ✦ Theme/Badges/Soft/Lime/background/Harness Open Source/Light */
+  --figma___badges-soft-lime-text: 75 100% 14% / 0.83;
+  /* ✦ Theme/Badges/Soft/Lime/text/Harness Open Source/Light */
+  --figma___badges-soft-mint-background: 164 99% 44% / 0.13;
+  /* ✦ Theme/Badges/Soft/Mint/background/Harness Open Source/Light */
+  --figma___badges-soft-mint-text: 172 100% 18% / 0.85;
+  /* ✦ Theme/Badges/Soft/Mint/text/Harness Open Source/Light */
+  --figma___badges-soft-orange-background: 34 100% 50% / 0.17;
+  /* ✦ Theme/Badges/Soft/Orange/background/Harness Open Source/Light */
+  --figma___badges-soft-orange-text: 16 100% 24% / 0.77;
+  /* ✦ Theme/Badges/Soft/Orange/text/Harness Open Source/Light */
+  --figma___badges-soft-pink-background: 323 99% 47% / 0.07;
+  /* ✦ Theme/Badges/Soft/Pink/background/Harness Open Source/Light */
+  --figma___badges-soft-pink-text: 322 100% 37% / 0.89;
+  /* ✦ Theme/Badges/Soft/Pink/text/Harness Open Source/Light */
+  --figma___badges-soft-plum-background: 300 99% 41% / 0.06;
+  /* ✦ Theme/Badges/Soft/Plum/background/Harness Open Source/Light */
+  --figma___badges-soft-plum-text: 292 100% 31% / 0.83;
+  /* ✦ Theme/Badges/Soft/Plum/text/Harness Open Source/Light */
+  --figma___badges-soft-purple-background: 277 100% 46% / 0.05;
+  /* ✦ Theme/Badges/Soft/Purple/background/Harness Open Source/Light */
+  --figma___badges-soft-purple-text: 273 100% 30% / 0.77;
+  /* ✦ Theme/Badges/Soft/Purple/text/Harness Open Source/Light */
+  --figma___badges-soft-red-background: 0 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Soft/Red/background/Harness Open Source/Light */
+  --figma___badges-soft-red-text: 358 100% 37% / 0.84;
+  /* ✦ Theme/Badges/Soft/Red/text/Harness Open Source/Light */
+  --figma___badges-soft-ruby-background: 344 100% 47% / 0.06;
+  /* ✦ Theme/Badges/Soft/Ruby/background/Harness Open Source/Light */
+  --figma___badges-soft-ruby-text: 345 100% 38% / 0.86;
+  /* ✦ Theme/Badges/Soft/Ruby/text/Harness Open Source/Light */
+  --figma___badges-soft-sky-background: 192 100% 50% / 0.11;
+  /* ✦ Theme/Badges/Soft/Sky/background/Harness Open Source/Light */
+  --figma___badges-soft-sky-text: 200 100% 25% / 0.86;
+  /* ✦ Theme/Badges/Soft/Sky/text/Harness Open Source/Light */
+  --figma___badges-soft-teal-background: 167 98% 38% / 0.09;
+  /* ✦ Theme/Badges/Soft/Teal/background/Harness Open Source/Light */
+  --figma___badges-soft-teal-text: 174 100% 23% / 0.98;
+  /* ✦ Theme/Badges/Soft/Teal/text/Harness Open Source/Light */
+  --figma___badges-soft-violet-background: 254 100% 50% / 0.05;
+  /* ✦ Theme/Badges/Soft/Violet/background/Harness Open Source/Light */
+  --figma___badges-soft-violet-text: 250 100% 28% / 0.73;
+  /* ✦ Theme/Badges/Soft/Violet/text/Harness Open Source/Light */
+  --figma___badges-soft-yellow-background: 53 100% 50% / 0.22;
+  /* ✦ Theme/Badges/Soft/Yellow/background/Harness Open Source/Light */
+  --figma___badges-soft-yellow-text: 42 100% 18% / 0.84;
+  /* ✦ Theme/Badges/Soft/Yellow/text/Harness Open Source/Light */
+  --figma___badges-soft-accent-background: 220 6% 90% / 1;
+  /* ✦ Theme/Badges/Soft/accent/background/Harness Open Source/Light */
+  --figma___badges-soft-accent-text: 210 6% 6% / 1;
+  /* ✦ Theme/Badges/Soft/accent/text/Harness Open Source/Light */
+  --figma___badges-soft-error-background: 0 100% 71% / 0.1;
+  /* ✦ Theme/Badges/Soft/error/background/Harness Open Source/Light */
+  --figma___badges-soft-error-text: 0 100% 71% / 0.1;
+  /* ✦ Theme/Badges/Soft/error/text/Harness Open Source/Light */
+  --figma___badges-soft-info-background: 210 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Soft/info/background/Harness Open Source/Light */
+  --figma___badges-soft-info-text: 211 100% 39% / 0.96;
+  /* ✦ Theme/Badges/Soft/info/text/Harness Open Source/Light */
+  --figma___badges-soft-success-background: 139 98% 37% / 0.09;
+  /* ✦ Theme/Badges/Soft/success/background/Harness Open Source/Light */
+  --figma___badges-soft-success-text: 153 100% 21% / 0.91;
+  /* ✦ Theme/Badges/Soft/success/text/Harness Open Source/Light */
+  --figma___badges-soft-warning-background: 45 100% 91% / 1;
+  /* ✦ Theme/Badges/Soft/warning/background/Harness Open Source/Light */
+  --figma___badges-soft-warning-text: 25 100% 24% / 0.81;
+  /* ✦ Theme/Badges/Soft/warning/text/Harness Open Source/Light */
+  --figma___badges-solid-amber-background: 42 100% 62% / 1;
+  /* ✦ Theme/Badges/Solid/Amber/background/Harness Open Source/Light */
+  --figma___badges-solid-blue-background: 214 73% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Blue/background/Harness Open Source/Light */
+  --figma___badges-solid-bronze-background: 18 20% 54% / 1;
+  /* ✦ Theme/Badges/Solid/Bronze/background/Harness Open Source/Light */
+  --figma___badges-solid-brown-background: 28 34% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Brown/background/Harness Open Source/Light */
+  --figma___badges-solid-crimson-background: 336 80% 58% / 1;
+  /* ✦ Theme/Badges/Solid/Crimson/background/Harness Open Source/Light */
+  --figma___badges-solid-cyan-background: 190 95% 39% / 1;
+  /* ✦ Theme/Badges/Solid/Cyan/background/Harness Open Source/Light */
+  --figma___badges-solid-gold-background: 36 20% 49% / 1;
+  /* ✦ Theme/Badges/Solid/Gold/background/Harness Open Source/Light */
+  --figma___badges-solid-grass-background: 132 59% 33% / 1;
+  /* ✦ Theme/Badges/Solid/Grass/background/Harness Open Source/Light */
+  --figma___badges-solid-green-background: 142 72% 29% / 1;
+  /* ✦ Theme/Badges/Solid/Green/background/Harness Open Source/Light */
+  --figma___badges-solid-indigo-background: 226 70% 55% / 1;
+  /* ✦ Theme/Badges/Solid/Indigo/background/Harness Open Source/Light */
+  --figma___badges-solid-iris-background: 240 60% 60% / 1;
+  /* ✦ Theme/Badges/Solid/Iris/background/Harness Open Source/Light */
+  --figma___badges-solid-jade-background: 164 60% 40% / 1;
+  /* ✦ Theme/Badges/Solid/Jade/background/Harness Open Source/Light */
+  --figma___badges-solid-lime-background: 81 80% 66% / 1;
+  /* ✦ Theme/Badges/Solid/Lime/background/Harness Open Source/Light */
+  --figma___badges-solid-mint-background: 176 59% 50% / 1;
+  /* ✦ Theme/Badges/Solid/Mint/background/Harness Open Source/Light */
+  --figma___badges-solid-orange-background: 24 94% 50% / 1;
+  /* ✦ Theme/Badges/Solid/Orange/background/Harness Open Source/Light */
+  --figma___badges-solid-pink-background: 322 65% 55% / 1;
+  /* ✦ Theme/Badges/Solid/Pink/background/Harness Open Source/Light */
+  --figma___badges-solid-plum-background: 292 45% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Plum/background/Harness Open Source/Light */
+  --figma___badges-solid-purple-background: 272 51% 54% / 1;
+  /* ✦ Theme/Badges/Solid/Purple/background/Harness Open Source/Light */
+  --figma___badges-solid-red-background: 358 75% 59% / 1;
+  /* ✦ Theme/Badges/Solid/Red/background/Harness Open Source/Light */
+  --figma___badges-solid-ruby-background: 348 75% 59% / 1;
+  /* ✦ Theme/Badges/Solid/Ruby/background/Harness Open Source/Light */
+  --figma___badges-solid-sky-background: 193 98% 74% / 1;
+  /* ✦ Theme/Badges/Solid/Sky/background/Harness Open Source/Light */
+  --figma___badges-solid-success-background: 142 72% 29% / 1;
+  /* ✦ Theme/Badges/Solid/Success/background/Harness Open Source/Light */
+  --figma___badges-solid-teal-background: 173 80% 36% / 1;
+  /* ✦ Theme/Badges/Solid/Teal/background/Harness Open Source/Light */
+  --figma___badges-solid-violet-background: 252 56% 57% / 1;
+  /* ✦ Theme/Badges/Solid/Violet/background/Harness Open Source/Light */
+  --figma___badges-solid-yellow-background: 53 96% 58% / 1;
+  /* ✦ Theme/Badges/Solid/Yellow/background/Harness Open Source/Light */
+  --figma___badges-solid-accent-background: 176 59% 50% / 1;
+  /* ✦ Theme/Badges/Solid/accent/background/Harness Open Source/Light */
+  --figma___badges-solid-info-background: 214 73% 51% / 1;
+  /* ✦ Theme/Badges/Solid/info/background/Harness Open Source/Light */
+  --figma___badges-solid-warning-background: 25 50% 38% / 1;
+  /* ✦ Theme/Badges/Solid/warning/background/Harness Open Source/Light */
+  --figma___badges-surface-amber-background: 40 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/Amber/background/Harness Open Source/Light */
+  --figma___badges-surface-amber-border: 37 100% 40% / 0.53;
+  /* ✦ Theme/Badges/Surface/Amber/border/Harness Open Source/Light */
+  --figma___badges-surface-amber-text: 25 100% 24% / 0.81;
+  /* ✦ Theme/Badges/Surface/Amber/text/Harness Open Source/Light */
+  --figma___badges-surface-blue-background: 210 100% 51% / 0.04;
+  /* ✦ Theme/Badges/Surface/Blue/background/Harness Open Source/Light */
+  --figma___badges-surface-blue-border: 208 100% 44% / 0.41;
+  /* ✦ Theme/Badges/Surface/Blue/border/Harness Open Source/Light */
+  --figma___badges-surface-blue-text: 211 100% 39% / 0.96;
+  /* ✦ Theme/Badges/Surface/Blue/text/Harness Open Source/Light */
+  --figma___badges-surface-bronze-background: 17 95% 40% / 0.04;
+  /* ✦ Theme/Badges/Surface/Bronze/background/Harness Open Source/Light */
+  --figma___badges-surface-bronze-border: 18 100% 22% / 0.31;
+  /* ✦ Theme/Badges/Surface/Bronze/border/Harness Open Source/Light */
+  --figma___badges-surface-bronze-text: 15 100% 12% / 0.67;
+  /* ✦ Theme/Badges/Surface/Bronze/text/Harness Open Source/Light */
+  --figma___badges-surface-brown-background: 30 94% 35% / 0.04;
+  /* ✦ Theme/Badges/Surface/Brown/background/Harness Open Source/Light */
+  --figma___badges-surface-brown-border: 29 100% 34% / 0.41;
+  /* ✦ Theme/Badges/Surface/Brown/border/Harness Open Source/Light */
+  --figma___badges-surface-brown-text: 24 100% 16% / 0.73;
+  /* ✦ Theme/Badges/Surface/Brown/text/Harness Open Source/Light */
+  --figma___badges-surface-crimson-border: 335 100% 39% / 0.32;
+  /* ✦ Theme/Badges/Surface/Crimson/Border/Harness Open Source/Light */
+  --figma___badges-surface-crimson-background: 330 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Crimson/background/Harness Open Source/Light */
+  --figma___badges-surface-crimson-text: 336 100% 38% / 0.89;
+  /* ✦ Theme/Badges/Surface/Crimson/text/Harness Open Source/Light */
+  --figma___badges-surface-cyan-border: 189 100% 35% / 0.48;
+  /* ✦ Theme/Badges/Surface/Cyan/Border/Harness Open Source/Light */
+  --figma___badges-surface-cyan-background: 186 100% 42% / 0.05;
+  /* ✦ Theme/Badges/Surface/Cyan/background/Harness Open Source/Light */
+  --figma___badges-surface-cyan-text: 192 100% 28% / 0.95;
+  /* ✦ Theme/Badges/Surface/Cyan/text/Harness Open Source/Light */
+  --figma___badges-surface-gold-border: 38 100% 22% / 0.36;
+  /* ✦ Theme/Badges/Surface/Gold/Border/Harness Open Source/Light */
+  --figma___badges-surface-gold-background: 47 100% 35% / 0.05;
+  /* ✦ Theme/Badges/Surface/Gold/background/Harness Open Source/Light */
+  --figma___badges-surface-gold-text: 36 100% 11% / 0.71;
+  /* ✦ Theme/Badges/Surface/Gold/text/Harness Open Source/Light */
+  --figma___badges-surface-grass-border: 125 100% 27% / 0.41;
+  /* ✦ Theme/Badges/Surface/Grass/Border/Harness Open Source/Light */
+  --figma___badges-surface-grass-background: 120 95% 39% / 0.05;
+  /* ✦ Theme/Badges/Surface/Grass/background/Harness Open Source/Light */
+  --figma___badges-surface-grass-text: 133 100% 19% / 0.84;
+  /* ✦ Theme/Badges/Surface/Grass/text/Harness Open Source/Light */
+  --figma___badges-surface-green-background: 139 98% 37% / 0.09;
+  /* ✦ Theme/Badges/Surface/Green/background/Harness Open Source/Light */
+  --figma___badges-surface-green-border: 146 100% 27% / 0.43;
+  /* ✦ Theme/Badges/Surface/Green/border/Harness Open Source/Light */
+  --figma___badges-surface-green-text: 153 100% 21% / 0.91;
+  /* ✦ Theme/Badges/Surface/Green/text/Harness Open Source/Light */
+  --figma___badges-surface-indigo-background: 223 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Indigo/background/Harness Open Source/Light */
+  --figma___badges-surface-indigo-border: 225 100% 44% / 0.32;
+  /* ✦ Theme/Badges/Surface/Indigo/border/Harness Open Source/Light */
+  --figma___badges-surface-indigo-text: 226 100% 31% / 0.8;
+  /* ✦ Theme/Badges/Surface/Indigo/text/Harness Open Source/Light */
+  --figma___badges-surface-iris-border: 239 100% 43% / 0.27;
+  /* ✦ Theme/Badges/Surface/Iris/Border/Harness Open Source/Light */
+  --figma___badges-surface-iris-background: 240 100% 51% / 0.02;
+  /* ✦ Theme/Badges/Surface/Iris/background/Harness Open Source/Light */
+  --figma___badges-surface-iris-text: 240 100% 34% / 0.72;
+  /* ✦ Theme/Badges/Surface/Iris/text/Harness Open Source/Light */
+  --figma___badges-surface-jade-border: 159 100% 29% / 0.44;
+  /* ✦ Theme/Badges/Surface/Jade/Border/Harness Open Source/Light */
+  --figma___badges-surface-jade-background: 150 99% 44% / 0.06;
+  /* ✦ Theme/Badges/Surface/Jade/background/Harness Open Source/Light */
+  --figma___badges-surface-jade-text: 163 100% 21% / 0.9;
+  /* ✦ Theme/Badges/Surface/Jade/text/Harness Open Source/Light */
+  --figma___badges-surface-lime-border: 79 100% 29% / 0.5;
+  /* ✦ Theme/Badges/Surface/Lime/Border/Harness Open Source/Light */
+  --figma___badges-surface-lime-background: 85 99% 40% / 0.06;
+  /* ✦ Theme/Badges/Surface/Lime/background/Harness Open Source/Light */
+  --figma___badges-surface-lime-text: 75 100% 14% / 0.83;
+  /* ✦ Theme/Badges/Surface/Lime/text/Harness Open Source/Light */
+  --figma___badges-surface-mint-background: 164 99% 47% / 0.06;
+  /* ✦ Theme/Badges/Surface/Mint/background/Harness Open Source/Light */
+  --figma___badges-surface-mint-border: 166 100% 30% / 0.47;
+  /* ✦ Theme/Badges/Surface/Mint/border/Harness Open Source/Light */
+  --figma___badges-surface-mint-text: 172 100% 18% / 0.85;
+  /* ✦ Theme/Badges/Surface/Mint/text/Harness Open Source/Light */
+  --figma___badges-surface-orange-background: 34 100% 50% / 0.17;
+  /* ✦ Theme/Badges/Surface/Orange/background/Harness Open Source/Light */
+  --figma___badges-surface-orange-border: 21 100% 50% / 0.51;
+  /* ✦ Theme/Badges/Surface/Orange/border/Harness Open Source/Light */
+  --figma___badges-surface-orange-text: 16 100% 24% / 0.77;
+  /* ✦ Theme/Badges/Surface/Orange/text/Harness Open Source/Light */
+  --figma___badges-surface-pink-background: 323 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Pink/background/Harness Open Source/Light */
+  --figma___badges-surface-pink-border: 323 100% 38% / 0.32;
+  /* ✦ Theme/Badges/Surface/Pink/border/Harness Open Source/Light */
+  --figma___badges-surface-pink-text: 322 100% 37% / 0.89;
+  /* ✦ Theme/Badges/Surface/Pink/text/Harness Open Source/Light */
+  --figma___badges-surface-plum-background: 300 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Plum/background/Harness Open Source/Light */
+  --figma___badges-surface-plum-border: 295 100% 33% / 0.31;
+  /* ✦ Theme/Badges/Surface/Plum/border/Harness Open Source/Light */
+  --figma___badges-surface-plum-text: 292 100% 31% / 0.83;
+  /* ✦ Theme/Badges/Surface/Plum/text/Harness Open Source/Light */
+  --figma___badges-surface-purple-background: 276 100% 51% / 0.02;
+  /* ✦ Theme/Badges/Surface/Purple/background/Harness Open Source/Light */
+  --figma___badges-surface-purple-border: 273 99% 38% / 0.29;
+  /* ✦ Theme/Badges/Surface/Purple/border/Harness Open Source/Light */
+  --figma___badges-surface-purple-text: 273 100% 30% / 0.77;
+  /* ✦ Theme/Badges/Surface/Purple/text/Harness Open Source/Light */
+  --figma___badges-surface-red-background: 0 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Red/background/Harness Open Source/Light */
+  --figma___badges-surface-red-border: 359 100% 43% / 0.32;
+  /* ✦ Theme/Badges/Surface/Red/border/Harness Open Source/Light */
+  --figma___badges-surface-red-text: 358 100% 37% / 0.84;
+  /* ✦ Theme/Badges/Surface/Red/text/Harness Open Source/Light */
+  --figma___badges-surface-ruby-background: 345 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Ruby/background/Harness Open Source/Light */
+  --figma___badges-surface-ruby-border: 348 100% 39% / 0.31;
+  /* ✦ Theme/Badges/Surface/Ruby/border/Harness Open Source/Light */
+  --figma___badges-surface-ruby-text: 345 100% 38% / 0.86;
+  /* ✦ Theme/Badges/Surface/Ruby/text/Harness Open Source/Light */
+  --figma___badges-surface-sky-background: 193 100% 50% / 0.05;
+  /* ✦ Theme/Badges/Surface/Sky/background/Harness Open Source/Light */
+  --figma___badges-surface-sky-border: 194 100% 38% / 0.49;
+  /* ✦ Theme/Badges/Surface/Sky/border/Harness Open Source/Light */
+  --figma___badges-surface-sky-text: 200 100% 25% / 0.86;
+  /* ✦ Theme/Badges/Surface/Sky/text/Harness Open Source/Light */
+  --figma___badges-surface-teal-background: 169 99% 39% / 0.05;
+  /* ✦ Theme/Badges/Surface/Teal/background/Harness Open Source/Light */
+  --figma___badges-surface-teal-border: 170 99% 29% / 0.45;
+  /* ✦ Theme/Badges/Surface/Teal/border/Harness Open Source/Light */
+  --figma___badges-surface-teal-text: 174 100% 23% / 0.98;
+  /* ✦ Theme/Badges/Surface/Teal/text/Harness Open Source/Light */
+  --figma___badges-surface-violet-background: 252 100% 51% / 0.02;
+  /* ✦ Theme/Badges/Surface/Violet/background/Harness Open Source/Light */
+  --figma___badges-surface-violet-border: 252 99% 42% / 0.28;
+  /* ✦ Theme/Badges/Surface/Violet/border/Harness Open Source/Light */
+  --figma___badges-surface-violet-text: 250 100% 28% / 0.73;
+  /* ✦ Theme/Badges/Surface/Violet/text/Harness Open Source/Light */
+  --figma___badges-surface-yellow-background: 52 100% 50% / 0.12;
+  /* ✦ Theme/Badges/Surface/Yellow/background/Harness Open Source/Light */
+  --figma___badges-surface-yellow-border: 48 100% 37% / 0.57;
+  /* ✦ Theme/Badges/Surface/Yellow/border/Harness Open Source/Light */
+  --figma___badges-surface-yellow-text: 42 100% 18% / 0.84;
+  /* ✦ Theme/Badges/Surface/Yellow/text/Harness Open Source/Light */
+  --figma___badges-surface-accent-background: 164 99% 47% / 0.06;
+  /* ✦ Theme/Badges/Surface/accent/background/Harness Open Source/Light */
+  --figma___badges-surface-accent-border: 166 100% 30% / 0.47;
+  /* ✦ Theme/Badges/Surface/accent/border/Harness Open Source/Light */
+  --figma___badges-surface-accent-text: 172 100% 18% / 0.85;
+  /* ✦ Theme/Badges/Surface/accent/text/Harness Open Source/Light */
+  --figma___badges-surface-error-background: 0 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/error/background/Harness Open Source/Light */
+  --figma___badges-surface-error-border: 359 100% 43% / 0.32;
+  /* ✦ Theme/Badges/Surface/error/border/Harness Open Source/Light */
+  --figma___badges-surface-error-text: 358 100% 37% / 0.84;
+  /* ✦ Theme/Badges/Surface/error/text/Harness Open Source/Light */
+  --figma___badges-surface-info-background: 192 100% 50% / 0.11;
+  /* ✦ Theme/Badges/Surface/info/background/Harness Open Source/Light */
+  --figma___badges-surface-info-border: 194 100% 38% / 0.49;
+  /* ✦ Theme/Badges/Surface/info/border/Harness Open Source/Light */
+  --figma___badges-surface-info-text: 200 100% 25% / 0.86;
+  /* ✦ Theme/Badges/Surface/info/text/Harness Open Source/Light */
+  --figma___badges-surface-success-background: 139 98% 37% / 0.09;
+  /* ✦ Theme/Badges/Surface/success/background/Harness Open Source/Light */
+  --figma___badges-surface-success-border: 146 100% 27% / 0.43;
+  /* ✦ Theme/Badges/Surface/success/border/Harness Open Source/Light */
+  --figma___badges-surface-success-text: 153 100% 21% / 0.91;
+  /* ✦ Theme/Badges/Surface/success/text/Harness Open Source/Light */
+  --figma___badges-surface-warning-background: 40 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/warning/background/Harness Open Source/Light */
+  --figma___badges-surface-warning-border: 37 100% 40% / 0.53;
+  /* ✦ Theme/Badges/Surface/warning/border/Harness Open Source/Light */
+  --figma___badges-surface-warning-text: 25 100% 24% / 0.81;
+  /* ✦ Theme/Badges/Surface/warning/text/Harness Open Source/Light */
+  --figma___border-disabled: 240 93% 11% / 0.08;
+  /* ✦ Theme/Border/Disabled/Harness Open Source/Light */
+  --figma___border-hover: 212 6% 50% / 1;
+  /* ✦ Theme/Border/Hover/Harness Open Source/Light */
+  --figma___border-primary: 240 7% 94% / 1;
+  /* ✦ Theme/Border/Primary/Harness Open Source/Light */
+  --figma___border-secondary: 210 7% 94% / 1;
+  /* ✦ Theme/Border/Secondary/Harness Open Source/Light */
+  --figma___border-selected: 216 6% 15% / 1;
+  /* ✦ Theme/Border/Selected/Harness Open Source/Light */
+  --figma___breadcrumbs-current: 200 7% 8% / 1;
+  /* ✦ Theme/Breadcrumbs/current/Harness Open Source/Light */
+  --figma___breadcrumbs-visited: 200 5% 12% / 1;
+  /* ✦ Theme/Breadcrumbs/visited/Harness Open Source/Light */
+  --figma___button-ghost-accent-active: 165 100% 42% / 0.2;
+  /* ✦ Theme/Button/Ghost/Accent/Active/Harness Open Source/Light */
+  --figma___button-ghost-accent-active-text: 172 50% 31% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Active text/Harness Open Source/Light */
+  --figma___button-ghost-accent-hover: 164 99% 44% / 0.13;
+  /* ✦ Theme/Button/Ghost/Accent/Hover/Harness Open Source/Light */
+  --figma___button-ghost-accent-hover-text: 172 50% 31% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Hover text/Harness Open Source/Light */
+  --figma___button-ghost-accent-text-disabled: 168 45% 53% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/Harness Open Source/Light */
+  --figma___button-ghost-accent-text-primary: 172 50% 31% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Text-primary/Harness Open Source/Light */
+  --figma___button-ghost-error-active: 0 100% 50% / 0.1;
+  /* ✦ Theme/Button/Ghost/Error/Active/Harness Open Source/Light */
+  --figma___button-ghost-error-active-text: 358 65% 47% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Active Text/Harness Open Source/Light */
+  --figma___button-ghost-error-hover: 0 100% 50% / 0.06;
+  /* ✦ Theme/Button/Ghost/Error/Hover/Harness Open Source/Light */
+  --figma___button-ghost-error-hover-text: 358 65% 47% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Hover text/Harness Open Source/Light */
+  --figma___button-ghost-error-text-disabled: 359 69% 74% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Text-disabled/Harness Open Source/Light */
+  --figma___button-ghost-error-text-primary: 358 65% 47% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Text-primary/Harness Open Source/Light */
+  --figma___button-ghost-neutral-active: 240 93% 11% / 0.08;
+  /* ✦ Theme/Button/Ghost/Neutral/Active/Harness Open Source/Light */
+  --figma___button-ghost-neutral-active-text: 220 6% 40% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Active Text/Harness Open Source/Light */
+  --figma___button-ghost-neutral-hover: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover/Harness Open Source/Light */
+  --figma___button-ghost-neutral-hover-text: 220 6% 40% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover text/Harness Open Source/Light */
+  --figma___button-ghost-neutral-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/Harness Open Source/Light */
+  --figma___button-ghost-neutral-text-primary: 200 7% 8% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/Harness Open Source/Light */
+  --figma___button-ghost-success-active: 139 99% 33% / 0.13;
+  /* ✦ Theme/Button/Ghost/Success/Active/Harness Open Source/Light */
+  --figma___button-ghost-success-active-text: 153 67% 28% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Active Text/Harness Open Source/Light */
+  --figma___button-ghost-success-hover: 139 98% 37% / 0.09;
+  /* ✦ Theme/Button/Ghost/Success/Hover/Harness Open Source/Light */
+  --figma___button-ghost-success-hover-text: 153 67% 28% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Hover text/Harness Open Source/Light */
+  --figma___button-ghost-success-text-disabled: 151 100% 29% / 0.64;
+  /* ✦ Theme/Button/Ghost/Success/Text-disabled/Harness Open Source/Light */
+  --figma___button-ghost-success-text-primary: 153 67% 28% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Text-primary/Harness Open Source/Light */
+  --figma___button-outline-accent-active: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Outline/Accent/Active/Harness Open Source/Light */
+  --figma___button-outline-accent-default-border: 200 7% 8% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Default border/Harness Open Source/Light */
+  --figma___button-outline-accent-disabled-border: 233 96% 9% / 0.17;
+  /* ✦ Theme/Button/Outline/Accent/Disabled Border/Harness Open Source/Light */
+  --figma___button-outline-accent-hover: 240 89% 18% / 0.02;
+  /* ✦ Theme/Button/Outline/Accent/Hover/Harness Open Source/Light */
+  --figma___button-outline-accent-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Text-disabled/Harness Open Source/Light */
+  --figma___button-outline-accent-text-primary: 210 6% 6% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Text-primary/Harness Open Source/Light */
+  --figma___button-outline-error-active: 0 100% 71% / 0.1;
+  /* ✦ Theme/Button/Outline/Error/Active/Harness Open Source/Light */
+  --figma___button-outline-error-default-border: 0 100% 71% / 0.16;
+  /* ✦ Theme/Button/Outline/Error/Default - border/Harness Open Source/Light */
+  --figma___button-outline-error-disabled-border: 0 100% 71% / 0.1;
+  /* ✦ Theme/Button/Outline/Error/Disabled-border/Harness Open Source/Light */
+  --figma___button-outline-error-hover: 0 100% 71% / 0.1;
+  /* ✦ Theme/Button/Outline/Error/Hover/Harness Open Source/Light */
+  --figma___button-outline-error-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Outline/Error/Text-disabled/Harness Open Source/Light */
+  --figma___button-outline-error-text-primary: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Outline/Error/Text-primary/Harness Open Source/Light */
+  --figma___button-outline-neutral-active: 240 96% 9% / 0.13;
+  /* ✦ Theme/Button/Outline/Neutral/Active/Harness Open Source/Light */
+  --figma___button-outline-neutral-default-border: 233 96% 9% / 0.17;
+  /* ✦ Theme/Button/Outline/Neutral/Default - border/Harness Open Source/Light */
+  --figma___button-outline-neutral-disabled-border: 230 100% 9% / 0.28;
+  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/Harness Open Source/Light */
+  --figma___button-outline-neutral-hover: 240 96% 9% / 0.13;
+  /* ✦ Theme/Button/Outline/Neutral/Hover/Harness Open Source/Light */
+  --figma___button-outline-neutral-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/Harness Open Source/Light */
+  --figma___button-outline-neutral-text-primary: 200 5% 12% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Text-primary/Harness Open Source/Light */
+  --figma___button-outline-success-active: 139 98% 37% / 0.09;
+  /* ✦ Theme/Button/Outline/Success/Active/Harness Open Source/Light */
+  --figma___button-outline-success-default-border: 146 100% 27% / 0.43;
+  /* ✦ Theme/Button/Outline/Success/Default-border/Harness Open Source/Light */
+  --figma___button-outline-success-disabled-border: 233 96% 9% / 0.17;
+  /* ✦ Theme/Button/Outline/Success/Disabled - border/Harness Open Source/Light */
+  --figma___button-outline-success-hover: 139 98% 37% / 0.09;
+  /* ✦ Theme/Button/Outline/Success/Hover/Harness Open Source/Light */
+  --figma___button-outline-success-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Outline/Success/Text-disabled/Harness Open Source/Light */
+  --figma___button-outline-success-text-primary: 153 100% 21% / 0.91;
+  /* ✦ Theme/Button/Outline/Success/Text-primary/Harness Open Source/Light */
+  --figma___button-soft-accent-active: 0 0% 0% / 0.13;
+  /* ✦ Theme/Button/Soft/Accent/Active/Harness Open Source/Light */
+  --figma___button-soft-accent-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Soft/Accent/Disabled/Harness Open Source/Light */
+  --figma___button-soft-accent-hover: 240 93% 11% / 0.08;
+  /* ✦ Theme/Button/Soft/Accent/Hover/Harness Open Source/Light */
+  --figma___button-soft-accent-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Text-disabled/Harness Open Source/Light */
+  --figma___button-soft-accent-text-primary: 210 6% 6% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Text-primary/Harness Open Source/Light */
+  --figma___button-soft-accent-default: 230 100% 9% / 0.28;
+  /* ✦ Theme/Button/Soft/Accent/default/Harness Open Source/Light */
+  --figma___button-soft-error-active: 0 100% 71% / 0.1;
+  /* ✦ Theme/Button/Soft/Error/Active/Harness Open Source/Light */
+  --figma___button-soft-error-disabled: 0 100% 71% / 0.1;
+  /* ✦ Theme/Button/Soft/Error/Disabled/Harness Open Source/Light */
+  --figma___button-soft-error-hover: 0 100% 71% / 0.16;
+  /* ✦ Theme/Button/Soft/Error/Hover/Harness Open Source/Light */
+  --figma___button-soft-error-text-disabled: 359 74% 82% / 1;
+  /* ✦ Theme/Button/Soft/Error/Text-disabled/Harness Open Source/Light */
+  --figma___button-soft-error-text-primary: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Soft/Error/Text-primary/Harness Open Source/Light */
+  --figma___button-soft-error-default: 0 100% 71% / 0.1;
+  /* ✦ Theme/Button/Soft/Error/default/Harness Open Source/Light */
+  --figma___button-soft-neutral-active: 240 100% 9% / 0.11;
+  /* ✦ Theme/Button/Soft/Neutral/Active/Harness Open Source/Light */
+  --figma___button-soft-neutral-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Soft/Neutral/Disabled/Harness Open Source/Light */
+  --figma___button-soft-neutral-hover: 240 93% 11% / 0.08;
+  /* ✦ Theme/Button/Soft/Neutral/Hover/Harness Open Source/Light */
+  --figma___button-soft-neutral-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/Harness Open Source/Light */
+  --figma___button-soft-neutral-text-primary: 200 5% 12% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Text-primary/Harness Open Source/Light */
+  --figma___button-soft-neutral-default: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Soft/Neutral/default/Harness Open Source/Light */
+  --figma___button-soft-success-active: 141 100% 30% / 0.2;
+  /* ✦ Theme/Button/Soft/Success/Active/Harness Open Source/Light */
+  --figma___button-soft-success-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Soft/Success/Disabled/Harness Open Source/Light */
+  --figma___button-soft-success-hover: 139 99% 33% / 0.13;
+  /* ✦ Theme/Button/Soft/Success/Hover/Harness Open Source/Light */
+  --figma___button-soft-success-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Soft/Success/Text-disabled/Harness Open Source/Light */
+  --figma___button-soft-success-text-primary: 153 67% 28% / 1;
+  /* ✦ Theme/Button/Soft/Success/Text-primary/Harness Open Source/Light */
+  --figma___button-soft-success-default: 139 98% 37% / 0.09;
+  /* ✦ Theme/Button/Soft/Success/default/Harness Open Source/Light */
+  --figma___button-solid-accent-active: 200 7% 8% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Active/Harness Open Source/Light */
+  --figma___button-solid-accent-disabled: 200 6% 10% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Disabled/Harness Open Source/Light */
+  --figma___button-solid-accent-hover: 216 6% 15% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Hover/Harness Open Source/Light */
+  --figma___button-solid-accent-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Text-disabled/Harness Open Source/Light */
+  --figma___button-solid-accent-text-primary: 0 0% 100% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Text-primary/Harness Open Source/Light */
+  --figma___button-solid-accent-default: 240 13% 3% / 1;
+  /* ✦ Theme/Button/Solid/Accent/default/Harness Open Source/Light */
+  --figma___button-solid-error-active: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Solid/Error/Active/Harness Open Source/Light */
+  --figma___button-solid-error-disabled: 0 100% 71% / 0.1;
+  /* ✦ Theme/Button/Solid/Error/Disabled/Harness Open Source/Light */
+  --figma___button-solid-error-hover: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Solid/Error/Hover/Harness Open Source/Light */
+  --figma___button-solid-error-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Solid/Error/Text-disabled/Harness Open Source/Light */
+  --figma___button-solid-error-default: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Solid/Error/default/Harness Open Source/Light */
+  --figma___button-solid-neutral-active: 210 6% 20% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Active/Harness Open Source/Light */
+  --figma___button-solid-neutral-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Solid/Neutral/Disabled/Harness Open Source/Light */
+  --figma___button-solid-neutral-hover: 210 6% 20% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Hover/Harness Open Source/Light */
+  --figma___button-solid-neutral-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/Harness Open Source/Light */
+  --figma___button-solid-neutral-default: 210 6% 20% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/default/Harness Open Source/Light */
+  --figma___button-solid-success-active: 142 72% 29% / 1;
+  /* ✦ Theme/Button/Solid/Success/Active/Harness Open Source/Light */
+  --figma___button-solid-success-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Solid/Success/Disabled/Harness Open Source/Light */
+  --figma___button-solid-success-hover: 152 57% 38% / 1;
+  /* ✦ Theme/Button/Solid/Success/Hover/Harness Open Source/Light */
+  --figma___button-solid-success-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Solid/Success/Text-disabled/Harness Open Source/Light */
+  --figma___button-solid-success-default: 142 72% 29% / 1;
+  /* ✦ Theme/Button/Solid/Success/default/Harness Open Source/Light */
+  --figma___button-surface-accent-active: 0 0% 100% / 0.13;
+  /* ✦ Theme/Button/Surface/Accent/Active/Harness Open Source/Light */
+  --figma___button-surface-accent-active-border: 0 0% 100% / 0.31;
+  /* ✦ Theme/Button/Surface/Accent/Active border/Harness Open Source/Light */
+  --figma___button-surface-accent-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Surface/Accent/Disabled/Harness Open Source/Light */
+  --figma___button-surface-accent-hover: 0 0% 100% / 0.1;
+  /* ✦ Theme/Button/Surface/Accent/Hover/Harness Open Source/Light */
+  --figma___button-surface-accent-hover-border: 0 0% 100% / 0.31;
+  /* ✦ Theme/Button/Surface/Accent/Hover Border/Harness Open Source/Light */
+  --figma___button-surface-accent-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Text-disabled/Harness Open Source/Light */
+  --figma___button-surface-accent-text-primary: 200 7% 8% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Text-primary/Harness Open Source/Light */
+  --figma___button-surface-accent-default: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Surface/Accent/default/Harness Open Source/Light */
+  --figma___button-surface-accent-default-border: 0 0% 100% / 0.22;
+  /* ✦ Theme/Button/Surface/Accent/default border/Harness Open Source/Light */
+  --figma___button-surface-error-active: 0 100% 71% / 0.1;
+  /* ✦ Theme/Button/Surface/Error/Active/Harness Open Source/Light */
+  --figma___button-surface-error-active-border: 0 100% 71% / 0.16;
+  /* ✦ Theme/Button/Surface/Error/Active border/Harness Open Source/Light */
+  --figma___button-surface-error-disabled: 0 100% 50% / 0.06;
+  /* ✦ Theme/Button/Surface/Error/Disabled/Harness Open Source/Light */
+  --figma___button-surface-error-hover: 0 100% 71% / 0.16;
+  /* ✦ Theme/Button/Surface/Error/Hover/Harness Open Source/Light */
+  --figma___button-surface-error-hover-border: 0 100% 71% / 0.16;
+  /* ✦ Theme/Button/Surface/Error/Hover border/Harness Open Source/Light */
+  --figma___button-surface-error-text-disabled: 359 74% 82% / 1;
+  /* ✦ Theme/Button/Surface/Error/Text-disabled/Harness Open Source/Light */
+  --figma___button-surface-error-text-primary: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Surface/Error/Text-primary/Harness Open Source/Light */
+  --figma___button-surface-error-border: 0 100% 71% / 0.1;
+  /* ✦ Theme/Button/Surface/Error/border/Harness Open Source/Light */
+  --figma___button-surface-error-default: 0 100% 71% / 0.1;
+  /* ✦ Theme/Button/Surface/Error/default/Harness Open Source/Light */
+  --figma___button-surface-neutral-active: 240 100% 9% / 0.11;
+  /* ✦ Theme/Button/Surface/Neutral/Active/Harness Open Source/Light */
+  --figma___button-surface-neutral-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Surface/Neutral/Disabled/Harness Open Source/Light */
+  --figma___button-surface-neutral-hover: 240 93% 11% / 0.08;
+  /* ✦ Theme/Button/Surface/Neutral/Hover/Harness Open Source/Light */
+  --figma___button-surface-neutral-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/Harness Open Source/Light */
+  --figma___button-surface-neutral-text-primary: 0 0% 39% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Text-primary/Harness Open Source/Light */
+  --figma___button-surface-neutral-border: 233 96% 9% / 0.17;
+  /* ✦ Theme/Button/Surface/Neutral/border/Harness Open Source/Light */
+  --figma___button-surface-neutral-default: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Surface/Neutral/default/Harness Open Source/Light */
+  --figma___button-surface-success-active: 141 100% 30% / 0.2;
+  /* ✦ Theme/Button/Surface/Success/Active/Harness Open Source/Light */
+  --figma___button-surface-success-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Surface/Success/Disabled/Harness Open Source/Light */
+  --figma___button-surface-success-hover: 139 99% 33% / 0.13;
+  /* ✦ Theme/Button/Surface/Success/Hover/Harness Open Source/Light */
+  --figma___button-surface-success-hover-border: 151 100% 29% / 0.64;
+  /* ✦ Theme/Button/Surface/Success/Hover border/Harness Open Source/Light */
+  --figma___button-surface-success-text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Surface/Success/Text-disabled/Harness Open Source/Light */
+  --figma___button-surface-success-text-primary: 153 100% 21% / 0.91;
+  /* ✦ Theme/Button/Surface/Success/Text-primary/Harness Open Source/Light */
+  --figma___button-surface-success-active-border: 151 100% 29% / 0.64;
+  /* ✦ Theme/Button/Surface/Success/active border/Harness Open Source/Light */
+  --figma___button-surface-success-default: 139 98% 37% / 0.09;
+  /* ✦ Theme/Button/Surface/Success/default/Harness Open Source/Light */
+  --figma___button-surface-success-default-border: 142 99% 29% / 0.29;
+  /* ✦ Theme/Button/Surface/Success/default border/Harness Open Source/Light */
+  --figma___calendar-background: 0 0% 100% / 1;
+  /* ✦ Theme/Calendar/Background/Harness Open Source/Light */
+  --figma___calendar-selected-date-background: 200 7% 8% / 1;
+  /* ✦ Theme/Calendar/Selected Date/Background/Harness Open Source/Light */
+  --figma___calendar-selected-range-background: 210 6% 60% / 1;
+  /* ✦ Theme/Calendar/Selected Range/Background/Harness Open Source/Light */
+  --figma___calendar-selected-range-text: 200 5% 12% / 1;
+  /* ✦ Theme/Calendar/Selected Range/Text/Harness Open Source/Light */
+  --figma___checkbox-background: 0 0% 100% / 1;
+  /* ✦ Theme/Checkbox/Background/Harness Open Source/Light */
+  --figma___checkbox-paper: 0 0% 100% / 0.5;
+  /* ✦ Theme/Checkbox/Paper/Harness Open Source/Light */
+  --figma___checkbox-surface-checked-active-active: 210 6% 20% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/Harness Open Source/Light */
+  --figma___checkbox-surface-checked-active-hover: 210 6% 20% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/Harness Open Source/Light */
+  --figma___checkbox-surface-checked-active-default-background: 216 6% 15% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/Harness Open Source/Light */
+  --figma___checkbox-surface-checked-disabled-check: 210 6% 20% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/Harness Open Source/Light */
+  --figma___checkbox-surface-checked-disabled-disabled: 210 6% 40% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/Harness Open Source/Light */
+  --figma___checkbox-surface-checked-disabled-border: 207 6% 30% / 0;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/Harness Open Source/Light */
+  --figma___checkbox-surface-intermediate-active-active-border: 200 6% 10% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/Harness Open Source/Light */
+  --figma___checkbox-surface-intermediate-active-hover-border: 200 6% 10% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/Harness Open Source/Light */
+  --figma___checkbox-surface-intermediate-active-default-background: 164 99% 44% / 0;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/Harness Open Source/Light */
+  --figma___checkbox-surface-intermediate-active-default-border: 216 6% 15% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/Harness Open Source/Light */
+  --figma___checkbox-surface-intermediate-disabled-check: 210 6% 20% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/Harness Open Source/Light */
+  --figma___checkbox-surface-intermediate-disabled-disabled: 0 0% 0% / 0;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/Harness Open Source/Light */
+  --figma___checkbox-surface-intermediate-disabled-border: 210 6% 20% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/Harness Open Source/Light */
+  --figma___checkbox-surface-unchecked-active-active-border: 200 6% 10% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/Harness Open Source/Light */
+  --figma___checkbox-surface-unchecked-active-hover-border: 200 6% 10% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/Harness Open Source/Light */
+  --figma___checkbox-surface-unchecked-active-default-background: 0 0% 98% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/Harness Open Source/Light */
+  --figma___checkbox-surface-unchecked-active-default-border: 216 6% 15% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/Harness Open Source/Light */
+  --figma___checkbox-surface-unchecked-disabled-disabled: 210 6% 60% / 0;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/Harness Open Source/Light */
+  --figma___checkbox-surface-unchecked-disabled-border: 210 6% 20% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/Harness Open Source/Light */
+  --figma___checkbox-border: 240 100% 12% / 0.05;
+  /* ✦ Theme/Checkbox/border/Harness Open Source/Light */
+  --figma___default-colors-black: 210 13% 3% / 1;
+  /* ✦ Theme/Default colors/black/Harness Open Source/Light */
+  --figma___default-colors-dark-to-white: 240 13% 3% / 1;
+  /* ✦ Theme/Default colors/dark-to-white/Harness Open Source/Light */
+  --figma___default-colors-white: 0 0% 100% / 1;
+  /* ✦ Theme/Default colors/white/Harness Open Source/Light */
+  --figma___default-colors-white-to-dark: 0 0% 100% / 1;
+  /* ✦ Theme/Default colors/white-to-dark/Harness Open Source/Light */
+  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
+  /* ✦ Theme/Dropdown/Dropdown Item/Default/Harness Open Source/Light */
+  --figma___dropdown-dropdown-item-hover: 220 6% 90% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Hover/Harness Open Source/Light */
+  --figma___dropdown-dropdown-item-selected: 220 6% 90% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Selected/Harness Open Source/Light */
+  --figma___dropdown-text-shortcut-text-selected: 210 6% 20% / 1;
+  /* ✦ Theme/Dropdown/Text/Shortcut text selected/Harness Open Source/Light */
+  --figma___dropdown-text-text-selected: 200 7% 8% / 1;
+  /* ✦ Theme/Dropdown/Text/Text Selected/Harness Open Source/Light */
+  --figma___dropdown-text-hover: 200 5% 12% / 1;
+  /* ✦ Theme/Dropdown/Text/hover/Harness Open Source/Light */
+  --figma___dropdown-background: 0 0% 100% / 1;
+  /* ✦ Theme/Dropdown/background/Harness Open Source/Light */
+  --figma___dropdown-border: 240 7% 94% / 1;
+  /* ✦ Theme/Dropdown/border/Harness Open Source/Light */
+  --figma___dropdown-separator: 207 6% 70% / 1;
+  /* ✦ Theme/Dropdown/separator/Harness Open Source/Light */
+  --figma___filter-active: 210 6% 60% / 1;
+  /* ✦ Theme/Filter/Active/Harness Open Source/Light */
+  --figma___filter-default: 207 6% 70% / 1;
+  /* ✦ Theme/Filter/Default/Harness Open Source/Light */
+  --figma___filter-hover: 210 6% 60% / 1;
+  /* ✦ Theme/Filter/Hover/Harness Open Source/Light */
+  --figma___inline-alert-banner-customisable: 240 20% 98% / 1;
+  /* ✦ Theme/Inline Alert Banner/Customisable/Harness Open Source/Light */
+  --figma___inline-alert-banner-error: 0 100% 50% / 0.06;
+  /* ✦ Theme/Inline Alert Banner/Error/Harness Open Source/Light */
+  --figma___inline-alert-banner-info: 210 100% 96% / 1;
+  /* ✦ Theme/Inline Alert Banner/Info/Harness Open Source/Light */
+  --figma___inline-alert-banner-reminder: 40 100% 96% / 1;
+  /* ✦ Theme/Inline Alert Banner/Reminder/Harness Open Source/Light */
+  --figma___inline-alert-banner-success: 139 57% 95% / 1;
+  /* ✦ Theme/Inline Alert Banner/Success/Harness Open Source/Light */
+  --figma___inline-alert-banner-warning: 34 100% 92% / 1;
+  /* ✦ Theme/Inline Alert Banner/Warning/Harness Open Source/Light */
+  --figma___modal-background: 0 0% 100% / 1;
+  /* ✦ Theme/Modal/Background/Harness Open Source/Light */
+  --figma___modal-paper: 0 0% 100% / 0.5;
+  /* ✦ Theme/Modal/Paper/Harness Open Source/Light */
+  --figma___modal-border: 240 100% 12% / 0.05;
+  /* ✦ Theme/Modal/border/Harness Open Source/Light */
+  --figma___neutral-color-gray-1: 0 0% 98% / 1;
+  /* ✦ Theme/Neutral color/Gray/1/Harness Open Source/Light */
+  --figma___neutral-color-gray-2: 210 7% 94% / 1;
+  /* ✦ Theme/Neutral color/Gray/2/Harness Open Source/Light */
+  --figma___neutral-color-gray-3: 220 6% 90% / 1;
+  /* ✦ Theme/Neutral color/Gray/3/Harness Open Source/Light */
+  --figma___neutral-color-gray-4: 240 6% 80% / 1;
+  /* ✦ Theme/Neutral color/Gray/4/Harness Open Source/Light */
+  --figma___neutral-color-gray-5: 207 6% 70% / 1;
+  /* ✦ Theme/Neutral color/Gray/5/Harness Open Source/Light */
+  --figma___neutral-color-gray-6: 210 6% 60% / 1;
+  /* ✦ Theme/Neutral color/Gray/6/Harness Open Source/Light */
+  --figma___neutral-color-gray-7: 212 6% 50% / 1;
+  /* ✦ Theme/Neutral color/Gray/7/Harness Open Source/Light */
+  --figma___neutral-color-gray-8: 210 6% 40% / 1;
+  /* ✦ Theme/Neutral color/Gray/8/Harness Open Source/Light */
+  --figma___neutral-color-gray-9: 210 6% 20% / 1;
+  /* ✦ Theme/Neutral color/Gray/9/Harness Open Source/Light */
+  --figma___neutral-color-gray-10: 216 6% 15% / 1;
+  /* ✦ Theme/Neutral color/Gray/10/Harness Open Source/Light */
+  --figma___neutral-color-gray-alpha-1: 240 89% 18% / 0.01;
+  /* ✦ Theme/Neutral color/Gray Alpha/1/Harness Open Source/Light */
+  --figma___neutral-color-gray-alpha-2: 240 89% 18% / 0.02;
+  /* ✦ Theme/Neutral color/Gray Alpha/2/Harness Open Source/Light */
+  --figma___neutral-color-gray-alpha-3: 240 100% 12% / 0.05;
+  /* ✦ Theme/Neutral color/Gray Alpha/3/Harness Open Source/Light */
+  --figma___neutral-color-gray-alpha-4: 240 93% 11% / 0.08;
+  /* ✦ Theme/Neutral color/Gray Alpha/4/Harness Open Source/Light */
+  --figma___neutral-color-gray-alpha-5: 240 100% 9% / 0.11;
+  /* ✦ Theme/Neutral color/Gray Alpha/5/Harness Open Source/Light */
+  --figma___neutral-color-gray-alpha-6: 240 96% 9% / 0.13;
+  /* ✦ Theme/Neutral color/Gray Alpha/6/Harness Open Source/Light */
+  --figma___neutral-color-gray-alpha-7: 233 96% 9% / 0.17;
+  /* ✦ Theme/Neutral color/Gray Alpha/7/Harness Open Source/Light */
+  --figma___neutral-color-gray-alpha-8: 230 100% 9% / 0.28;
+  /* ✦ Theme/Neutral color/Gray Alpha/8/Harness Open Source/Light */
+  --figma___neutral-color-gray-alpha-9: 232 100% 6% / 0.46;
+  /* ✦ Theme/Neutral color/Gray Alpha/9/Harness Open Source/Light */
+  --figma___neutral-color-gray-alpha-10: 230 100% 5% / 0.51;
+  /* ✦ Theme/Neutral color/Gray Alpha/10/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-1: 270 50% 99% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/1/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-2: 252 100% 99% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/2/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-3: 254 100% 97% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/3/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-4: 251 91% 95% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/4/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-5: 252 83% 93% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/5/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-6: 251 78% 89% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/6/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-7: 252 56% 57% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/7/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-8: 251 48% 53% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/8/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-9: 250 43% 48% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/9/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-10: 249 43% 26% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/10/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-alpha-1: 270 94% 35% / 0.01;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/1/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-alpha-2: 252 100% 51% / 0.02;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/2/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-alpha-3: 254 100% 50% / 0.05;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/3/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-alpha-4: 251 98% 48% / 0.09;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/4/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-alpha-5: 252 99% 46% / 0.13;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/5/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-alpha-6: 251 99% 44% / 0.19;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/6/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-alpha-7: 252 100% 36% / 0.66;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/7/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-alpha-8: 251 100% 32% / 0.69;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/8/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-alpha-9: 250 100% 28% / 0.73;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/9/Harness Open Source/Light */
+  --figma___other-colors-ai-violet-alpha-10: 249 100% 13% / 0.85;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/10/Harness Open Source/Light */
+  --figma___other-colors-blue-1: 210 100% 99% / 1;
+  /* ✦ Theme/Other Colors/Blue/1/Harness Open Source/Light */
+  --figma___other-colors-blue-2: 210 100% 98% / 1;
+  /* ✦ Theme/Other Colors/Blue/2/Harness Open Source/Light */
+  --figma___other-colors-blue-3: 210 100% 96% / 1;
+  /* ✦ Theme/Other Colors/Blue/3/Harness Open Source/Light */
+  --figma___other-colors-blue-4: 210 100% 94% / 1;
+  /* ✦ Theme/Other Colors/Blue/4/Harness Open Source/Light */
+  --figma___other-colors-blue-5: 209 96% 90% / 1;
+  /* ✦ Theme/Other Colors/Blue/5/Harness Open Source/Light */
+  --figma___other-colors-blue-6: 209 82% 85% / 1;
+  /* ✦ Theme/Other Colors/Blue/6/Harness Open Source/Light */
+  --figma___other-colors-blue-7: 214 73% 51% / 1;
+  /* ✦ Theme/Other Colors/Blue/7/Harness Open Source/Light */
+  --figma___other-colors-blue-8: 208 93% 47% / 1;
+  /* ✦ Theme/Other Colors/Blue/8/Harness Open Source/Light */
+  --figma___other-colors-blue-9: 211 90% 42% / 1;
+  /* ✦ Theme/Other Colors/Blue/9/Harness Open Source/Light */
+  --figma___other-colors-blue-10: 216 71% 23% / 1;
+  /* ✦ Theme/Other Colors/Blue/10/Harness Open Source/Light */
+  --figma___other-colors-blue-alpha-1: 210 100% 51% / 0.02;
+  /* ✦ Theme/Other Colors/Blue Alpha/1/Harness Open Source/Light */
+  --figma___other-colors-blue-alpha-2: 210 100% 51% / 0.04;
+  /* ✦ Theme/Other Colors/Blue Alpha/2/Harness Open Source/Light */
+  --figma___other-colors-blue-alpha-3: 210 100% 50% / 0.07;
+  /* ✦ Theme/Other Colors/Blue Alpha/3/Harness Open Source/Light */
+  --figma___other-colors-blue-alpha-4: 210 99% 49% / 0.19;
+  /* ✦ Theme/Other Colors/Blue Alpha/4/Harness Open Source/Light */
+  --figma___other-colors-blue-alpha-5: 209 99% 45% / 0.28;
+  /* ✦ Theme/Other Colors/Blue Alpha/5/Harness Open Source/Light */
+  --figma___other-colors-blue-alpha-6: 209 99% 45% / 0.28;
+  /* ✦ Theme/Other Colors/Blue Alpha/6/Harness Open Source/Light */
+  --figma___other-colors-blue-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/7/Harness Open Source/Light */
+  --figma___other-colors-blue-alpha-8: 208 100% 46% / 0.97;
+  /* ✦ Theme/Other Colors/Blue Alpha/8/Harness Open Source/Light */
+  --figma___other-colors-blue-alpha-9: 211 100% 39% / 0.96;
+  /* ✦ Theme/Other Colors/Blue Alpha/9/Harness Open Source/Light */
+  --figma___other-colors-blue-alpha-10: 216 100% 17% / 0.93;
+  /* ✦ Theme/Other Colors/Blue Alpha/10/Harness Open Source/Light */
+  --figma___other-colors-indigo-1: 240 33% 99% / 1;
+  /* ✦ Theme/Other Colors/Indigo/1/Harness Open Source/Light */
+  --figma___other-colors-indigo-2: 223 100% 99% / 1;
+  /* ✦ Theme/Other Colors/Indigo/2/Harness Open Source/Light */
+  --figma___other-colors-indigo-3: 224 100% 97% / 1;
+  /* ✦ Theme/Other Colors/Indigo/3/Harness Open Source/Light */
+  --figma___other-colors-indigo-4: 222 92% 95% / 1;
+  /* ✦ Theme/Other Colors/Indigo/4/Harness Open Source/Light */
+  --figma___other-colors-indigo-5: 225 85% 92% / 1;
+  /* ✦ Theme/Other Colors/Indigo/5/Harness Open Source/Light */
+  --figma___other-colors-indigo-6: 224 81% 88% / 1;
+  /* ✦ Theme/Other Colors/Indigo/6/Harness Open Source/Light */
+  --figma___other-colors-indigo-7: 226 70% 55% / 1;
+  /* ✦ Theme/Other Colors/Indigo/7/Harness Open Source/Light */
+  --figma___other-colors-indigo-8: 226 59% 51% / 1;
+  /* ✦ Theme/Other Colors/Indigo/8/Harness Open Source/Light */
+  --figma___other-colors-indigo-9: 226 55% 45% / 1;
+  /* ✦ Theme/Other Colors/Indigo/9/Harness Open Source/Light */
+  --figma___other-colors-indigo-10: 226 63% 17% / 1;
+  /* ✦ Theme/Other Colors/Indigo/10/Harness Open Source/Light */
+  --figma___other-colors-indigo-alpha-1: 240 93% 26% / 0.01;
+  /* ✦ Theme/Other Colors/Indigo Alpha/1/Harness Open Source/Light */
+  --figma___other-colors-indigo-alpha-2: 223 100% 51% / 0.03;
+  /* ✦ Theme/Other Colors/Indigo Alpha/2/Harness Open Source/Light */
+  --figma___other-colors-indigo-alpha-3: 224 100% 50% / 0.06;
+  /* ✦ Theme/Other Colors/Indigo Alpha/3/Harness Open Source/Light */
+  --figma___other-colors-indigo-alpha-4: 222 98% 48% / 0.1;
+  /* ✦ Theme/Other Colors/Indigo Alpha/4/Harness Open Source/Light */
+  --figma___other-colors-indigo-alpha-5: 225 98% 46% / 0.15;
+  /* ✦ Theme/Other Colors/Indigo Alpha/5/Harness Open Source/Light */
+  --figma___other-colors-indigo-alpha-6: 224 99% 45% / 0.22;
+  /* ✦ Theme/Other Colors/Indigo Alpha/6/Harness Open Source/Light */
+  --figma___other-colors-indigo-alpha-7: 226 100% 41% / 0.76;
+  /* ✦ Theme/Other Colors/Indigo Alpha/7/Harness Open Source/Light */
+  --figma___other-colors-indigo-alpha-8: 226 100% 37% / 0.77;
+  /* ✦ Theme/Other Colors/Indigo Alpha/8/Harness Open Source/Light */
+  --figma___other-colors-indigo-alpha-9: 226 100% 31% / 0.8;
+  /* ✦ Theme/Other Colors/Indigo Alpha/9/Harness Open Source/Light */
+  --figma___other-colors-indigo-alpha-10: 225 100% 14% / 0.88;
+  /* ✦ Theme/Other Colors/Indigo Alpha/10/Harness Open Source/Light */
+  --figma___other-colors-mint-1: 168 71% 99% / 1;
+  /* ✦ Theme/Other Colors/Mint/1/Harness Open Source/Light */
+  --figma___other-colors-mint-2: 164 88% 97% / 1;
+  /* ✦ Theme/Other Colors/Mint/2/Harness Open Source/Light */
+  --figma___other-colors-mint-3: 164 79% 93% / 1;
+  /* ✦ Theme/Other Colors/Mint/3/Harness Open Source/Light */
+  --figma___other-colors-mint-4: 165 73% 88% / 1;
+  /* ✦ Theme/Other Colors/Mint/4/Harness Open Source/Light */
+  --figma___other-colors-mint-5: 166 60% 83% / 1;
+  /* ✦ Theme/Other Colors/Mint/5/Harness Open Source/Light */
+  --figma___other-colors-mint-6: 166 50% 77% / 1;
+  /* ✦ Theme/Other Colors/Mint/6/Harness Open Source/Light */
+  --figma___other-colors-mint-7: 176 59% 50% / 1;
+  /* ✦ Theme/Other Colors/Mint/7/Harness Open Source/Light */
+  --figma___other-colors-mint-8: 176 59% 40% / 1;
+  /* ✦ Theme/Other Colors/Mint/8/Harness Open Source/Light */
+  --figma___other-colors-mint-9: 172 50% 31% / 1;
+  /* ✦ Theme/Other Colors/Mint/9/Harness Open Source/Light */
+  --figma___other-colors-mint-10: 171 51% 17% / 1;
+  /* ✦ Theme/Other Colors/Mint/10/Harness Open Source/Light */
+  --figma___other-colors-mint-alpha-1: 168 95% 43% / 0.02;
+  /* ✦ Theme/Other Colors/Mint Alpha/1/Harness Open Source/Light */
+  --figma___other-colors-mint-alpha-2: 164 99% 47% / 0.06;
+  /* ✦ Theme/Other Colors/Mint Alpha/2/Harness Open Source/Light */
+  --figma___other-colors-mint-alpha-3: 164 99% 44% / 0.13;
+  /* ✦ Theme/Other Colors/Mint Alpha/3/Harness Open Source/Light */
+  --figma___other-colors-mint-alpha-4: 165 100% 42% / 0.2;
+  /* ✦ Theme/Other Colors/Mint Alpha/4/Harness Open Source/Light */
+  --figma___other-colors-mint-alpha-5: 166 100% 38% / 0.27;
+  /* ✦ Theme/Other Colors/Mint Alpha/5/Harness Open Source/Light */
+  --figma___other-colors-mint-alpha-6: 166 99% 33% / 0.35;
+  /* ✦ Theme/Other Colors/Mint Alpha/6/Harness Open Source/Light */
+  --figma___other-colors-mint-alpha-7: 167 100% 41% / 0.47;
+  /* ✦ Theme/Other Colors/Mint Alpha/7/Harness Open Source/Light */
+  --figma___other-colors-mint-alpha-8: 167 100% 38% / 0.5;
+  /* ✦ Theme/Other Colors/Mint Alpha/8/Harness Open Source/Light */
+  --figma___other-colors-mint-alpha-9: 172 100% 18% / 0.85;
+  /* ✦ Theme/Other Colors/Mint Alpha/9/Harness Open Source/Light */
+  --figma___other-colors-mint-alpha-10: 171 100% 10% / 0.91;
+  /* ✦ Theme/Other Colors/Mint Alpha/10/Harness Open Source/Light */
+  --figma___other-colors-orange-1: 20 60% 99% / 1;
+  /* ✦ Theme/Other Colors/Orange/1/Harness Open Source/Light */
+  --figma___other-colors-orange-2: 22 100% 98% / 1;
+  /* ✦ Theme/Other Colors/Orange/2/Harness Open Source/Light */
+  --figma___other-colors-orange-3: 34 100% 92% / 1;
+  /* ✦ Theme/Other Colors/Orange/3/Harness Open Source/Light */
+  --figma___other-colors-orange-4: 33 100% 87% / 1;
+  /* ✦ Theme/Other Colors/Orange/4/Harness Open Source/Light */
+  --figma___other-colors-orange-5: 31 100% 82% / 1;
+  /* ✦ Theme/Other Colors/Orange/5/Harness Open Source/Light */
+  --figma___other-colors-orange-6: 27 100% 78% / 1;
+  /* ✦ Theme/Other Colors/Orange/6/Harness Open Source/Light */
+  --figma___other-colors-orange-7: 24 94% 50% / 1;
+  /* ✦ Theme/Other Colors/Orange/7/Harness Open Source/Light */
+  --figma___other-colors-orange-8: 24 100% 46% / 1;
+  /* ✦ Theme/Other Colors/Orange/8/Harness Open Source/Light */
+  --figma___other-colors-orange-9: 16 45% 41% / 1;
+  /* ✦ Theme/Other Colors/Orange/9/Harness Open Source/Light */
+  --figma___other-colors-orange-10: 16 50% 23% / 1;
+  /* ✦ Theme/Other Colors/Orange/10/Harness Open Source/Light */
+  --figma___other-colors-orange-alpha-1: 20 95% 39% / 0.02;
+  /* ✦ Theme/Other Colors/Orange Alpha/1/Harness Open Source/Light */
+  --figma___other-colors-orange-alpha-2: 22 100% 51% / 0.04;
+  /* ✦ Theme/Other Colors/Orange Alpha/2/Harness Open Source/Light */
+  --figma___other-colors-orange-alpha-3: 34 100% 50% / 0.17;
+  /* ✦ Theme/Other Colors/Orange Alpha/3/Harness Open Source/Light */
+  --figma___other-colors-orange-alpha-4: 33 100% 50% / 0.27;
+  /* ✦ Theme/Other Colors/Orange Alpha/4/Harness Open Source/Light */
+  --figma___other-colors-orange-alpha-5: 31 100% 50% / 0.36;
+  /* ✦ Theme/Other Colors/Orange Alpha/5/Harness Open Source/Light */
+  --figma___other-colors-orange-alpha-6: 27 100% 50% / 0.43;
+  /* ✦ Theme/Other Colors/Orange Alpha/6/Harness Open Source/Light */
+  --figma___other-colors-orange-alpha-7: 24 100% 48% / 0.97;
+  /* ✦ Theme/Other Colors/Orange Alpha/7/Harness Open Source/Light */
+  --figma___other-colors-orange-alpha-8: 24 100% 46% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/8/Harness Open Source/Light */
+  --figma___other-colors-orange-alpha-9: 16 100% 24% / 0.77;
+  /* ✦ Theme/Other Colors/Orange Alpha/9/Harness Open Source/Light */
+  --figma___other-colors-orange-alpha-10: 16 100% 13% / 0.89;
+  /* ✦ Theme/Other Colors/Orange Alpha/10/Harness Open Source/Light */
+  --figma___other-colors-yellow-1: 60 50% 98% / 1;
+  /* ✦ Theme/Other Colors/Yellow/1/Harness Open Source/Light */
+  --figma___other-colors-yellow-2: 52 100% 94% / 1;
+  /* ✦ Theme/Other Colors/Yellow/2/Harness Open Source/Light */
+  --figma___other-colors-yellow-3: 53 100% 89% / 1;
+  /* ✦ Theme/Other Colors/Yellow/3/Harness Open Source/Light */
+  --figma___other-colors-yellow-4: 53 93% 84% / 1;
+  /* ✦ Theme/Other Colors/Yellow/4/Harness Open Source/Light */
+  --figma___other-colors-yellow-5: 52 85% 79% / 1;
+  /* ✦ Theme/Other Colors/Yellow/5/Harness Open Source/Light */
+  --figma___other-colors-yellow-6: 51 73% 72% / 1;
+  /* ✦ Theme/Other Colors/Yellow/6/Harness Open Source/Light */
+  --figma___other-colors-yellow-7: 53 96% 58% / 1;
+  /* ✦ Theme/Other Colors/Yellow/7/Harness Open Source/Light */
+  --figma___other-colors-yellow-8: 52 95% 52% / 1;
+  /* ✦ Theme/Other Colors/Yellow/8/Harness Open Source/Light */
+  --figma___other-colors-yellow-9: 42 50% 31% / 1;
+  /* ✦ Theme/Other Colors/Yellow/9/Harness Open Source/Light */
+  --figma___other-colors-yellow-10: 42 39% 20% / 1;
+  /* ✦ Theme/Other Colors/Yellow/10/Harness Open Source/Light */
+  --figma___other-colors-yellow-alpha-1: 60 50% 98% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/1/Harness Open Source/Light */
+  --figma___other-colors-yellow-alpha-2: 52 100% 94% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/2/Harness Open Source/Light */
+  --figma___other-colors-yellow-alpha-3: 53 100% 89% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/3/Harness Open Source/Light */
+  --figma___other-colors-yellow-alpha-4: 53 93% 84% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/4/Harness Open Source/Light */
+  --figma___other-colors-yellow-alpha-5: 52 85% 79% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/5/Harness Open Source/Light */
+  --figma___other-colors-yellow-alpha-6: 51 73% 72% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/6/Harness Open Source/Light */
+  --figma___other-colors-yellow-alpha-7: 53 96% 58% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/7/Harness Open Source/Light */
+  --figma___other-colors-yellow-alpha-8: 52 95% 52% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/8/Harness Open Source/Light */
+  --figma___other-colors-yellow-alpha-9: 42 50% 31% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/9/Harness Open Source/Light */
+  --figma___other-colors-yellow-alpha-10: 42 39% 20% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/10/Harness Open Source/Light */
+  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01;
+  /* ✦ Theme/Overlays/Black Alpha/1/Harness Open Source/Light */
+  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02;
+  /* ✦ Theme/Overlays/Black Alpha/2/Harness Open Source/Light */
+  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05;
+  /* ✦ Theme/Overlays/Black Alpha/3/Harness Open Source/Light */
+  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08;
+  /* ✦ Theme/Overlays/Black Alpha/4/Harness Open Source/Light */
+  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11;
+  /* ✦ Theme/Overlays/Black Alpha/5/Harness Open Source/Light */
+  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13;
+  /* ✦ Theme/Overlays/Black Alpha/6/Harness Open Source/Light */
+  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45;
+  /* ✦ Theme/Overlays/Black Alpha/7/Harness Open Source/Light */
+  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5;
+  /* ✦ Theme/Overlays/Black Alpha/8/Harness Open Source/Light */
+  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61;
+  /* ✦ Theme/Overlays/Black Alpha/9/Harness Open Source/Light */
+  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88;
+  /* ✦ Theme/Overlays/Black Alpha/10/Harness Open Source/Light */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 0;
+  /* ✦ Theme/Overlays/White Alpha/1/Harness Open Source/Light */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01;
+  /* ✦ Theme/Overlays/White Alpha/2/Harness Open Source/Light */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07;
+  /* ✦ Theme/Overlays/White Alpha/3/Harness Open Source/Light */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1;
+  /* ✦ Theme/Overlays/White Alpha/4/Harness Open Source/Light */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13;
+  /* ✦ Theme/Overlays/White Alpha/5/Harness Open Source/Light */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17;
+  /* ✦ Theme/Overlays/White Alpha/6/Harness Open Source/Light */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37;
+  /* ✦ Theme/Overlays/White Alpha/7/Harness Open Source/Light */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46;
+  /* ✦ Theme/Overlays/White Alpha/8/Harness Open Source/Light */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66;
+  /* ✦ Theme/Overlays/White Alpha/9/Harness Open Source/Light */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93;
+  /* ✦ Theme/Overlays/White Alpha/10/Harness Open Source/Light */
+  --figma___pagination-active-background: 207 6% 70% / 1;
+  /* ✦ Theme/Pagination/Active/Background/Harness Open Source/Light */
+  --figma___pagination-active-border: 210 6% 60% / 1;
+  /* ✦ Theme/Pagination/Active/Border/Harness Open Source/Light */
+  --figma___pagination-active-text: 200 7% 8% / 1;
+  /* ✦ Theme/Pagination/Active/Text/Harness Open Source/Light */
+  --figma___pagination-background: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Background/Harness Open Source/Light */
+  --figma___pagination-default-background: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Default/Background/Harness Open Source/Light */
+  --figma___pagination-default-border: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Default/Border/Harness Open Source/Light */
+  --figma___pagination-default-text: 200 7% 8% / 1;
+  /* ✦ Theme/Pagination/Default/Text/Harness Open Source/Light */
+  --figma___pagination-hover-background: 207 6% 70% / 1;
+  /* ✦ Theme/Pagination/Hover/Background/Harness Open Source/Light */
+  --figma___pagination-hover-border: 210 6% 60% / 1;
+  /* ✦ Theme/Pagination/Hover/Border/Harness Open Source/Light */
+  --figma___pagination-hover-text: 200 5% 12% / 1;
+  /* ✦ Theme/Pagination/Hover/Text/Harness Open Source/Light */
+  --figma___pagination-pagination-shadow-1: 0 0% 0% / 0;
+  /* ✦ Theme/Pagination/Pagination shadow/1/Harness Open Source/Light */
+  --figma___pagination-pagination-shadow-2: 240 100% 12% / 0;
+  /* ✦ Theme/Pagination/Pagination shadow/2/Harness Open Source/Light */
+  --figma___primary-color-primary-accent-1: 0 0% 98% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/1/Harness Open Source/Light */
+  --figma___primary-color-primary-accent-2: 210 7% 94% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/2/Harness Open Source/Light */
+  --figma___primary-color-primary-accent-3: 220 6% 90% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/3/Harness Open Source/Light */
+  --figma___primary-color-primary-accent-4: 240 6% 80% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/4/Harness Open Source/Light */
+  --figma___primary-color-primary-accent-5: 210 6% 60% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/5/Harness Open Source/Light */
+  --figma___primary-color-primary-accent-6: 210 6% 40% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/6/Harness Open Source/Light */
+  --figma___primary-color-primary-accent-7: 200 7% 8% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/7/Harness Open Source/Light */
+  --figma___primary-color-primary-accent-8: 216 6% 15% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/8/Harness Open Source/Light */
+  --figma___primary-color-primary-accent-9: 210 6% 6% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/9/Harness Open Source/Light */
+  --figma___primary-color-primary-accent-10: 200 7% 8% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/10/Harness Open Source/Light */
+  --figma___primary-color-primary-alpha-1: 240 89% 18% / 0.01;
+  /* ✦ Theme/Primary Color/Primary Alpha/1/Harness Open Source/Light */
+  --figma___primary-color-primary-alpha-2: 240 89% 18% / 0.02;
+  /* ✦ Theme/Primary Color/Primary Alpha/2/Harness Open Source/Light */
+  --figma___primary-color-primary-alpha-3: 240 100% 12% / 0.05;
+  /* ✦ Theme/Primary Color/Primary Alpha/3/Harness Open Source/Light */
+  --figma___primary-color-primary-alpha-4: 240 93% 11% / 0.08;
+  /* ✦ Theme/Primary Color/Primary Alpha/4/Harness Open Source/Light */
+  --figma___primary-color-primary-alpha-5: 0 0% 0% / 0.13;
+  /* ✦ Theme/Primary Color/Primary Alpha/5/Harness Open Source/Light */
+  --figma___primary-color-primary-alpha-6: 0 0% 0% / 0.27;
+  /* ✦ Theme/Primary Color/Primary Alpha/6/Harness Open Source/Light */
+  --figma___primary-color-primary-alpha-7: 200 7% 8% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/7/Harness Open Source/Light */
+  --figma___primary-color-primary-alpha-8: 216 6% 15% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/8/Harness Open Source/Light */
+  --figma___primary-color-primary-alpha-9: 210 6% 6% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/9/Harness Open Source/Light */
+  --figma___primary-color-primary-alpha-10: 200 7% 8% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/10/Harness Open Source/Light */
+  --figma___radio-button-background: 0 0% 100% / 1;
+  /* ✦ Theme/Radio button/Background/Harness Open Source/Light */
+  --figma___radio-button-checked-active-active-border: 210 6% 20% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active Border/Harness Open Source/Light */
+  --figma___radio-button-checked-active-active-background: 210 6% 20% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active background/Harness Open Source/Light */
+  --figma___radio-button-checked-active-hover-background: 210 6% 20% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover background/Harness Open Source/Light */
+  --figma___radio-button-checked-active-hover-border: 210 6% 20% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover border/Harness Open Source/Light */
+  --figma___radio-button-checked-active-default-background: 216 6% 15% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default background/Harness Open Source/Light */
+  --figma___radio-button-checked-active-default-border: 216 6% 15% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default border/Harness Open Source/Light */
+  --figma___radio-button-checked-disabled-dot: 210 6% 60% / 1;
+  /* ✦ Theme/Radio button/Checked/Disabled/Dot/Harness Open Source/Light */
+  --figma___radio-button-checked-disabled-background: 240 100% 12% / 0.05;
+  /* ✦ Theme/Radio button/Checked/Disabled/background/Harness Open Source/Light */
+  --figma___radio-button-checked-disabled-border: 210 6% 60% / 1;
+  /* ✦ Theme/Radio button/Checked/Disabled/border/Harness Open Source/Light */
+  --figma___radio-button-paper: 0 0% 100% / 0.5;
+  /* ✦ Theme/Radio button/Paper/Harness Open Source/Light */
+  --figma___radio-button-unchecked-active-active-border: 210 6% 20% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/Active border/Harness Open Source/Light */
+  --figma___radio-button-unchecked-active-hover-border: 210 6% 20% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/Harness Open Source/Light */
+  --figma___radio-button-unchecked-active-default-background: 0 0% 98% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/default background/Harness Open Source/Light */
+  --figma___radio-button-unchecked-active-default-border: 216 6% 15% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/default border/Harness Open Source/Light */
+  --figma___radio-button-unchecked-disabled-background: 0 0% 0% / 0.05;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/background/Harness Open Source/Light */
+  --figma___radio-button-unchecked-disabled-border: 210 6% 60% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/border/Harness Open Source/Light */
+  --figma___radio-button-border: 240 100% 12% / 0.05;
+  /* ✦ Theme/Radio button/border/Harness Open Source/Light */
+  --figma___secondary-crimson-crimson-1: 340 100% 99% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 1/Harness Open Source/Light */
+  --figma___secondary-crimson-crimson-10: 332 63% 24% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 10/Harness Open Source/Light */
+  --figma___secondary-crimson-crimson-2: 330 100% 98% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 2/Harness Open Source/Light */
+  --figma___secondary-crimson-crimson-3: 332 88% 97% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 3/Harness Open Source/Light */
+  --figma___secondary-crimson-crimson-4: 331 79% 94% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 4/Harness Open Source/Light */
+  --figma___secondary-crimson-crimson-5: 333 73% 91% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 5/Harness Open Source/Light */
+  --figma___secondary-crimson-crimson-6: 333 68% 87% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 6/Harness Open Source/Light */
+  --figma___secondary-crimson-crimson-7: 336 80% 58% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 7/Harness Open Source/Light */
+  --figma___secondary-crimson-crimson-8: 336 71% 53% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 8/Harness Open Source/Light */
+  --figma___secondary-crimson-crimson-9: 336 75% 45% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 9/Harness Open Source/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-1: 340 100% 51% / 0.01;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Open Source/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-10: 336 100% 38% / 0.89;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Open Source/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-11: 332 100% 16% / 0.91;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Open Source/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-2: 330 100% 51% / 0.03;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Open Source/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-3: 332 100% 51% / 0.03;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Open Source/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-4: 331 100% 44% / 0.1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Open Source/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-5: 333 100% 42% / 0.15;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Open Source/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-6: 333 99% 41% / 0.22;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Open Source/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-8: 336 100% 44% / 0.76;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Open Source/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-9: 336 100% 42% / 0.81;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Open Source/Light */
+  --figma___secondary-lime-1: 80 43% 99% / 1;
+  /* ✦ Theme/Secondary/Lime/1/Harness Open Source/Light */
+  --figma___secondary-lime-2: 85 67% 96% / 1;
+  /* ✦ Theme/Secondary/Lime/2/Harness Open Source/Light */
+  --figma___secondary-lime-3: 84 76% 92% / 1;
+  /* ✦ Theme/Secondary/Lime/3/Harness Open Source/Light */
+  --figma___secondary-lime-4: 83 71% 86% / 1;
+  /* ✦ Theme/Secondary/Lime/4/Harness Open Source/Light */
+  --figma___secondary-lime-5: 83 63% 81% / 1;
+  /* ✦ Theme/Secondary/Lime/5/Harness Open Source/Light */
+  --figma___secondary-lime-6: 81 51% 74% / 1;
+  /* ✦ Theme/Secondary/Lime/6/Harness Open Source/Light */
+  --figma___secondary-lime-7: 81 80% 66% / 1;
+  /* ✦ Theme/Secondary/Lime/7/Harness Open Source/Light */
+  --figma___secondary-lime-8: 81 75% 60% / 1;
+  /* ✦ Theme/Secondary/Lime/8/Harness Open Source/Light */
+  --figma___secondary-lime-9: 75 41% 29% / 1;
+  /* ✦ Theme/Secondary/Lime/9/Harness Open Source/Light */
+  --figma___secondary-lime-10: 75 39% 18% / 1;
+  /* ✦ Theme/Secondary/Lime/10/Harness Open Source/Light */
+  --figma___secondary-lime-alpha-1: 80 94% 31% / 0.02;
+  /* ✦ Theme/Secondary/Lime Alpha/1/Harness Open Source/Light */
+  --figma___secondary-lime-alpha-2: 85 99% 40% / 0.06;
+  /* ✦ Theme/Secondary/Lime Alpha/2/Harness Open Source/Light */
+  --figma___secondary-lime-alpha-3: 84 99% 44% / 0.15;
+  /* ✦ Theme/Secondary/Lime Alpha/3/Harness Open Source/Light */
+  --figma___secondary-lime-alpha-4: 83 99% 42% / 0.23;
+  /* ✦ Theme/Secondary/Lime Alpha/4/Harness Open Source/Light */
+  --figma___secondary-lime-alpha-5: 83 100% 39% / 0.31;
+  /* ✦ Theme/Secondary/Lime Alpha/5/Harness Open Source/Light */
+  --figma___secondary-lime-alpha-6: 81 100% 34% / 0.4;
+  /* ✦ Theme/Secondary/Lime Alpha/6/Harness Open Source/Light */
+  --figma___secondary-lime-alpha-7: 81 100% 45% / 0.61;
+  /* ✦ Theme/Secondary/Lime Alpha/7/Harness Open Source/Light */
+  --figma___secondary-lime-alpha-8: 81 100% 43% / 0.7;
+  /* ✦ Theme/Secondary/Lime Alpha/8/Harness Open Source/Light */
+  --figma___secondary-lime-alpha-9: 75 100% 14% / 0.83;
+  /* ✦ Theme/Secondary/Lime Alpha/9/Harness Open Source/Light */
+  --figma___secondary-lime-alpha-10: 76 100% 8% / 0.89;
+  /* ✦ Theme/Secondary/Lime Alpha/10/Harness Open Source/Light */
+  --figma___secondary-purple-1: 300 50% 99% / 1;
+  /* ✦ Theme/Secondary/Purple/1/Harness Open Source/Light */
+  --figma___secondary-purple-2: 276 100% 99% / 1;
+  /* ✦ Theme/Secondary/Purple/2/Harness Open Source/Light */
+  --figma___secondary-purple-3: 277 87% 97% / 1;
+  /* ✦ Theme/Secondary/Purple/3/Harness Open Source/Light */
+  --figma___secondary-purple-4: 274 78% 95% / 1;
+  /* ✦ Theme/Secondary/Purple/4/Harness Open Source/Light */
+  --figma___secondary-purple-5: 276 71% 92% / 1;
+  /* ✦ Theme/Secondary/Purple/5/Harness Open Source/Light */
+  --figma___secondary-purple-6: 274 65% 88% / 1;
+  /* ✦ Theme/Secondary/Purple/6/Harness Open Source/Light */
+  --figma___secondary-purple-7: 272 51% 54% / 1;
+  /* ✦ Theme/Secondary/Purple/7/Harness Open Source/Light */
+  --figma___secondary-purple-8: 272 47% 50% / 1;
+  /* ✦ Theme/Secondary/Purple/8/Harness Open Source/Light */
+  --figma___secondary-purple-9: 272 50% 46% / 1;
+  /* ✦ Theme/Secondary/Purple/9/Harness Open Source/Light */
+  --figma___secondary-purple-10: 270 50% 25% / 1;
+  /* ✦ Theme/Secondary/Purple/10/Harness Open Source/Light */
+  --figma___secondary-purple-alpha-1: 300 94% 35% / 0.01;
+  /* ✦ Theme/Secondary/Purple Alpha/1/Harness Open Source/Light */
+  --figma___secondary-purple-alpha-2: 276 100% 51% / 0.02;
+  /* ✦ Theme/Secondary/Purple Alpha/2/Harness Open Source/Light */
+  --figma___secondary-purple-alpha-3: 277 100% 46% / 0.05;
+  /* ✦ Theme/Secondary/Purple Alpha/3/Harness Open Source/Light */
+  --figma___secondary-purple-alpha-4: 274 98% 44% / 0.09;
+  /* ✦ Theme/Secondary/Purple Alpha/4/Harness Open Source/Light */
+  --figma___secondary-purple-alpha-5: 276 99% 42% / 0.14;
+  /* ✦ Theme/Secondary/Purple Alpha/5/Harness Open Source/Light */
+  --figma___secondary-purple-alpha-6: 275 100% 39% / 0.2;
+  /* ✦ Theme/Secondary/Purple Alpha/6/Harness Open Source/Light */
+  --figma___secondary-purple-alpha-7: 272 100% 34% / 0.69;
+  /* ✦ Theme/Secondary/Purple Alpha/7/Harness Open Source/Light */
+  --figma___secondary-purple-alpha-8: 272 100% 32% / 0.73;
+  /* ✦ Theme/Secondary/Purple Alpha/8/Harness Open Source/Light */
+  --figma___secondary-purple-alpha-9: 273 100% 30% / 0.77;
+  /* ✦ Theme/Secondary/Purple Alpha/9/Harness Open Source/Light */
+  --figma___secondary-purple-alpha-10: 270 100% 14% / 0.88;
+  /* ✦ Theme/Secondary/Purple Alpha/10/Harness Open Source/Light */
+  --figma___secondary-teal-1: 165 67% 99% / 1;
+  /* ✦ Theme/Secondary/Teal/1/Harness Open Source/Light */
+  --figma___secondary-teal-2: 169 65% 97% / 1;
+  /* ✦ Theme/Secondary/Teal/2/Harness Open Source/Light */
+  --figma___secondary-teal-3: 167 60% 94% / 1;
+  /* ✦ Theme/Secondary/Teal/3/Harness Open Source/Light */
+  --figma___secondary-teal-4: 168 52% 90% / 1;
+  /* ✦ Theme/Secondary/Teal/4/Harness Open Source/Light */
+  --figma___secondary-teal-5: 170 47% 85% / 1;
+  /* ✦ Theme/Secondary/Teal/5/Harness Open Source/Light */
+  --figma___secondary-teal-6: 170 43% 78% / 1;
+  /* ✦ Theme/Secondary/Teal/6/Harness Open Source/Light */
+  --figma___secondary-teal-7: 173 80% 36% / 1;
+  /* ✦ Theme/Secondary/Teal/7/Harness Open Source/Light */
+  --figma___secondary-teal-8: 173 83% 33% / 1;
+  /* ✦ Theme/Secondary/Teal/8/Harness Open Source/Light */
+  --figma___secondary-teal-9: 174 91% 25% / 1;
+  /* ✦ Theme/Secondary/Teal/9/Harness Open Source/Light */
+  --figma___secondary-teal-10: 174 65% 15% / 1;
+  /* ✦ Theme/Secondary/Teal/10/Harness Open Source/Light */
+  --figma___secondary-teal-alpha-1: 165 95% 41% / 0.02;
+  /* ✦ Theme/Secondary/Teal Alpha/1/Harness Open Source/Light */
+  --figma___secondary-teal-alpha-2: 169 99% 39% / 0.05;
+  /* ✦ Theme/Secondary/Teal Alpha/2/Harness Open Source/Light */
+  --figma___secondary-teal-alpha-3: 167 98% 38% / 0.09;
+  /* ✦ Theme/Secondary/Teal Alpha/3/Harness Open Source/Light */
+  --figma___secondary-teal-alpha-4: 168 98% 35% / 0.15;
+  /* ✦ Theme/Secondary/Teal Alpha/4/Harness Open Source/Light */
+  --figma___secondary-teal-alpha-5: 170 100% 32% / 0.22;
+  /* ✦ Theme/Secondary/Teal Alpha/5/Harness Open Source/Light */
+  --figma___secondary-teal-alpha-6: 170 100% 30% / 0.31;
+  /* ✦ Theme/Secondary/Teal Alpha/6/Harness Open Source/Light */
+  --figma___secondary-teal-alpha-7: 173 100% 31% / 0.93;
+  /* ✦ Theme/Secondary/Teal Alpha/7/Harness Open Source/Light */
+  --figma___secondary-teal-alpha-8: 173 100% 29% / 0.95;
+  /* ✦ Theme/Secondary/Teal Alpha/8/Harness Open Source/Light */
+  --figma___secondary-teal-alpha-9: 174 100% 23% / 0.98;
+  /* ✦ Theme/Secondary/Teal Alpha/9/Harness Open Source/Light */
+  --figma___secondary-teal-alpha-10: 174 100% 10% / 0.95;
+  /* ✦ Theme/Secondary/Teal Alpha/10/Harness Open Source/Light */
+  --figma___shadow-shadow-button-1: 0 0% 100% / 0.17;
+  /* ✦ Theme/Shadow/Shadow - button/1/Harness Open Source/Light */
+  --figma___shadow-shadow-button-2: 0 0% 100% / 0.07;
+  /* ✦ Theme/Shadow/Shadow - button/2/Harness Open Source/Light */
+  --figma___shadow-shadow-button-3: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow - button/3/Harness Open Source/Light */
+  --figma___shadow-shadow-button-4: 0 0% 0% / 0.08;
+  /* ✦ Theme/Shadow/Shadow - button/4/Harness Open Source/Light */
+  --figma___shadow-shadow-1-1: 0 0% 0% / 0.13;
+  /* ✦ Theme/Shadow/Shadow 1/1/Harness Open Source/Light */
+  --figma___shadow-shadow-2-1: 0 0% 0% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 2/1/Harness Open Source/Light */
+  --figma___shadow-shadow-2-2: 240 100% 12% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 2/2/Harness Open Source/Light */
+  --figma___shadow-shadow-2-3: 240 100% 12% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 2/3/Harness Open Source/Light */
+  --figma___shadow-shadow-3-1: 0 0% 0% / 0.08;
+  /* ✦ Theme/Shadow/Shadow 3/1/Harness Open Source/Light */
+  --figma___shadow-shadow-3-2: 0 0% 0% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 3/2/Harness Open Source/Light */
+  --figma___shadow-shadow-3-3: 240 100% 12% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 3/3/Harness Open Source/Light */
+  --figma___shadow-shadow-4-1: 0 0% 0% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 4/1/Harness Open Source/Light */
+  --figma___shadow-shadow-4-2: 240 100% 12% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 4/2/Harness Open Source/Light */
+  --figma___shadow-shadow-5-1: 0 0% 0% / 0.13;
+  /* ✦ Theme/Shadow/Shadow 5/1/Harness Open Source/Light */
+  --figma___shadow-shadow-5-2: 240 96% 9% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 5/2/Harness Open Source/Light */
+  --figma___shadow-shadow-6-1: 233 96% 9% / 0.17;
+  /* ✦ Theme/Shadow/Shadow 6/1/Harness Open Source/Light */
+  --figma___shadow-shadow-6-2: 233 96% 9% / 0.17;
+  /* ✦ Theme/Shadow/Shadow 6/2/Harness Open Source/Light */
+  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
+  /* ✦ Theme/Shadow/Shadow-button-active/1/Harness Open Source/Light */
+  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
+  /* ✦ Theme/Shadow/Shadow-button-active/2/Harness Open Source/Light */
+  --figma___shadow-shadow-button-active-3: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow-button-active/3/Harness Open Source/Light */
+  --figma___shadow-shadow-button-active-4: 0 0% 0% / 0.08;
+  /* ✦ Theme/Shadow/Shadow-button-active/4/Harness Open Source/Light */
+  --figma___side-nav-container-nav-background: 0 0% 100% / 1;
+  /* ✦ Theme/Side nav/Container/Nav-background/Harness Open Source/Light */
+  --figma___side-nav-container-nav-border: 220 6% 90% / 1;
+  /* ✦ Theme/Side nav/Container/Nav-border/Harness Open Source/Light */
+  --figma___side-nav-module-logo-text: 200 7% 8% / 1;
+  /* ✦ Theme/Side nav/Module Logo Text/Harness Open Source/Light */
+  --figma___side-nav-nav-item-default-icon: 210 6% 40% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Default/Icon/Harness Open Source/Light */
+  --figma___side-nav-nav-item-default-text: 200 5% 12% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Default/Text/Harness Open Source/Light */
+  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
+  /* ✦ Theme/Side nav/Nav-item/Default/default/Harness Open Source/Light */
+  --figma___side-nav-nav-item-hover-background: 0 0% 95% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Background/Harness Open Source/Light */
+  --figma___side-nav-nav-item-hover-icon: 200 5% 12% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/Harness Open Source/Light */
+  --figma___side-nav-nav-item-hover-text: 200 5% 12% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Text/Harness Open Source/Light */
+  --figma___side-nav-nav-item-selected-background: 0 0% 0% / 0.04;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Background/Harness Open Source/Light */
+  --figma___side-nav-nav-item-selected-icon: 200 7% 8% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/Harness Open Source/Light */
+  --figma___side-nav-nav-item-selected-text: 200 7% 8% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Text/Harness Open Source/Light */
+  --figma___side-nav-profile-role: 210 6% 20% / 1;
+  /* ✦ Theme/Side nav/Profile/Role/Harness Open Source/Light */
+  --figma___side-nav-profile-text: 200 7% 8% / 1;
+  /* ✦ Theme/Side nav/Profile/Text/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-default-border: 240 7% 94% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Border/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-default-main-text-icon: 200 7% 8% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-default-scope-name: 210 6% 20% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-hover-border: 210 6% 6% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-hover-main-text-icon: 200 7% 8% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-hover-scope-name: 210 6% 20% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-selected-border: 210 6% 6% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-selected-main-text-icon: 200 7% 8% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-selected-scope-name: 210 6% 20% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/Harness Open Source/Light */
+  --figma___side-nav-separator: 240 7% 94% / 1;
+  /* ✦ Theme/Side nav/Separator/Harness Open Source/Light */
+  --figma___status-colors-error-1: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/1/Harness Open Source/Light */
+  --figma___status-colors-error-2: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/2/Harness Open Source/Light */
+  --figma___status-colors-error-3: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/3/Harness Open Source/Light */
+  --figma___status-colors-error-4: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/4/Harness Open Source/Light */
+  --figma___status-colors-error-5: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/5/Harness Open Source/Light */
+  --figma___status-colors-error-6: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/6/Harness Open Source/Light */
+  --figma___status-colors-error-7: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/7/Harness Open Source/Light */
+  --figma___status-colors-error-8: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/8/Harness Open Source/Light */
+  --figma___status-colors-error-9: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/9/Harness Open Source/Light */
+  --figma___status-colors-error-10: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/10/Harness Open Source/Light */
+  --figma___status-colors-error-alpha-1: 0 100% 71% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/1/Harness Open Source/Light */
+  --figma___status-colors-error-alpha-2: 0 100% 71% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/2/Harness Open Source/Light */
+  --figma___status-colors-error-alpha-3: 0 100% 71% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/3/Harness Open Source/Light */
+  --figma___status-colors-error-alpha-4: 0 100% 71% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/4/Harness Open Source/Light */
+  --figma___status-colors-error-alpha-5: 0 100% 71% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/5/Harness Open Source/Light */
+  --figma___status-colors-error-alpha-6: 0 100% 71% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/6/Harness Open Source/Light */
+  --figma___status-colors-error-alpha-7: 0 100% 71% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/7/Harness Open Source/Light */
+  --figma___status-colors-error-alpha-8: 0 100% 71% / 0.16;
+  /* ✦ Theme/Status colors/Error Alpha/8/Harness Open Source/Light */
+  --figma___status-colors-error-alpha-9: 0 100% 71% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/9/Harness Open Source/Light */
+  --figma___status-colors-error-alpha-10: 0 100% 71% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/10/Harness Open Source/Light */
+  --figma___status-colors-info-1: 210 100% 99% / 1;
+  /* ✦ Theme/Status colors/Info/1/Harness Open Source/Light */
+  --figma___status-colors-info-2: 210 100% 98% / 1;
+  /* ✦ Theme/Status colors/Info/2/Harness Open Source/Light */
+  --figma___status-colors-info-3: 210 100% 96% / 1;
+  /* ✦ Theme/Status colors/Info/3/Harness Open Source/Light */
+  --figma___status-colors-info-4: 210 100% 94% / 1;
+  /* ✦ Theme/Status colors/Info/4/Harness Open Source/Light */
+  --figma___status-colors-info-5: 209 96% 90% / 1;
+  /* ✦ Theme/Status colors/Info/5/Harness Open Source/Light */
+  --figma___status-colors-info-6: 209 82% 85% / 1;
+  /* ✦ Theme/Status colors/Info/6/Harness Open Source/Light */
+  --figma___status-colors-info-7: 214 73% 51% / 1;
+  /* ✦ Theme/Status colors/Info/7/Harness Open Source/Light */
+  --figma___status-colors-info-8: 208 93% 47% / 1;
+  /* ✦ Theme/Status colors/Info/8/Harness Open Source/Light */
+  --figma___status-colors-info-9: 211 90% 42% / 1;
+  /* ✦ Theme/Status colors/Info/9/Harness Open Source/Light */
+  --figma___status-colors-info-10: 216 71% 23% / 1;
+  /* ✦ Theme/Status colors/Info/10/Harness Open Source/Light */
+  --figma___status-colors-info-alpha-1: 210 100% 51% / 0.02;
+  /* ✦ Theme/Status colors/Info Alpha/1/Harness Open Source/Light */
+  --figma___status-colors-info-alpha-2: 210 100% 51% / 0.04;
+  /* ✦ Theme/Status colors/Info Alpha/2/Harness Open Source/Light */
+  --figma___status-colors-info-alpha-3: 210 100% 50% / 0.07;
+  /* ✦ Theme/Status colors/Info Alpha/3/Harness Open Source/Light */
+  --figma___status-colors-info-alpha-4: 210 99% 49% / 0.19;
+  /* ✦ Theme/Status colors/Info Alpha/4/Harness Open Source/Light */
+  --figma___status-colors-info-alpha-5: 209 99% 49% / 0.19;
+  /* ✦ Theme/Status colors/Info Alpha/5/Harness Open Source/Light */
+  --figma___status-colors-info-alpha-6: 209 99% 45% / 0.28;
+  /* ✦ Theme/Status colors/Info Alpha/6/Harness Open Source/Light */
+  --figma___status-colors-info-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/7/Harness Open Source/Light */
+  --figma___status-colors-info-alpha-8: 208 100% 46% / 0.97;
+  /* ✦ Theme/Status colors/Info Alpha/8/Harness Open Source/Light */
+  --figma___status-colors-info-alpha-9: 211 100% 39% / 0.96;
+  /* ✦ Theme/Status colors/Info Alpha/9/Harness Open Source/Light */
+  --figma___status-colors-info-alpha-10: 216 100% 17% / 0.93;
+  /* ✦ Theme/Status colors/Info Alpha/10/Harness Open Source/Light */
+  --figma___status-colors-success-1: 140 60% 99% / 1;
+  /* ✦ Theme/Status colors/Success/1/Harness Open Source/Light */
+  --figma___status-colors-success-2: 138 63% 97% / 1;
+  /* ✦ Theme/Status colors/Success/2/Harness Open Source/Light */
+  --figma___status-colors-success-3: 139 57% 95% / 1;
+  /* ✦ Theme/Status colors/Success/3/Harness Open Source/Light */
+  --figma___status-colors-success-4: 139 48% 91% / 1;
+  /* ✦ Theme/Status colors/Success/4/Harness Open Source/Light */
+  --figma___status-colors-success-5: 141 44% 86% / 1;
+  /* ✦ Theme/Status colors/Success/5/Harness Open Source/Light */
+  --figma___status-colors-success-6: 142 40% 79% / 1;
+  /* ✦ Theme/Status colors/Success/6/Harness Open Source/Light */
+  --figma___status-colors-success-7: 142 72% 29% / 1;
+  /* ✦ Theme/Status colors/Success/7/Harness Open Source/Light */
+  --figma___status-colors-success-8: 152 57% 38% / 1;
+  /* ✦ Theme/Status colors/Success/8/Harness Open Source/Light */
+  --figma___status-colors-success-9: 153 67% 28% / 1;
+  /* ✦ Theme/Status colors/Success/9/Harness Open Source/Light */
+  --figma___status-colors-success-10: 155 40% 16% / 1;
+  /* ✦ Theme/Status colors/Success/10/Harness Open Source/Light */
+  --figma___status-colors-success-alpha-1: 140 95% 39% / 0.02;
+  /* ✦ Theme/Status colors/Success Alpha/1/Harness Open Source/Light */
+  --figma___status-colors-success-alpha-2: 139 98% 37% / 0.09;
+  /* ✦ Theme/Status colors/Success Alpha/2/Harness Open Source/Light */
+  --figma___status-colors-success-alpha-3: 139 98% 37% / 0.09;
+  /* ✦ Theme/Status colors/Success Alpha/3/Harness Open Source/Light */
+  --figma___status-colors-success-alpha-4: 139 99% 33% / 0.13;
+  /* ✦ Theme/Status colors/Success Alpha/4/Harness Open Source/Light */
+  --figma___status-colors-success-alpha-5: 141 100% 30% / 0.2;
+  /* ✦ Theme/Status colors/Success Alpha/5/Harness Open Source/Light */
+  --figma___status-colors-success-alpha-6: 142 99% 29% / 0.29;
+  /* ✦ Theme/Status colors/Success Alpha/6/Harness Open Source/Light */
+  --figma___status-colors-success-alpha-7: 151 100% 28% / 0.81;
+  /* ✦ Theme/Status colors/Success Alpha/7/Harness Open Source/Light */
+  --figma___status-colors-success-alpha-8: 153 100% 26% / 0.84;
+  /* ✦ Theme/Status colors/Success Alpha/8/Harness Open Source/Light */
+  --figma___status-colors-success-alpha-9: 153 100% 21% / 0.91;
+  /* ✦ Theme/Status colors/Success Alpha/9/Harness Open Source/Light */
+  --figma___status-colors-success-alpha-10: 155 100% 7% / 0.9;
+  /* ✦ Theme/Status colors/Success Alpha/10/Harness Open Source/Light */
+  --figma___status-colors-warning-1: 40 60% 99% / 1;
+  /* ✦ Theme/Status colors/Warning/1/Harness Open Source/Light */
+  --figma___status-colors-warning-2: 40 100% 96% / 1;
+  /* ✦ Theme/Status colors/Warning/2/Harness Open Source/Light */
+  --figma___status-colors-warning-3: 45 100% 91% / 1;
+  /* ✦ Theme/Status colors/Warning/3/Harness Open Source/Light */
+  --figma___status-colors-warning-4: 44 100% 86% / 1;
+  /* ✦ Theme/Status colors/Warning/4/Harness Open Source/Light */
+  --figma___status-colors-warning-5: 40 100% 82% / 1;
+  /* ✦ Theme/Status colors/Warning/5/Harness Open Source/Light */
+  --figma___status-colors-warning-6: 39 84% 75% / 1;
+  /* ✦ Theme/Status colors/Warning/6/Harness Open Source/Light */
+  --figma___status-colors-warning-7: 42 100% 62% / 1;
+  /* ✦ Theme/Status colors/Warning/7/Harness Open Source/Light */
+  --figma___status-colors-warning-8: 42 100% 55% / 1;
+  /* ✦ Theme/Status colors/Warning/8/Harness Open Source/Light */
+  --figma___status-colors-warning-9: 25 50% 38% / 1;
+  /* ✦ Theme/Status colors/Warning/9/Harness Open Source/Light */
+  --figma___status-colors-warning-10: 24 40% 22% / 1;
+  /* ✦ Theme/Status colors/Warning/10/Harness Open Source/Light */
+  --figma___status-colors-warning-alpha-1: 40 95% 39% / 0.02;
+  /* ✦ Theme/Status colors/Warning Alpha/1/Harness Open Source/Light */
+  --figma___status-colors-warning-alpha-2: 40 100% 50% / 0.07;
+  /* ✦ Theme/Status colors/Warning Alpha/2/Harness Open Source/Light */
+  --figma___status-colors-warning-alpha-3: 45 100% 50% / 0.19;
+  /* ✦ Theme/Status colors/Warning Alpha/3/Harness Open Source/Light */
+  --figma___status-colors-warning-alpha-4: 44 100% 50% / 0.28;
+  /* ✦ Theme/Status colors/Warning Alpha/4/Harness Open Source/Light */
+  --figma___status-colors-warning-alpha-5: 40 99% 50% / 0.37;
+  /* ✦ Theme/Status colors/Warning Alpha/5/Harness Open Source/Light */
+  --figma___status-colors-warning-alpha-6: 39 100% 46% / 0.45;
+  /* ✦ Theme/Status colors/Warning Alpha/6/Harness Open Source/Light */
+  --figma___status-colors-warning-alpha-7: 42 100% 50% / 0.76;
+  /* ✦ Theme/Status colors/Warning Alpha/7/Harness Open Source/Light */
+  --figma___status-colors-warning-alpha-8: 42 100% 50% / 0.9;
+  /* ✦ Theme/Status colors/Warning Alpha/8/Harness Open Source/Light */
+  --figma___status-colors-warning-alpha-9: 25 100% 24% / 0.81;
+  /* ✦ Theme/Status colors/Warning Alpha/9/Harness Open Source/Light */
+  --figma___status-colors-warning-alpha-10: 24 100% 10% / 0.87;
+  /* ✦ Theme/Status colors/Warning Alpha/10/Harness Open Source/Light */
+  --figma___switch-background: 0 0% 100% / 1;
+  /* ✦ Theme/Switch/Background/Harness Open Source/Light */
+  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/Harness Open Source/Light */
+  --figma___switch-checked-active-background: 200 7% 8% / 1;
+  /* ✦ Theme/Switch/Checked/Active/background/Harness Open Source/Light */
+  --figma___switch-checked-active-border: 210 6% 60% / 0;
+  /* ✦ Theme/Switch/Checked/Active/border/Harness Open Source/Light */
+  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/Harness Open Source/Light */
+  --figma___switch-checked-default-default-background: 200 7% 8% / 1;
+  /* ✦ Theme/Switch/Checked/Default/default background/Harness Open Source/Light */
+  --figma___switch-checked-default-default-border: 210 6% 60% / 0;
+  /* ✦ Theme/Switch/Checked/Default/default border/Harness Open Source/Light */
+  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/Harness Open Source/Light */
+  --figma___switch-checked-disabled-background: 200 7% 8% / 1;
+  /* ✦ Theme/Switch/Checked/Disabled/background/Harness Open Source/Light */
+  --figma___switch-checked-disabled-border: 210 6% 60% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/border/Harness Open Source/Light */
+  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/Harness Open Source/Light */
+  --figma___switch-checked-hover-background: 176 59% 40% / 1;
+  /* ✦ Theme/Switch/Checked/Hover/background/Harness Open Source/Light */
+  --figma___switch-checked-hover-border: 210 6% 60% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/border/Harness Open Source/Light */
+  --figma___switch-paper: 0 0% 100% / 0.5;
+  /* ✦ Theme/Switch/Paper/Harness Open Source/Light */
+  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/Harness Open Source/Light */
+  --figma___switch-unchecked-active-background: 207 6% 70% / 1;
+  /* ✦ Theme/Switch/Unchecked/Active/background/Harness Open Source/Light */
+  --figma___switch-unchecked-active-border: 210 6% 60% / 1;
+  /* ✦ Theme/Switch/Unchecked/Active/border/Harness Open Source/Light */
+  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/Harness Open Source/Light */
+  --figma___switch-unchecked-default-default-background: 210 6% 40% / 1;
+  /* ✦ Theme/Switch/Unchecked/Default/default background/Harness Open Source/Light */
+  --figma___switch-unchecked-default-default-border: 210 6% 60% / 1;
+  /* ✦ Theme/Switch/Unchecked/Default/default border/Harness Open Source/Light */
+  --figma___switch-unchecked-disabled-thumb-thumb-background: 240 13% 95% / 1;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/Harness Open Source/Light */
+  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/Harness Open Source/Light */
+  --figma___switch-unchecked-disabled-background: 0 0% 0% / 0.11;
+  /* ✦ Theme/Switch/Unchecked/Disabled/background/Harness Open Source/Light */
+  --figma___switch-unchecked-disabled-border: 210 6% 60% / 1;
+  /* ✦ Theme/Switch/Unchecked/Disabled/border/Harness Open Source/Light */
+  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/Harness Open Source/Light */
+  --figma___switch-unchecked-hover-background: 210 6% 20% / 1;
+  /* ✦ Theme/Switch/Unchecked/Hover/background/Harness Open Source/Light */
+  --figma___switch-unchecked-hover-border: 210 6% 60% / 1;
+  /* ✦ Theme/Switch/Unchecked/Hover/border/Harness Open Source/Light */
+  --figma___switch-border: 240 100% 12% / 0.05;
+  /* ✦ Theme/Switch/border/Harness Open Source/Light */
+  --figma___tabs-number-active-background: 240 13% 3% / 1;
+  /* ✦ Theme/Tabs/Number/Active/Background/Harness Open Source/Light */
+  --figma___tabs-number-active-text: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Number/Active/text/Harness Open Source/Light */
+  --figma___tabs-number-default-hover-background: 240 6% 80% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/Background/Harness Open Source/Light */
+  --figma___tabs-number-default-hover-text: 200 7% 8% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/text/Harness Open Source/Light */
+  --figma___tabs-pills-active-active: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Active/Harness Open Source/Light */
+  --figma___tabs-pills-active-text: 210 13% 3% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Text/Harness Open Source/Light */
+  --figma___tabs-pills-active-border-grad-1: 219 100% 84% / 0.1;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 1/Harness Open Source/Light */
+  --figma___tabs-pills-active-border-grad-2: 219 100% 84% / 0.05;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 2/Harness Open Source/Light */
+  --figma___tabs-pills-backgrounds: 240 7% 94% / 1;
+  /* ✦ Theme/Tabs/Pills/Backgrounds/Harness Open Source/Light */
+  --figma___tabs-pills-default-background: 240 6% 40% / 0;
+  /* ✦ Theme/Tabs/Pills/Default/Background/Harness Open Source/Light */
+  --figma___tabs-pills-default-text: 240 6% 40% / 1;
+  /* ✦ Theme/Tabs/Pills/Default/Text/Harness Open Source/Light */
+  --figma___tabs-pills-hover-background: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Background/Harness Open Source/Light */
+  --figma___tabs-pills-hover-text: 200 5% 12% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Text/Harness Open Source/Light */
+  --figma___tabs-pills-number-active-background: 200 7% 8% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/Background/Harness Open Source/Light */
+  --figma___tabs-pills-number-active-text: 0 0% 98% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/text/Harness Open Source/Light */
+  --figma___tabs-pills-border-grad-1: 219 100% 84% / 0.07;
+  /* ✦ Theme/Tabs/Pills/border grad 1/Harness Open Source/Light */
+  --figma___tabs-pills-border-grad-2: 219 100% 84% / 0.02;
+  /* ✦ Theme/Tabs/Pills/border grad 2/Harness Open Source/Light */
+  --figma___tabs-primary-active-text: 200 7% 8% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Text/Harness Open Source/Light */
+  --figma___tabs-primary-active-underline: 200 7% 8% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Underline/Harness Open Source/Light */
+  --figma___tabs-primary-border: 272 50% 46% / 1;
+  /* ✦ Theme/Tabs/Primary/Border/Harness Open Source/Light */
+  --figma___tabs-primary-default-background: 240 6% 40% / 0;
+  /* ✦ Theme/Tabs/Primary/Default/Background/Harness Open Source/Light */
+  --figma___tabs-primary-default-text: 210 6% 20% / 1;
+  /* ✦ Theme/Tabs/Primary/Default/Text/Harness Open Source/Light */
+  --figma___tabs-primary-hover-background: 240 93% 11% / 0.08;
+  /* ✦ Theme/Tabs/Primary/Hover/Background/Harness Open Source/Light */
+  --figma___tabs-primary-hover-text: 200 7% 8% / 1;
+  /* ✦ Theme/Tabs/Primary/Hover/Text/Harness Open Source/Light */
+  --figma___tabs-primary-pills-pills: 272 47% 50% / 1;
+  /* ✦ Theme/Tabs/Primary/Pills/Pills/Harness Open Source/Light */
+  --figma___text-disabled: 212 6% 50% / 1;
+  /* ✦ Theme/Text/Disabled/Harness Open Source/Light */
+  --figma___text-links: 216 100% 59% / 1;
+  /* ✦ Theme/Text/Links/Harness Open Source/Light */
+  --figma___text-secondary: 200 5% 12% / 1;
+  /* ✦ Theme/Text/Secondary/Harness Open Source/Light */
+  --figma___text-tertiary: 210 6% 20% / 1;
+  /* ✦ Theme/Text/Tertiary/Harness Open Source/Light */
+  --figma___text-primary: 200 7% 8% / 1;
+  /* ✦ Theme/Text/primary/Harness Open Source/Light */
+  --figma___textfield-assistive-text-primary: 210 6% 20% / 1;
+  /* ✦ Theme/Textfield/Assistive Text/Primary/Harness Open Source/Light */
+  --figma___textfield-background: 0 0% 100% / 0;
+  /* ✦ Theme/Textfield/Background/Harness Open Source/Light */
+  --figma___textfield-input-field-background: 0 0% 98% / 0;
+  /* ✦ Theme/Textfield/Input Field/Background/Harness Open Source/Light */
+  --figma___textfield-input-field-default: 212 6% 50% / 1;
+  /* ✦ Theme/Textfield/Input Field/Default/Harness Open Source/Light */
+  --figma___textfield-input-field-error: 0 80% 65% / 1;
+  /* ✦ Theme/Textfield/Input Field/Error/Harness Open Source/Light */
+  --figma___textfield-input-field-hover: 207 6% 70% / 1;
+  /* ✦ Theme/Textfield/Input Field/Hover/Harness Open Source/Light */
+  --figma___textfield-label-info-icon: 210 6% 20% / 1;
+  /* ✦ Theme/Textfield/Label/Info Icon/Harness Open Source/Light */
+  --figma___textfield-label-link: 206 82% 65% / 1;
+  /* ✦ Theme/Textfield/Label/Link/Harness Open Source/Light */
+  --figma___textfield-label-main: 200 7% 8% / 1;
+  /* ✦ Theme/Textfield/Label/Main/Harness Open Source/Light */
+  --figma___textfield-label-optional: 210 6% 20% / 1;
+  /* ✦ Theme/Textfield/Label/Optional/Harness Open Source/Light */
+  --figma___textfield-pin-soft-background: 240 100% 12% / 0.05;
+  /* ✦ Theme/Textfield/Pin/Soft/Background/Harness Open Source/Light */
+  --figma___textfield-pin-soft-border: 0 0% 0% / 0.17;
+  /* ✦ Theme/Textfield/Pin/Soft/border/Harness Open Source/Light */
+  --figma___textfield-pin-soft-pin: 200 6% 10% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/pin/Harness Open Source/Light */
+  --figma___textfield-pin-surface-background: 220 6% 90% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/Background/Harness Open Source/Light */
+  --figma___textfield-pin-surface-border: 210 6% 40% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/border/Harness Open Source/Light */
+  --figma___textfield-pin-surface-pin: 200 5% 12% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/pin/Harness Open Source/Light */
+  --figma___tooltip-background: 0 0% 100% / 1;
+  /* ✦ Theme/Tooltip/Background/Harness Open Source/Light */
+  --figma___tooltip-body-text: 200 5% 12% / 1;
+  /* ✦ Theme/Tooltip/Body Text/Harness Open Source/Light */
+  --figma___tooltip-dismissable-icon: 200 6% 10% / 1;
+  /* ✦ Theme/Tooltip/Dismissable icon/Harness Open Source/Light */
+  --figma___tooltip-tooltip-title: 200 7% 8% / 1;
+  /* ✦ Theme/Tooltip/Tooltip Title/Harness Open Source/Light */
+  --figma___badges-solid-amber-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Amber/text/Harness Open Source/Light */
+  --figma___badges-solid-blue-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Blue/text/Harness Open Source/Light */
+  --figma___badges-solid-bronze-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Bronze/text/Harness Open Source/Light */
+  --figma___badges-solid-brown-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Brown/text/Harness Open Source/Light */
+  --figma___badges-solid-crimson-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Crimson/text/Harness Open Source/Light */
+  --figma___badges-solid-cyan-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Cyan/text/Harness Open Source/Light */
+  --figma___badges-solid-gold-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Gold/text/Harness Open Source/Light */
+  --figma___badges-solid-grass-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Grass/text/Harness Open Source/Light */
+  --figma___badges-solid-green-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Green/text/Harness Open Source/Light */
+  --figma___badges-solid-indigo-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Indigo/text/Harness Open Source/Light */
+  --figma___badges-solid-iris-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Iris/text/Harness Open Source/Light */
+  --figma___badges-solid-jade-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Jade/text/Harness Open Source/Light */
+  --figma___badges-solid-lime-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Lime/text/Harness Open Source/Light */
+  --figma___badges-solid-mint-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Mint/text/Harness Open Source/Light */
+  --figma___badges-solid-orange-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Orange/text/Harness Open Source/Light */
+  --figma___badges-solid-pink-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Pink/text/Harness Open Source/Light */
+  --figma___badges-solid-plum-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Plum/text/Harness Open Source/Light */
+  --figma___badges-solid-purple-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Purple/text/Harness Open Source/Light */
+  --figma___badges-solid-red-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Red/text/Harness Open Source/Light */
+  --figma___badges-solid-ruby-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Ruby/text/Harness Open Source/Light */
+  --figma___badges-solid-sky-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Sky/text/Harness Open Source/Light */
+  --figma___badges-solid-success-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Success/text/Harness Open Source/Light */
+  --figma___badges-solid-teal-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Teal/text/Harness Open Source/Light */
+  --figma___badges-solid-violet-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Violet/text/Harness Open Source/Light */
+  --figma___badges-solid-yellow-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Yellow/text/Harness Open Source/Light */
+  --figma___badges-solid-accent-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/accent/text/Harness Open Source/Light */
+  --figma___badges-solid-info-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/info/text/Harness Open Source/Light */
+  --figma___badges-solid-warning-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/warning/text/Harness Open Source/Light */
+  --figma___button-solid-error-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Error/Text-primary/Harness Open Source/Light */
+  --figma___button-solid-neutral-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Neutral/Text-primary/Harness Open Source/Light */
+  --figma___button-solid-success-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Success/Text-primary/Harness Open Source/Light */
+  --figma___calendar-selected-date-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Calendar/Selected Date/Text/Harness Open Source/Light */
+  --figma___checkbox-surface-checked-active-check: var(--figma___default-colors-white);
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/Harness Open Source/Light */
+  --figma___checkbox-surface-intermediate-active-check: var(--figma___default-colors-white);
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/Harness Open Source/Light */
+  --figma___radio-button-checked-active-dot: var(--figma___default-colors-white);
+  /* ✦ Theme/Radio button/Checked/Active/Dot/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-default-default: var(--figma___textfield-background);
+  /* ✦ Theme/Side nav/Scope Selector/Default/default/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-hover-default: var(--figma___textfield-background);
+  /* ✦ Theme/Side nav/Scope Selector/Hover/default/Harness Open Source/Light */
+  --figma___side-nav-scope-selector-selected-background: var(--figma___textfield-background);
+  /* ✦ Theme/Side nav/Scope Selector/Selected/background/Harness Open Source/Light */
+  --figma___switch-checked-active-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/Harness Open Source/Light */
+  --figma___switch-checked-default-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/Harness Open Source/Light */
+  --figma___switch-checked-disabled-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/Harness Open Source/Light */
+  --figma___switch-checked-hover-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/Harness Open Source/Light */
+  --figma___switch-unchecked-active-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/Harness Open Source/Light */
+  --figma___switch-unchecked-default-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/Harness Open Source/Light */
+  --figma___switch-unchecked-hover-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/Harness Open Source/Light */
+}
+
+/* Color variables - dark mode */
+.harness-open-source-dark {
+  --figma___background-backdrop: 0 0% 0% / 0.75;
+  /* ✦ Theme/Background/Backdrop/Harness Open Source/Dark */
+  --figma___background-cards-and-rows-default: 240 5% 12% / 0;
+  /* ✦ Theme/Background/Cards and Rows/Default/Harness Open Source/Dark */
+  --figma___background-cards-and-rows-hover: 200 7% 8% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Hover/Harness Open Source/Dark */
+  --figma___background-cards-and-rows-primary-blue-selected: 240 100% 12% / 0.05;
+  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/Harness Open Source/Dark */
+  --figma___background-cards-and-rows-selected: 210 6% 20% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Selected/Harness Open Source/Dark */
+  --figma___background-header-page-header: 240 6% 6% / 1;
+  /* ✦ Theme/Background/Header/Page Header/Harness Open Source/Dark */
+  --figma___background-header-table-header: 200 7% 8% / 1;
+  /* ✦ Theme/Background/Header/Table Header/Harness Open Source/Dark */
+  --figma___background-paper: 210 6% 6% / 1;
+  /* ✦ Theme/Background/Paper/Harness Open Source/Dark */
+  --figma___background-primary: 210 6% 6% / 1;
+  /* ✦ Theme/Background/Primary/Harness Open Source/Dark */
+  --figma___background-solid: 0 4% 5% / 1;
+  /* ✦ Theme/Background/Solid/Harness Open Source/Dark */
+  --figma___badges-soft-amber-background: 24 100% 50% / 0.1;
+  /* ✦ Theme/Badges/Soft/Amber/background/Harness Open Source/Dark */
+  --figma___badges-soft-amber-text: 43 100% 65% / 1;
+  /* ✦ Theme/Badges/Soft/Amber/text/Harness Open Source/Dark */
+  --figma___badges-soft-blue-background: 216 100% 50% / 0.17;
+  /* ✦ Theme/Badges/Soft/Blue/background/Harness Open Source/Dark */
+  --figma___badges-soft-blue-text: 205 100% 71% / 1;
+  /* ✦ Theme/Badges/Soft/Blue/text/Harness Open Source/Dark */
+  --figma___badges-soft-bronze-background: 17 100% 79% / 0.06;
+  /* ✦ Theme/Badges/Soft/Bronze/background/Harness Open Source/Dark */
+  --figma___badges-soft-bronze-text: 19 100% 89% / 0.81;
+  /* ✦ Theme/Badges/Soft/Bronze/text/Harness Open Source/Dark */
+  --figma___badges-soft-brown-background: 25 99% 68% / 0.07;
+  /* ✦ Theme/Badges/Soft/Brown/background/Harness Open Source/Dark */
+  --figma___badges-soft-brown-text: 28 100% 84% / 0.85;
+  /* ✦ Theme/Badges/Soft/Brown/text/Harness Open Source/Dark */
+  --figma___badges-soft-crimson-background: 335 100% 55% / 0.14;
+  /* ✦ Theme/Badges/Soft/Crimson/background/Harness Open Source/Dark */
+  --figma___badges-soft-crimson-text: 341 100% 76% / 1;
+  /* ✦ Theme/Badges/Soft/Crimson/text/Harness Open Source/Dark */
+  --figma___badges-soft-cyan-background: 197 100% 50% / 0.1;
+  /* ✦ Theme/Badges/Soft/Cyan/background/Harness Open Source/Dark */
+  --figma___badges-soft-cyan-text: 190 100% 56% / 0.95;
+  /* ✦ Theme/Badges/Soft/Cyan/text/Harness Open Source/Dark */
+  --figma___badges-soft-gold-background: 50 100% 77% / 0.05;
+  /* ✦ Theme/Badges/Soft/Gold/background/Harness Open Source/Dark */
+  --figma___badges-soft-gold-text: 35 100% 89% / 0.77;
+  /* ✦ Theme/Badges/Soft/Gold/text/Harness Open Source/Dark */
+  --figma___badges-soft-grass-background: 139 98% 54% / 0.07;
+  /* ✦ Theme/Badges/Soft/Grass/background/Harness Open Source/Dark */
+  --figma___badges-soft-grass-text: 131 100% 77% / 0.8;
+  /* ✦ Theme/Badges/Soft/Grass/text/Harness Open Source/Dark */
+  --figma___badges-soft-green-background: 149 100% 49% / 0.07;
+  /* ✦ Theme/Badges/Soft/Green/background/Harness Open Source/Dark */
+  --figma___badges-soft-green-text: 151 100% 64% / 0.82;
+  /* ✦ Theme/Badges/Soft/Green/text/Harness Open Source/Dark */
+  --figma___badges-soft-indigo-background: 228 100% 57% / 0.18;
+  /* ✦ Theme/Badges/Soft/Indigo/background/Harness Open Source/Dark */
+  --figma___badges-soft-indigo-text: 235 100% 80% / 1;
+  /* ✦ Theme/Badges/Soft/Indigo/text/Harness Open Source/Dark */
+  --figma___badges-soft-iris-background: 244 99% 64% / 0.17;
+  /* ✦ Theme/Badges/Soft/Iris/background/Harness Open Source/Dark */
+  --figma___badges-soft-iris-text: 242 100% 81% / 1;
+  /* ✦ Theme/Badges/Soft/Iris/text/Harness Open Source/Dark */
+  --figma___badges-soft-jade-background: 145 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Soft/Jade/background/Harness Open Source/Dark */
+  --figma___badges-soft-jade-text: 163 99% 56% / 0.83;
+  /* ✦ Theme/Badges/Soft/Jade/text/Harness Open Source/Dark */
+  --figma___badges-soft-lime-background: 89 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Soft/Lime/background/Harness Open Source/Dark */
+  --figma___badges-soft-lime-text: 70 100% 58% / 0.84;
+  /* ✦ Theme/Badges/Soft/Lime/text/Harness Open Source/Dark */
+  --figma___badges-soft-mint-background: 174 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Soft/Mint/background/Harness Open Source/Dark */
+  --figma___badges-soft-mint-text: 167 100% 66% / 0.86;
+  /* ✦ Theme/Badges/Soft/Mint/text/Harness Open Source/Dark */
+  --figma___badges-soft-orange-background: 13 100% 50% / 0.12;
+  /* ✦ Theme/Badges/Soft/Orange/background/Harness Open Source/Dark */
+  --figma___badges-soft-orange-text: 24 100% 70% / 1;
+  /* ✦ Theme/Badges/Soft/Orange/text/Harness Open Source/Dark */
+  --figma___badges-soft-pink-background: 318 99% 56% / 0.14;
+  /* ✦ Theme/Badges/Soft/Pink/background/Harness Open Source/Dark */
+  --figma___badges-soft-pink-text: 325 100% 77% / 0.98;
+  /* ✦ Theme/Badges/Soft/Pink/text/Harness Open Source/Dark */
+  --figma___badges-soft-plum-background: 300 99% 59% / 0.12;
+  /* ✦ Theme/Badges/Soft/Plum/background/Harness Open Source/Dark */
+  --figma___badges-soft-plum-text: 290 100% 80% / 0.91;
+  /* ✦ Theme/Badges/Soft/Plum/text/Harness Open Source/Dark */
+  --figma___badges-soft-purple-background: 282 99% 60% / 0.15;
+  /* ✦ Theme/Badges/Soft/Purple/background/Harness Open Source/Dark */
+  --figma___badges-soft-purple-text: 270 100% 80% / 0.98;
+  /* ✦ Theme/Badges/Soft/Purple/text/Harness Open Source/Dark */
+  --figma___badges-soft-red-background: 353 99% 56% / 0.15;
+  /* ✦ Theme/Badges/Soft/Red/background/Harness Open Source/Dark */
+  --figma___badges-soft-red-text: 358 100% 76% / 1;
+  /* ✦ Theme/Badges/Soft/Red/text/Harness Open Source/Dark */
+  --figma___badges-soft-ruby-background: 348 99% 56% / 0.15;
+  /* ✦ Theme/Badges/Soft/Ruby/background/Harness Open Source/Dark */
+  --figma___badges-soft-ruby-text: 348 100% 76% / 1;
+  /* ✦ Theme/Badges/Soft/Ruby/text/Harness Open Source/Dark */
+  --figma___badges-soft-sky-background: 204 100% 50% / 0.12;
+  /* ✦ Theme/Badges/Soft/Sky/background/Harness Open Source/Dark */
+  --figma___badges-soft-sky-text: 195 100% 66% / 1;
+  /* ✦ Theme/Badges/Soft/Sky/text/Harness Open Source/Dark */
+  --figma___badges-soft-teal-background: 161 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Soft/Teal/background/Harness Open Source/Dark */
+  --figma___badges-soft-teal-text: 170 100% 52% / 0.83;
+  /* ✦ Theme/Badges/Soft/Teal/text/Harness Open Source/Dark */
+  --figma___badges-soft-violet-background: 255 99% 63% / 0.17;
+  /* ✦ Theme/Badges/Soft/Violet/background/Harness Open Source/Dark */
+  --figma___badges-soft-violet-text: 255 100% 80% / 1;
+  /* ✦ Theme/Badges/Soft/Violet/text/Harness Open Source/Dark */
+  --figma___badges-soft-yellow-background: 36 100% 50% / 0.09;
+  /* ✦ Theme/Badges/Soft/Yellow/background/Harness Open Source/Dark */
+  --figma___badges-soft-yellow-text: 55 100% 60% / 1;
+  /* ✦ Theme/Badges/Soft/Yellow/text/Harness Open Source/Dark */
+  --figma___badges-soft-accent-background: 200 6% 10% / 1;
+  /* ✦ Theme/Badges/Soft/accent/background/Harness Open Source/Dark */
+  --figma___badges-soft-accent-text: 220 6% 90% / 1;
+  /* ✦ Theme/Badges/Soft/accent/text/Harness Open Source/Dark */
+  --figma___badges-soft-error-background: 0 80% 65% / 0.1;
+  /* ✦ Theme/Badges/Soft/error/background/Harness Open Source/Dark */
+  --figma___badges-soft-error-text: 0 80% 65% / 0.1;
+  /* ✦ Theme/Badges/Soft/error/text/Harness Open Source/Dark */
+  --figma___badges-soft-info-background: 216 100% 50% / 0.17;
+  /* ✦ Theme/Badges/Soft/info/background/Harness Open Source/Dark */
+  --figma___badges-soft-info-text: 205 100% 71% / 1;
+  /* ✦ Theme/Badges/Soft/info/text/Harness Open Source/Dark */
+  --figma___badges-soft-success-background: 149 100% 49% / 0.07;
+  /* ✦ Theme/Badges/Soft/success/background/Harness Open Source/Dark */
+  --figma___badges-soft-success-text: 151 100% 64% / 0.82;
+  /* ✦ Theme/Badges/Soft/success/text/Harness Open Source/Dark */
+  --figma___badges-soft-warning-background: 34 63% 12% / 1;
+  /* ✦ Theme/Badges/Soft/warning/background/Harness Open Source/Dark */
+  --figma___badges-soft-warning-text: 43 100% 65% / 1;
+  /* ✦ Theme/Badges/Soft/warning/text/Harness Open Source/Dark */
+  --figma___badges-solid-amber-background: 42 100% 62% / 1;
+  /* ✦ Theme/Badges/Solid/Amber/background/Harness Open Source/Dark */
+  --figma___badges-solid-blue-background: 214 73% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Blue/background/Harness Open Source/Dark */
+  --figma___badges-solid-bronze-background: 18 20% 54% / 1;
+  /* ✦ Theme/Badges/Solid/Bronze/background/Harness Open Source/Dark */
+  --figma___badges-solid-brown-background: 28 34% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Brown/background/Harness Open Source/Dark */
+  --figma___badges-solid-crimson-background: 336 80% 58% / 1;
+  /* ✦ Theme/Badges/Solid/Crimson/background/Harness Open Source/Dark */
+  --figma___badges-solid-cyan-background: 190 95% 39% / 1;
+  /* ✦ Theme/Badges/Solid/Cyan/background/Harness Open Source/Dark */
+  --figma___badges-solid-gold-background: 36 20% 49% / 1;
+  /* ✦ Theme/Badges/Solid/Gold/background/Harness Open Source/Dark */
+  --figma___badges-solid-grass-background: 132 59% 33% / 1;
+  /* ✦ Theme/Badges/Solid/Grass/background/Harness Open Source/Dark */
+  --figma___badges-solid-green-background: 142 72% 29% / 1;
+  /* ✦ Theme/Badges/Solid/Green/background/Harness Open Source/Dark */
+  --figma___badges-solid-indigo-background: 226 70% 55% / 1;
+  /* ✦ Theme/Badges/Solid/Indigo/background/Harness Open Source/Dark */
+  --figma___badges-solid-iris-background: 240 60% 60% / 1;
+  /* ✦ Theme/Badges/Solid/Iris/background/Harness Open Source/Dark */
+  --figma___badges-solid-jade-background: 164 60% 40% / 1;
+  /* ✦ Theme/Badges/Solid/Jade/background/Harness Open Source/Dark */
+  --figma___badges-solid-lime-background: 81 80% 66% / 1;
+  /* ✦ Theme/Badges/Solid/Lime/background/Harness Open Source/Dark */
+  --figma___badges-solid-mint-background: 176 59% 50% / 1;
+  /* ✦ Theme/Badges/Solid/Mint/background/Harness Open Source/Dark */
+  --figma___badges-solid-orange-background: 24 94% 50% / 1;
+  /* ✦ Theme/Badges/Solid/Orange/background/Harness Open Source/Dark */
+  --figma___badges-solid-pink-background: 322 65% 55% / 1;
+  /* ✦ Theme/Badges/Solid/Pink/background/Harness Open Source/Dark */
+  --figma___badges-solid-plum-background: 292 45% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Plum/background/Harness Open Source/Dark */
+  --figma___badges-solid-purple-background: 272 51% 54% / 1;
+  /* ✦ Theme/Badges/Solid/Purple/background/Harness Open Source/Dark */
+  --figma___badges-solid-red-background: 358 75% 59% / 1;
+  /* ✦ Theme/Badges/Solid/Red/background/Harness Open Source/Dark */
+  --figma___badges-solid-ruby-background: 348 75% 59% / 1;
+  /* ✦ Theme/Badges/Solid/Ruby/background/Harness Open Source/Dark */
+  --figma___badges-solid-sky-background: 193 98% 74% / 1;
+  /* ✦ Theme/Badges/Solid/Sky/background/Harness Open Source/Dark */
+  --figma___badges-solid-success-background: 142 72% 29% / 1;
+  /* ✦ Theme/Badges/Solid/Success/background/Harness Open Source/Dark */
+  --figma___badges-solid-teal-background: 173 80% 36% / 1;
+  /* ✦ Theme/Badges/Solid/Teal/background/Harness Open Source/Dark */
+  --figma___badges-solid-violet-background: 252 56% 57% / 1;
+  /* ✦ Theme/Badges/Solid/Violet/background/Harness Open Source/Dark */
+  --figma___badges-solid-yellow-background: 53 96% 58% / 1;
+  /* ✦ Theme/Badges/Solid/Yellow/background/Harness Open Source/Dark */
+  --figma___badges-solid-accent-background: 176 59% 50% / 1;
+  /* ✦ Theme/Badges/Solid/accent/background/Harness Open Source/Dark */
+  --figma___badges-solid-info-background: 214 73% 51% / 1;
+  /* ✦ Theme/Badges/Solid/info/background/Harness Open Source/Dark */
+  --figma___badges-solid-warning-background: 43 100% 65% / 1;
+  /* ✦ Theme/Badges/Solid/warning/background/Harness Open Source/Dark */
+  --figma___badges-surface-amber-background: 6 100% 49% / 0.06;
+  /* ✦ Theme/Badges/Surface/Amber/background/Harness Open Source/Dark */
+  --figma___badges-surface-amber-border: 35 100% 57% / 0.38;
+  /* ✦ Theme/Badges/Surface/Amber/border/Harness Open Source/Dark */
+  --figma___badges-surface-amber-text: 43 100% 65% / 1;
+  /* ✦ Theme/Badges/Surface/Amber/text/Harness Open Source/Dark */
+  --figma___badges-surface-blue-background: 227 100% 50% / 0.09;
+  /* ✦ Theme/Badges/Surface/Blue/background/Harness Open Source/Dark */
+  --figma___badges-surface-blue-border: 211 100% 51% / 0.55;
+  /* ✦ Theme/Badges/Surface/Blue/border/Harness Open Source/Dark */
+  --figma___badges-surface-blue-text: 205 100% 71% / 1;
+  /* ✦ Theme/Badges/Surface/Blue/text/Harness Open Source/Dark */
+  --figma___badges-surface-bronze-background: 15 93% 53% / 0.02;
+  /* ✦ Theme/Badges/Surface/Bronze/background/Harness Open Source/Dark */
+  --figma___badges-surface-bronze-border: 17 100% 84% / 0.3;
+  /* ✦ Theme/Badges/Surface/Bronze/border/Harness Open Source/Dark */
+  --figma___badges-surface-bronze-text: 19 100% 89% / 0.81;
+  /* ✦ Theme/Badges/Surface/Bronze/text/Harness Open Source/Dark */
+  --figma___badges-surface-brown-background: 24 100% 50% / 0.03;
+  /* ✦ Theme/Badges/Surface/Brown/background/Harness Open Source/Dark */
+  --figma___badges-surface-brown-border: 28 98% 75% / 0.32;
+  /* ✦ Theme/Badges/Surface/Brown/border/Harness Open Source/Dark */
+  --figma___badges-surface-brown-text: 28 100% 84% / 0.85;
+  /* ✦ Theme/Badges/Surface/Brown/text/Harness Open Source/Dark */
+  --figma___badges-surface-crimson-border: 336 100% 57% / 0.49;
+  /* ✦ Theme/Badges/Surface/Crimson/Border/Harness Open Source/Dark */
+  --figma___badges-surface-crimson-background: 338 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/Crimson/background/Harness Open Source/Dark */
+  --figma___badges-surface-crimson-text: 341 100% 76% / 1;
+  /* ✦ Theme/Badges/Surface/Crimson/text/Harness Open Source/Dark */
+  --figma___badges-surface-cyan-border: 192 100% 57% / 0.35;
+  /* ✦ Theme/Badges/Surface/Cyan/Border/Harness Open Source/Dark */
+  --figma___badges-surface-cyan-background: 207 100% 49% / 0.04;
+  /* ✦ Theme/Badges/Surface/Cyan/background/Harness Open Source/Dark */
+  --figma___badges-surface-cyan-text: 190 100% 56% / 0.95;
+  /* ✦ Theme/Badges/Surface/Cyan/text/Harness Open Source/Dark */
+  --figma___badges-surface-gold-border: 39 97% 85% / 0.27;
+  /* ✦ Theme/Badges/Surface/Gold/Border/Harness Open Source/Dark */
+  --figma___badges-surface-gold-background: 42 100% 50% / 0.01;
+  /* ✦ Theme/Badges/Surface/Gold/background/Harness Open Source/Dark */
+  --figma___badges-surface-gold-text: 35 100% 89% / 0.77;
+  /* ✦ Theme/Badges/Surface/Gold/text/Harness Open Source/Dark */
+  --figma___badges-surface-grass-border: 135 100% 68% / 0.3;
+  /* ✦ Theme/Badges/Surface/Grass/Border/Harness Open Source/Dark */
+  --figma___badges-surface-grass-background: 120 100% 49% / 0.02;
+  /* ✦ Theme/Badges/Surface/Grass/background/Harness Open Source/Dark */
+  --figma___badges-surface-grass-text: 131 100% 77% / 0.8;
+  /* ✦ Theme/Badges/Surface/Grass/text/Harness Open Source/Dark */
+  --figma___badges-surface-green-background: 120 100% 49% / 0.02;
+  /* ✦ Theme/Badges/Surface/Green/background/Harness Open Source/Dark */
+  --figma___badges-surface-green-border: 152 99% 59% / 0.3;
+  /* ✦ Theme/Badges/Surface/Green/border/Harness Open Source/Dark */
+  --figma___badges-surface-green-text: 151 100% 64% / 0.82;
+  /* ✦ Theme/Badges/Surface/Green/text/Harness Open Source/Dark */
+  --figma___badges-surface-indigo-background: 232 100% 50% / 0.09;
+  /* ✦ Theme/Badges/Surface/Indigo/background/Harness Open Source/Dark */
+  --figma___badges-surface-indigo-border: 226 100% 62% / 0.52;
+  /* ✦ Theme/Badges/Surface/Indigo/border/Harness Open Source/Dark */
+  --figma___badges-surface-indigo-text: 235 100% 80% / 1;
+  /* ✦ Theme/Badges/Surface/Indigo/text/Harness Open Source/Dark */
+  --figma___badges-surface-iris-border: 240 100% 71% / 0.49;
+  /* ✦ Theme/Badges/Surface/Iris/Border/Harness Open Source/Dark */
+  --figma___badges-surface-iris-background: 243 100% 55% / 0.09;
+  /* ✦ Theme/Badges/Surface/Iris/background/Harness Open Source/Dark */
+  --figma___badges-surface-iris-text: 242 100% 81% / 1;
+  /* ✦ Theme/Badges/Surface/Iris/text/Harness Open Source/Dark */
+  --figma___badges-surface-jade-border: 159 99% 58% / 0.3;
+  /* ✦ Theme/Badges/Surface/Jade/Border/Harness Open Source/Dark */
+  --figma___badges-surface-jade-background: 120 100% 49% / 0.03;
+  /* ✦ Theme/Badges/Surface/Jade/background/Harness Open Source/Dark */
+  --figma___badges-surface-jade-text: 163 99% 56% / 0.83;
+  /* ✦ Theme/Badges/Surface/Jade/text/Harness Open Source/Dark */
+  --figma___badges-surface-lime-border: 78 100% 61% / 0.28;
+  /* ✦ Theme/Badges/Surface/Lime/Border/Harness Open Source/Dark */
+  --figma___badges-surface-lime-background: 114 100% 49% / 0.02;
+  /* ✦ Theme/Badges/Surface/Lime/background/Harness Open Source/Dark */
+  --figma___badges-surface-lime-text: 70 100% 58% / 0.84;
+  /* ✦ Theme/Badges/Surface/Lime/text/Harness Open Source/Dark */
+  --figma___badges-surface-mint-background: 165 100% 49% / 0.03;
+  /* ✦ Theme/Badges/Surface/Mint/background/Harness Open Source/Dark */
+  --figma___badges-surface-mint-border: 173 100% 55% / 0.31;
+  /* ✦ Theme/Badges/Surface/Mint/border/Harness Open Source/Dark */
+  --figma___badges-surface-mint-text: 167 100% 66% / 0.86;
+  /* ✦ Theme/Badges/Surface/Mint/text/Harness Open Source/Dark */
+  --figma___badges-surface-orange-background: 13 100% 50% / 0.12;
+  /* ✦ Theme/Badges/Surface/Orange/background/Harness Open Source/Dark */
+  --figma___badges-surface-orange-border: 25 100% 51% / 0.44;
+  /* ✦ Theme/Badges/Surface/Orange/border/Harness Open Source/Dark */
+  --figma___badges-surface-orange-text: 24 100% 70% / 1;
+  /* ✦ Theme/Badges/Surface/Orange/text/Harness Open Source/Dark */
+  --figma___badges-surface-pink-background: 319 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/Pink/background/Harness Open Source/Dark */
+  --figma___badges-surface-pink-border: 320 100% 62% / 0.43;
+  /* ✦ Theme/Badges/Surface/Pink/border/Harness Open Source/Dark */
+  --figma___badges-surface-pink-text: 325 100% 77% / 0.98;
+  /* ✦ Theme/Badges/Surface/Pink/text/Harness Open Source/Dark */
+  --figma___badges-surface-plum-background: 300 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Surface/Plum/background/Harness Open Source/Dark */
+  --figma___badges-surface-plum-border: 294 100% 69% / 0.39;
+  /* ✦ Theme/Badges/Surface/Plum/border/Harness Open Source/Dark */
+  --figma___badges-surface-plum-text: 290 100% 80% / 0.91;
+  /* ✦ Theme/Badges/Surface/Plum/text/Harness Open Source/Dark */
+  --figma___badges-surface-purple-background: 283 100% 49% / 0.07;
+  /* ✦ Theme/Badges/Surface/Purple/background/Harness Open Source/Dark */
+  --figma___badges-surface-purple-border: 276 100% 67% / 0.44;
+  /* ✦ Theme/Badges/Surface/Purple/border/Harness Open Source/Dark */
+  --figma___badges-surface-purple-text: 270 100% 80% / 0.98;
+  /* ✦ Theme/Badges/Surface/Purple/text/Harness Open Source/Dark */
+  --figma___badges-surface-red-background: 354 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/Red/background/Harness Open Source/Dark */
+  --figma___badges-surface-red-border: 354 100% 57% / 0.5;
+  /* ✦ Theme/Badges/Surface/Red/border/Harness Open Source/Dark */
+  --figma___badges-surface-red-text: 358 100% 76% / 1;
+  /* ✦ Theme/Badges/Surface/Red/text/Harness Open Source/Dark */
+  --figma___badges-surface-ruby-background: 351 100% 50% / 0.08;
+  /* ✦ Theme/Badges/Surface/Ruby/background/Harness Open Source/Dark */
+  --figma___badges-surface-ruby-border: 348 100% 57% / 0.49;
+  /* ✦ Theme/Badges/Surface/Ruby/border/Harness Open Source/Dark */
+  --figma___badges-surface-ruby-text: 348 100% 76% / 1;
+  /* ✦ Theme/Badges/Surface/Ruby/text/Harness Open Source/Dark */
+  --figma___badges-surface-sky-background: 215 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Surface/Sky/background/Harness Open Source/Dark */
+  --figma___badges-surface-sky-border: 200 100% 59% / 0.4;
+  /* ✦ Theme/Badges/Surface/Sky/border/Harness Open Source/Dark */
+  --figma___badges-surface-sky-text: 195 100% 66% / 1;
+  /* ✦ Theme/Badges/Surface/Sky/text/Harness Open Source/Dark */
+  --figma___badges-surface-teal-background: 141 100% 49% / 0.03;
+  /* ✦ Theme/Badges/Surface/Teal/background/Harness Open Source/Dark */
+  --figma___badges-surface-teal-border: 171 99% 56% / 0.3;
+  /* ✦ Theme/Badges/Surface/Teal/border/Harness Open Source/Dark */
+  --figma___badges-surface-teal-text: 170 100% 52% / 0.83;
+  /* ✦ Theme/Badges/Surface/Teal/text/Harness Open Source/Dark */
+  --figma___badges-surface-violet-background: 255 98% 52% / 0.08;
+  /* ✦ Theme/Badges/Surface/Violet/background/Harness Open Source/Dark */
+  --figma___badges-surface-violet-border: 251 100% 70% / 0.49;
+  /* ✦ Theme/Badges/Surface/Violet/border/Harness Open Source/Dark */
+  --figma___badges-surface-violet-text: 255 100% 80% / 1;
+  /* ✦ Theme/Badges/Surface/Violet/text/Harness Open Source/Dark */
+  --figma___badges-surface-yellow-background: 17 100% 49% / 0.04;
+  /* ✦ Theme/Badges/Surface/Yellow/background/Harness Open Source/Dark */
+  --figma___badges-surface-yellow-border: 47 99% 55% / 0.32;
+  /* ✦ Theme/Badges/Surface/Yellow/border/Harness Open Source/Dark */
+  --figma___badges-surface-yellow-text: 55 100% 60% / 1;
+  /* ✦ Theme/Badges/Surface/Yellow/text/Harness Open Source/Dark */
+  --figma___badges-surface-accent-background: 165 100% 49% / 0.03;
+  /* ✦ Theme/Badges/Surface/accent/background/Harness Open Source/Dark */
+  --figma___badges-surface-accent-border: 173 100% 55% / 0.31;
+  /* ✦ Theme/Badges/Surface/accent/border/Harness Open Source/Dark */
+  --figma___badges-surface-accent-text: 167 100% 66% / 0.86;
+  /* ✦ Theme/Badges/Surface/accent/text/Harness Open Source/Dark */
+  --figma___badges-surface-error-background: 354 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/error/background/Harness Open Source/Dark */
+  --figma___badges-surface-error-border: 354 100% 57% / 0.5;
+  /* ✦ Theme/Badges/Surface/error/border/Harness Open Source/Dark */
+  --figma___badges-surface-error-text: 358 100% 76% / 1;
+  /* ✦ Theme/Badges/Surface/error/text/Harness Open Source/Dark */
+  --figma___badges-surface-info-background: 204 100% 50% / 0.12;
+  /* ✦ Theme/Badges/Surface/info/background/Harness Open Source/Dark */
+  --figma___badges-surface-info-border: 200 100% 59% / 0.4;
+  /* ✦ Theme/Badges/Surface/info/border/Harness Open Source/Dark */
+  --figma___badges-surface-info-text: 195 100% 66% / 1;
+  /* ✦ Theme/Badges/Surface/info/text/Harness Open Source/Dark */
+  --figma___badges-surface-success-background: 120 100% 49% / 0.02;
+  /* ✦ Theme/Badges/Surface/success/background/Harness Open Source/Dark */
+  --figma___badges-surface-success-border: 152 99% 59% / 0.3;
+  /* ✦ Theme/Badges/Surface/success/border/Harness Open Source/Dark */
+  --figma___badges-surface-success-text: 151 100% 64% / 0.82;
+  /* ✦ Theme/Badges/Surface/success/text/Harness Open Source/Dark */
+  --figma___badges-surface-warning-background: 6 100% 49% / 0.06;
+  /* ✦ Theme/Badges/Surface/warning/background/Harness Open Source/Dark */
+  --figma___badges-surface-warning-border: 35 100% 57% / 0.38;
+  /* ✦ Theme/Badges/Surface/warning/border/Harness Open Source/Dark */
+  --figma___badges-surface-warning-text: 43 100% 65% / 1;
+  /* ✦ Theme/Badges/Surface/warning/text/Harness Open Source/Dark */
+  --figma___border-disabled: 224 96% 89% / 0.13;
+  /* ✦ Theme/Border/Disabled/Harness Open Source/Dark */
+  --figma___border-hover: 207 6% 30% / 1;
+  /* ✦ Theme/Border/Hover/Harness Open Source/Dark */
+  --figma___border-primary: 240 6% 10% / 1;
+  /* ✦ Theme/Border/Primary/Harness Open Source/Dark */
+  --figma___border-secondary: 200 5% 12% / 1;
+  /* ✦ Theme/Border/Secondary/Harness Open Source/Dark */
+  --figma___border-selected: 240 7% 94% / 1;
+  /* ✦ Theme/Border/Selected/Harness Open Source/Dark */
+  --figma___breadcrumbs-current: 0 0% 98% / 1;
+  /* ✦ Theme/Breadcrumbs/current/Harness Open Source/Dark */
+  --figma___breadcrumbs-visited: 207 6% 70% / 1;
+  /* ✦ Theme/Breadcrumbs/visited/Harness Open Source/Dark */
+  --figma___button-ghost-accent-active: 172 100% 50% / 0.11;
+  /* ✦ Theme/Button/Ghost/Accent/Active/Harness Open Source/Dark */
+  --figma___button-ghost-accent-active-text: 167 70% 58% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Active text/Harness Open Source/Dark */
+  --figma___button-ghost-accent-hover: 174 100% 50% / 0.07;
+  /* ✦ Theme/Button/Ghost/Accent/Hover/Harness Open Source/Dark */
+  --figma___button-ghost-accent-hover-text: 167 70% 58% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Hover text/Harness Open Source/Dark */
+  --figma___button-ghost-accent-text-disabled: 170 60% 35% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/Harness Open Source/Dark */
+  --figma___button-ghost-accent-text-primary: 167 70% 58% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Text-primary/Harness Open Source/Dark */
+  --figma___button-ghost-error-active: 352 100% 56% / 0.21;
+  /* ✦ Theme/Button/Ghost/Error/Active/Harness Open Source/Dark */
+  --figma___button-ghost-error-active-text: 358 100% 76% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Active Text/Harness Open Source/Dark */
+  --figma___button-ghost-error-hover: 353 99% 56% / 0.15;
+  /* ✦ Theme/Button/Ghost/Error/Hover/Harness Open Source/Dark */
+  --figma___button-ghost-error-hover-text: 358 100% 76% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Hover text/Harness Open Source/Dark */
+  --figma___button-ghost-error-text-disabled: 358 75% 47% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Text-disabled/Harness Open Source/Dark */
+  --figma___button-ghost-error-text-primary: 358 100% 76% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Text-primary/Harness Open Source/Dark */
+  --figma___button-ghost-neutral-active: 224 96% 89% / 0.13;
+  /* ✦ Theme/Button/Ghost/Neutral/Active/Harness Open Source/Dark */
+  --figma___button-ghost-neutral-active-text: 218 7% 70% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Active Text/Harness Open Source/Dark */
+  --figma___button-ghost-neutral-hover: 230 100% 87% / 0.09;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover/Harness Open Source/Dark */
+  --figma___button-ghost-neutral-hover-text: 218 7% 70% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover text/Harness Open Source/Dark */
+  --figma___button-ghost-neutral-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/Harness Open Source/Dark */
+  --figma___button-ghost-neutral-text-primary: 0 0% 98% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/Harness Open Source/Dark */
+  --figma___button-ghost-success-active: 154 100% 50% / 0.11;
+  /* ✦ Theme/Button/Ghost/Success/Active/Harness Open Source/Dark */
+  --figma___button-ghost-success-active-text: 151 65% 54% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Active Text/Harness Open Source/Dark */
+  --figma___button-ghost-success-hover: 149 100% 49% / 0.07;
+  /* ✦ Theme/Button/Ghost/Success/Hover/Harness Open Source/Dark */
+  --figma___button-ghost-success-hover-text: 151 65% 54% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Hover text/Harness Open Source/Dark */
+  --figma___button-ghost-success-text-disabled: 151 100% 63% / 0.5;
+  /* ✦ Theme/Button/Ghost/Success/Text-disabled/Harness Open Source/Dark */
+  --figma___button-ghost-success-text-primary: 151 65% 54% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Text-primary/Harness Open Source/Dark */
+  --figma___button-outline-accent-active: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Outline/Accent/Active/Harness Open Source/Dark */
+  --figma___button-outline-accent-default-border: 0 0% 98% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Default border/Harness Open Source/Dark */
+  --figma___button-outline-accent-disabled-border: 209 95% 92% / 0.24;
+  /* ✦ Theme/Button/Outline/Accent/Disabled Border/Harness Open Source/Dark */
+  --figma___button-outline-accent-hover: 240 89% 18% / 0.02;
+  /* ✦ Theme/Button/Outline/Accent/Hover/Harness Open Source/Dark */
+  --figma___button-outline-accent-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Text-disabled/Harness Open Source/Dark */
+  --figma___button-outline-accent-text-primary: 220 6% 90% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Text-primary/Harness Open Source/Dark */
+  --figma___button-outline-error-active: 0 80% 65% / 0.1;
+  /* ✦ Theme/Button/Outline/Error/Active/Harness Open Source/Dark */
+  --figma___button-outline-error-default-border: 0 80% 65% / 0.16;
+  /* ✦ Theme/Button/Outline/Error/Default - border/Harness Open Source/Dark */
+  --figma___button-outline-error-disabled-border: 0 80% 65% / 0.1;
+  /* ✦ Theme/Button/Outline/Error/Disabled-border/Harness Open Source/Dark */
+  --figma___button-outline-error-hover: 0 80% 65% / 0.1;
+  /* ✦ Theme/Button/Outline/Error/Hover/Harness Open Source/Dark */
+  --figma___button-outline-error-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Outline/Error/Text-disabled/Harness Open Source/Dark */
+  --figma___button-outline-error-text-primary: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Outline/Error/Text-primary/Harness Open Source/Dark */
+  --figma___button-outline-neutral-active: 217 95% 91% / 0.19;
+  /* ✦ Theme/Button/Outline/Neutral/Active/Harness Open Source/Dark */
+  --figma___button-outline-neutral-default-border: 209 95% 92% / 0.24;
+  /* ✦ Theme/Button/Outline/Neutral/Default - border/Harness Open Source/Dark */
+  --figma___button-outline-neutral-disabled-border: 202 88% 93% / 0.33;
+  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/Harness Open Source/Dark */
+  --figma___button-outline-neutral-hover: 217 95% 91% / 0.19;
+  /* ✦ Theme/Button/Outline/Neutral/Hover/Harness Open Source/Dark */
+  --figma___button-outline-neutral-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/Harness Open Source/Dark */
+  --figma___button-outline-neutral-text-primary: 207 6% 70% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Text-primary/Harness Open Source/Dark */
+  --figma___button-outline-success-active: 149 100% 49% / 0.07;
+  /* ✦ Theme/Button/Outline/Success/Active/Harness Open Source/Dark */
+  --figma___button-outline-success-default-border: 152 99% 59% / 0.3;
+  /* ✦ Theme/Button/Outline/Success/Default-border/Harness Open Source/Dark */
+  --figma___button-outline-success-disabled-border: 209 95% 92% / 0.24;
+  /* ✦ Theme/Button/Outline/Success/Disabled - border/Harness Open Source/Dark */
+  --figma___button-outline-success-hover: 120 100% 49% / 0.02;
+  /* ✦ Theme/Button/Outline/Success/Hover/Harness Open Source/Dark */
+  --figma___button-outline-success-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Outline/Success/Text-disabled/Harness Open Source/Dark */
+  --figma___button-outline-success-text-primary: 151 100% 64% / 0.82;
+  /* ✦ Theme/Button/Outline/Success/Text-primary/Harness Open Source/Dark */
+  --figma___button-soft-accent-active: 240 96% 9% / 0.13;
+  /* ✦ Theme/Button/Soft/Accent/Active/Harness Open Source/Dark */
+  --figma___button-soft-accent-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Soft/Accent/Disabled/Harness Open Source/Dark */
+  --figma___button-soft-accent-hover: 240 93% 11% / 0.08;
+  /* ✦ Theme/Button/Soft/Accent/Hover/Harness Open Source/Dark */
+  --figma___button-soft-accent-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Text-disabled/Harness Open Source/Dark */
+  --figma___button-soft-accent-text-primary: 220 6% 90% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Text-primary/Harness Open Source/Dark */
+  --figma___button-soft-accent-default: 202 88% 93% / 0.33;
+  /* ✦ Theme/Button/Soft/Accent/default/Harness Open Source/Dark */
+  --figma___button-soft-error-active: 0 80% 65% / 0.1;
+  /* ✦ Theme/Button/Soft/Error/Active/Harness Open Source/Dark */
+  --figma___button-soft-error-disabled: 0 80% 65% / 0.1;
+  /* ✦ Theme/Button/Soft/Error/Disabled/Harness Open Source/Dark */
+  --figma___button-soft-error-hover: 0 80% 65% / 0.16;
+  /* ✦ Theme/Button/Soft/Error/Hover/Harness Open Source/Dark */
+  --figma___button-soft-error-text-disabled: 354 66% 33% / 1;
+  /* ✦ Theme/Button/Soft/Error/Text-disabled/Harness Open Source/Dark */
+  --figma___button-soft-error-text-primary: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Soft/Error/Text-primary/Harness Open Source/Dark */
+  --figma___button-soft-error-default: 0 80% 65% / 0.1;
+  /* ✦ Theme/Button/Soft/Error/default/Harness Open Source/Dark */
+  --figma___button-soft-neutral-active: 223 100% 91% / 0.16;
+  /* ✦ Theme/Button/Soft/Neutral/Active/Harness Open Source/Dark */
+  --figma___button-soft-neutral-disabled: 230 100% 87% / 0.09;
+  /* ✦ Theme/Button/Soft/Neutral/Disabled/Harness Open Source/Dark */
+  --figma___button-soft-neutral-hover: 224 96% 89% / 0.13;
+  /* ✦ Theme/Button/Soft/Neutral/Hover/Harness Open Source/Dark */
+  --figma___button-soft-neutral-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/Harness Open Source/Dark */
+  --figma___button-soft-neutral-text-primary: 207 6% 70% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Text-primary/Harness Open Source/Dark */
+  --figma___button-soft-neutral-default: 230 100% 87% / 0.09;
+  /* ✦ Theme/Button/Soft/Neutral/default/Harness Open Source/Dark */
+  --figma___button-soft-success-active: 153 99% 53% / 0.15;
+  /* ✦ Theme/Button/Soft/Success/Active/Harness Open Source/Dark */
+  --figma___button-soft-success-disabled: 230 100% 87% / 0.09;
+  /* ✦ Theme/Button/Soft/Success/Disabled/Harness Open Source/Dark */
+  --figma___button-soft-success-hover: 154 100% 50% / 0.11;
+  /* ✦ Theme/Button/Soft/Success/Hover/Harness Open Source/Dark */
+  --figma___button-soft-success-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Soft/Success/Text-disabled/Harness Open Source/Dark */
+  --figma___button-soft-success-text-primary: 151 65% 54% / 1;
+  /* ✦ Theme/Button/Soft/Success/Text-primary/Harness Open Source/Dark */
+  --figma___button-soft-success-default: 149 100% 49% / 0.07;
+  /* ✦ Theme/Button/Soft/Success/default/Harness Open Source/Dark */
+  --figma___button-solid-accent-active: 0 0% 98% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Active/Harness Open Source/Dark */
+  --figma___button-solid-accent-disabled: 240 6% 80% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Disabled/Harness Open Source/Dark */
+  --figma___button-solid-accent-hover: 240 7% 94% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Hover/Harness Open Source/Dark */
+  --figma___button-solid-accent-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Text-disabled/Harness Open Source/Dark */
+  --figma___button-solid-accent-text-primary: 240 13% 3% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Text-primary/Harness Open Source/Dark */
+  --figma___button-solid-accent-default: 0 0% 100% / 1;
+  /* ✦ Theme/Button/Solid/Accent/default/Harness Open Source/Dark */
+  --figma___button-solid-error-active: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Solid/Error/Active/Harness Open Source/Dark */
+  --figma___button-solid-error-disabled: 0 80% 65% / 0.1;
+  /* ✦ Theme/Button/Solid/Error/Disabled/Harness Open Source/Dark */
+  --figma___button-solid-error-hover: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Solid/Error/Hover/Harness Open Source/Dark */
+  --figma___button-solid-error-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Solid/Error/Text-disabled/Harness Open Source/Dark */
+  --figma___button-solid-error-default: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Solid/Error/default/Harness Open Source/Dark */
+  --figma___button-solid-neutral-active: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Active/Harness Open Source/Dark */
+  --figma___button-solid-neutral-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Solid/Neutral/Disabled/Harness Open Source/Dark */
+  --figma___button-solid-neutral-hover: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Hover/Harness Open Source/Dark */
+  --figma___button-solid-neutral-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/Harness Open Source/Dark */
+  --figma___button-solid-neutral-default: 212 6% 50% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/default/Harness Open Source/Dark */
+  --figma___button-solid-success-active: 142 72% 29% / 1;
+  /* ✦ Theme/Button/Solid/Success/Active/Harness Open Source/Dark */
+  --figma___button-solid-success-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Solid/Success/Disabled/Harness Open Source/Dark */
+  --figma___button-solid-success-hover: 151 55% 47% / 1;
+  /* ✦ Theme/Button/Solid/Success/Hover/Harness Open Source/Dark */
+  --figma___button-solid-success-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Solid/Success/Text-disabled/Harness Open Source/Dark */
+  --figma___button-solid-success-default: 142 72% 29% / 1;
+  /* ✦ Theme/Button/Solid/Success/default/Harness Open Source/Dark */
+  --figma___button-surface-accent-active: 0 0% 100% / 0.13;
+  /* ✦ Theme/Button/Surface/Accent/Active/Harness Open Source/Dark */
+  --figma___button-surface-accent-active-border: 0 0% 100% / 0.31;
+  /* ✦ Theme/Button/Surface/Accent/Active border/Harness Open Source/Dark */
+  --figma___button-surface-accent-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Surface/Accent/Disabled/Harness Open Source/Dark */
+  --figma___button-surface-accent-hover: 0 0% 100% / 0.1;
+  /* ✦ Theme/Button/Surface/Accent/Hover/Harness Open Source/Dark */
+  --figma___button-surface-accent-hover-border: 0 0% 100% / 0.31;
+  /* ✦ Theme/Button/Surface/Accent/Hover Border/Harness Open Source/Dark */
+  --figma___button-surface-accent-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Text-disabled/Harness Open Source/Dark */
+  --figma___button-surface-accent-text-primary: 0 0% 98% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Text-primary/Harness Open Source/Dark */
+  --figma___button-surface-accent-default: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Surface/Accent/default/Harness Open Source/Dark */
+  --figma___button-surface-accent-default-border: 0 0% 100% / 0.22;
+  /* ✦ Theme/Button/Surface/Accent/default border/Harness Open Source/Dark */
+  --figma___button-surface-error-active: 0 80% 65% / 0.1;
+  /* ✦ Theme/Button/Surface/Error/Active/Harness Open Source/Dark */
+  --figma___button-surface-error-active-border: 0 80% 65% / 0.16;
+  /* ✦ Theme/Button/Surface/Error/Active border/Harness Open Source/Dark */
+  --figma___button-surface-error-disabled: 353 99% 56% / 0.15;
+  /* ✦ Theme/Button/Surface/Error/Disabled/Harness Open Source/Dark */
+  --figma___button-surface-error-hover: 0 80% 65% / 0.16;
+  /* ✦ Theme/Button/Surface/Error/Hover/Harness Open Source/Dark */
+  --figma___button-surface-error-hover-border: 0 80% 65% / 0.16;
+  /* ✦ Theme/Button/Surface/Error/Hover border/Harness Open Source/Dark */
+  --figma___button-surface-error-text-disabled: 354 66% 33% / 1;
+  /* ✦ Theme/Button/Surface/Error/Text-disabled/Harness Open Source/Dark */
+  --figma___button-surface-error-text-primary: 0 80% 65% / 1;
+  /* ✦ Theme/Button/Surface/Error/Text-primary/Harness Open Source/Dark */
+  --figma___button-surface-error-border: 0 80% 65% / 0.1;
+  /* ✦ Theme/Button/Surface/Error/border/Harness Open Source/Dark */
+  --figma___button-surface-error-default: 0 80% 65% / 0.1;
+  /* ✦ Theme/Button/Surface/Error/default/Harness Open Source/Dark */
+  --figma___button-surface-neutral-active: 223 100% 91% / 0.16;
+  /* ✦ Theme/Button/Surface/Neutral/Active/Harness Open Source/Dark */
+  --figma___button-surface-neutral-disabled: 230 100% 87% / 0.09;
+  /* ✦ Theme/Button/Surface/Neutral/Disabled/Harness Open Source/Dark */
+  --figma___button-surface-neutral-hover: 224 96% 89% / 0.13;
+  /* ✦ Theme/Button/Surface/Neutral/Hover/Harness Open Source/Dark */
+  --figma___button-surface-neutral-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/Harness Open Source/Dark */
+  --figma___button-surface-neutral-text-primary: 0 0% 69% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Text-primary/Harness Open Source/Dark */
+  --figma___button-surface-neutral-border: 209 95% 92% / 0.24;
+  /* ✦ Theme/Button/Surface/Neutral/border/Harness Open Source/Dark */
+  --figma___button-surface-neutral-default: 230 100% 87% / 0.09;
+  /* ✦ Theme/Button/Surface/Neutral/default/Harness Open Source/Dark */
+  --figma___button-surface-success-active: 153 99% 53% / 0.15;
+  /* ✦ Theme/Button/Surface/Success/Active/Harness Open Source/Dark */
+  --figma___button-surface-success-disabled: 230 100% 87% / 0.09;
+  /* ✦ Theme/Button/Surface/Success/Disabled/Harness Open Source/Dark */
+  --figma___button-surface-success-hover: 154 100% 50% / 0.11;
+  /* ✦ Theme/Button/Surface/Success/Hover/Harness Open Source/Dark */
+  --figma___button-surface-success-hover-border: 151 100% 63% / 0.5;
+  /* ✦ Theme/Button/Surface/Success/Hover border/Harness Open Source/Dark */
+  --figma___button-surface-success-text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Button/Surface/Success/Text-disabled/Harness Open Source/Dark */
+  --figma___button-surface-success-text-primary: 151 100% 64% / 0.82;
+  /* ✦ Theme/Button/Surface/Success/Text-primary/Harness Open Source/Dark */
+  --figma___button-surface-success-active-border: 151 100% 63% / 0.5;
+  /* ✦ Theme/Button/Surface/Success/active border/Harness Open Source/Dark */
+  --figma___button-surface-success-default: 149 100% 49% / 0.07;
+  /* ✦ Theme/Button/Surface/Success/default/Harness Open Source/Dark */
+  --figma___button-surface-success-default-border: 155 99% 55% / 0.2;
+  /* ✦ Theme/Button/Surface/Success/default border/Harness Open Source/Dark */
+  --figma___calendar-background: 200 5% 12% / 1;
+  /* ✦ Theme/Calendar/Background/Harness Open Source/Dark */
+  --figma___calendar-selected-date-background: 0 0% 98% / 1;
+  /* ✦ Theme/Calendar/Selected Date/Background/Harness Open Source/Dark */
+  --figma___calendar-selected-range-background: 210 6% 20% / 1;
+  /* ✦ Theme/Calendar/Selected Range/Background/Harness Open Source/Dark */
+  --figma___calendar-selected-range-text: 207 6% 70% / 1;
+  /* ✦ Theme/Calendar/Selected Range/Text/Harness Open Source/Dark */
+  --figma___checkbox-background: 200 5% 12% / 1;
+  /* ✦ Theme/Checkbox/Background/Harness Open Source/Dark */
+  --figma___checkbox-paper: 0 0% 100% / 0.03;
+  /* ✦ Theme/Checkbox/Paper/Harness Open Source/Dark */
+  --figma___checkbox-surface-checked-active-active: 212 6% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/Harness Open Source/Dark */
+  --figma___checkbox-surface-checked-active-hover: 212 6% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/Harness Open Source/Dark */
+  --figma___checkbox-surface-checked-active-default-background: 240 7% 94% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/Harness Open Source/Dark */
+  --figma___checkbox-surface-checked-disabled-check: 212 6% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/Harness Open Source/Dark */
+  --figma___checkbox-surface-checked-disabled-disabled: 210 6% 40% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/Harness Open Source/Dark */
+  --figma___checkbox-surface-checked-disabled-border: 207 6% 30% / 0;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/Harness Open Source/Dark */
+  --figma___checkbox-surface-intermediate-active-active-border: 240 6% 80% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/Harness Open Source/Dark */
+  --figma___checkbox-surface-intermediate-active-hover-border: 240 6% 80% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/Harness Open Source/Dark */
+  --figma___checkbox-surface-intermediate-active-default-background: 164 99% 44% / 0;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/Harness Open Source/Dark */
+  --figma___checkbox-surface-intermediate-active-default-border: 240 7% 94% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/Harness Open Source/Dark */
+  --figma___checkbox-surface-intermediate-disabled-check: 212 6% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/Harness Open Source/Dark */
+  --figma___checkbox-surface-intermediate-disabled-disabled: 0 0% 0% / 0;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/Harness Open Source/Dark */
+  --figma___checkbox-surface-intermediate-disabled-border: 212 6% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/Harness Open Source/Dark */
+  --figma___checkbox-surface-unchecked-active-active-border: 240 6% 80% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/Harness Open Source/Dark */
+  --figma___checkbox-surface-unchecked-active-hover-border: 240 6% 80% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/Harness Open Source/Dark */
+  --figma___checkbox-surface-unchecked-active-default-background: 210 6% 6% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/Harness Open Source/Dark */
+  --figma___checkbox-surface-unchecked-active-default-border: 240 7% 94% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/Harness Open Source/Dark */
+  --figma___checkbox-surface-unchecked-disabled-disabled: 210 6% 60% / 0;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/Harness Open Source/Dark */
+  --figma___checkbox-surface-unchecked-disabled-border: 212 6% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/Harness Open Source/Dark */
+  --figma___checkbox-border: 230 100% 87% / 0.09;
+  /* ✦ Theme/Checkbox/border/Harness Open Source/Dark */
+  --figma___default-colors-black: 210 13% 3% / 1;
+  /* ✦ Theme/Default colors/black/Harness Open Source/Dark */
+  --figma___default-colors-dark-to-white: 0 0% 100% / 1;
+  /* ✦ Theme/Default colors/dark-to-white/Harness Open Source/Dark */
+  --figma___default-colors-white: 0 0% 100% / 1;
+  /* ✦ Theme/Default colors/white/Harness Open Source/Dark */
+  --figma___default-colors-white-to-dark: 240 13% 3% / 1;
+  /* ✦ Theme/Default colors/white-to-dark/Harness Open Source/Dark */
+  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
+  /* ✦ Theme/Dropdown/Dropdown Item/Default/Harness Open Source/Dark */
+  --figma___dropdown-dropdown-item-hover: 200 6% 10% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Hover/Harness Open Source/Dark */
+  --figma___dropdown-dropdown-item-selected: 200 6% 10% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Selected/Harness Open Source/Dark */
+  --figma___dropdown-text-shortcut-text-selected: 212 6% 50% / 1;
+  /* ✦ Theme/Dropdown/Text/Shortcut text selected/Harness Open Source/Dark */
+  --figma___dropdown-text-text-selected: 0 0% 98% / 1;
+  /* ✦ Theme/Dropdown/Text/Text Selected/Harness Open Source/Dark */
+  --figma___dropdown-text-hover: 207 6% 70% / 1;
+  /* ✦ Theme/Dropdown/Text/hover/Harness Open Source/Dark */
+  --figma___dropdown-background: 200 5% 12% / 1;
+  /* ✦ Theme/Dropdown/background/Harness Open Source/Dark */
+  --figma___dropdown-border: 240 6% 10% / 1;
+  /* ✦ Theme/Dropdown/border/Harness Open Source/Dark */
+  --figma___dropdown-separator: 216 6% 15% / 1;
+  /* ✦ Theme/Dropdown/separator/Harness Open Source/Dark */
+  --figma___filter-active: 210 6% 20% / 1;
+  /* ✦ Theme/Filter/Active/Harness Open Source/Dark */
+  --figma___filter-default: 216 6% 15% / 1;
+  /* ✦ Theme/Filter/Default/Harness Open Source/Dark */
+  --figma___filter-hover: 210 6% 20% / 1;
+  /* ✦ Theme/Filter/Hover/Harness Open Source/Dark */
+  --figma___inline-alert-banner-customisable: 240 7% 11% / 1;
+  /* ✦ Theme/Inline Alert Banner/Customisable/Harness Open Source/Dark */
+  --figma___inline-alert-banner-error: 353 99% 56% / 0.15;
+  /* ✦ Theme/Inline Alert Banner/Error/Harness Open Source/Dark */
+  --figma___inline-alert-banner-info: 214 58% 16% / 1;
+  /* ✦ Theme/Inline Alert Banner/Info/Harness Open Source/Dark */
+  --figma___inline-alert-banner-reminder: 36 80% 8% / 1;
+  /* ✦ Theme/Inline Alert Banner/Reminder/Harness Open Source/Dark */
+  --figma___inline-alert-banner-success: 155 38% 11% / 1;
+  /* ✦ Theme/Inline Alert Banner/Success/Harness Open Source/Dark */
+  --figma___inline-alert-banner-warning: 26 68% 12% / 1;
+  /* ✦ Theme/Inline Alert Banner/Warning/Harness Open Source/Dark */
+  --figma___modal-background: 200 5% 12% / 1;
+  /* ✦ Theme/Modal/Background/Harness Open Source/Dark */
+  --figma___modal-paper: 0 0% 100% / 0.03;
+  /* ✦ Theme/Modal/Paper/Harness Open Source/Dark */
+  --figma___modal-border: 230 100% 87% / 0.09;
+  /* ✦ Theme/Modal/border/Harness Open Source/Dark */
+  --figma___neutral-color-gray-1: 200 7% 8% / 1;
+  /* ✦ Theme/Neutral color/Gray/1/Harness Open Source/Dark */
+  --figma___neutral-color-gray-2: 210 6% 6% / 1;
+  /* ✦ Theme/Neutral color/Gray/2/Harness Open Source/Dark */
+  --figma___neutral-color-gray-3: 200 6% 10% / 1;
+  /* ✦ Theme/Neutral color/Gray/3/Harness Open Source/Dark */
+  --figma___neutral-color-gray-4: 200 5% 12% / 1;
+  /* ✦ Theme/Neutral color/Gray/4/Harness Open Source/Dark */
+  --figma___neutral-color-gray-5: 216 6% 15% / 1;
+  /* ✦ Theme/Neutral color/Gray/5/Harness Open Source/Dark */
+  --figma___neutral-color-gray-6: 210 6% 20% / 1;
+  /* ✦ Theme/Neutral color/Gray/6/Harness Open Source/Dark */
+  --figma___neutral-color-gray-7: 207 6% 30% / 1;
+  /* ✦ Theme/Neutral color/Gray/7/Harness Open Source/Dark */
+  --figma___neutral-color-gray-8: 210 6% 40% / 1;
+  /* ✦ Theme/Neutral color/Gray/8/Harness Open Source/Dark */
+  --figma___neutral-color-gray-9: 212 6% 50% / 1;
+  /* ✦ Theme/Neutral color/Gray/9/Harness Open Source/Dark */
+  --figma___neutral-color-gray-10: 240 7% 94% / 1;
+  /* ✦ Theme/Neutral color/Gray/10/Harness Open Source/Dark */
+  --figma___neutral-color-gray-alpha-1: 240 93% 53% / 0.01;
+  /* ✦ Theme/Neutral color/Gray Alpha/1/Harness Open Source/Dark */
+  --figma___neutral-color-gray-alpha-2: 240 93% 73% / 0.03;
+  /* ✦ Theme/Neutral color/Gray Alpha/2/Harness Open Source/Dark */
+  --figma___neutral-color-gray-alpha-3: 230 100% 87% / 0.09;
+  /* ✦ Theme/Neutral color/Gray Alpha/3/Harness Open Source/Dark */
+  --figma___neutral-color-gray-alpha-4: 224 96% 89% / 0.13;
+  /* ✦ Theme/Neutral color/Gray Alpha/4/Harness Open Source/Dark */
+  --figma___neutral-color-gray-alpha-5: 223 100% 91% / 0.16;
+  /* ✦ Theme/Neutral color/Gray Alpha/5/Harness Open Source/Dark */
+  --figma___neutral-color-gray-alpha-6: 217 95% 91% / 0.19;
+  /* ✦ Theme/Neutral color/Gray Alpha/6/Harness Open Source/Dark */
+  --figma___neutral-color-gray-alpha-7: 209 95% 92% / 0.24;
+  /* ✦ Theme/Neutral color/Gray Alpha/7/Harness Open Source/Dark */
+  --figma___neutral-color-gray-alpha-8: 202 88% 93% / 0.33;
+  /* ✦ Theme/Neutral color/Gray Alpha/8/Harness Open Source/Dark */
+  --figma___neutral-color-gray-alpha-9: 219 100% 93% / 0.41;
+  /* ✦ Theme/Neutral color/Gray Alpha/9/Harness Open Source/Dark */
+  --figma___neutral-color-gray-alpha-10: 218 100% 95% / 0.49;
+  /* ✦ Theme/Neutral color/Gray Alpha/10/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-1: 252 19% 10% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/1/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-2: 255 30% 13% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/2/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-3: 255 34% 18% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/3/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-4: 252 35% 22% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/4/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-5: 253 35% 25% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/5/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-6: 253 37% 30% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/6/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-7: 252 56% 57% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/7/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-8: 253 63% 64% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/8/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-9: 255 100% 80% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/9/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-10: 249 94% 93% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/10/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-alpha-1: 240 100% 49% / 0.03;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/1/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-alpha-2: 255 98% 52% / 0.08;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/2/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-alpha-3: 255 99% 63% / 0.17;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/3/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-alpha-4: 252 99% 66% / 0.23;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/4/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-alpha-5: 252 99% 67% / 0.28;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/5/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-alpha-6: 253 100% 68% / 0.35;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/6/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-alpha-7: 252 100% 70% / 0.79;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/7/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-alpha-8: 253 100% 74% / 0.85;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/8/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-alpha-9: 255 100% 80% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/9/Harness Open Source/Dark */
+  --figma___other-colors-ai-violet-alpha-10: 249 100% 94% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/10/Harness Open Source/Dark */
+  --figma___other-colors-blue-1: 212 36% 9% / 1;
+  /* ✦ Theme/Other Colors/Blue/1/Harness Open Source/Dark */
+  --figma___other-colors-blue-2: 216 50% 12% / 1;
+  /* ✦ Theme/Other Colors/Blue/2/Harness Open Source/Dark */
+  --figma___other-colors-blue-3: 214 58% 16% / 1;
+  /* ✦ Theme/Other Colors/Blue/3/Harness Open Source/Dark */
+  --figma___other-colors-blue-4: 214 65% 18% / 1;
+  /* ✦ Theme/Other Colors/Blue/4/Harness Open Source/Dark */
+  --figma___other-colors-blue-5: 213 67% 21% / 1;
+  /* ✦ Theme/Other Colors/Blue/5/Harness Open Source/Dark */
+  --figma___other-colors-blue-6: 212 72% 25% / 1;
+  /* ✦ Theme/Other Colors/Blue/6/Harness Open Source/Dark */
+  --figma___other-colors-blue-7: 214 73% 51% / 1;
+  /* ✦ Theme/Other Colors/Blue/7/Harness Open Source/Dark */
+  --figma___other-colors-blue-8: 206 100% 62% / 1;
+  /* ✦ Theme/Other Colors/Blue/8/Harness Open Source/Dark */
+  --figma___other-colors-blue-9: 205 100% 71% / 1;
+  /* ✦ Theme/Other Colors/Blue/9/Harness Open Source/Dark */
+  --figma___other-colors-blue-10: 206 100% 88% / 1;
+  /* ✦ Theme/Other Colors/Blue/10/Harness Open Source/Dark */
+  --figma___other-colors-blue-alpha-1: 240 100% 49% / 0.04;
+  /* ✦ Theme/Other Colors/Blue Alpha/1/Harness Open Source/Dark */
+  --figma___other-colors-blue-alpha-2: 227 100% 50% / 0.09;
+  /* ✦ Theme/Other Colors/Blue Alpha/2/Harness Open Source/Dark */
+  --figma___other-colors-blue-alpha-3: 216 100% 50% / 0.17;
+  /* ✦ Theme/Other Colors/Blue Alpha/3/Harness Open Source/Dark */
+  --figma___other-colors-blue-alpha-4: 214 100% 50% / 0.23;
+  /* ✦ Theme/Other Colors/Blue Alpha/4/Harness Open Source/Dark */
+  --figma___other-colors-blue-alpha-5: 212 100% 52% / 0.38;
+  /* ✦ Theme/Other Colors/Blue Alpha/5/Harness Open Source/Dark */
+  --figma___other-colors-blue-alpha-6: 212 100% 52% / 0.38;
+  /* ✦ Theme/Other Colors/Blue Alpha/6/Harness Open Source/Dark */
+  --figma___other-colors-blue-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/7/Harness Open Source/Dark */
+  --figma___other-colors-blue-alpha-8: 206 100% 62% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/8/Harness Open Source/Dark */
+  --figma___other-colors-blue-alpha-9: 205 100% 71% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/9/Harness Open Source/Dark */
+  --figma___other-colors-blue-alpha-10: 206 100% 88% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/10/Harness Open Source/Dark */
+  --figma___other-colors-indigo-1: 226 25% 10% / 1;
+  /* ✦ Theme/Other Colors/Indigo/1/Harness Open Source/Dark */
+  --figma___other-colors-indigo-2: 230 36% 13% / 1;
+  /* ✦ Theme/Other Colors/Indigo/2/Harness Open Source/Dark */
+  --figma___other-colors-indigo-3: 228 43% 18% / 1;
+  /* ✦ Theme/Other Colors/Indigo/3/Harness Open Source/Dark */
+  --figma___other-colors-indigo-4: 228 45% 21% / 1;
+  /* ✦ Theme/Other Colors/Indigo/4/Harness Open Source/Dark */
+  --figma___other-colors-indigo-5: 227 48% 24% / 1;
+  /* ✦ Theme/Other Colors/Indigo/5/Harness Open Source/Dark */
+  --figma___other-colors-indigo-6: 225 51% 29% / 1;
+  /* ✦ Theme/Other Colors/Indigo/6/Harness Open Source/Dark */
+  --figma___other-colors-indigo-7: 226 70% 55% / 1;
+  /* ✦ Theme/Other Colors/Indigo/7/Harness Open Source/Dark */
+  --figma___other-colors-indigo-8: 230 74% 63% / 1;
+  /* ✦ Theme/Other Colors/Indigo/8/Harness Open Source/Dark */
+  --figma___other-colors-indigo-9: 235 100% 80% / 1;
+  /* ✦ Theme/Other Colors/Indigo/9/Harness Open Source/Dark */
+  --figma___other-colors-indigo-10: 236 94% 93% / 1;
+  /* ✦ Theme/Other Colors/Indigo/10/Harness Open Source/Dark */
+  --figma___other-colors-indigo-alpha-1: 240 100% 49% / 0.04;
+  /* ✦ Theme/Other Colors/Indigo Alpha/1/Harness Open Source/Dark */
+  --figma___other-colors-indigo-alpha-2: 232 100% 50% / 0.09;
+  /* ✦ Theme/Other Colors/Indigo Alpha/2/Harness Open Source/Dark */
+  --figma___other-colors-indigo-alpha-3: 228 100% 57% / 0.18;
+  /* ✦ Theme/Other Colors/Indigo Alpha/3/Harness Open Source/Dark */
+  --figma___other-colors-indigo-alpha-4: 228 99% 59% / 0.24;
+  /* ✦ Theme/Other Colors/Indigo Alpha/4/Harness Open Source/Dark */
+  --figma___other-colors-indigo-alpha-5: 227 99% 60% / 0.29;
+  /* ✦ Theme/Other Colors/Indigo Alpha/5/Harness Open Source/Dark */
+  --figma___other-colors-indigo-alpha-6: 225 100% 61% / 0.37;
+  /* ✦ Theme/Other Colors/Indigo Alpha/6/Harness Open Source/Dark */
+  --figma___other-colors-indigo-alpha-7: 226 100% 63% / 0.85;
+  /* ✦ Theme/Other Colors/Indigo Alpha/7/Harness Open Source/Dark */
+  --figma___other-colors-indigo-alpha-8: 230 100% 70% / 0.9;
+  /* ✦ Theme/Other Colors/Indigo Alpha/8/Harness Open Source/Dark */
+  --figma___other-colors-indigo-alpha-9: 235 100% 80% / 1;
+  /* ✦ Theme/Other Colors/Indigo Alpha/9/Harness Open Source/Dark */
+  --figma___other-colors-indigo-alpha-10: 236 100% 94% / 1;
+  /* ✦ Theme/Other Colors/Indigo Alpha/10/Harness Open Source/Dark */
+  --figma___other-colors-mint-1: 173 52% 6% / 1;
+  /* ✦ Theme/Other Colors/Mint/1/Harness Open Source/Dark */
+  --figma___other-colors-mint-2: 174 51% 8% / 1;
+  /* ✦ Theme/Other Colors/Mint/2/Harness Open Source/Dark */
+  --figma___other-colors-mint-3: 176 52% 11% / 1;
+  /* ✦ Theme/Other Colors/Mint/3/Harness Open Source/Dark */
+  --figma___other-colors-mint-4: 173 56% 13% / 1;
+  /* ✦ Theme/Other Colors/Mint/4/Harness Open Source/Dark */
+  --figma___other-colors-mint-5: 173 57% 15% / 1;
+  /* ✦ Theme/Other Colors/Mint/5/Harness Open Source/Dark */
+  --figma___other-colors-mint-6: 173 58% 18% / 1;
+  /* ✦ Theme/Other Colors/Mint/6/Harness Open Source/Dark */
+  --figma___other-colors-mint-7: 176 59% 50% / 1;
+  /* ✦ Theme/Other Colors/Mint/7/Harness Open Source/Dark */
+  --figma___other-colors-mint-8: 176 59% 60% / 1;
+  /* ✦ Theme/Other Colors/Mint/8/Harness Open Source/Dark */
+  --figma___other-colors-mint-9: 167 70% 58% / 1;
+  /* ✦ Theme/Other Colors/Mint/9/Harness Open Source/Dark */
+  --figma___other-colors-mint-10: 175 60% 65% / 1;
+  /* ✦ Theme/Other Colors/Mint/10/Harness Open Source/Dark */
+  --figma___other-colors-mint-alpha-1: 120 100% 44% / 0;
+  /* ✦ Theme/Other Colors/Mint Alpha/1/Harness Open Source/Dark */
+  --figma___other-colors-mint-alpha-2: 165 100% 49% / 0.03;
+  /* ✦ Theme/Other Colors/Mint Alpha/2/Harness Open Source/Dark */
+  --figma___other-colors-mint-alpha-3: 174 100% 50% / 0.07;
+  /* ✦ Theme/Other Colors/Mint Alpha/3/Harness Open Source/Dark */
+  --figma___other-colors-mint-alpha-4: 172 100% 50% / 0.11;
+  /* ✦ Theme/Other Colors/Mint Alpha/4/Harness Open Source/Dark */
+  --figma___other-colors-mint-alpha-5: 172 100% 50% / 0.15;
+  /* ✦ Theme/Other Colors/Mint Alpha/5/Harness Open Source/Dark */
+  --figma___other-colors-mint-alpha-6: 173 100% 50% / 0.21;
+  /* ✦ Theme/Other Colors/Mint Alpha/6/Harness Open Source/Dark */
+  --figma___other-colors-mint-alpha-7: 167 100% 78% / 0.91;
+  /* ✦ Theme/Other Colors/Mint Alpha/7/Harness Open Source/Dark */
+  --figma___other-colors-mint-alpha-8: 163 100% 81% / 0.95;
+  /* ✦ Theme/Other Colors/Mint Alpha/8/Harness Open Source/Dark */
+  --figma___other-colors-mint-alpha-9: 167 100% 66% / 0.86;
+  /* ✦ Theme/Other Colors/Mint Alpha/9/Harness Open Source/Dark */
+  --figma___other-colors-mint-alpha-10: 155 100% 90% / 0.96;
+  /* ✦ Theme/Other Colors/Mint Alpha/10/Harness Open Source/Dark */
+  --figma___other-colors-orange-1: 29 68% 7% / 1;
+  /* ✦ Theme/Other Colors/Orange/1/Harness Open Source/Dark */
+  --figma___other-colors-orange-2: 29 81% 8% / 1;
+  /* ✦ Theme/Other Colors/Orange/2/Harness Open Source/Dark */
+  --figma___other-colors-orange-3: 26 68% 12% / 1;
+  /* ✦ Theme/Other Colors/Orange/3/Harness Open Source/Dark */
+  --figma___other-colors-orange-4: 25 66% 15% / 1;
+  /* ✦ Theme/Other Colors/Orange/4/Harness Open Source/Dark */
+  --figma___other-colors-orange-5: 25 65% 18% / 1;
+  /* ✦ Theme/Other Colors/Orange/5/Harness Open Source/Dark */
+  --figma___other-colors-orange-6: 25 66% 22% / 1;
+  /* ✦ Theme/Other Colors/Orange/6/Harness Open Source/Dark */
+  --figma___other-colors-orange-7: 24 94% 50% / 1;
+  /* ✦ Theme/Other Colors/Orange/7/Harness Open Source/Dark */
+  --figma___other-colors-orange-8: 24 100% 58% / 1;
+  /* ✦ Theme/Other Colors/Orange/8/Harness Open Source/Dark */
+  --figma___other-colors-orange-9: 24 100% 70% / 1;
+  /* ✦ Theme/Other Colors/Orange/9/Harness Open Source/Dark */
+  --figma___other-colors-orange-10: 30 100% 88% / 1;
+  /* ✦ Theme/Other Colors/Orange/10/Harness Open Source/Dark */
+  --figma___other-colors-orange-alpha-1: 0 100% 49% / 0.03;
+  /* ✦ Theme/Other Colors/Orange Alpha/1/Harness Open Source/Dark */
+  --figma___other-colors-orange-alpha-2: 0 100% 50% / 0.06;
+  /* ✦ Theme/Other Colors/Orange Alpha/2/Harness Open Source/Dark */
+  --figma___other-colors-orange-alpha-3: 13 100% 50% / 0.12;
+  /* ✦ Theme/Other Colors/Orange Alpha/3/Harness Open Source/Dark */
+  --figma___other-colors-orange-alpha-4: 20 100% 50% / 0.17;
+  /* ✦ Theme/Other Colors/Orange Alpha/4/Harness Open Source/Dark */
+  --figma___other-colors-orange-alpha-5: 24 100% 50% / 0.22;
+  /* ✦ Theme/Other Colors/Orange Alpha/5/Harness Open Source/Dark */
+  --figma___other-colors-orange-alpha-6: 25 100% 51% / 0.3;
+  /* ✦ Theme/Other Colors/Orange Alpha/6/Harness Open Source/Dark */
+  --figma___other-colors-orange-alpha-7: 24 100% 51% / 0.97;
+  /* ✦ Theme/Other Colors/Orange Alpha/7/Harness Open Source/Dark */
+  --figma___other-colors-orange-alpha-8: 24 100% 58% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/8/Harness Open Source/Dark */
+  --figma___other-colors-orange-alpha-9: 24 100% 70% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/9/Harness Open Source/Dark */
+  --figma___other-colors-orange-alpha-10: 30 100% 88% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/10/Harness Open Source/Dark */
+  --figma___other-colors-yellow-1: 45 100% 5% / 1;
+  /* ✦ Theme/Other Colors/Yellow/1/Harness Open Source/Dark */
+  --figma___other-colors-yellow-2: 44 79% 7% / 1;
+  /* ✦ Theme/Other Colors/Yellow/2/Harness Open Source/Dark */
+  --figma___other-colors-yellow-3: 44 63% 11% / 1;
+  /* ✦ Theme/Other Colors/Yellow/3/Harness Open Source/Dark */
+  --figma___other-colors-yellow-4: 44 58% 13% / 1;
+  /* ✦ Theme/Other Colors/Yellow/4/Harness Open Source/Dark */
+  --figma___other-colors-yellow-5: 45 56% 15% / 1;
+  /* ✦ Theme/Other Colors/Yellow/5/Harness Open Source/Dark */
+  --figma___other-colors-yellow-6: 46 57% 18% / 1;
+  /* ✦ Theme/Other Colors/Yellow/6/Harness Open Source/Dark */
+  --figma___other-colors-yellow-7: 53 96% 58% / 1;
+  /* ✦ Theme/Other Colors/Yellow/7/Harness Open Source/Dark */
+  --figma___other-colors-yellow-8: 53 96% 67% / 1;
+  /* ✦ Theme/Other Colors/Yellow/8/Harness Open Source/Dark */
+  --figma___other-colors-yellow-9: 55 100% 60% / 1;
+  /* ✦ Theme/Other Colors/Yellow/9/Harness Open Source/Dark */
+  --figma___other-colors-yellow-10: 53 100% 84% / 1;
+  /* ✦ Theme/Other Colors/Yellow/10/Harness Open Source/Dark */
+  --figma___other-colors-yellow-alpha-1: 45 100% 5% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/1/Harness Open Source/Dark */
+  --figma___other-colors-yellow-alpha-2: 44 79% 7% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/2/Harness Open Source/Dark */
+  --figma___other-colors-yellow-alpha-3: 44 63% 11% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/3/Harness Open Source/Dark */
+  --figma___other-colors-yellow-alpha-4: 44 58% 13% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/4/Harness Open Source/Dark */
+  --figma___other-colors-yellow-alpha-5: 45 56% 15% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/5/Harness Open Source/Dark */
+  --figma___other-colors-yellow-alpha-6: 46 57% 18% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/6/Harness Open Source/Dark */
+  --figma___other-colors-yellow-alpha-7: 53 96% 58% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/7/Harness Open Source/Dark */
+  --figma___other-colors-yellow-alpha-8: 53 96% 67% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/8/Harness Open Source/Dark */
+  --figma___other-colors-yellow-alpha-9: 55 100% 60% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/9/Harness Open Source/Dark */
+  --figma___other-colors-yellow-alpha-10: 53 100% 84% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/10/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01;
+  /* ✦ Theme/Overlays/Black Alpha/1/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02;
+  /* ✦ Theme/Overlays/Black Alpha/2/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05;
+  /* ✦ Theme/Overlays/Black Alpha/3/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08;
+  /* ✦ Theme/Overlays/Black Alpha/4/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11;
+  /* ✦ Theme/Overlays/Black Alpha/5/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13;
+  /* ✦ Theme/Overlays/Black Alpha/6/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45;
+  /* ✦ Theme/Overlays/Black Alpha/7/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5;
+  /* ✦ Theme/Overlays/Black Alpha/8/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61;
+  /* ✦ Theme/Overlays/Black Alpha/9/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88;
+  /* ✦ Theme/Overlays/Black Alpha/10/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 0;
+  /* ✦ Theme/Overlays/White Alpha/1/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01;
+  /* ✦ Theme/Overlays/White Alpha/2/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07;
+  /* ✦ Theme/Overlays/White Alpha/3/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1;
+  /* ✦ Theme/Overlays/White Alpha/4/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13;
+  /* ✦ Theme/Overlays/White Alpha/5/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17;
+  /* ✦ Theme/Overlays/White Alpha/6/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37;
+  /* ✦ Theme/Overlays/White Alpha/7/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46;
+  /* ✦ Theme/Overlays/White Alpha/8/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66;
+  /* ✦ Theme/Overlays/White Alpha/9/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93;
+  /* ✦ Theme/Overlays/White Alpha/10/Harness Open Source/Dark */
+  --figma___pagination-active-background: 216 6% 15% / 1;
+  /* ✦ Theme/Pagination/Active/Background/Harness Open Source/Dark */
+  --figma___pagination-active-border: 210 6% 20% / 1;
+  /* ✦ Theme/Pagination/Active/Border/Harness Open Source/Dark */
+  --figma___pagination-active-text: 0 0% 98% / 1;
+  /* ✦ Theme/Pagination/Active/Text/Harness Open Source/Dark */
+  --figma___pagination-background: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Background/Harness Open Source/Dark */
+  --figma___pagination-default-background: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Default/Background/Harness Open Source/Dark */
+  --figma___pagination-default-border: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Default/Border/Harness Open Source/Dark */
+  --figma___pagination-default-text: 0 0% 98% / 1;
+  /* ✦ Theme/Pagination/Default/Text/Harness Open Source/Dark */
+  --figma___pagination-hover-background: 216 6% 15% / 1;
+  /* ✦ Theme/Pagination/Hover/Background/Harness Open Source/Dark */
+  --figma___pagination-hover-border: 210 6% 20% / 1;
+  /* ✦ Theme/Pagination/Hover/Border/Harness Open Source/Dark */
+  --figma___pagination-hover-text: 207 6% 70% / 1;
+  /* ✦ Theme/Pagination/Hover/Text/Harness Open Source/Dark */
+  --figma___pagination-pagination-shadow-1: 0 0% 0% / 0;
+  /* ✦ Theme/Pagination/Pagination shadow/1/Harness Open Source/Dark */
+  --figma___pagination-pagination-shadow-2: 240 100% 12% / 0;
+  /* ✦ Theme/Pagination/Pagination shadow/2/Harness Open Source/Dark */
+  --figma___primary-color-primary-accent-1: 200 7% 8% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/1/Harness Open Source/Dark */
+  --figma___primary-color-primary-accent-2: 210 6% 6% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/2/Harness Open Source/Dark */
+  --figma___primary-color-primary-accent-3: 200 6% 10% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/3/Harness Open Source/Dark */
+  --figma___primary-color-primary-accent-4: 200 5% 12% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/4/Harness Open Source/Dark */
+  --figma___primary-color-primary-accent-5: 210 6% 20% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/5/Harness Open Source/Dark */
+  --figma___primary-color-primary-accent-6: 210 6% 40% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/6/Harness Open Source/Dark */
+  --figma___primary-color-primary-accent-7: 0 0% 98% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/7/Harness Open Source/Dark */
+  --figma___primary-color-primary-accent-8: 240 7% 94% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/8/Harness Open Source/Dark */
+  --figma___primary-color-primary-accent-9: 220 6% 90% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/9/Harness Open Source/Dark */
+  --figma___primary-color-primary-accent-10: 0 0% 98% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/10/Harness Open Source/Dark */
+  --figma___primary-color-primary-alpha-1: 240 89% 18% / 0.01;
+  /* ✦ Theme/Primary Color/Primary Alpha/1/Harness Open Source/Dark */
+  --figma___primary-color-primary-alpha-2: 240 89% 18% / 0.02;
+  /* ✦ Theme/Primary Color/Primary Alpha/2/Harness Open Source/Dark */
+  --figma___primary-color-primary-alpha-3: 240 100% 12% / 0.05;
+  /* ✦ Theme/Primary Color/Primary Alpha/3/Harness Open Source/Dark */
+  --figma___primary-color-primary-alpha-4: 240 93% 11% / 0.08;
+  /* ✦ Theme/Primary Color/Primary Alpha/4/Harness Open Source/Dark */
+  --figma___primary-color-primary-alpha-5: 240 96% 9% / 0.13;
+  /* ✦ Theme/Primary Color/Primary Alpha/5/Harness Open Source/Dark */
+  --figma___primary-color-primary-alpha-6: 230 100% 9% / 0.28;
+  /* ✦ Theme/Primary Color/Primary Alpha/6/Harness Open Source/Dark */
+  --figma___primary-color-primary-alpha-7: 0 0% 98% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/7/Harness Open Source/Dark */
+  --figma___primary-color-primary-alpha-8: 240 7% 94% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/8/Harness Open Source/Dark */
+  --figma___primary-color-primary-alpha-9: 220 6% 90% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/9/Harness Open Source/Dark */
+  --figma___primary-color-primary-alpha-10: 0 0% 98% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/10/Harness Open Source/Dark */
+  --figma___radio-button-background: 200 5% 12% / 1;
+  /* ✦ Theme/Radio button/Background/Harness Open Source/Dark */
+  --figma___radio-button-checked-active-active-border: 212 6% 50% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active Border/Harness Open Source/Dark */
+  --figma___radio-button-checked-active-active-background: 212 6% 50% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active background/Harness Open Source/Dark */
+  --figma___radio-button-checked-active-hover-background: 212 6% 50% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover background/Harness Open Source/Dark */
+  --figma___radio-button-checked-active-hover-border: 212 6% 50% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover border/Harness Open Source/Dark */
+  --figma___radio-button-checked-active-default-background: 240 7% 94% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default background/Harness Open Source/Dark */
+  --figma___radio-button-checked-active-default-border: 240 7% 94% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default border/Harness Open Source/Dark */
+  --figma___radio-button-checked-disabled-dot: 210 6% 20% / 1;
+  /* ✦ Theme/Radio button/Checked/Disabled/Dot/Harness Open Source/Dark */
+  --figma___radio-button-checked-disabled-background: 240 100% 12% / 0.05;
+  /* ✦ Theme/Radio button/Checked/Disabled/background/Harness Open Source/Dark */
+  --figma___radio-button-checked-disabled-border: 210 6% 20% / 1;
+  /* ✦ Theme/Radio button/Checked/Disabled/border/Harness Open Source/Dark */
+  --figma___radio-button-paper: 0 0% 100% / 0.03;
+  /* ✦ Theme/Radio button/Paper/Harness Open Source/Dark */
+  --figma___radio-button-unchecked-active-active-border: 212 6% 50% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/Active border/Harness Open Source/Dark */
+  --figma___radio-button-unchecked-active-hover-border: 212 6% 50% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/Harness Open Source/Dark */
+  --figma___radio-button-unchecked-active-default-background: 210 6% 6% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/default background/Harness Open Source/Dark */
+  --figma___radio-button-unchecked-active-default-border: 240 7% 94% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/default border/Harness Open Source/Dark */
+  --figma___radio-button-unchecked-disabled-background: 0 0% 100% / 0.07;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/background/Harness Open Source/Dark */
+  --figma___radio-button-unchecked-disabled-border: 210 6% 20% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/border/Harness Open Source/Dark */
+  --figma___radio-button-border: 230 100% 87% / 0.09;
+  /* ✦ Theme/Radio button/border/Harness Open Source/Dark */
+  --figma___secondary-crimson-crimson-1: 333 18% 10% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 1/Harness Open Source/Dark */
+  --figma___secondary-crimson-crimson-10: 330 91% 91% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 10/Harness Open Source/Dark */
+  --figma___secondary-crimson-crimson-2: 336 32% 12% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 2/Harness Open Source/Dark */
+  --figma___secondary-crimson-crimson-3: 335 41% 16% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 3/Harness Open Source/Dark */
+  --figma___secondary-crimson-crimson-4: 336 45% 18% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 4/Harness Open Source/Dark */
+  --figma___secondary-crimson-crimson-5: 336 49% 21% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 5/Harness Open Source/Dark */
+  --figma___secondary-crimson-crimson-6: 336 54% 25% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 6/Harness Open Source/Dark */
+  --figma___secondary-crimson-crimson-7: 336 80% 58% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 7/Harness Open Source/Dark */
+  --figma___secondary-crimson-crimson-8: 339 87% 67% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 8/Harness Open Source/Dark */
+  --figma___secondary-crimson-crimson-9: 341 100% 76% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 9/Harness Open Source/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-1: 354 100% 49% / 0.02;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Open Source/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-10: 341 100% 76% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Open Source/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-11: 329 100% 92% / 0.99;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Open Source/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-2: 338 100% 50% / 0.07;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Open Source/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-3: 335 100% 55% / 0.14;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Open Source/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-4: 336 99% 56% / 0.19;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Open Source/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-5: 336 100% 58% / 0.25;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Open Source/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-6: 336 99% 58% / 0.33;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Open Source/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-8: 336 100% 63% / 0.9;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Open Source/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-9: 339 100% 70% / 0.95;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Open Source/Dark */
+  --figma___secondary-lime-1: 74 55% 6% / 1;
+  /* ✦ Theme/Secondary/Lime/1/Harness Open Source/Dark */
+  --figma___secondary-lime-2: 78 41% 8% / 1;
+  /* ✦ Theme/Secondary/Lime/2/Harness Open Source/Dark */
+  --figma___secondary-lime-3: 82 39% 11% / 1;
+  /* ✦ Theme/Secondary/Lime/3/Harness Open Source/Dark */
+  --figma___secondary-lime-4: 82 40% 13% / 1;
+  /* ✦ Theme/Secondary/Lime/4/Harness Open Source/Dark */
+  --figma___secondary-lime-5: 81 41% 15% / 1;
+  /* ✦ Theme/Secondary/Lime/5/Harness Open Source/Dark */
+  --figma___secondary-lime-6: 80 43% 18% / 1;
+  /* ✦ Theme/Secondary/Lime/6/Harness Open Source/Dark */
+  --figma___secondary-lime-7: 81 80% 66% / 1;
+  /* ✦ Theme/Secondary/Lime/7/Harness Open Source/Dark */
+  --figma___secondary-lime-8: 75 85% 60% / 1;
+  /* ✦ Theme/Secondary/Lime/8/Harness Open Source/Dark */
+  --figma___secondary-lime-9: 70 70% 50% / 1;
+  /* ✦ Theme/Secondary/Lime/9/Harness Open Source/Dark */
+  --figma___secondary-lime-10: 80 79% 85% / 1;
+  /* ✦ Theme/Secondary/Lime/10/Harness Open Source/Dark */
+  --figma___secondary-lime-alpha-1: 75 100% 5% / 0.71;
+  /* ✦ Theme/Secondary/Lime Alpha/1/Harness Open Source/Dark */
+  --figma___secondary-lime-alpha-2: 114 100% 49% / 0.02;
+  /* ✦ Theme/Secondary/Lime Alpha/2/Harness Open Source/Dark */
+  --figma___secondary-lime-alpha-3: 89 100% 50% / 0.06;
+  /* ✦ Theme/Secondary/Lime Alpha/3/Harness Open Source/Dark */
+  --figma___secondary-lime-alpha-4: 84 100% 50% / 0.1;
+  /* ✦ Theme/Secondary/Lime Alpha/4/Harness Open Source/Dark */
+  --figma___secondary-lime-alpha-5: 81 99% 53% / 0.14;
+  /* ✦ Theme/Secondary/Lime Alpha/5/Harness Open Source/Dark */
+  --figma___secondary-lime-alpha-6: 80 99% 58% / 0.19;
+  /* ✦ Theme/Secondary/Lime Alpha/6/Harness Open Source/Dark */
+  --figma___secondary-lime-alpha-7: 81 100% 71% / 0.93;
+  /* ✦ Theme/Secondary/Lime Alpha/7/Harness Open Source/Dark */
+  --figma___secondary-lime-alpha-8: 75 100% 64% / 0.94;
+  /* ✦ Theme/Secondary/Lime Alpha/8/Harness Open Source/Dark */
+  --figma___secondary-lime-alpha-9: 70 100% 58% / 0.84;
+  /* ✦ Theme/Secondary/Lime Alpha/9/Harness Open Source/Dark */
+  --figma___secondary-lime-alpha-10: 80 100% 88% / 0.97;
+  /* ✦ Theme/Secondary/Lime Alpha/10/Harness Open Source/Dark */
+  --figma___secondary-purple-1: 287 18% 10% / 1;
+  /* ✦ Theme/Secondary/Purple/1/Harness Open Source/Dark */
+  --figma___secondary-purple-2: 284 31% 12% / 1;
+  /* ✦ Theme/Secondary/Purple/2/Harness Open Source/Dark */
+  --figma___secondary-purple-3: 282 35% 17% / 1;
+  /* ✦ Theme/Secondary/Purple/3/Harness Open Source/Dark */
+  --figma___secondary-purple-4: 281 37% 20% / 1;
+  /* ✦ Theme/Secondary/Purple/4/Harness Open Source/Dark */
+  --figma___secondary-purple-5: 280 38% 23% / 1;
+  /* ✦ Theme/Secondary/Purple/5/Harness Open Source/Dark */
+  --figma___secondary-purple-6: 278 40% 27% / 1;
+  /* ✦ Theme/Secondary/Purple/6/Harness Open Source/Dark */
+  --figma___secondary-purple-7: 272 51% 54% / 1;
+  /* ✦ Theme/Secondary/Purple/7/Harness Open Source/Dark */
+  --figma___secondary-purple-8: 271 58% 61% / 1;
+  /* ✦ Theme/Secondary/Purple/8/Harness Open Source/Dark */
+  --figma___secondary-purple-9: 270 89% 78% / 1;
+  /* ✦ Theme/Secondary/Purple/9/Harness Open Source/Dark */
+  --figma___secondary-purple-10: 275 77% 92% / 1;
+  /* ✦ Theme/Secondary/Purple/10/Harness Open Source/Dark */
+  --figma___secondary-purple-alpha-1: 278 100% 49% / 0.02;
+  /* ✦ Theme/Secondary/Purple Alpha/1/Harness Open Source/Dark */
+  --figma___secondary-purple-alpha-2: 283 100% 49% / 0.07;
+  /* ✦ Theme/Secondary/Purple Alpha/2/Harness Open Source/Dark */
+  --figma___secondary-purple-alpha-3: 282 99% 60% / 0.15;
+  /* ✦ Theme/Secondary/Purple Alpha/3/Harness Open Source/Dark */
+  --figma___secondary-purple-alpha-4: 281 99% 62% / 0.2;
+  /* ✦ Theme/Secondary/Purple Alpha/4/Harness Open Source/Dark */
+  --figma___secondary-purple-alpha-5: 280 100% 64% / 0.25;
+  /* ✦ Theme/Secondary/Purple Alpha/5/Harness Open Source/Dark */
+  --figma___secondary-purple-alpha-6: 278 99% 66% / 0.32;
+  /* ✦ Theme/Secondary/Purple Alpha/6/Harness Open Source/Dark */
+  --figma___secondary-purple-alpha-7: 272 100% 69% / 0.75;
+  /* ✦ Theme/Secondary/Purple Alpha/7/Harness Open Source/Dark */
+  --figma___secondary-purple-alpha-8: 271 100% 73% / 0.82;
+  /* ✦ Theme/Secondary/Purple Alpha/8/Harness Open Source/Dark */
+  --figma___secondary-purple-alpha-9: 270 100% 80% / 0.98;
+  /* ✦ Theme/Secondary/Purple Alpha/9/Harness Open Source/Dark */
+  --figma___secondary-purple-alpha-10: 275 100% 93% / 0.98;
+  /* ✦ Theme/Secondary/Purple Alpha/10/Harness Open Source/Dark */
+  --figma___secondary-teal-1: 166 49% 7% / 1;
+  /* ✦ Theme/Secondary/Teal/1/Harness Open Source/Dark */
+  --figma___secondary-teal-2: 166 55% 8% / 1;
+  /* ✦ Theme/Secondary/Teal/2/Harness Open Source/Dark */
+  --figma___secondary-teal-3: 167 52% 11% / 1;
+  /* ✦ Theme/Secondary/Teal/3/Harness Open Source/Dark */
+  --figma___secondary-teal-4: 169 53% 13% / 1;
+  /* ✦ Theme/Secondary/Teal/4/Harness Open Source/Dark */
+  --figma___secondary-teal-5: 168 53% 15% / 1;
+  /* ✦ Theme/Secondary/Teal/5/Harness Open Source/Dark */
+  --figma___secondary-teal-6: 169 52% 18% / 1;
+  /* ✦ Theme/Secondary/Teal/6/Harness Open Source/Dark */
+  --figma___secondary-teal-7: 173 80% 36% / 1;
+  /* ✦ Theme/Secondary/Teal/7/Harness Open Source/Dark */
+  --figma___secondary-teal-8: 172 90% 39% / 1;
+  /* ✦ Theme/Secondary/Teal/8/Harness Open Source/Dark */
+  --figma___secondary-teal-9: 170 90% 45% / 1;
+  /* ✦ Theme/Secondary/Teal/9/Harness Open Source/Dark */
+  --figma___secondary-teal-10: 163 69% 81% / 1;
+  /* ✦ Theme/Secondary/Teal/10/Harness Open Source/Dark */
+  --figma___secondary-teal-alpha-1: 120 100% 48% / 0.01;
+  /* ✦ Theme/Secondary/Teal Alpha/1/Harness Open Source/Dark */
+  --figma___secondary-teal-alpha-2: 141 100% 49% / 0.03;
+  /* ✦ Theme/Secondary/Teal Alpha/2/Harness Open Source/Dark */
+  --figma___secondary-teal-alpha-3: 161 100% 50% / 0.07;
+  /* ✦ Theme/Secondary/Teal Alpha/3/Harness Open Source/Dark */
+  --figma___secondary-teal-alpha-4: 167 100% 50% / 0.11;
+  /* ✦ Theme/Secondary/Teal Alpha/4/Harness Open Source/Dark */
+  --figma___secondary-teal-alpha-5: 167 100% 50% / 0.15;
+  /* ✦ Theme/Secondary/Teal Alpha/5/Harness Open Source/Dark */
+  --figma___secondary-teal-alpha-6: 169 99% 53% / 0.2;
+  /* ✦ Theme/Secondary/Teal Alpha/6/Harness Open Source/Dark */
+  --figma___secondary-teal-alpha-7: 173 100% 53% / 0.61;
+  /* ✦ Theme/Secondary/Teal Alpha/7/Harness Open Source/Dark */
+  --figma___secondary-teal-alpha-8: 172 100% 51% / 0.71;
+  /* ✦ Theme/Secondary/Teal Alpha/8/Harness Open Source/Dark */
+  --figma___secondary-teal-alpha-9: 170 100% 52% / 0.83;
+  /* ✦ Theme/Secondary/Teal Alpha/9/Harness Open Source/Dark */
+  --figma___secondary-teal-alpha-10: 163 100% 86% / 0.94;
+  /* ✦ Theme/Secondary/Teal Alpha/10/Harness Open Source/Dark */
+  --figma___shadow-shadow-button-1: 0 0% 100% / 0.17;
+  /* ✦ Theme/Shadow/Shadow - button/1/Harness Open Source/Dark */
+  --figma___shadow-shadow-button-2: 0 0% 100% / 0.07;
+  /* ✦ Theme/Shadow/Shadow - button/2/Harness Open Source/Dark */
+  --figma___shadow-shadow-button-3: 0 0% 100% / 0.27;
+  /* ✦ Theme/Shadow/Shadow - button/3/Harness Open Source/Dark */
+  --figma___shadow-shadow-button-4: 0 0% 100% / 0.11;
+  /* ✦ Theme/Shadow/Shadow - button/4/Harness Open Source/Dark */
+  --figma___shadow-shadow-1-1: 0 0% 0% / 0.03;
+  /* ✦ Theme/Shadow/Shadow 1/1/Harness Open Source/Dark */
+  --figma___shadow-shadow-2-1: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 2/1/Harness Open Source/Dark */
+  --figma___shadow-shadow-2-2: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 2/2/Harness Open Source/Dark */
+  --figma___shadow-shadow-2-3: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 2/3/Harness Open Source/Dark */
+  --figma___shadow-shadow-3-1: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 3/1/Harness Open Source/Dark */
+  --figma___shadow-shadow-3-2: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow 3/2/Harness Open Source/Dark */
+  --figma___shadow-shadow-3-3: 0 0% 0% / 0.11;
+  /* ✦ Theme/Shadow/Shadow 3/3/Harness Open Source/Dark */
+  --figma___shadow-shadow-4-1: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow 4/1/Harness Open Source/Dark */
+  --figma___shadow-shadow-4-2: 0 0% 0% / 0.17;
+  /* ✦ Theme/Shadow/Shadow 4/2/Harness Open Source/Dark */
+  --figma___shadow-shadow-5-1: 0 0% 0% / 0.5;
+  /* ✦ Theme/Shadow/Shadow 5/1/Harness Open Source/Dark */
+  --figma___shadow-shadow-5-2: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow 5/2/Harness Open Source/Dark */
+  --figma___shadow-shadow-6-1: 0 0% 0% / 0.88;
+  /* ✦ Theme/Shadow/Shadow 6/1/Harness Open Source/Dark */
+  --figma___shadow-shadow-6-2: 0 0% 0% / 0.61;
+  /* ✦ Theme/Shadow/Shadow 6/2/Harness Open Source/Dark */
+  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
+  /* ✦ Theme/Shadow/Shadow-button-active/1/Harness Open Source/Dark */
+  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
+  /* ✦ Theme/Shadow/Shadow-button-active/2/Harness Open Source/Dark */
+  --figma___shadow-shadow-button-active-3: 0 0% 100% / 0.27;
+  /* ✦ Theme/Shadow/Shadow-button-active/3/Harness Open Source/Dark */
+  --figma___shadow-shadow-button-active-4: 0 0% 100% / 0.11;
+  /* ✦ Theme/Shadow/Shadow-button-active/4/Harness Open Source/Dark */
+  --figma___side-nav-container-nav-background: 210 13% 3% / 1;
+  /* ✦ Theme/Side nav/Container/Nav-background/Harness Open Source/Dark */
+  --figma___side-nav-container-nav-border: 200 6% 10% / 1;
+  /* ✦ Theme/Side nav/Container/Nav-border/Harness Open Source/Dark */
+  --figma___side-nav-module-logo-text: 0 0% 98% / 1;
+  /* ✦ Theme/Side nav/Module Logo Text/Harness Open Source/Dark */
+  --figma___side-nav-nav-item-default-icon: 210 6% 40% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Default/Icon/Harness Open Source/Dark */
+  --figma___side-nav-nav-item-default-text: 207 6% 70% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Default/Text/Harness Open Source/Dark */
+  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
+  /* ✦ Theme/Side nav/Nav-item/Default/default/Harness Open Source/Dark */
+  --figma___side-nav-nav-item-hover-background: 210 6% 20% / 0.15;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Background/Harness Open Source/Dark */
+  --figma___side-nav-nav-item-hover-icon: 207 6% 70% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/Harness Open Source/Dark */
+  --figma___side-nav-nav-item-hover-text: 207 6% 70% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Text/Harness Open Source/Dark */
+  --figma___side-nav-nav-item-selected-background: 200 6% 10% / 0;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Background/Harness Open Source/Dark */
+  --figma___side-nav-nav-item-selected-icon: 0 0% 98% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/Harness Open Source/Dark */
+  --figma___side-nav-nav-item-selected-text: 0 0% 98% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Text/Harness Open Source/Dark */
+  --figma___side-nav-profile-role: 212 6% 50% / 1;
+  /* ✦ Theme/Side nav/Profile/Role/Harness Open Source/Dark */
+  --figma___side-nav-profile-text: 0 0% 98% / 1;
+  /* ✦ Theme/Side nav/Profile/Text/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-default-border: 240 6% 10% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Border/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-default-main-text-icon: 0 0% 98% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-default-scope-name: 212 6% 50% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-hover-border: 220 6% 90% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-hover-main-text-icon: 0 0% 98% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-hover-scope-name: 212 6% 50% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-selected-border: 220 6% 90% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-selected-main-text-icon: 0 0% 98% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-selected-scope-name: 212 6% 50% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/Harness Open Source/Dark */
+  --figma___side-nav-separator: 240 6% 10% / 1;
+  /* ✦ Theme/Side nav/Separator/Harness Open Source/Dark */
+  --figma___status-colors-error-1: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/1/Harness Open Source/Dark */
+  --figma___status-colors-error-2: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/2/Harness Open Source/Dark */
+  --figma___status-colors-error-3: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/3/Harness Open Source/Dark */
+  --figma___status-colors-error-4: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/4/Harness Open Source/Dark */
+  --figma___status-colors-error-5: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/5/Harness Open Source/Dark */
+  --figma___status-colors-error-6: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/6/Harness Open Source/Dark */
+  --figma___status-colors-error-7: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/7/Harness Open Source/Dark */
+  --figma___status-colors-error-8: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/8/Harness Open Source/Dark */
+  --figma___status-colors-error-9: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/9/Harness Open Source/Dark */
+  --figma___status-colors-error-10: 0 80% 65% / 1;
+  /* ✦ Theme/Status colors/Error/10/Harness Open Source/Dark */
+  --figma___status-colors-error-alpha-1: 0 80% 65% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/1/Harness Open Source/Dark */
+  --figma___status-colors-error-alpha-2: 0 80% 65% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/2/Harness Open Source/Dark */
+  --figma___status-colors-error-alpha-3: 0 80% 65% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/3/Harness Open Source/Dark */
+  --figma___status-colors-error-alpha-4: 0 80% 65% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/4/Harness Open Source/Dark */
+  --figma___status-colors-error-alpha-5: 0 80% 65% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/5/Harness Open Source/Dark */
+  --figma___status-colors-error-alpha-6: 0 80% 65% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/6/Harness Open Source/Dark */
+  --figma___status-colors-error-alpha-7: 0 80% 65% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/7/Harness Open Source/Dark */
+  --figma___status-colors-error-alpha-8: 0 80% 65% / 0.16;
+  /* ✦ Theme/Status colors/Error Alpha/8/Harness Open Source/Dark */
+  --figma___status-colors-error-alpha-9: 0 80% 65% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/9/Harness Open Source/Dark */
+  --figma___status-colors-error-alpha-10: 0 80% 65% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/10/Harness Open Source/Dark */
+  --figma___status-colors-info-1: 212 36% 9% / 1;
+  /* ✦ Theme/Status colors/Info/1/Harness Open Source/Dark */
+  --figma___status-colors-info-2: 216 50% 12% / 1;
+  /* ✦ Theme/Status colors/Info/2/Harness Open Source/Dark */
+  --figma___status-colors-info-3: 214 58% 16% / 1;
+  /* ✦ Theme/Status colors/Info/3/Harness Open Source/Dark */
+  --figma___status-colors-info-4: 214 65% 18% / 1;
+  /* ✦ Theme/Status colors/Info/4/Harness Open Source/Dark */
+  --figma___status-colors-info-5: 213 67% 21% / 1;
+  /* ✦ Theme/Status colors/Info/5/Harness Open Source/Dark */
+  --figma___status-colors-info-6: 212 72% 25% / 1;
+  /* ✦ Theme/Status colors/Info/6/Harness Open Source/Dark */
+  --figma___status-colors-info-7: 214 73% 51% / 1;
+  /* ✦ Theme/Status colors/Info/7/Harness Open Source/Dark */
+  --figma___status-colors-info-8: 206 100% 62% / 1;
+  /* ✦ Theme/Status colors/Info/8/Harness Open Source/Dark */
+  --figma___status-colors-info-9: 205 100% 71% / 1;
+  /* ✦ Theme/Status colors/Info/9/Harness Open Source/Dark */
+  --figma___status-colors-info-10: 206 100% 88% / 1;
+  /* ✦ Theme/Status colors/Info/10/Harness Open Source/Dark */
+  --figma___status-colors-info-alpha-1: 240 100% 49% / 0.04;
+  /* ✦ Theme/Status colors/Info Alpha/1/Harness Open Source/Dark */
+  --figma___status-colors-info-alpha-2: 227 100% 50% / 0.09;
+  /* ✦ Theme/Status colors/Info Alpha/2/Harness Open Source/Dark */
+  --figma___status-colors-info-alpha-3: 216 100% 50% / 0.17;
+  /* ✦ Theme/Status colors/Info Alpha/3/Harness Open Source/Dark */
+  --figma___status-colors-info-alpha-4: 214 100% 50% / 0.23;
+  /* ✦ Theme/Status colors/Info Alpha/4/Harness Open Source/Dark */
+  --figma___status-colors-info-alpha-5: 213 100% 51% / 0.29;
+  /* ✦ Theme/Status colors/Info Alpha/5/Harness Open Source/Dark */
+  --figma___status-colors-info-alpha-6: 212 100% 52% / 0.38;
+  /* ✦ Theme/Status colors/Info Alpha/6/Harness Open Source/Dark */
+  --figma___status-colors-info-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/7/Harness Open Source/Dark */
+  --figma___status-colors-info-alpha-8: 206 100% 62% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/8/Harness Open Source/Dark */
+  --figma___status-colors-info-alpha-9: 205 100% 71% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/9/Harness Open Source/Dark */
+  --figma___status-colors-info-alpha-10: 206 100% 88% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/10/Harness Open Source/Dark */
+  --figma___status-colors-success-1: 145 32% 7% / 1;
+  /* ✦ Theme/Status colors/Success/1/Harness Open Source/Dark */
+  --figma___status-colors-success-2: 154 32% 9% / 1;
+  /* ✦ Theme/Status colors/Success/2/Harness Open Source/Dark */
+  --figma___status-colors-success-3: 155 38% 11% / 1;
+  /* ✦ Theme/Status colors/Success/3/Harness Open Source/Dark */
+  --figma___status-colors-success-4: 155 42% 14% / 1;
+  /* ✦ Theme/Status colors/Success/4/Harness Open Source/Dark */
+  --figma___status-colors-success-5: 153 43% 16% / 1;
+  /* ✦ Theme/Status colors/Success/5/Harness Open Source/Dark */
+  --figma___status-colors-success-6: 155 47% 19% / 1;
+  /* ✦ Theme/Status colors/Success/6/Harness Open Source/Dark */
+  --figma___status-colors-success-7: 142 72% 29% / 1;
+  /* ✦ Theme/Status colors/Success/7/Harness Open Source/Dark */
+  --figma___status-colors-success-8: 151 55% 47% / 1;
+  /* ✦ Theme/Status colors/Success/8/Harness Open Source/Dark */
+  --figma___status-colors-success-9: 151 65% 54% / 1;
+  /* ✦ Theme/Status colors/Success/9/Harness Open Source/Dark */
+  --figma___status-colors-success-10: 144 70% 82% / 1;
+  /* ✦ Theme/Status colors/Success/10/Harness Open Source/Dark */
+  --figma___status-colors-success-alpha-1: 120 100% 44% / 0;
+  /* ✦ Theme/Status colors/Success Alpha/1/Harness Open Source/Dark */
+  --figma___status-colors-success-alpha-2: 120 100% 49% / 0.02;
+  /* ✦ Theme/Status colors/Success Alpha/2/Harness Open Source/Dark */
+  --figma___status-colors-success-alpha-3: 149 100% 49% / 0.07;
+  /* ✦ Theme/Status colors/Success Alpha/3/Harness Open Source/Dark */
+  --figma___status-colors-success-alpha-4: 154 100% 50% / 0.11;
+  /* ✦ Theme/Status colors/Success Alpha/4/Harness Open Source/Dark */
+  --figma___status-colors-success-alpha-5: 153 99% 53% / 0.15;
+  /* ✦ Theme/Status colors/Success Alpha/5/Harness Open Source/Dark */
+  --figma___status-colors-success-alpha-6: 155 99% 55% / 0.2;
+  /* ✦ Theme/Status colors/Success Alpha/6/Harness Open Source/Dark */
+  --figma___status-colors-success-alpha-7: 151 100% 62% / 0.61;
+  /* ✦ Theme/Status colors/Success Alpha/7/Harness Open Source/Dark */
+  --figma___status-colors-success-alpha-8: 151 100% 63% / 0.7;
+  /* ✦ Theme/Status colors/Success Alpha/8/Harness Open Source/Dark */
+  --figma___status-colors-success-alpha-9: 151 100% 64% / 0.82;
+  /* ✦ Theme/Status colors/Success Alpha/9/Harness Open Source/Dark */
+  --figma___status-colors-success-alpha-10: 144 100% 87% / 0.94;
+  /* ✦ Theme/Status colors/Success Alpha/10/Harness Open Source/Dark */
+  --figma___status-colors-warning-1: 37 100% 6% / 1;
+  /* ✦ Theme/Status colors/Warning/1/Harness Open Source/Dark */
+  --figma___status-colors-warning-2: 36 80% 8% / 1;
+  /* ✦ Theme/Status colors/Warning/2/Harness Open Source/Dark */
+  --figma___status-colors-warning-3: 34 63% 12% / 1;
+  /* ✦ Theme/Status colors/Warning/3/Harness Open Source/Dark */
+  --figma___status-colors-warning-4: 34 58% 14% / 1;
+  /* ✦ Theme/Status colors/Warning/4/Harness Open Source/Dark */
+  --figma___status-colors-warning-5: 34 58% 17% / 1;
+  /* ✦ Theme/Status colors/Warning/5/Harness Open Source/Dark */
+  --figma___status-colors-warning-6: 34 58% 21% / 1;
+  /* ✦ Theme/Status colors/Warning/6/Harness Open Source/Dark */
+  --figma___status-colors-warning-7: 42 100% 62% / 1;
+  /* ✦ Theme/Status colors/Warning/7/Harness Open Source/Dark */
+  --figma___status-colors-warning-8: 43 100% 64% / 1;
+  /* ✦ Theme/Status colors/Warning/8/Harness Open Source/Dark */
+  --figma___status-colors-warning-9: 43 100% 65% / 1;
+  /* ✦ Theme/Status colors/Warning/9/Harness Open Source/Dark */
+  --figma___status-colors-warning-10: 41 100% 85% / 1;
+  /* ✦ Theme/Status colors/Warning/10/Harness Open Source/Dark */
+  --figma___status-colors-warning-alpha-1: 0 100% 49% / 0.03;
+  /* ✦ Theme/Status colors/Warning Alpha/1/Harness Open Source/Dark */
+  --figma___status-colors-warning-alpha-2: 6 100% 49% / 0.06;
+  /* ✦ Theme/Status colors/Warning Alpha/2/Harness Open Source/Dark */
+  --figma___status-colors-warning-alpha-3: 24 100% 50% / 0.1;
+  /* ✦ Theme/Status colors/Warning Alpha/3/Harness Open Source/Dark */
+  --figma___status-colors-warning-alpha-4: 30 100% 50% / 0.14;
+  /* ✦ Theme/Status colors/Warning Alpha/4/Harness Open Source/Dark */
+  --figma___status-colors-warning-alpha-5: 33 100% 50% / 0.19;
+  /* ✦ Theme/Status colors/Warning Alpha/5/Harness Open Source/Dark */
+  --figma___status-colors-warning-alpha-6: 34 100% 53% / 0.26;
+  /* ✦ Theme/Status colors/Warning Alpha/6/Harness Open Source/Dark */
+  --figma___status-colors-warning-alpha-7: 42 100% 62% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/7/Harness Open Source/Dark */
+  --figma___status-colors-warning-alpha-8: 43 100% 64% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/8/Harness Open Source/Dark */
+  --figma___status-colors-warning-alpha-9: 43 100% 65% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/9/Harness Open Source/Dark */
+  --figma___status-colors-warning-alpha-10: 41 100% 85% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/10/Harness Open Source/Dark */
+  --figma___switch-background: 200 5% 12% / 1;
+  /* ✦ Theme/Switch/Background/Harness Open Source/Dark */
+  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/Harness Open Source/Dark */
+  --figma___switch-checked-active-background: 0 0% 98% / 1;
+  /* ✦ Theme/Switch/Checked/Active/background/Harness Open Source/Dark */
+  --figma___switch-checked-active-border: 210 6% 60% / 0;
+  /* ✦ Theme/Switch/Checked/Active/border/Harness Open Source/Dark */
+  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/Harness Open Source/Dark */
+  --figma___switch-checked-default-default-background: 0 0% 98% / 1;
+  /* ✦ Theme/Switch/Checked/Default/default background/Harness Open Source/Dark */
+  --figma___switch-checked-default-default-border: 210 6% 60% / 0;
+  /* ✦ Theme/Switch/Checked/Default/default border/Harness Open Source/Dark */
+  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/Harness Open Source/Dark */
+  --figma___switch-checked-disabled-background: 0 0% 98% / 1;
+  /* ✦ Theme/Switch/Checked/Disabled/background/Harness Open Source/Dark */
+  --figma___switch-checked-disabled-border: 210 6% 60% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/border/Harness Open Source/Dark */
+  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/Harness Open Source/Dark */
+  --figma___switch-checked-hover-background: 176 59% 60% / 1;
+  /* ✦ Theme/Switch/Checked/Hover/background/Harness Open Source/Dark */
+  --figma___switch-checked-hover-border: 210 6% 60% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/border/Harness Open Source/Dark */
+  --figma___switch-paper: 0 0% 100% / 0.03;
+  /* ✦ Theme/Switch/Paper/Harness Open Source/Dark */
+  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/Harness Open Source/Dark */
+  --figma___switch-unchecked-active-background: 216 6% 15% / 1;
+  /* ✦ Theme/Switch/Unchecked/Active/background/Harness Open Source/Dark */
+  --figma___switch-unchecked-active-border: 210 6% 20% / 1;
+  /* ✦ Theme/Switch/Unchecked/Active/border/Harness Open Source/Dark */
+  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/Harness Open Source/Dark */
+  --figma___switch-unchecked-default-default-background: 210 6% 40% / 1;
+  /* ✦ Theme/Switch/Unchecked/Default/default background/Harness Open Source/Dark */
+  --figma___switch-unchecked-default-default-border: 210 6% 20% / 1;
+  /* ✦ Theme/Switch/Unchecked/Default/default border/Harness Open Source/Dark */
+  --figma___switch-unchecked-disabled-thumb-thumb-background: 230 7% 16% / 1;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/Harness Open Source/Dark */
+  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/Harness Open Source/Dark */
+  --figma___switch-unchecked-disabled-background: 240 100% 9% / 0.11;
+  /* ✦ Theme/Switch/Unchecked/Disabled/background/Harness Open Source/Dark */
+  --figma___switch-unchecked-disabled-border: 210 6% 20% / 1;
+  /* ✦ Theme/Switch/Unchecked/Disabled/border/Harness Open Source/Dark */
+  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/Harness Open Source/Dark */
+  --figma___switch-unchecked-hover-background: 212 6% 50% / 1;
+  /* ✦ Theme/Switch/Unchecked/Hover/background/Harness Open Source/Dark */
+  --figma___switch-unchecked-hover-border: 210 6% 20% / 1;
+  /* ✦ Theme/Switch/Unchecked/Hover/border/Harness Open Source/Dark */
+  --figma___switch-border: 230 100% 87% / 0.09;
+  /* ✦ Theme/Switch/border/Harness Open Source/Dark */
+  --figma___tabs-number-active-background: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Number/Active/Background/Harness Open Source/Dark */
+  --figma___tabs-number-active-text: 240 13% 3% / 1;
+  /* ✦ Theme/Tabs/Number/Active/text/Harness Open Source/Dark */
+  --figma___tabs-number-default-hover-background: 200 5% 12% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/Background/Harness Open Source/Dark */
+  --figma___tabs-number-default-hover-text: 0 0% 98% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/text/Harness Open Source/Dark */
+  --figma___tabs-pills-active-active: 240 13% 3% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Active/Harness Open Source/Dark */
+  --figma___tabs-pills-active-text: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Text/Harness Open Source/Dark */
+  --figma___tabs-pills-active-border-grad-1: 219 100% 84% / 0.05;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 1/Harness Open Source/Dark */
+  --figma___tabs-pills-active-border-grad-2: 219 100% 84% / 0.1;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 2/Harness Open Source/Dark */
+  --figma___tabs-pills-backgrounds: 240 6% 10% / 1;
+  /* ✦ Theme/Tabs/Pills/Backgrounds/Harness Open Source/Dark */
+  --figma___tabs-pills-default-background: 240 6% 40% / 0;
+  /* ✦ Theme/Tabs/Pills/Default/Background/Harness Open Source/Dark */
+  --figma___tabs-pills-default-text: 240 6% 60% / 1;
+  /* ✦ Theme/Tabs/Pills/Default/Text/Harness Open Source/Dark */
+  --figma___tabs-pills-hover-background: 240 13% 3% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Background/Harness Open Source/Dark */
+  --figma___tabs-pills-hover-text: 207 6% 70% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Text/Harness Open Source/Dark */
+  --figma___tabs-pills-number-active-background: 0 0% 98% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/Background/Harness Open Source/Dark */
+  --figma___tabs-pills-number-active-text: 200 7% 8% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/text/Harness Open Source/Dark */
+  --figma___tabs-pills-border-grad-1: 219 100% 84% / 0.07;
+  /* ✦ Theme/Tabs/Pills/border grad 1/Harness Open Source/Dark */
+  --figma___tabs-pills-border-grad-2: 219 100% 84% / 0.02;
+  /* ✦ Theme/Tabs/Pills/border grad 2/Harness Open Source/Dark */
+  --figma___tabs-primary-active-text: 0 0% 98% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Text/Harness Open Source/Dark */
+  --figma___tabs-primary-active-underline: 0 0% 98% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Underline/Harness Open Source/Dark */
+  --figma___tabs-primary-border: 270 89% 78% / 1;
+  /* ✦ Theme/Tabs/Primary/Border/Harness Open Source/Dark */
+  --figma___tabs-primary-default-background: 240 6% 40% / 0;
+  /* ✦ Theme/Tabs/Primary/Default/Background/Harness Open Source/Dark */
+  --figma___tabs-primary-default-text: 212 6% 50% / 1;
+  /* ✦ Theme/Tabs/Primary/Default/Text/Harness Open Source/Dark */
+  --figma___tabs-primary-hover-background: 240 93% 11% / 0.08;
+  /* ✦ Theme/Tabs/Primary/Hover/Background/Harness Open Source/Dark */
+  --figma___tabs-primary-hover-text: 0 0% 98% / 1;
+  /* ✦ Theme/Tabs/Primary/Hover/Text/Harness Open Source/Dark */
+  --figma___tabs-primary-pills-pills: 271 58% 61% / 1;
+  /* ✦ Theme/Tabs/Primary/Pills/Pills/Harness Open Source/Dark */
+  --figma___text-disabled: 207 6% 30% / 1;
+  /* ✦ Theme/Text/Disabled/Harness Open Source/Dark */
+  --figma___text-links: 216 100% 59% / 1;
+  /* ✦ Theme/Text/Links/Harness Open Source/Dark */
+  --figma___text-secondary: 207 6% 70% / 1;
+  /* ✦ Theme/Text/Secondary/Harness Open Source/Dark */
+  --figma___text-tertiary: 212 6% 50% / 1;
+  /* ✦ Theme/Text/Tertiary/Harness Open Source/Dark */
+  --figma___text-primary: 0 0% 98% / 1;
+  /* ✦ Theme/Text/primary/Harness Open Source/Dark */
+  --figma___textfield-assistive-text-primary: 212 6% 50% / 1;
+  /* ✦ Theme/Textfield/Assistive Text/Primary/Harness Open Source/Dark */
+  --figma___textfield-background: 0 0% 100% / 0;
+  /* ✦ Theme/Textfield/Background/Harness Open Source/Dark */
+  --figma___textfield-input-field-background: 0 0% 98% / 0;
+  /* ✦ Theme/Textfield/Input Field/Background/Harness Open Source/Dark */
+  --figma___textfield-input-field-default: 207 6% 30% / 1;
+  /* ✦ Theme/Textfield/Input Field/Default/Harness Open Source/Dark */
+  --figma___textfield-input-field-error: 0 80% 65% / 1;
+  /* ✦ Theme/Textfield/Input Field/Error/Harness Open Source/Dark */
+  --figma___textfield-input-field-hover: 216 6% 15% / 1;
+  /* ✦ Theme/Textfield/Input Field/Hover/Harness Open Source/Dark */
+  --figma___textfield-label-info-icon: 212 6% 50% / 1;
+  /* ✦ Theme/Textfield/Label/Info Icon/Harness Open Source/Dark */
+  --figma___textfield-label-link: 211 85% 48% / 1;
+  /* ✦ Theme/Textfield/Label/Link/Harness Open Source/Dark */
+  --figma___textfield-label-main: 0 0% 98% / 1;
+  /* ✦ Theme/Textfield/Label/Main/Harness Open Source/Dark */
+  --figma___textfield-label-optional: 212 6% 50% / 1;
+  /* ✦ Theme/Textfield/Label/Optional/Harness Open Source/Dark */
+  --figma___textfield-pin-soft-background: 240 100% 12% / 0.05;
+  /* ✦ Theme/Textfield/Pin/Soft/Background/Harness Open Source/Dark */
+  --figma___textfield-pin-soft-border: 233 96% 9% / 0.17;
+  /* ✦ Theme/Textfield/Pin/Soft/border/Harness Open Source/Dark */
+  --figma___textfield-pin-soft-pin: 240 6% 80% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/pin/Harness Open Source/Dark */
+  --figma___textfield-pin-surface-background: 200 6% 10% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/Background/Harness Open Source/Dark */
+  --figma___textfield-pin-surface-border: 210 6% 40% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/border/Harness Open Source/Dark */
+  --figma___textfield-pin-surface-pin: 207 6% 70% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/pin/Harness Open Source/Dark */
+  --figma___tooltip-background: 200 5% 12% / 1;
+  /* ✦ Theme/Tooltip/Background/Harness Open Source/Dark */
+  --figma___tooltip-body-text: 207 6% 70% / 1;
+  /* ✦ Theme/Tooltip/Body Text/Harness Open Source/Dark */
+  --figma___tooltip-dismissable-icon: 240 6% 80% / 1;
+  /* ✦ Theme/Tooltip/Dismissable icon/Harness Open Source/Dark */
+  --figma___tooltip-tooltip-title: 0 0% 98% / 1;
+  /* ✦ Theme/Tooltip/Tooltip Title/Harness Open Source/Dark */
+  --figma___badges-solid-amber-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Amber/text/Harness Open Source/Dark */
+  --figma___badges-solid-blue-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Blue/text/Harness Open Source/Dark */
+  --figma___badges-solid-bronze-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Bronze/text/Harness Open Source/Dark */
+  --figma___badges-solid-brown-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Brown/text/Harness Open Source/Dark */
+  --figma___badges-solid-crimson-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Crimson/text/Harness Open Source/Dark */
+  --figma___badges-solid-cyan-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Cyan/text/Harness Open Source/Dark */
+  --figma___badges-solid-gold-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Gold/text/Harness Open Source/Dark */
+  --figma___badges-solid-grass-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Grass/text/Harness Open Source/Dark */
+  --figma___badges-solid-green-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Green/text/Harness Open Source/Dark */
+  --figma___badges-solid-indigo-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Indigo/text/Harness Open Source/Dark */
+  --figma___badges-solid-iris-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Iris/text/Harness Open Source/Dark */
+  --figma___badges-solid-jade-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Jade/text/Harness Open Source/Dark */
+  --figma___badges-solid-lime-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Lime/text/Harness Open Source/Dark */
+  --figma___badges-solid-mint-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Mint/text/Harness Open Source/Dark */
+  --figma___badges-solid-orange-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Orange/text/Harness Open Source/Dark */
+  --figma___badges-solid-pink-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Pink/text/Harness Open Source/Dark */
+  --figma___badges-solid-plum-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Plum/text/Harness Open Source/Dark */
+  --figma___badges-solid-purple-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Purple/text/Harness Open Source/Dark */
+  --figma___badges-solid-red-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Red/text/Harness Open Source/Dark */
+  --figma___badges-solid-ruby-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Ruby/text/Harness Open Source/Dark */
+  --figma___badges-solid-sky-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Sky/text/Harness Open Source/Dark */
+  --figma___badges-solid-success-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Success/text/Harness Open Source/Dark */
+  --figma___badges-solid-teal-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Teal/text/Harness Open Source/Dark */
+  --figma___badges-solid-violet-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Violet/text/Harness Open Source/Dark */
+  --figma___badges-solid-yellow-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Yellow/text/Harness Open Source/Dark */
+  --figma___badges-solid-accent-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/accent/text/Harness Open Source/Dark */
+  --figma___badges-solid-info-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/info/text/Harness Open Source/Dark */
+  --figma___badges-solid-warning-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/warning/text/Harness Open Source/Dark */
+  --figma___button-solid-error-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Error/Text-primary/Harness Open Source/Dark */
+  --figma___button-solid-neutral-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Neutral/Text-primary/Harness Open Source/Dark */
+  --figma___button-solid-success-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Success/Text-primary/Harness Open Source/Dark */
+  --figma___calendar-selected-date-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Calendar/Selected Date/Text/Harness Open Source/Dark */
+  --figma___checkbox-surface-checked-active-check: var(--figma___default-colors-white);
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/Harness Open Source/Dark */
+  --figma___checkbox-surface-intermediate-active-check: var(--figma___default-colors-white);
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/Harness Open Source/Dark */
+  --figma___radio-button-checked-active-dot: var(--figma___default-colors-white);
+  /* ✦ Theme/Radio button/Checked/Active/Dot/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-default-default: var(--figma___textfield-background);
+  /* ✦ Theme/Side nav/Scope Selector/Default/default/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-hover-default: var(--figma___textfield-background);
+  /* ✦ Theme/Side nav/Scope Selector/Hover/default/Harness Open Source/Dark */
+  --figma___side-nav-scope-selector-selected-background: var(--figma___textfield-background);
+  /* ✦ Theme/Side nav/Scope Selector/Selected/background/Harness Open Source/Dark */
+  --figma___switch-checked-active-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/Harness Open Source/Dark */
+  --figma___switch-checked-default-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/Harness Open Source/Dark */
+  --figma___switch-checked-disabled-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/Harness Open Source/Dark */
+  --figma___switch-checked-hover-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/Harness Open Source/Dark */
+  --figma___switch-unchecked-active-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/Harness Open Source/Dark */
+  --figma___switch-unchecked-default-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/Harness Open Source/Dark */
+  --figma___switch-unchecked-hover-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/Harness Open Source/Dark */
+}

--- a/packages/canary/src/style-tokens/themes/harness-open-source.css
+++ b/packages/canary/src/style-tokens/themes/harness-open-source.css
@@ -1,3767 +1,804 @@
 /* Non color variables */
 :root {
-  --figma___badges-badge-radius: 100px;
-  /* ✦ Theme/Badges/badge-radius/Harness Open Source/Mode 1 */
-  --figma___grids-extra-large-1920-col: 12px;
-  /* ✦ Theme/Grids/Extra Large (> 1920)/Col/Harness Open Source/Mode 1 */
-  --figma___grids-extra-large-1920-gutters: 20px;
-  /* ✦ Theme/Grids/Extra Large (> 1920)/Gutters/Harness Open Source/Mode 1 */
-  --figma___grids-extra-large-1920-width: 138px;
-  /* ✦ Theme/Grids/Extra Large (> 1920)/Width/Harness Open Source/Mode 1 */
-  --figma___grids-extra-small-0-to-480-col: 2px;
-  /* ✦ Theme/Grids/Extra Small (0 to 480)/Col/Harness Open Source/Mode 1 */
-  --figma___grids-extra-small-0-to-480-gutters: 16px;
-  /* ✦ Theme/Grids/Extra Small (0 to 480)/Gutters/Harness Open Source/Mode 1 */
-  --figma___grids-extra-small-0-to-480-margins: 16px;
-  /* ✦ Theme/Grids/Extra Small (0 to 480)/Margins/Harness Open Source/Mode 1 */
-  --figma___grids-large-1280-to-1920-col: 12px;
-  /* ✦ Theme/Grids/Large (1280 to 1920)/Col/Harness Open Source/Mode 1 */
-  --figma___grids-large-1280-to-1920-gutters: 20px;
-  /* ✦ Theme/Grids/Large (1280 to 1920)/Gutters/Harness Open Source/Mode 1 */
-  --figma___grids-large-1280-to-1920-margins: 24px;
-  /* ✦ Theme/Grids/Large (1280 to 1920)/Margins/Harness Open Source/Mode 1 */
-  --figma___grids-medium-576-to-1279-col: 8px;
-  /* ✦ Theme/Grids/Medium (576 to 1279)/Col/Harness Open Source/Mode 1 */
-  --figma___grids-medium-576-to-1279-gutters: 16px;
-  /* ✦ Theme/Grids/Medium (576 to 1279)/Gutters/Harness Open Source/Mode 1 */
-  --figma___grids-medium-576-to-1279-margins: 24px;
-  /* ✦ Theme/Grids/Medium (576 to 1279)/Margins/Harness Open Source/Mode 1 */
-  --figma___grids-small-480-to-575-col: 4px;
-  /* ✦ Theme/Grids/Small (480 to 575)/Col/Harness Open Source/Mode 1 */
-  --figma___grids-small-480-to-575-gutters: 16px;
-  /* ✦ Theme/Grids/Small (480 to 575)/Gutters/Harness Open Source/Mode 1 */
-  --figma___grids-small-480-to-575-margins: 24px;
-  /* ✦ Theme/Grids/Small (480 to 575)/Margins/Harness Open Source/Mode 1 */
-  --figma___height-button-height-1: 24px;
-  /* ✦ Theme/Height/button-height-1/Harness Open Source/Mode 1 */
-  --figma___height-button-height-2: 32px;
-  /* ✦ Theme/Height/button-height-2/Harness Open Source/Mode 1 */
-  --figma___height-button-height-3: 40px;
-  /* ✦ Theme/Height/button-height-3/Harness Open Source/Mode 1 */
-  --figma___height-button-height-4: 48px;
-  /* ✦ Theme/Height/button-height-4/Harness Open Source/Mode 1 */
-  --figma___height-menu-item-height-1: 24px;
-  /* ✦ Theme/Height/menu-item-height-1/Harness Open Source/Mode 1 */
-  --figma___height-menu-item-height-2: 32px;
-  /* ✦ Theme/Height/menu-item-height-2/Harness Open Source/Mode 1 */
-  --figma___height-table-cell-min-height-1: 36px;
-  /* ✦ Theme/Height/table-cell-min-height-1/Harness Open Source/Mode 1 */
-  --figma___height-table-cell-min-height-2: 44px;
-  /* ✦ Theme/Height/table-cell-min-height-2/Harness Open Source/Mode 1 */
-  --figma___height-table-cell-min-height-3: 48px;
-  /* ✦ Theme/Height/table-cell-min-height-3/Harness Open Source/Mode 1 */
-  --figma___padding-main-content-padding: 0px;
-  /* ✦ Theme/Padding/Main content padding/Harness Open Source/Mode 1 */
-  --figma___padding-table-cell-padding-1: 8px;
-  /* ✦ Theme/Padding/table-cell-padding-1/Harness Open Source/Mode 1 */
-  --figma___padding-table-cell-padding-2: 12px;
-  /* ✦ Theme/Padding/table-cell-padding-2/Harness Open Source/Mode 1 */
-  --figma___padding-table-cell-padding-3: 16px;
-  /* ✦ Theme/Padding/table-cell-padding-3/Harness Open Source/Mode 1 */
-  --figma___pagination-active-border-radius: 32px;
-  /* ✦ Theme/Pagination/Active/Border-radius/Harness Open Source/Mode 1 */
-  --figma___pagination-border-radius: 0px;
-  /* ✦ Theme/Pagination/Border-radius/Harness Open Source/Mode 1 */
-  --figma___pagination-default-border-radius: 4px;
-  /* ✦ Theme/Pagination/Default/Border-radius/Harness Open Source/Mode 1 */
-  --figma___pagination-gap: 0px;
-  /* ✦ Theme/Pagination/Gap/Harness Open Source/Mode 1 */
-  --figma___pagination-hover-border-radius: 100px;
-  /* ✦ Theme/Pagination/Hover/Border-radius/Harness Open Source/Mode 1 */
-  --figma___radius-1: 3px;
-  /* ✦ Theme/Radius/1/Harness Open Source/Mode 1 */
-  --figma___radius-2: 4px;
-  /* ✦ Theme/Radius/2/Harness Open Source/Mode 1 */
-  --figma___radius-3: 6px;
-  /* ✦ Theme/Radius/3/Harness Open Source/Mode 1 */
-  --figma___radius-4: 8px;
-  /* ✦ Theme/Radius/4/Harness Open Source/Mode 1 */
-  --figma___radius-5: 12px;
-  /* ✦ Theme/Radius/5/Harness Open Source/Mode 1 */
-  --figma___radius-6: 16px;
-  /* ✦ Theme/Radius/6/Harness Open Source/Mode 1 */
-  --figma___radius-1-max: 3px;
-  /* ✦ Theme/Radius/1-max/Harness Open Source/Mode 1 */
-  --figma___radius-2-max: 4px;
-  /* ✦ Theme/Radius/2-max/Harness Open Source/Mode 1 */
-  --figma___radius-3-max: 6px;
-  /* ✦ Theme/Radius/3-max/Harness Open Source/Mode 1 */
-  --figma___radius-4-max: 8px;
-  /* ✦ Theme/Radius/4-max/Harness Open Source/Mode 1 */
-  --figma___radius-5-max: 12px;
-  /* ✦ Theme/Radius/5-max/Harness Open Source/Mode 1 */
-  --figma___radius-6-max: 16px;
-  /* ✦ Theme/Radius/6-max/Harness Open Source/Mode 1 */
-  --figma___radius-main-content-radius: 0px;
-  /* ✦ Theme/Radius/Main content radius/Harness Open Source/Mode 1 */
-  --figma___radius-full: 9999px;
-  /* ✦ Theme/Radius/full/Harness Open Source/Mode 1 */
-  --figma___space-1: 4px;
-  /* ✦ Theme/Space/1/Harness Open Source/Mode 1 */
-  --figma___space-2: 8px;
-  /* ✦ Theme/Space/2/Harness Open Source/Mode 1 */
-  --figma___space-3: 12px;
-  /* ✦ Theme/Space/3/Harness Open Source/Mode 1 */
-  --figma___space-4: 16px;
-  /* ✦ Theme/Space/4/Harness Open Source/Mode 1 */
-  --figma___space-5: 24px;
-  /* ✦ Theme/Space/5/Harness Open Source/Mode 1 */
-  --figma___space-6: 32px;
-  /* ✦ Theme/Space/6/Harness Open Source/Mode 1 */
-  --figma___space-7: 40px;
-  /* ✦ Theme/Space/7/Harness Open Source/Mode 1 */
-  --figma___space-8: 48px;
-  /* ✦ Theme/Space/8/Harness Open Source/Mode 1 */
-  --figma___space-9: 64px;
-  /* ✦ Theme/Space/9/Harness Open Source/Mode 1 */
-  --figma___switch-thumb-size-1: 12px;
-  /* ✦ Theme/Switch/Thumb Size/1/Harness Open Source/Mode 1 */
-  --figma___switch-thumb-size-2: 16px;
-  /* ✦ Theme/Switch/Thumb Size/2/Harness Open Source/Mode 1 */
-  --figma___switch-thumb-size-3: 20px;
-  /* ✦ Theme/Switch/Thumb Size/3/Harness Open Source/Mode 1 */
-  --figma___tabs-pills-border-radius: 6px;
-  /* ✦ Theme/Tabs/Pills/border-radius/Harness Open Source/Mode 1 */
-  --figma___tabs-pills-padding: 4px;
-  /* ✦ Theme/Tabs/Pills/padding/Harness Open Source/Mode 1 */
-  --figma___tabs-pills-pill-border-radius: 4px;
-  /* ✦ Theme/Tabs/Pills/pill border radius/Harness Open Source/Mode 1 */
-  --figma___textfield-assistive-text-assistive-text: 14px;
-  /* ✦ Theme/Textfield/Assistive Text/Assistive Text/Harness Open Source/Mode 1 */
-  --figma___textfield-gap: 8px;
-  /* ✦ Theme/Textfield/Gap/Harness Open Source/Mode 1 */
-  --figma___textfield-input-field-textfield-height: 36px;
-  /* ✦ Theme/Textfield/Input Field/Textfield Height/Harness Open Source/Mode 1 */
+  --figma___component-pagination-border-radius: 0px; /* ✦ Theme/Component/Pagination/Border-radius/Harness Open Source/Mode 1 */
+  --figma___component-pagination-gap: 0px; /* ✦ Theme/Component/Pagination/Gap/Harness Open Source/Mode 1 */
+  --figma___component-switch-thumb-size-1: 12px; /* ✦ Theme/Component/Switch/Thumb Size/1/Harness Open Source/Mode 1 */
+  --figma___component-switch-thumb-size-2: 16px; /* ✦ Theme/Component/Switch/Thumb Size/2/Harness Open Source/Mode 1 */
+  --figma___component-switch-thumb-size-3: 20px; /* ✦ Theme/Component/Switch/Thumb Size/3/Harness Open Source/Mode 1 */
+  --figma___component-textfield-gap: 8px; /* ✦ Theme/Component/Textfield/Gap/Harness Open Source/Mode 1 */
+  --figma___padding-main-content-padding: 0px; /* ✦ Theme/Padding/Main content padding/Harness Open Source/Mode 1 */
+  --figma___radius-1: 3px; /* ✦ Theme/Radius/1/Harness Open Source/Mode 1 */
+  --figma___radius-2: 4px; /* ✦ Theme/Radius/2/Harness Open Source/Mode 1 */
+  --figma___radius-3: 6px; /* ✦ Theme/Radius/3/Harness Open Source/Mode 1 */
+  --figma___radius-4: 8px; /* ✦ Theme/Radius/4/Harness Open Source/Mode 1 */
+  --figma___radius-5: 12px; /* ✦ Theme/Radius/5/Harness Open Source/Mode 1 */
+  --figma___radius-6: 16px; /* ✦ Theme/Radius/6/Harness Open Source/Mode 1 */
+  --figma___radius-main-content-radius: 0px; /* ✦ Theme/Radius/Main content radius/Harness Open Source/Mode 1 */
+  --figma___radius-full: 9999px; /* ✦ Theme/Radius/full/Harness Open Source/Mode 1 */
 }
 
 /* Color variables - light mode */
 .harness-open-source-light {
-  --figma___background-backdrop: 230 100% 9% / 0.28;
-  /* ✦ Theme/Background/Backdrop/Harness Open Source/Light */
-  --figma___background-cards-and-rows-default: 0 0% 100% / 0;
-  /* ✦ Theme/Background/Cards and Rows/Default/Harness Open Source/Light */
-  --figma___background-cards-and-rows-hover: 0 0% 0% / 0.03;
-  /* ✦ Theme/Background/Cards and Rows/Hover/Harness Open Source/Light */
-  --figma___background-cards-and-rows-primary-blue-selected: 240 100% 12% / 0.05;
-  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/Harness Open Source/Light */
-  --figma___background-cards-and-rows-selected: 0 0% 0% / 0.04;
-  /* ✦ Theme/Background/Cards and Rows/Selected/Harness Open Source/Light */
-  --figma___background-header-page-header: 0 0% 100% / 1;
-  /* ✦ Theme/Background/Header/Page Header/Harness Open Source/Light */
-  --figma___background-header-table-header: 0 0% 98% / 1;
-  /* ✦ Theme/Background/Header/Table Header/Harness Open Source/Light */
-  --figma___background-paper: 0 0% 98% / 1;
-  /* ✦ Theme/Background/Paper/Harness Open Source/Light */
-  --figma___background-primary: 0 0% 98% / 1;
-  /* ✦ Theme/Background/Primary/Harness Open Source/Light */
-  --figma___background-solid: 0 0% 100% / 1;
-  /* ✦ Theme/Background/Solid/Harness Open Source/Light */
-  --figma___badges-soft-amber-background: 45 100% 50% / 0.19;
-  /* ✦ Theme/Badges/Soft/Amber/background/Harness Open Source/Light */
-  --figma___badges-soft-amber-text: 25 100% 24% / 0.81;
-  /* ✦ Theme/Badges/Soft/Amber/text/Harness Open Source/Light */
-  --figma___badges-soft-blue-background: 210 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Soft/Blue/background/Harness Open Source/Light */
-  --figma___badges-soft-blue-text: 211 100% 39% / 0.96;
-  /* ✦ Theme/Badges/Soft/Blue/text/Harness Open Source/Light */
-  --figma___badges-soft-bronze-background: 18 99% 30% / 0.07;
-  /* ✦ Theme/Badges/Soft/Bronze/background/Harness Open Source/Light */
-  --figma___badges-soft-bronze-text: 15 100% 12% / 0.67;
-  /* ✦ Theme/Badges/Soft/Bronze/text/Harness Open Source/Light */
-  --figma___badges-soft-brown-background: 30 98% 34% / 0.08;
-  /* ✦ Theme/Badges/Soft/Brown/background/Harness Open Source/Light */
-  --figma___badges-soft-brown-text: 24 100% 16% / 0.73;
-  /* ✦ Theme/Badges/Soft/Brown/text/Harness Open Source/Light */
-  --figma___badges-soft-crimson-background: 332 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Soft/Crimson/background/Harness Open Source/Light */
-  --figma___badges-soft-crimson-text: 336 100% 38% / 0.89;
-  /* ✦ Theme/Badges/Soft/Crimson/text/Harness Open Source/Light */
-  --figma___badges-soft-cyan-background: 186 98% 42% / 0.09;
-  /* ✦ Theme/Badges/Soft/Cyan/background/Harness Open Source/Light */
-  --figma___badges-soft-cyan-text: 192 100% 28% / 0.95;
-  /* ✦ Theme/Badges/Soft/Cyan/text/Harness Open Source/Light */
-  --figma___badges-soft-gold-background: 45 97% 28% / 0.09;
-  /* ✦ Theme/Badges/Soft/Gold/background/Harness Open Source/Light */
-  --figma___badges-soft-gold-text: 36 100% 11% / 0.71;
-  /* ✦ Theme/Badges/Soft/Gold/text/Harness Open Source/Light */
-  --figma___badges-soft-grass-background: 120 98% 35% / 0.08;
-  /* ✦ Theme/Badges/Soft/Grass/background/Harness Open Source/Light */
-  --figma___badges-soft-grass-text: 133 100% 19% / 0.84;
-  /* ✦ Theme/Badges/Soft/Grass/text/Harness Open Source/Light */
-  --figma___badges-soft-green-background: 139 98% 37% / 0.09;
-  /* ✦ Theme/Badges/Soft/Green/background/Harness Open Source/Light */
-  --figma___badges-soft-green-text: 153 100% 21% / 0.91;
-  /* ✦ Theme/Badges/Soft/Green/text/Harness Open Source/Light */
-  --figma___badges-soft-indigo-background: 224 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Soft/Indigo/background/Harness Open Source/Light */
-  --figma___badges-soft-indigo-text: 226 100% 31% / 0.8;
-  /* ✦ Theme/Badges/Soft/Indigo/text/Harness Open Source/Light */
-  --figma___badges-soft-iris-background: 240 100% 51% / 0.05;
-  /* ✦ Theme/Badges/Soft/Iris/background/Harness Open Source/Light */
-  --figma___badges-soft-iris-text: 240 100% 34% / 0.72;
-  /* ✦ Theme/Badges/Soft/Iris/text/Harness Open Source/Light */
-  --figma___badges-soft-jade-background: 150 100% 41% / 0.11;
-  /* ✦ Theme/Badges/Soft/Jade/background/Harness Open Source/Light */
-  --figma___badges-soft-jade-text: 163 100% 21% / 0.9;
-  /* ✦ Theme/Badges/Soft/Jade/text/Harness Open Source/Light */
-  --figma___badges-soft-lime-background: 84 99% 44% / 0.15;
-  /* ✦ Theme/Badges/Soft/Lime/background/Harness Open Source/Light */
-  --figma___badges-soft-lime-text: 75 100% 14% / 0.83;
-  /* ✦ Theme/Badges/Soft/Lime/text/Harness Open Source/Light */
-  --figma___badges-soft-mint-background: 164 99% 44% / 0.13;
-  /* ✦ Theme/Badges/Soft/Mint/background/Harness Open Source/Light */
-  --figma___badges-soft-mint-text: 172 100% 18% / 0.85;
-  /* ✦ Theme/Badges/Soft/Mint/text/Harness Open Source/Light */
-  --figma___badges-soft-orange-background: 34 100% 50% / 0.17;
-  /* ✦ Theme/Badges/Soft/Orange/background/Harness Open Source/Light */
-  --figma___badges-soft-orange-text: 16 100% 24% / 0.77;
-  /* ✦ Theme/Badges/Soft/Orange/text/Harness Open Source/Light */
-  --figma___badges-soft-pink-background: 323 99% 47% / 0.07;
-  /* ✦ Theme/Badges/Soft/Pink/background/Harness Open Source/Light */
-  --figma___badges-soft-pink-text: 322 100% 37% / 0.89;
-  /* ✦ Theme/Badges/Soft/Pink/text/Harness Open Source/Light */
-  --figma___badges-soft-plum-background: 300 99% 41% / 0.06;
-  /* ✦ Theme/Badges/Soft/Plum/background/Harness Open Source/Light */
-  --figma___badges-soft-plum-text: 292 100% 31% / 0.83;
-  /* ✦ Theme/Badges/Soft/Plum/text/Harness Open Source/Light */
-  --figma___badges-soft-purple-background: 277 100% 46% / 0.05;
-  /* ✦ Theme/Badges/Soft/Purple/background/Harness Open Source/Light */
-  --figma___badges-soft-purple-text: 273 100% 30% / 0.77;
-  /* ✦ Theme/Badges/Soft/Purple/text/Harness Open Source/Light */
-  --figma___badges-soft-red-background: 0 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Soft/Red/background/Harness Open Source/Light */
-  --figma___badges-soft-red-text: 358 100% 37% / 0.84;
-  /* ✦ Theme/Badges/Soft/Red/text/Harness Open Source/Light */
-  --figma___badges-soft-ruby-background: 344 100% 47% / 0.06;
-  /* ✦ Theme/Badges/Soft/Ruby/background/Harness Open Source/Light */
-  --figma___badges-soft-ruby-text: 345 100% 38% / 0.86;
-  /* ✦ Theme/Badges/Soft/Ruby/text/Harness Open Source/Light */
-  --figma___badges-soft-sky-background: 192 100% 50% / 0.11;
-  /* ✦ Theme/Badges/Soft/Sky/background/Harness Open Source/Light */
-  --figma___badges-soft-sky-text: 200 100% 25% / 0.86;
-  /* ✦ Theme/Badges/Soft/Sky/text/Harness Open Source/Light */
-  --figma___badges-soft-teal-background: 167 98% 38% / 0.09;
-  /* ✦ Theme/Badges/Soft/Teal/background/Harness Open Source/Light */
-  --figma___badges-soft-teal-text: 174 100% 23% / 0.98;
-  /* ✦ Theme/Badges/Soft/Teal/text/Harness Open Source/Light */
-  --figma___badges-soft-violet-background: 254 100% 50% / 0.05;
-  /* ✦ Theme/Badges/Soft/Violet/background/Harness Open Source/Light */
-  --figma___badges-soft-violet-text: 250 100% 28% / 0.73;
-  /* ✦ Theme/Badges/Soft/Violet/text/Harness Open Source/Light */
-  --figma___badges-soft-yellow-background: 53 100% 50% / 0.22;
-  /* ✦ Theme/Badges/Soft/Yellow/background/Harness Open Source/Light */
-  --figma___badges-soft-yellow-text: 42 100% 18% / 0.84;
-  /* ✦ Theme/Badges/Soft/Yellow/text/Harness Open Source/Light */
-  --figma___badges-soft-accent-background: 220 6% 90% / 1;
-  /* ✦ Theme/Badges/Soft/accent/background/Harness Open Source/Light */
-  --figma___badges-soft-accent-text: 210 6% 6% / 1;
-  /* ✦ Theme/Badges/Soft/accent/text/Harness Open Source/Light */
-  --figma___badges-soft-error-background: 0 100% 71% / 0.1;
-  /* ✦ Theme/Badges/Soft/error/background/Harness Open Source/Light */
-  --figma___badges-soft-error-text: 0 100% 71% / 0.1;
-  /* ✦ Theme/Badges/Soft/error/text/Harness Open Source/Light */
-  --figma___badges-soft-info-background: 210 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Soft/info/background/Harness Open Source/Light */
-  --figma___badges-soft-info-text: 211 100% 39% / 0.96;
-  /* ✦ Theme/Badges/Soft/info/text/Harness Open Source/Light */
-  --figma___badges-soft-success-background: 139 98% 37% / 0.09;
-  /* ✦ Theme/Badges/Soft/success/background/Harness Open Source/Light */
-  --figma___badges-soft-success-text: 153 100% 21% / 0.91;
-  /* ✦ Theme/Badges/Soft/success/text/Harness Open Source/Light */
-  --figma___badges-soft-warning-background: 45 100% 91% / 1;
-  /* ✦ Theme/Badges/Soft/warning/background/Harness Open Source/Light */
-  --figma___badges-soft-warning-text: 25 100% 24% / 0.81;
-  /* ✦ Theme/Badges/Soft/warning/text/Harness Open Source/Light */
-  --figma___badges-solid-amber-background: 42 100% 62% / 1;
-  /* ✦ Theme/Badges/Solid/Amber/background/Harness Open Source/Light */
-  --figma___badges-solid-blue-background: 214 73% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Blue/background/Harness Open Source/Light */
-  --figma___badges-solid-bronze-background: 18 20% 54% / 1;
-  /* ✦ Theme/Badges/Solid/Bronze/background/Harness Open Source/Light */
-  --figma___badges-solid-brown-background: 28 34% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Brown/background/Harness Open Source/Light */
-  --figma___badges-solid-crimson-background: 336 80% 58% / 1;
-  /* ✦ Theme/Badges/Solid/Crimson/background/Harness Open Source/Light */
-  --figma___badges-solid-cyan-background: 190 95% 39% / 1;
-  /* ✦ Theme/Badges/Solid/Cyan/background/Harness Open Source/Light */
-  --figma___badges-solid-gold-background: 36 20% 49% / 1;
-  /* ✦ Theme/Badges/Solid/Gold/background/Harness Open Source/Light */
-  --figma___badges-solid-grass-background: 132 59% 33% / 1;
-  /* ✦ Theme/Badges/Solid/Grass/background/Harness Open Source/Light */
-  --figma___badges-solid-green-background: 142 72% 29% / 1;
-  /* ✦ Theme/Badges/Solid/Green/background/Harness Open Source/Light */
-  --figma___badges-solid-indigo-background: 226 70% 55% / 1;
-  /* ✦ Theme/Badges/Solid/Indigo/background/Harness Open Source/Light */
-  --figma___badges-solid-iris-background: 240 60% 60% / 1;
-  /* ✦ Theme/Badges/Solid/Iris/background/Harness Open Source/Light */
-  --figma___badges-solid-jade-background: 164 60% 40% / 1;
-  /* ✦ Theme/Badges/Solid/Jade/background/Harness Open Source/Light */
-  --figma___badges-solid-lime-background: 81 80% 66% / 1;
-  /* ✦ Theme/Badges/Solid/Lime/background/Harness Open Source/Light */
-  --figma___badges-solid-mint-background: 176 59% 50% / 1;
-  /* ✦ Theme/Badges/Solid/Mint/background/Harness Open Source/Light */
-  --figma___badges-solid-orange-background: 24 94% 50% / 1;
-  /* ✦ Theme/Badges/Solid/Orange/background/Harness Open Source/Light */
-  --figma___badges-solid-pink-background: 322 65% 55% / 1;
-  /* ✦ Theme/Badges/Solid/Pink/background/Harness Open Source/Light */
-  --figma___badges-solid-plum-background: 292 45% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Plum/background/Harness Open Source/Light */
-  --figma___badges-solid-purple-background: 272 51% 54% / 1;
-  /* ✦ Theme/Badges/Solid/Purple/background/Harness Open Source/Light */
-  --figma___badges-solid-red-background: 358 75% 59% / 1;
-  /* ✦ Theme/Badges/Solid/Red/background/Harness Open Source/Light */
-  --figma___badges-solid-ruby-background: 348 75% 59% / 1;
-  /* ✦ Theme/Badges/Solid/Ruby/background/Harness Open Source/Light */
-  --figma___badges-solid-sky-background: 193 98% 74% / 1;
-  /* ✦ Theme/Badges/Solid/Sky/background/Harness Open Source/Light */
-  --figma___badges-solid-success-background: 142 72% 29% / 1;
-  /* ✦ Theme/Badges/Solid/Success/background/Harness Open Source/Light */
-  --figma___badges-solid-teal-background: 173 80% 36% / 1;
-  /* ✦ Theme/Badges/Solid/Teal/background/Harness Open Source/Light */
-  --figma___badges-solid-violet-background: 252 56% 57% / 1;
-  /* ✦ Theme/Badges/Solid/Violet/background/Harness Open Source/Light */
-  --figma___badges-solid-yellow-background: 53 96% 58% / 1;
-  /* ✦ Theme/Badges/Solid/Yellow/background/Harness Open Source/Light */
-  --figma___badges-solid-accent-background: 176 59% 50% / 1;
-  /* ✦ Theme/Badges/Solid/accent/background/Harness Open Source/Light */
-  --figma___badges-solid-info-background: 214 73% 51% / 1;
-  /* ✦ Theme/Badges/Solid/info/background/Harness Open Source/Light */
-  --figma___badges-solid-warning-background: 25 50% 38% / 1;
-  /* ✦ Theme/Badges/Solid/warning/background/Harness Open Source/Light */
-  --figma___badges-surface-amber-background: 40 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/Amber/background/Harness Open Source/Light */
-  --figma___badges-surface-amber-border: 37 100% 40% / 0.53;
-  /* ✦ Theme/Badges/Surface/Amber/border/Harness Open Source/Light */
-  --figma___badges-surface-amber-text: 25 100% 24% / 0.81;
-  /* ✦ Theme/Badges/Surface/Amber/text/Harness Open Source/Light */
-  --figma___badges-surface-blue-background: 210 100% 51% / 0.04;
-  /* ✦ Theme/Badges/Surface/Blue/background/Harness Open Source/Light */
-  --figma___badges-surface-blue-border: 208 100% 44% / 0.41;
-  /* ✦ Theme/Badges/Surface/Blue/border/Harness Open Source/Light */
-  --figma___badges-surface-blue-text: 211 100% 39% / 0.96;
-  /* ✦ Theme/Badges/Surface/Blue/text/Harness Open Source/Light */
-  --figma___badges-surface-bronze-background: 17 95% 40% / 0.04;
-  /* ✦ Theme/Badges/Surface/Bronze/background/Harness Open Source/Light */
-  --figma___badges-surface-bronze-border: 18 100% 22% / 0.31;
-  /* ✦ Theme/Badges/Surface/Bronze/border/Harness Open Source/Light */
-  --figma___badges-surface-bronze-text: 15 100% 12% / 0.67;
-  /* ✦ Theme/Badges/Surface/Bronze/text/Harness Open Source/Light */
-  --figma___badges-surface-brown-background: 30 94% 35% / 0.04;
-  /* ✦ Theme/Badges/Surface/Brown/background/Harness Open Source/Light */
-  --figma___badges-surface-brown-border: 29 100% 34% / 0.41;
-  /* ✦ Theme/Badges/Surface/Brown/border/Harness Open Source/Light */
-  --figma___badges-surface-brown-text: 24 100% 16% / 0.73;
-  /* ✦ Theme/Badges/Surface/Brown/text/Harness Open Source/Light */
-  --figma___badges-surface-crimson-border: 335 100% 39% / 0.32;
-  /* ✦ Theme/Badges/Surface/Crimson/Border/Harness Open Source/Light */
-  --figma___badges-surface-crimson-background: 330 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Crimson/background/Harness Open Source/Light */
-  --figma___badges-surface-crimson-text: 336 100% 38% / 0.89;
-  /* ✦ Theme/Badges/Surface/Crimson/text/Harness Open Source/Light */
-  --figma___badges-surface-cyan-border: 189 100% 35% / 0.48;
-  /* ✦ Theme/Badges/Surface/Cyan/Border/Harness Open Source/Light */
-  --figma___badges-surface-cyan-background: 186 100% 42% / 0.05;
-  /* ✦ Theme/Badges/Surface/Cyan/background/Harness Open Source/Light */
-  --figma___badges-surface-cyan-text: 192 100% 28% / 0.95;
-  /* ✦ Theme/Badges/Surface/Cyan/text/Harness Open Source/Light */
-  --figma___badges-surface-gold-border: 38 100% 22% / 0.36;
-  /* ✦ Theme/Badges/Surface/Gold/Border/Harness Open Source/Light */
-  --figma___badges-surface-gold-background: 47 100% 35% / 0.05;
-  /* ✦ Theme/Badges/Surface/Gold/background/Harness Open Source/Light */
-  --figma___badges-surface-gold-text: 36 100% 11% / 0.71;
-  /* ✦ Theme/Badges/Surface/Gold/text/Harness Open Source/Light */
-  --figma___badges-surface-grass-border: 125 100% 27% / 0.41;
-  /* ✦ Theme/Badges/Surface/Grass/Border/Harness Open Source/Light */
-  --figma___badges-surface-grass-background: 120 95% 39% / 0.05;
-  /* ✦ Theme/Badges/Surface/Grass/background/Harness Open Source/Light */
-  --figma___badges-surface-grass-text: 133 100% 19% / 0.84;
-  /* ✦ Theme/Badges/Surface/Grass/text/Harness Open Source/Light */
-  --figma___badges-surface-green-background: 139 98% 37% / 0.09;
-  /* ✦ Theme/Badges/Surface/Green/background/Harness Open Source/Light */
-  --figma___badges-surface-green-border: 146 100% 27% / 0.43;
-  /* ✦ Theme/Badges/Surface/Green/border/Harness Open Source/Light */
-  --figma___badges-surface-green-text: 153 100% 21% / 0.91;
-  /* ✦ Theme/Badges/Surface/Green/text/Harness Open Source/Light */
-  --figma___badges-surface-indigo-background: 223 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Indigo/background/Harness Open Source/Light */
-  --figma___badges-surface-indigo-border: 225 100% 44% / 0.32;
-  /* ✦ Theme/Badges/Surface/Indigo/border/Harness Open Source/Light */
-  --figma___badges-surface-indigo-text: 226 100% 31% / 0.8;
-  /* ✦ Theme/Badges/Surface/Indigo/text/Harness Open Source/Light */
-  --figma___badges-surface-iris-border: 239 100% 43% / 0.27;
-  /* ✦ Theme/Badges/Surface/Iris/Border/Harness Open Source/Light */
-  --figma___badges-surface-iris-background: 240 100% 51% / 0.02;
-  /* ✦ Theme/Badges/Surface/Iris/background/Harness Open Source/Light */
-  --figma___badges-surface-iris-text: 240 100% 34% / 0.72;
-  /* ✦ Theme/Badges/Surface/Iris/text/Harness Open Source/Light */
-  --figma___badges-surface-jade-border: 159 100% 29% / 0.44;
-  /* ✦ Theme/Badges/Surface/Jade/Border/Harness Open Source/Light */
-  --figma___badges-surface-jade-background: 150 99% 44% / 0.06;
-  /* ✦ Theme/Badges/Surface/Jade/background/Harness Open Source/Light */
-  --figma___badges-surface-jade-text: 163 100% 21% / 0.9;
-  /* ✦ Theme/Badges/Surface/Jade/text/Harness Open Source/Light */
-  --figma___badges-surface-lime-border: 79 100% 29% / 0.5;
-  /* ✦ Theme/Badges/Surface/Lime/Border/Harness Open Source/Light */
-  --figma___badges-surface-lime-background: 85 99% 40% / 0.06;
-  /* ✦ Theme/Badges/Surface/Lime/background/Harness Open Source/Light */
-  --figma___badges-surface-lime-text: 75 100% 14% / 0.83;
-  /* ✦ Theme/Badges/Surface/Lime/text/Harness Open Source/Light */
-  --figma___badges-surface-mint-background: 164 99% 47% / 0.06;
-  /* ✦ Theme/Badges/Surface/Mint/background/Harness Open Source/Light */
-  --figma___badges-surface-mint-border: 166 100% 30% / 0.47;
-  /* ✦ Theme/Badges/Surface/Mint/border/Harness Open Source/Light */
-  --figma___badges-surface-mint-text: 172 100% 18% / 0.85;
-  /* ✦ Theme/Badges/Surface/Mint/text/Harness Open Source/Light */
-  --figma___badges-surface-orange-background: 34 100% 50% / 0.17;
-  /* ✦ Theme/Badges/Surface/Orange/background/Harness Open Source/Light */
-  --figma___badges-surface-orange-border: 21 100% 50% / 0.51;
-  /* ✦ Theme/Badges/Surface/Orange/border/Harness Open Source/Light */
-  --figma___badges-surface-orange-text: 16 100% 24% / 0.77;
-  /* ✦ Theme/Badges/Surface/Orange/text/Harness Open Source/Light */
-  --figma___badges-surface-pink-background: 323 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Pink/background/Harness Open Source/Light */
-  --figma___badges-surface-pink-border: 323 100% 38% / 0.32;
-  /* ✦ Theme/Badges/Surface/Pink/border/Harness Open Source/Light */
-  --figma___badges-surface-pink-text: 322 100% 37% / 0.89;
-  /* ✦ Theme/Badges/Surface/Pink/text/Harness Open Source/Light */
-  --figma___badges-surface-plum-background: 300 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Plum/background/Harness Open Source/Light */
-  --figma___badges-surface-plum-border: 295 100% 33% / 0.31;
-  /* ✦ Theme/Badges/Surface/Plum/border/Harness Open Source/Light */
-  --figma___badges-surface-plum-text: 292 100% 31% / 0.83;
-  /* ✦ Theme/Badges/Surface/Plum/text/Harness Open Source/Light */
-  --figma___badges-surface-purple-background: 276 100% 51% / 0.02;
-  /* ✦ Theme/Badges/Surface/Purple/background/Harness Open Source/Light */
-  --figma___badges-surface-purple-border: 273 99% 38% / 0.29;
-  /* ✦ Theme/Badges/Surface/Purple/border/Harness Open Source/Light */
-  --figma___badges-surface-purple-text: 273 100% 30% / 0.77;
-  /* ✦ Theme/Badges/Surface/Purple/text/Harness Open Source/Light */
-  --figma___badges-surface-red-background: 0 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Red/background/Harness Open Source/Light */
-  --figma___badges-surface-red-border: 359 100% 43% / 0.32;
-  /* ✦ Theme/Badges/Surface/Red/border/Harness Open Source/Light */
-  --figma___badges-surface-red-text: 358 100% 37% / 0.84;
-  /* ✦ Theme/Badges/Surface/Red/text/Harness Open Source/Light */
-  --figma___badges-surface-ruby-background: 345 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Ruby/background/Harness Open Source/Light */
-  --figma___badges-surface-ruby-border: 348 100% 39% / 0.31;
-  /* ✦ Theme/Badges/Surface/Ruby/border/Harness Open Source/Light */
-  --figma___badges-surface-ruby-text: 345 100% 38% / 0.86;
-  /* ✦ Theme/Badges/Surface/Ruby/text/Harness Open Source/Light */
-  --figma___badges-surface-sky-background: 193 100% 50% / 0.05;
-  /* ✦ Theme/Badges/Surface/Sky/background/Harness Open Source/Light */
-  --figma___badges-surface-sky-border: 194 100% 38% / 0.49;
-  /* ✦ Theme/Badges/Surface/Sky/border/Harness Open Source/Light */
-  --figma___badges-surface-sky-text: 200 100% 25% / 0.86;
-  /* ✦ Theme/Badges/Surface/Sky/text/Harness Open Source/Light */
-  --figma___badges-surface-teal-background: 169 99% 39% / 0.05;
-  /* ✦ Theme/Badges/Surface/Teal/background/Harness Open Source/Light */
-  --figma___badges-surface-teal-border: 170 99% 29% / 0.45;
-  /* ✦ Theme/Badges/Surface/Teal/border/Harness Open Source/Light */
-  --figma___badges-surface-teal-text: 174 100% 23% / 0.98;
-  /* ✦ Theme/Badges/Surface/Teal/text/Harness Open Source/Light */
-  --figma___badges-surface-violet-background: 252 100% 51% / 0.02;
-  /* ✦ Theme/Badges/Surface/Violet/background/Harness Open Source/Light */
-  --figma___badges-surface-violet-border: 252 99% 42% / 0.28;
-  /* ✦ Theme/Badges/Surface/Violet/border/Harness Open Source/Light */
-  --figma___badges-surface-violet-text: 250 100% 28% / 0.73;
-  /* ✦ Theme/Badges/Surface/Violet/text/Harness Open Source/Light */
-  --figma___badges-surface-yellow-background: 52 100% 50% / 0.12;
-  /* ✦ Theme/Badges/Surface/Yellow/background/Harness Open Source/Light */
-  --figma___badges-surface-yellow-border: 48 100% 37% / 0.57;
-  /* ✦ Theme/Badges/Surface/Yellow/border/Harness Open Source/Light */
-  --figma___badges-surface-yellow-text: 42 100% 18% / 0.84;
-  /* ✦ Theme/Badges/Surface/Yellow/text/Harness Open Source/Light */
-  --figma___badges-surface-accent-background: 164 99% 47% / 0.06;
-  /* ✦ Theme/Badges/Surface/accent/background/Harness Open Source/Light */
-  --figma___badges-surface-accent-border: 166 100% 30% / 0.47;
-  /* ✦ Theme/Badges/Surface/accent/border/Harness Open Source/Light */
-  --figma___badges-surface-accent-text: 172 100% 18% / 0.85;
-  /* ✦ Theme/Badges/Surface/accent/text/Harness Open Source/Light */
-  --figma___badges-surface-error-background: 0 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/error/background/Harness Open Source/Light */
-  --figma___badges-surface-error-border: 359 100% 43% / 0.32;
-  /* ✦ Theme/Badges/Surface/error/border/Harness Open Source/Light */
-  --figma___badges-surface-error-text: 358 100% 37% / 0.84;
-  /* ✦ Theme/Badges/Surface/error/text/Harness Open Source/Light */
-  --figma___badges-surface-info-background: 192 100% 50% / 0.11;
-  /* ✦ Theme/Badges/Surface/info/background/Harness Open Source/Light */
-  --figma___badges-surface-info-border: 194 100% 38% / 0.49;
-  /* ✦ Theme/Badges/Surface/info/border/Harness Open Source/Light */
-  --figma___badges-surface-info-text: 200 100% 25% / 0.86;
-  /* ✦ Theme/Badges/Surface/info/text/Harness Open Source/Light */
-  --figma___badges-surface-success-background: 139 98% 37% / 0.09;
-  /* ✦ Theme/Badges/Surface/success/background/Harness Open Source/Light */
-  --figma___badges-surface-success-border: 146 100% 27% / 0.43;
-  /* ✦ Theme/Badges/Surface/success/border/Harness Open Source/Light */
-  --figma___badges-surface-success-text: 153 100% 21% / 0.91;
-  /* ✦ Theme/Badges/Surface/success/text/Harness Open Source/Light */
-  --figma___badges-surface-warning-background: 40 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/warning/background/Harness Open Source/Light */
-  --figma___badges-surface-warning-border: 37 100% 40% / 0.53;
-  /* ✦ Theme/Badges/Surface/warning/border/Harness Open Source/Light */
-  --figma___badges-surface-warning-text: 25 100% 24% / 0.81;
-  /* ✦ Theme/Badges/Surface/warning/text/Harness Open Source/Light */
-  --figma___border-disabled: 240 93% 11% / 0.08;
-  /* ✦ Theme/Border/Disabled/Harness Open Source/Light */
-  --figma___border-hover: 212 6% 50% / 1;
-  /* ✦ Theme/Border/Hover/Harness Open Source/Light */
-  --figma___border-primary: 240 7% 94% / 1;
-  /* ✦ Theme/Border/Primary/Harness Open Source/Light */
-  --figma___border-secondary: 210 7% 94% / 1;
-  /* ✦ Theme/Border/Secondary/Harness Open Source/Light */
-  --figma___border-selected: 216 6% 15% / 1;
-  /* ✦ Theme/Border/Selected/Harness Open Source/Light */
-  --figma___breadcrumbs-current: 200 7% 8% / 1;
-  /* ✦ Theme/Breadcrumbs/current/Harness Open Source/Light */
-  --figma___breadcrumbs-visited: 200 5% 12% / 1;
-  /* ✦ Theme/Breadcrumbs/visited/Harness Open Source/Light */
-  --figma___button-ghost-accent-active: 165 100% 42% / 0.2;
-  /* ✦ Theme/Button/Ghost/Accent/Active/Harness Open Source/Light */
-  --figma___button-ghost-accent-active-text: 172 50% 31% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Active text/Harness Open Source/Light */
-  --figma___button-ghost-accent-hover: 164 99% 44% / 0.13;
-  /* ✦ Theme/Button/Ghost/Accent/Hover/Harness Open Source/Light */
-  --figma___button-ghost-accent-hover-text: 172 50% 31% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Hover text/Harness Open Source/Light */
-  --figma___button-ghost-accent-text-disabled: 168 45% 53% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/Harness Open Source/Light */
-  --figma___button-ghost-accent-text-primary: 172 50% 31% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Text-primary/Harness Open Source/Light */
-  --figma___button-ghost-error-active: 0 100% 50% / 0.1;
-  /* ✦ Theme/Button/Ghost/Error/Active/Harness Open Source/Light */
-  --figma___button-ghost-error-active-text: 358 65% 47% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Active Text/Harness Open Source/Light */
-  --figma___button-ghost-error-hover: 0 100% 50% / 0.06;
-  /* ✦ Theme/Button/Ghost/Error/Hover/Harness Open Source/Light */
-  --figma___button-ghost-error-hover-text: 358 65% 47% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Hover text/Harness Open Source/Light */
-  --figma___button-ghost-error-text-disabled: 359 69% 74% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Text-disabled/Harness Open Source/Light */
-  --figma___button-ghost-error-text-primary: 358 65% 47% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Text-primary/Harness Open Source/Light */
-  --figma___button-ghost-neutral-active: 240 93% 11% / 0.08;
-  /* ✦ Theme/Button/Ghost/Neutral/Active/Harness Open Source/Light */
-  --figma___button-ghost-neutral-active-text: 220 6% 40% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Active Text/Harness Open Source/Light */
-  --figma___button-ghost-neutral-hover: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover/Harness Open Source/Light */
-  --figma___button-ghost-neutral-hover-text: 220 6% 40% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover text/Harness Open Source/Light */
-  --figma___button-ghost-neutral-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/Harness Open Source/Light */
-  --figma___button-ghost-neutral-text-primary: 200 7% 8% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/Harness Open Source/Light */
-  --figma___button-ghost-success-active: 139 99% 33% / 0.13;
-  /* ✦ Theme/Button/Ghost/Success/Active/Harness Open Source/Light */
-  --figma___button-ghost-success-active-text: 153 67% 28% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Active Text/Harness Open Source/Light */
-  --figma___button-ghost-success-hover: 139 98% 37% / 0.09;
-  /* ✦ Theme/Button/Ghost/Success/Hover/Harness Open Source/Light */
-  --figma___button-ghost-success-hover-text: 153 67% 28% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Hover text/Harness Open Source/Light */
-  --figma___button-ghost-success-text-disabled: 151 100% 29% / 0.64;
-  /* ✦ Theme/Button/Ghost/Success/Text-disabled/Harness Open Source/Light */
-  --figma___button-ghost-success-text-primary: 153 67% 28% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Text-primary/Harness Open Source/Light */
-  --figma___button-outline-accent-active: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Outline/Accent/Active/Harness Open Source/Light */
-  --figma___button-outline-accent-default-border: 200 7% 8% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Default border/Harness Open Source/Light */
-  --figma___button-outline-accent-disabled-border: 233 96% 9% / 0.17;
-  /* ✦ Theme/Button/Outline/Accent/Disabled Border/Harness Open Source/Light */
-  --figma___button-outline-accent-hover: 240 89% 18% / 0.02;
-  /* ✦ Theme/Button/Outline/Accent/Hover/Harness Open Source/Light */
-  --figma___button-outline-accent-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Text-disabled/Harness Open Source/Light */
-  --figma___button-outline-accent-text-primary: 210 6% 6% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Text-primary/Harness Open Source/Light */
-  --figma___button-outline-error-active: 0 100% 71% / 0.1;
-  /* ✦ Theme/Button/Outline/Error/Active/Harness Open Source/Light */
-  --figma___button-outline-error-default-border: 0 100% 71% / 0.16;
-  /* ✦ Theme/Button/Outline/Error/Default - border/Harness Open Source/Light */
-  --figma___button-outline-error-disabled-border: 0 100% 71% / 0.1;
-  /* ✦ Theme/Button/Outline/Error/Disabled-border/Harness Open Source/Light */
-  --figma___button-outline-error-hover: 0 100% 71% / 0.1;
-  /* ✦ Theme/Button/Outline/Error/Hover/Harness Open Source/Light */
-  --figma___button-outline-error-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Outline/Error/Text-disabled/Harness Open Source/Light */
-  --figma___button-outline-error-text-primary: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Outline/Error/Text-primary/Harness Open Source/Light */
-  --figma___button-outline-neutral-active: 240 96% 9% / 0.13;
-  /* ✦ Theme/Button/Outline/Neutral/Active/Harness Open Source/Light */
-  --figma___button-outline-neutral-default-border: 233 96% 9% / 0.17;
-  /* ✦ Theme/Button/Outline/Neutral/Default - border/Harness Open Source/Light */
-  --figma___button-outline-neutral-disabled-border: 230 100% 9% / 0.28;
-  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/Harness Open Source/Light */
-  --figma___button-outline-neutral-hover: 240 96% 9% / 0.13;
-  /* ✦ Theme/Button/Outline/Neutral/Hover/Harness Open Source/Light */
-  --figma___button-outline-neutral-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/Harness Open Source/Light */
-  --figma___button-outline-neutral-text-primary: 200 5% 12% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Text-primary/Harness Open Source/Light */
-  --figma___button-outline-success-active: 139 98% 37% / 0.09;
-  /* ✦ Theme/Button/Outline/Success/Active/Harness Open Source/Light */
-  --figma___button-outline-success-default-border: 146 100% 27% / 0.43;
-  /* ✦ Theme/Button/Outline/Success/Default-border/Harness Open Source/Light */
-  --figma___button-outline-success-disabled-border: 233 96% 9% / 0.17;
-  /* ✦ Theme/Button/Outline/Success/Disabled - border/Harness Open Source/Light */
-  --figma___button-outline-success-hover: 139 98% 37% / 0.09;
-  /* ✦ Theme/Button/Outline/Success/Hover/Harness Open Source/Light */
-  --figma___button-outline-success-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Outline/Success/Text-disabled/Harness Open Source/Light */
-  --figma___button-outline-success-text-primary: 153 100% 21% / 0.91;
-  /* ✦ Theme/Button/Outline/Success/Text-primary/Harness Open Source/Light */
-  --figma___button-soft-accent-active: 0 0% 0% / 0.13;
-  /* ✦ Theme/Button/Soft/Accent/Active/Harness Open Source/Light */
-  --figma___button-soft-accent-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Soft/Accent/Disabled/Harness Open Source/Light */
-  --figma___button-soft-accent-hover: 240 93% 11% / 0.08;
-  /* ✦ Theme/Button/Soft/Accent/Hover/Harness Open Source/Light */
-  --figma___button-soft-accent-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Text-disabled/Harness Open Source/Light */
-  --figma___button-soft-accent-text-primary: 210 6% 6% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Text-primary/Harness Open Source/Light */
-  --figma___button-soft-accent-default: 230 100% 9% / 0.28;
-  /* ✦ Theme/Button/Soft/Accent/default/Harness Open Source/Light */
-  --figma___button-soft-error-active: 0 100% 71% / 0.1;
-  /* ✦ Theme/Button/Soft/Error/Active/Harness Open Source/Light */
-  --figma___button-soft-error-disabled: 0 100% 71% / 0.1;
-  /* ✦ Theme/Button/Soft/Error/Disabled/Harness Open Source/Light */
-  --figma___button-soft-error-hover: 0 100% 71% / 0.16;
-  /* ✦ Theme/Button/Soft/Error/Hover/Harness Open Source/Light */
-  --figma___button-soft-error-text-disabled: 359 74% 82% / 1;
-  /* ✦ Theme/Button/Soft/Error/Text-disabled/Harness Open Source/Light */
-  --figma___button-soft-error-text-primary: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Soft/Error/Text-primary/Harness Open Source/Light */
-  --figma___button-soft-error-default: 0 100% 71% / 0.1;
-  /* ✦ Theme/Button/Soft/Error/default/Harness Open Source/Light */
-  --figma___button-soft-neutral-active: 240 100% 9% / 0.11;
-  /* ✦ Theme/Button/Soft/Neutral/Active/Harness Open Source/Light */
-  --figma___button-soft-neutral-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Soft/Neutral/Disabled/Harness Open Source/Light */
-  --figma___button-soft-neutral-hover: 240 93% 11% / 0.08;
-  /* ✦ Theme/Button/Soft/Neutral/Hover/Harness Open Source/Light */
-  --figma___button-soft-neutral-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/Harness Open Source/Light */
-  --figma___button-soft-neutral-text-primary: 200 5% 12% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Text-primary/Harness Open Source/Light */
-  --figma___button-soft-neutral-default: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Soft/Neutral/default/Harness Open Source/Light */
-  --figma___button-soft-success-active: 141 100% 30% / 0.2;
-  /* ✦ Theme/Button/Soft/Success/Active/Harness Open Source/Light */
-  --figma___button-soft-success-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Soft/Success/Disabled/Harness Open Source/Light */
-  --figma___button-soft-success-hover: 139 99% 33% / 0.13;
-  /* ✦ Theme/Button/Soft/Success/Hover/Harness Open Source/Light */
-  --figma___button-soft-success-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Soft/Success/Text-disabled/Harness Open Source/Light */
-  --figma___button-soft-success-text-primary: 153 67% 28% / 1;
-  /* ✦ Theme/Button/Soft/Success/Text-primary/Harness Open Source/Light */
-  --figma___button-soft-success-default: 139 98% 37% / 0.09;
-  /* ✦ Theme/Button/Soft/Success/default/Harness Open Source/Light */
-  --figma___button-solid-accent-active: 200 7% 8% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Active/Harness Open Source/Light */
-  --figma___button-solid-accent-disabled: 200 6% 10% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Disabled/Harness Open Source/Light */
-  --figma___button-solid-accent-hover: 216 6% 15% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Hover/Harness Open Source/Light */
-  --figma___button-solid-accent-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Text-disabled/Harness Open Source/Light */
-  --figma___button-solid-accent-text-primary: 0 0% 100% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Text-primary/Harness Open Source/Light */
-  --figma___button-solid-accent-default: 240 13% 3% / 1;
-  /* ✦ Theme/Button/Solid/Accent/default/Harness Open Source/Light */
-  --figma___button-solid-error-active: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Solid/Error/Active/Harness Open Source/Light */
-  --figma___button-solid-error-disabled: 0 100% 71% / 0.1;
-  /* ✦ Theme/Button/Solid/Error/Disabled/Harness Open Source/Light */
-  --figma___button-solid-error-hover: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Solid/Error/Hover/Harness Open Source/Light */
-  --figma___button-solid-error-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Solid/Error/Text-disabled/Harness Open Source/Light */
-  --figma___button-solid-error-default: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Solid/Error/default/Harness Open Source/Light */
-  --figma___button-solid-neutral-active: 210 6% 20% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Active/Harness Open Source/Light */
-  --figma___button-solid-neutral-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Solid/Neutral/Disabled/Harness Open Source/Light */
-  --figma___button-solid-neutral-hover: 210 6% 20% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Hover/Harness Open Source/Light */
-  --figma___button-solid-neutral-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/Harness Open Source/Light */
-  --figma___button-solid-neutral-default: 210 6% 20% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/default/Harness Open Source/Light */
-  --figma___button-solid-success-active: 142 72% 29% / 1;
-  /* ✦ Theme/Button/Solid/Success/Active/Harness Open Source/Light */
-  --figma___button-solid-success-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Solid/Success/Disabled/Harness Open Source/Light */
-  --figma___button-solid-success-hover: 152 57% 38% / 1;
-  /* ✦ Theme/Button/Solid/Success/Hover/Harness Open Source/Light */
-  --figma___button-solid-success-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Solid/Success/Text-disabled/Harness Open Source/Light */
-  --figma___button-solid-success-default: 142 72% 29% / 1;
-  /* ✦ Theme/Button/Solid/Success/default/Harness Open Source/Light */
-  --figma___button-surface-accent-active: 0 0% 100% / 0.13;
-  /* ✦ Theme/Button/Surface/Accent/Active/Harness Open Source/Light */
-  --figma___button-surface-accent-active-border: 0 0% 100% / 0.31;
-  /* ✦ Theme/Button/Surface/Accent/Active border/Harness Open Source/Light */
-  --figma___button-surface-accent-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Surface/Accent/Disabled/Harness Open Source/Light */
-  --figma___button-surface-accent-hover: 0 0% 100% / 0.1;
-  /* ✦ Theme/Button/Surface/Accent/Hover/Harness Open Source/Light */
-  --figma___button-surface-accent-hover-border: 0 0% 100% / 0.31;
-  /* ✦ Theme/Button/Surface/Accent/Hover Border/Harness Open Source/Light */
-  --figma___button-surface-accent-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Text-disabled/Harness Open Source/Light */
-  --figma___button-surface-accent-text-primary: 200 7% 8% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Text-primary/Harness Open Source/Light */
-  --figma___button-surface-accent-default: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Surface/Accent/default/Harness Open Source/Light */
-  --figma___button-surface-accent-default-border: 0 0% 100% / 0.22;
-  /* ✦ Theme/Button/Surface/Accent/default border/Harness Open Source/Light */
-  --figma___button-surface-error-active: 0 100% 71% / 0.1;
-  /* ✦ Theme/Button/Surface/Error/Active/Harness Open Source/Light */
-  --figma___button-surface-error-active-border: 0 100% 71% / 0.16;
-  /* ✦ Theme/Button/Surface/Error/Active border/Harness Open Source/Light */
-  --figma___button-surface-error-disabled: 0 100% 50% / 0.06;
-  /* ✦ Theme/Button/Surface/Error/Disabled/Harness Open Source/Light */
-  --figma___button-surface-error-hover: 0 100% 71% / 0.16;
-  /* ✦ Theme/Button/Surface/Error/Hover/Harness Open Source/Light */
-  --figma___button-surface-error-hover-border: 0 100% 71% / 0.16;
-  /* ✦ Theme/Button/Surface/Error/Hover border/Harness Open Source/Light */
-  --figma___button-surface-error-text-disabled: 359 74% 82% / 1;
-  /* ✦ Theme/Button/Surface/Error/Text-disabled/Harness Open Source/Light */
-  --figma___button-surface-error-text-primary: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Surface/Error/Text-primary/Harness Open Source/Light */
-  --figma___button-surface-error-border: 0 100% 71% / 0.1;
-  /* ✦ Theme/Button/Surface/Error/border/Harness Open Source/Light */
-  --figma___button-surface-error-default: 0 100% 71% / 0.1;
-  /* ✦ Theme/Button/Surface/Error/default/Harness Open Source/Light */
-  --figma___button-surface-neutral-active: 240 100% 9% / 0.11;
-  /* ✦ Theme/Button/Surface/Neutral/Active/Harness Open Source/Light */
-  --figma___button-surface-neutral-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Surface/Neutral/Disabled/Harness Open Source/Light */
-  --figma___button-surface-neutral-hover: 240 93% 11% / 0.08;
-  /* ✦ Theme/Button/Surface/Neutral/Hover/Harness Open Source/Light */
-  --figma___button-surface-neutral-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/Harness Open Source/Light */
-  --figma___button-surface-neutral-text-primary: 0 0% 39% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Text-primary/Harness Open Source/Light */
-  --figma___button-surface-neutral-border: 233 96% 9% / 0.17;
-  /* ✦ Theme/Button/Surface/Neutral/border/Harness Open Source/Light */
-  --figma___button-surface-neutral-default: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Surface/Neutral/default/Harness Open Source/Light */
-  --figma___button-surface-success-active: 141 100% 30% / 0.2;
-  /* ✦ Theme/Button/Surface/Success/Active/Harness Open Source/Light */
-  --figma___button-surface-success-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Surface/Success/Disabled/Harness Open Source/Light */
-  --figma___button-surface-success-hover: 139 99% 33% / 0.13;
-  /* ✦ Theme/Button/Surface/Success/Hover/Harness Open Source/Light */
-  --figma___button-surface-success-hover-border: 151 100% 29% / 0.64;
-  /* ✦ Theme/Button/Surface/Success/Hover border/Harness Open Source/Light */
-  --figma___button-surface-success-text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Surface/Success/Text-disabled/Harness Open Source/Light */
-  --figma___button-surface-success-text-primary: 153 100% 21% / 0.91;
-  /* ✦ Theme/Button/Surface/Success/Text-primary/Harness Open Source/Light */
-  --figma___button-surface-success-active-border: 151 100% 29% / 0.64;
-  /* ✦ Theme/Button/Surface/Success/active border/Harness Open Source/Light */
-  --figma___button-surface-success-default: 139 98% 37% / 0.09;
-  /* ✦ Theme/Button/Surface/Success/default/Harness Open Source/Light */
-  --figma___button-surface-success-default-border: 142 99% 29% / 0.29;
-  /* ✦ Theme/Button/Surface/Success/default border/Harness Open Source/Light */
-  --figma___calendar-background: 0 0% 100% / 1;
-  /* ✦ Theme/Calendar/Background/Harness Open Source/Light */
-  --figma___calendar-selected-date-background: 200 7% 8% / 1;
-  /* ✦ Theme/Calendar/Selected Date/Background/Harness Open Source/Light */
-  --figma___calendar-selected-range-background: 210 6% 60% / 1;
-  /* ✦ Theme/Calendar/Selected Range/Background/Harness Open Source/Light */
-  --figma___calendar-selected-range-text: 200 5% 12% / 1;
-  /* ✦ Theme/Calendar/Selected Range/Text/Harness Open Source/Light */
-  --figma___checkbox-background: 0 0% 100% / 1;
-  /* ✦ Theme/Checkbox/Background/Harness Open Source/Light */
-  --figma___checkbox-paper: 0 0% 100% / 0.5;
-  /* ✦ Theme/Checkbox/Paper/Harness Open Source/Light */
-  --figma___checkbox-surface-checked-active-active: 210 6% 20% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/Harness Open Source/Light */
-  --figma___checkbox-surface-checked-active-hover: 210 6% 20% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/Harness Open Source/Light */
-  --figma___checkbox-surface-checked-active-default-background: 216 6% 15% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/Harness Open Source/Light */
-  --figma___checkbox-surface-checked-disabled-check: 210 6% 20% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/Harness Open Source/Light */
-  --figma___checkbox-surface-checked-disabled-disabled: 210 6% 40% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/Harness Open Source/Light */
-  --figma___checkbox-surface-checked-disabled-border: 207 6% 30% / 0;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/Harness Open Source/Light */
-  --figma___checkbox-surface-intermediate-active-active-border: 200 6% 10% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/Harness Open Source/Light */
-  --figma___checkbox-surface-intermediate-active-hover-border: 200 6% 10% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/Harness Open Source/Light */
-  --figma___checkbox-surface-intermediate-active-default-background: 164 99% 44% / 0;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/Harness Open Source/Light */
-  --figma___checkbox-surface-intermediate-active-default-border: 216 6% 15% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/Harness Open Source/Light */
-  --figma___checkbox-surface-intermediate-disabled-check: 210 6% 20% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/Harness Open Source/Light */
-  --figma___checkbox-surface-intermediate-disabled-disabled: 0 0% 0% / 0;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/Harness Open Source/Light */
-  --figma___checkbox-surface-intermediate-disabled-border: 210 6% 20% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/Harness Open Source/Light */
-  --figma___checkbox-surface-unchecked-active-active-border: 200 6% 10% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/Harness Open Source/Light */
-  --figma___checkbox-surface-unchecked-active-hover-border: 200 6% 10% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/Harness Open Source/Light */
-  --figma___checkbox-surface-unchecked-active-default-background: 0 0% 98% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/Harness Open Source/Light */
-  --figma___checkbox-surface-unchecked-active-default-border: 216 6% 15% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/Harness Open Source/Light */
-  --figma___checkbox-surface-unchecked-disabled-disabled: 210 6% 60% / 0;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/Harness Open Source/Light */
-  --figma___checkbox-surface-unchecked-disabled-border: 210 6% 20% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/Harness Open Source/Light */
-  --figma___checkbox-border: 240 100% 12% / 0.05;
-  /* ✦ Theme/Checkbox/border/Harness Open Source/Light */
-  --figma___default-colors-black: 210 13% 3% / 1;
-  /* ✦ Theme/Default colors/black/Harness Open Source/Light */
-  --figma___default-colors-dark-to-white: 240 13% 3% / 1;
-  /* ✦ Theme/Default colors/dark-to-white/Harness Open Source/Light */
-  --figma___default-colors-white: 0 0% 100% / 1;
-  /* ✦ Theme/Default colors/white/Harness Open Source/Light */
-  --figma___default-colors-white-to-dark: 0 0% 100% / 1;
-  /* ✦ Theme/Default colors/white-to-dark/Harness Open Source/Light */
-  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
-  /* ✦ Theme/Dropdown/Dropdown Item/Default/Harness Open Source/Light */
-  --figma___dropdown-dropdown-item-hover: 220 6% 90% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Hover/Harness Open Source/Light */
-  --figma___dropdown-dropdown-item-selected: 220 6% 90% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Selected/Harness Open Source/Light */
-  --figma___dropdown-text-shortcut-text-selected: 210 6% 20% / 1;
-  /* ✦ Theme/Dropdown/Text/Shortcut text selected/Harness Open Source/Light */
-  --figma___dropdown-text-text-selected: 200 7% 8% / 1;
-  /* ✦ Theme/Dropdown/Text/Text Selected/Harness Open Source/Light */
-  --figma___dropdown-text-hover: 200 5% 12% / 1;
-  /* ✦ Theme/Dropdown/Text/hover/Harness Open Source/Light */
-  --figma___dropdown-background: 0 0% 100% / 1;
-  /* ✦ Theme/Dropdown/background/Harness Open Source/Light */
-  --figma___dropdown-border: 240 7% 94% / 1;
-  /* ✦ Theme/Dropdown/border/Harness Open Source/Light */
-  --figma___dropdown-separator: 207 6% 70% / 1;
-  /* ✦ Theme/Dropdown/separator/Harness Open Source/Light */
-  --figma___filter-active: 210 6% 60% / 1;
-  /* ✦ Theme/Filter/Active/Harness Open Source/Light */
-  --figma___filter-default: 207 6% 70% / 1;
-  /* ✦ Theme/Filter/Default/Harness Open Source/Light */
-  --figma___filter-hover: 210 6% 60% / 1;
-  /* ✦ Theme/Filter/Hover/Harness Open Source/Light */
-  --figma___inline-alert-banner-customisable: 240 20% 98% / 1;
-  /* ✦ Theme/Inline Alert Banner/Customisable/Harness Open Source/Light */
-  --figma___inline-alert-banner-error: 0 100% 50% / 0.06;
-  /* ✦ Theme/Inline Alert Banner/Error/Harness Open Source/Light */
-  --figma___inline-alert-banner-info: 210 100% 96% / 1;
-  /* ✦ Theme/Inline Alert Banner/Info/Harness Open Source/Light */
-  --figma___inline-alert-banner-reminder: 40 100% 96% / 1;
-  /* ✦ Theme/Inline Alert Banner/Reminder/Harness Open Source/Light */
-  --figma___inline-alert-banner-success: 139 57% 95% / 1;
-  /* ✦ Theme/Inline Alert Banner/Success/Harness Open Source/Light */
-  --figma___inline-alert-banner-warning: 34 100% 92% / 1;
-  /* ✦ Theme/Inline Alert Banner/Warning/Harness Open Source/Light */
-  --figma___modal-background: 0 0% 100% / 1;
-  /* ✦ Theme/Modal/Background/Harness Open Source/Light */
-  --figma___modal-paper: 0 0% 100% / 0.5;
-  /* ✦ Theme/Modal/Paper/Harness Open Source/Light */
-  --figma___modal-border: 240 100% 12% / 0.05;
-  /* ✦ Theme/Modal/border/Harness Open Source/Light */
-  --figma___neutral-color-gray-1: 0 0% 98% / 1;
-  /* ✦ Theme/Neutral color/Gray/1/Harness Open Source/Light */
-  --figma___neutral-color-gray-2: 210 7% 94% / 1;
-  /* ✦ Theme/Neutral color/Gray/2/Harness Open Source/Light */
-  --figma___neutral-color-gray-3: 220 6% 90% / 1;
-  /* ✦ Theme/Neutral color/Gray/3/Harness Open Source/Light */
-  --figma___neutral-color-gray-4: 240 6% 80% / 1;
-  /* ✦ Theme/Neutral color/Gray/4/Harness Open Source/Light */
-  --figma___neutral-color-gray-5: 207 6% 70% / 1;
-  /* ✦ Theme/Neutral color/Gray/5/Harness Open Source/Light */
-  --figma___neutral-color-gray-6: 210 6% 60% / 1;
-  /* ✦ Theme/Neutral color/Gray/6/Harness Open Source/Light */
-  --figma___neutral-color-gray-7: 212 6% 50% / 1;
-  /* ✦ Theme/Neutral color/Gray/7/Harness Open Source/Light */
-  --figma___neutral-color-gray-8: 210 6% 40% / 1;
-  /* ✦ Theme/Neutral color/Gray/8/Harness Open Source/Light */
-  --figma___neutral-color-gray-9: 210 6% 20% / 1;
-  /* ✦ Theme/Neutral color/Gray/9/Harness Open Source/Light */
-  --figma___neutral-color-gray-10: 216 6% 15% / 1;
-  /* ✦ Theme/Neutral color/Gray/10/Harness Open Source/Light */
-  --figma___neutral-color-gray-alpha-1: 240 89% 18% / 0.01;
-  /* ✦ Theme/Neutral color/Gray Alpha/1/Harness Open Source/Light */
-  --figma___neutral-color-gray-alpha-2: 240 89% 18% / 0.02;
-  /* ✦ Theme/Neutral color/Gray Alpha/2/Harness Open Source/Light */
-  --figma___neutral-color-gray-alpha-3: 240 100% 12% / 0.05;
-  /* ✦ Theme/Neutral color/Gray Alpha/3/Harness Open Source/Light */
-  --figma___neutral-color-gray-alpha-4: 240 93% 11% / 0.08;
-  /* ✦ Theme/Neutral color/Gray Alpha/4/Harness Open Source/Light */
-  --figma___neutral-color-gray-alpha-5: 240 100% 9% / 0.11;
-  /* ✦ Theme/Neutral color/Gray Alpha/5/Harness Open Source/Light */
-  --figma___neutral-color-gray-alpha-6: 240 96% 9% / 0.13;
-  /* ✦ Theme/Neutral color/Gray Alpha/6/Harness Open Source/Light */
-  --figma___neutral-color-gray-alpha-7: 233 96% 9% / 0.17;
-  /* ✦ Theme/Neutral color/Gray Alpha/7/Harness Open Source/Light */
-  --figma___neutral-color-gray-alpha-8: 230 100% 9% / 0.28;
-  /* ✦ Theme/Neutral color/Gray Alpha/8/Harness Open Source/Light */
-  --figma___neutral-color-gray-alpha-9: 232 100% 6% / 0.46;
-  /* ✦ Theme/Neutral color/Gray Alpha/9/Harness Open Source/Light */
-  --figma___neutral-color-gray-alpha-10: 230 100% 5% / 0.51;
-  /* ✦ Theme/Neutral color/Gray Alpha/10/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-1: 270 50% 99% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/1/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-2: 252 100% 99% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/2/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-3: 254 100% 97% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/3/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-4: 251 91% 95% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/4/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-5: 252 83% 93% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/5/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-6: 251 78% 89% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/6/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-7: 252 56% 57% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/7/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-8: 251 48% 53% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/8/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-9: 250 43% 48% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/9/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-10: 249 43% 26% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/10/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-alpha-1: 270 94% 35% / 0.01;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/1/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-alpha-2: 252 100% 51% / 0.02;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/2/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-alpha-3: 254 100% 50% / 0.05;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/3/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-alpha-4: 251 98% 48% / 0.09;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/4/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-alpha-5: 252 99% 46% / 0.13;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/5/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-alpha-6: 251 99% 44% / 0.19;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/6/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-alpha-7: 252 100% 36% / 0.66;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/7/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-alpha-8: 251 100% 32% / 0.69;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/8/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-alpha-9: 250 100% 28% / 0.73;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/9/Harness Open Source/Light */
-  --figma___other-colors-ai-violet-alpha-10: 249 100% 13% / 0.85;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/10/Harness Open Source/Light */
-  --figma___other-colors-blue-1: 210 100% 99% / 1;
-  /* ✦ Theme/Other Colors/Blue/1/Harness Open Source/Light */
-  --figma___other-colors-blue-2: 210 100% 98% / 1;
-  /* ✦ Theme/Other Colors/Blue/2/Harness Open Source/Light */
-  --figma___other-colors-blue-3: 210 100% 96% / 1;
-  /* ✦ Theme/Other Colors/Blue/3/Harness Open Source/Light */
-  --figma___other-colors-blue-4: 210 100% 94% / 1;
-  /* ✦ Theme/Other Colors/Blue/4/Harness Open Source/Light */
-  --figma___other-colors-blue-5: 209 96% 90% / 1;
-  /* ✦ Theme/Other Colors/Blue/5/Harness Open Source/Light */
-  --figma___other-colors-blue-6: 209 82% 85% / 1;
-  /* ✦ Theme/Other Colors/Blue/6/Harness Open Source/Light */
-  --figma___other-colors-blue-7: 214 73% 51% / 1;
-  /* ✦ Theme/Other Colors/Blue/7/Harness Open Source/Light */
-  --figma___other-colors-blue-8: 208 93% 47% / 1;
-  /* ✦ Theme/Other Colors/Blue/8/Harness Open Source/Light */
-  --figma___other-colors-blue-9: 211 90% 42% / 1;
-  /* ✦ Theme/Other Colors/Blue/9/Harness Open Source/Light */
-  --figma___other-colors-blue-10: 216 71% 23% / 1;
-  /* ✦ Theme/Other Colors/Blue/10/Harness Open Source/Light */
-  --figma___other-colors-blue-alpha-1: 210 100% 51% / 0.02;
-  /* ✦ Theme/Other Colors/Blue Alpha/1/Harness Open Source/Light */
-  --figma___other-colors-blue-alpha-2: 210 100% 51% / 0.04;
-  /* ✦ Theme/Other Colors/Blue Alpha/2/Harness Open Source/Light */
-  --figma___other-colors-blue-alpha-3: 210 100% 50% / 0.07;
-  /* ✦ Theme/Other Colors/Blue Alpha/3/Harness Open Source/Light */
-  --figma___other-colors-blue-alpha-4: 210 99% 49% / 0.19;
-  /* ✦ Theme/Other Colors/Blue Alpha/4/Harness Open Source/Light */
-  --figma___other-colors-blue-alpha-5: 209 99% 45% / 0.28;
-  /* ✦ Theme/Other Colors/Blue Alpha/5/Harness Open Source/Light */
-  --figma___other-colors-blue-alpha-6: 209 99% 45% / 0.28;
-  /* ✦ Theme/Other Colors/Blue Alpha/6/Harness Open Source/Light */
-  --figma___other-colors-blue-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/7/Harness Open Source/Light */
-  --figma___other-colors-blue-alpha-8: 208 100% 46% / 0.97;
-  /* ✦ Theme/Other Colors/Blue Alpha/8/Harness Open Source/Light */
-  --figma___other-colors-blue-alpha-9: 211 100% 39% / 0.96;
-  /* ✦ Theme/Other Colors/Blue Alpha/9/Harness Open Source/Light */
-  --figma___other-colors-blue-alpha-10: 216 100% 17% / 0.93;
-  /* ✦ Theme/Other Colors/Blue Alpha/10/Harness Open Source/Light */
-  --figma___other-colors-indigo-1: 240 33% 99% / 1;
-  /* ✦ Theme/Other Colors/Indigo/1/Harness Open Source/Light */
-  --figma___other-colors-indigo-2: 223 100% 99% / 1;
-  /* ✦ Theme/Other Colors/Indigo/2/Harness Open Source/Light */
-  --figma___other-colors-indigo-3: 224 100% 97% / 1;
-  /* ✦ Theme/Other Colors/Indigo/3/Harness Open Source/Light */
-  --figma___other-colors-indigo-4: 222 92% 95% / 1;
-  /* ✦ Theme/Other Colors/Indigo/4/Harness Open Source/Light */
-  --figma___other-colors-indigo-5: 225 85% 92% / 1;
-  /* ✦ Theme/Other Colors/Indigo/5/Harness Open Source/Light */
-  --figma___other-colors-indigo-6: 224 81% 88% / 1;
-  /* ✦ Theme/Other Colors/Indigo/6/Harness Open Source/Light */
-  --figma___other-colors-indigo-7: 226 70% 55% / 1;
-  /* ✦ Theme/Other Colors/Indigo/7/Harness Open Source/Light */
-  --figma___other-colors-indigo-8: 226 59% 51% / 1;
-  /* ✦ Theme/Other Colors/Indigo/8/Harness Open Source/Light */
-  --figma___other-colors-indigo-9: 226 55% 45% / 1;
-  /* ✦ Theme/Other Colors/Indigo/9/Harness Open Source/Light */
-  --figma___other-colors-indigo-10: 226 63% 17% / 1;
-  /* ✦ Theme/Other Colors/Indigo/10/Harness Open Source/Light */
-  --figma___other-colors-indigo-alpha-1: 240 93% 26% / 0.01;
-  /* ✦ Theme/Other Colors/Indigo Alpha/1/Harness Open Source/Light */
-  --figma___other-colors-indigo-alpha-2: 223 100% 51% / 0.03;
-  /* ✦ Theme/Other Colors/Indigo Alpha/2/Harness Open Source/Light */
-  --figma___other-colors-indigo-alpha-3: 224 100% 50% / 0.06;
-  /* ✦ Theme/Other Colors/Indigo Alpha/3/Harness Open Source/Light */
-  --figma___other-colors-indigo-alpha-4: 222 98% 48% / 0.1;
-  /* ✦ Theme/Other Colors/Indigo Alpha/4/Harness Open Source/Light */
-  --figma___other-colors-indigo-alpha-5: 225 98% 46% / 0.15;
-  /* ✦ Theme/Other Colors/Indigo Alpha/5/Harness Open Source/Light */
-  --figma___other-colors-indigo-alpha-6: 224 99% 45% / 0.22;
-  /* ✦ Theme/Other Colors/Indigo Alpha/6/Harness Open Source/Light */
-  --figma___other-colors-indigo-alpha-7: 226 100% 41% / 0.76;
-  /* ✦ Theme/Other Colors/Indigo Alpha/7/Harness Open Source/Light */
-  --figma___other-colors-indigo-alpha-8: 226 100% 37% / 0.77;
-  /* ✦ Theme/Other Colors/Indigo Alpha/8/Harness Open Source/Light */
-  --figma___other-colors-indigo-alpha-9: 226 100% 31% / 0.8;
-  /* ✦ Theme/Other Colors/Indigo Alpha/9/Harness Open Source/Light */
-  --figma___other-colors-indigo-alpha-10: 225 100% 14% / 0.88;
-  /* ✦ Theme/Other Colors/Indigo Alpha/10/Harness Open Source/Light */
-  --figma___other-colors-mint-1: 168 71% 99% / 1;
-  /* ✦ Theme/Other Colors/Mint/1/Harness Open Source/Light */
-  --figma___other-colors-mint-2: 164 88% 97% / 1;
-  /* ✦ Theme/Other Colors/Mint/2/Harness Open Source/Light */
-  --figma___other-colors-mint-3: 164 79% 93% / 1;
-  /* ✦ Theme/Other Colors/Mint/3/Harness Open Source/Light */
-  --figma___other-colors-mint-4: 165 73% 88% / 1;
-  /* ✦ Theme/Other Colors/Mint/4/Harness Open Source/Light */
-  --figma___other-colors-mint-5: 166 60% 83% / 1;
-  /* ✦ Theme/Other Colors/Mint/5/Harness Open Source/Light */
-  --figma___other-colors-mint-6: 166 50% 77% / 1;
-  /* ✦ Theme/Other Colors/Mint/6/Harness Open Source/Light */
-  --figma___other-colors-mint-7: 176 59% 50% / 1;
-  /* ✦ Theme/Other Colors/Mint/7/Harness Open Source/Light */
-  --figma___other-colors-mint-8: 176 59% 40% / 1;
-  /* ✦ Theme/Other Colors/Mint/8/Harness Open Source/Light */
-  --figma___other-colors-mint-9: 172 50% 31% / 1;
-  /* ✦ Theme/Other Colors/Mint/9/Harness Open Source/Light */
-  --figma___other-colors-mint-10: 171 51% 17% / 1;
-  /* ✦ Theme/Other Colors/Mint/10/Harness Open Source/Light */
-  --figma___other-colors-mint-alpha-1: 168 95% 43% / 0.02;
-  /* ✦ Theme/Other Colors/Mint Alpha/1/Harness Open Source/Light */
-  --figma___other-colors-mint-alpha-2: 164 99% 47% / 0.06;
-  /* ✦ Theme/Other Colors/Mint Alpha/2/Harness Open Source/Light */
-  --figma___other-colors-mint-alpha-3: 164 99% 44% / 0.13;
-  /* ✦ Theme/Other Colors/Mint Alpha/3/Harness Open Source/Light */
-  --figma___other-colors-mint-alpha-4: 165 100% 42% / 0.2;
-  /* ✦ Theme/Other Colors/Mint Alpha/4/Harness Open Source/Light */
-  --figma___other-colors-mint-alpha-5: 166 100% 38% / 0.27;
-  /* ✦ Theme/Other Colors/Mint Alpha/5/Harness Open Source/Light */
-  --figma___other-colors-mint-alpha-6: 166 99% 33% / 0.35;
-  /* ✦ Theme/Other Colors/Mint Alpha/6/Harness Open Source/Light */
-  --figma___other-colors-mint-alpha-7: 167 100% 41% / 0.47;
-  /* ✦ Theme/Other Colors/Mint Alpha/7/Harness Open Source/Light */
-  --figma___other-colors-mint-alpha-8: 167 100% 38% / 0.5;
-  /* ✦ Theme/Other Colors/Mint Alpha/8/Harness Open Source/Light */
-  --figma___other-colors-mint-alpha-9: 172 100% 18% / 0.85;
-  /* ✦ Theme/Other Colors/Mint Alpha/9/Harness Open Source/Light */
-  --figma___other-colors-mint-alpha-10: 171 100% 10% / 0.91;
-  /* ✦ Theme/Other Colors/Mint Alpha/10/Harness Open Source/Light */
-  --figma___other-colors-orange-1: 20 60% 99% / 1;
-  /* ✦ Theme/Other Colors/Orange/1/Harness Open Source/Light */
-  --figma___other-colors-orange-2: 22 100% 98% / 1;
-  /* ✦ Theme/Other Colors/Orange/2/Harness Open Source/Light */
-  --figma___other-colors-orange-3: 34 100% 92% / 1;
-  /* ✦ Theme/Other Colors/Orange/3/Harness Open Source/Light */
-  --figma___other-colors-orange-4: 33 100% 87% / 1;
-  /* ✦ Theme/Other Colors/Orange/4/Harness Open Source/Light */
-  --figma___other-colors-orange-5: 31 100% 82% / 1;
-  /* ✦ Theme/Other Colors/Orange/5/Harness Open Source/Light */
-  --figma___other-colors-orange-6: 27 100% 78% / 1;
-  /* ✦ Theme/Other Colors/Orange/6/Harness Open Source/Light */
-  --figma___other-colors-orange-7: 24 94% 50% / 1;
-  /* ✦ Theme/Other Colors/Orange/7/Harness Open Source/Light */
-  --figma___other-colors-orange-8: 24 100% 46% / 1;
-  /* ✦ Theme/Other Colors/Orange/8/Harness Open Source/Light */
-  --figma___other-colors-orange-9: 16 45% 41% / 1;
-  /* ✦ Theme/Other Colors/Orange/9/Harness Open Source/Light */
-  --figma___other-colors-orange-10: 16 50% 23% / 1;
-  /* ✦ Theme/Other Colors/Orange/10/Harness Open Source/Light */
-  --figma___other-colors-orange-alpha-1: 20 95% 39% / 0.02;
-  /* ✦ Theme/Other Colors/Orange Alpha/1/Harness Open Source/Light */
-  --figma___other-colors-orange-alpha-2: 22 100% 51% / 0.04;
-  /* ✦ Theme/Other Colors/Orange Alpha/2/Harness Open Source/Light */
-  --figma___other-colors-orange-alpha-3: 34 100% 50% / 0.17;
-  /* ✦ Theme/Other Colors/Orange Alpha/3/Harness Open Source/Light */
-  --figma___other-colors-orange-alpha-4: 33 100% 50% / 0.27;
-  /* ✦ Theme/Other Colors/Orange Alpha/4/Harness Open Source/Light */
-  --figma___other-colors-orange-alpha-5: 31 100% 50% / 0.36;
-  /* ✦ Theme/Other Colors/Orange Alpha/5/Harness Open Source/Light */
-  --figma___other-colors-orange-alpha-6: 27 100% 50% / 0.43;
-  /* ✦ Theme/Other Colors/Orange Alpha/6/Harness Open Source/Light */
-  --figma___other-colors-orange-alpha-7: 24 100% 48% / 0.97;
-  /* ✦ Theme/Other Colors/Orange Alpha/7/Harness Open Source/Light */
-  --figma___other-colors-orange-alpha-8: 24 100% 46% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/8/Harness Open Source/Light */
-  --figma___other-colors-orange-alpha-9: 16 100% 24% / 0.77;
-  /* ✦ Theme/Other Colors/Orange Alpha/9/Harness Open Source/Light */
-  --figma___other-colors-orange-alpha-10: 16 100% 13% / 0.89;
-  /* ✦ Theme/Other Colors/Orange Alpha/10/Harness Open Source/Light */
-  --figma___other-colors-yellow-1: 60 50% 98% / 1;
-  /* ✦ Theme/Other Colors/Yellow/1/Harness Open Source/Light */
-  --figma___other-colors-yellow-2: 52 100% 94% / 1;
-  /* ✦ Theme/Other Colors/Yellow/2/Harness Open Source/Light */
-  --figma___other-colors-yellow-3: 53 100% 89% / 1;
-  /* ✦ Theme/Other Colors/Yellow/3/Harness Open Source/Light */
-  --figma___other-colors-yellow-4: 53 93% 84% / 1;
-  /* ✦ Theme/Other Colors/Yellow/4/Harness Open Source/Light */
-  --figma___other-colors-yellow-5: 52 85% 79% / 1;
-  /* ✦ Theme/Other Colors/Yellow/5/Harness Open Source/Light */
-  --figma___other-colors-yellow-6: 51 73% 72% / 1;
-  /* ✦ Theme/Other Colors/Yellow/6/Harness Open Source/Light */
-  --figma___other-colors-yellow-7: 53 96% 58% / 1;
-  /* ✦ Theme/Other Colors/Yellow/7/Harness Open Source/Light */
-  --figma___other-colors-yellow-8: 52 95% 52% / 1;
-  /* ✦ Theme/Other Colors/Yellow/8/Harness Open Source/Light */
-  --figma___other-colors-yellow-9: 42 50% 31% / 1;
-  /* ✦ Theme/Other Colors/Yellow/9/Harness Open Source/Light */
-  --figma___other-colors-yellow-10: 42 39% 20% / 1;
-  /* ✦ Theme/Other Colors/Yellow/10/Harness Open Source/Light */
-  --figma___other-colors-yellow-alpha-1: 60 50% 98% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/1/Harness Open Source/Light */
-  --figma___other-colors-yellow-alpha-2: 52 100% 94% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/2/Harness Open Source/Light */
-  --figma___other-colors-yellow-alpha-3: 53 100% 89% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/3/Harness Open Source/Light */
-  --figma___other-colors-yellow-alpha-4: 53 93% 84% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/4/Harness Open Source/Light */
-  --figma___other-colors-yellow-alpha-5: 52 85% 79% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/5/Harness Open Source/Light */
-  --figma___other-colors-yellow-alpha-6: 51 73% 72% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/6/Harness Open Source/Light */
-  --figma___other-colors-yellow-alpha-7: 53 96% 58% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/7/Harness Open Source/Light */
-  --figma___other-colors-yellow-alpha-8: 52 95% 52% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/8/Harness Open Source/Light */
-  --figma___other-colors-yellow-alpha-9: 42 50% 31% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/9/Harness Open Source/Light */
-  --figma___other-colors-yellow-alpha-10: 42 39% 20% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/10/Harness Open Source/Light */
-  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01;
-  /* ✦ Theme/Overlays/Black Alpha/1/Harness Open Source/Light */
-  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02;
-  /* ✦ Theme/Overlays/Black Alpha/2/Harness Open Source/Light */
-  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05;
-  /* ✦ Theme/Overlays/Black Alpha/3/Harness Open Source/Light */
-  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08;
-  /* ✦ Theme/Overlays/Black Alpha/4/Harness Open Source/Light */
-  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11;
-  /* ✦ Theme/Overlays/Black Alpha/5/Harness Open Source/Light */
-  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13;
-  /* ✦ Theme/Overlays/Black Alpha/6/Harness Open Source/Light */
-  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45;
-  /* ✦ Theme/Overlays/Black Alpha/7/Harness Open Source/Light */
-  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5;
-  /* ✦ Theme/Overlays/Black Alpha/8/Harness Open Source/Light */
-  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61;
-  /* ✦ Theme/Overlays/Black Alpha/9/Harness Open Source/Light */
-  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88;
-  /* ✦ Theme/Overlays/Black Alpha/10/Harness Open Source/Light */
-  --figma___overlays-white-alpha-1: 0 0% 100% / 0;
-  /* ✦ Theme/Overlays/White Alpha/1/Harness Open Source/Light */
-  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01;
-  /* ✦ Theme/Overlays/White Alpha/2/Harness Open Source/Light */
-  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07;
-  /* ✦ Theme/Overlays/White Alpha/3/Harness Open Source/Light */
-  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1;
-  /* ✦ Theme/Overlays/White Alpha/4/Harness Open Source/Light */
-  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13;
-  /* ✦ Theme/Overlays/White Alpha/5/Harness Open Source/Light */
-  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17;
-  /* ✦ Theme/Overlays/White Alpha/6/Harness Open Source/Light */
-  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37;
-  /* ✦ Theme/Overlays/White Alpha/7/Harness Open Source/Light */
-  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46;
-  /* ✦ Theme/Overlays/White Alpha/8/Harness Open Source/Light */
-  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66;
-  /* ✦ Theme/Overlays/White Alpha/9/Harness Open Source/Light */
-  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93;
-  /* ✦ Theme/Overlays/White Alpha/10/Harness Open Source/Light */
-  --figma___pagination-active-background: 207 6% 70% / 1;
-  /* ✦ Theme/Pagination/Active/Background/Harness Open Source/Light */
-  --figma___pagination-active-border: 210 6% 60% / 1;
-  /* ✦ Theme/Pagination/Active/Border/Harness Open Source/Light */
-  --figma___pagination-active-text: 200 7% 8% / 1;
-  /* ✦ Theme/Pagination/Active/Text/Harness Open Source/Light */
-  --figma___pagination-background: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Background/Harness Open Source/Light */
-  --figma___pagination-default-background: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Default/Background/Harness Open Source/Light */
-  --figma___pagination-default-border: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Default/Border/Harness Open Source/Light */
-  --figma___pagination-default-text: 200 7% 8% / 1;
-  /* ✦ Theme/Pagination/Default/Text/Harness Open Source/Light */
-  --figma___pagination-hover-background: 207 6% 70% / 1;
-  /* ✦ Theme/Pagination/Hover/Background/Harness Open Source/Light */
-  --figma___pagination-hover-border: 210 6% 60% / 1;
-  /* ✦ Theme/Pagination/Hover/Border/Harness Open Source/Light */
-  --figma___pagination-hover-text: 200 5% 12% / 1;
-  /* ✦ Theme/Pagination/Hover/Text/Harness Open Source/Light */
-  --figma___pagination-pagination-shadow-1: 0 0% 0% / 0;
-  /* ✦ Theme/Pagination/Pagination shadow/1/Harness Open Source/Light */
-  --figma___pagination-pagination-shadow-2: 240 100% 12% / 0;
-  /* ✦ Theme/Pagination/Pagination shadow/2/Harness Open Source/Light */
-  --figma___primary-color-primary-accent-1: 0 0% 98% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/1/Harness Open Source/Light */
-  --figma___primary-color-primary-accent-2: 210 7% 94% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/2/Harness Open Source/Light */
-  --figma___primary-color-primary-accent-3: 220 6% 90% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/3/Harness Open Source/Light */
-  --figma___primary-color-primary-accent-4: 240 6% 80% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/4/Harness Open Source/Light */
-  --figma___primary-color-primary-accent-5: 210 6% 60% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/5/Harness Open Source/Light */
-  --figma___primary-color-primary-accent-6: 210 6% 40% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/6/Harness Open Source/Light */
-  --figma___primary-color-primary-accent-7: 200 7% 8% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/7/Harness Open Source/Light */
-  --figma___primary-color-primary-accent-8: 216 6% 15% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/8/Harness Open Source/Light */
-  --figma___primary-color-primary-accent-9: 210 6% 6% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/9/Harness Open Source/Light */
-  --figma___primary-color-primary-accent-10: 200 7% 8% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/10/Harness Open Source/Light */
-  --figma___primary-color-primary-alpha-1: 240 89% 18% / 0.01;
-  /* ✦ Theme/Primary Color/Primary Alpha/1/Harness Open Source/Light */
-  --figma___primary-color-primary-alpha-2: 240 89% 18% / 0.02;
-  /* ✦ Theme/Primary Color/Primary Alpha/2/Harness Open Source/Light */
-  --figma___primary-color-primary-alpha-3: 240 100% 12% / 0.05;
-  /* ✦ Theme/Primary Color/Primary Alpha/3/Harness Open Source/Light */
-  --figma___primary-color-primary-alpha-4: 240 93% 11% / 0.08;
-  /* ✦ Theme/Primary Color/Primary Alpha/4/Harness Open Source/Light */
-  --figma___primary-color-primary-alpha-5: 0 0% 0% / 0.13;
-  /* ✦ Theme/Primary Color/Primary Alpha/5/Harness Open Source/Light */
-  --figma___primary-color-primary-alpha-6: 0 0% 0% / 0.27;
-  /* ✦ Theme/Primary Color/Primary Alpha/6/Harness Open Source/Light */
-  --figma___primary-color-primary-alpha-7: 200 7% 8% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/7/Harness Open Source/Light */
-  --figma___primary-color-primary-alpha-8: 216 6% 15% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/8/Harness Open Source/Light */
-  --figma___primary-color-primary-alpha-9: 210 6% 6% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/9/Harness Open Source/Light */
-  --figma___primary-color-primary-alpha-10: 200 7% 8% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/10/Harness Open Source/Light */
-  --figma___radio-button-background: 0 0% 100% / 1;
-  /* ✦ Theme/Radio button/Background/Harness Open Source/Light */
-  --figma___radio-button-checked-active-active-border: 210 6% 20% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active Border/Harness Open Source/Light */
-  --figma___radio-button-checked-active-active-background: 210 6% 20% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active background/Harness Open Source/Light */
-  --figma___radio-button-checked-active-hover-background: 210 6% 20% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover background/Harness Open Source/Light */
-  --figma___radio-button-checked-active-hover-border: 210 6% 20% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover border/Harness Open Source/Light */
-  --figma___radio-button-checked-active-default-background: 216 6% 15% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default background/Harness Open Source/Light */
-  --figma___radio-button-checked-active-default-border: 216 6% 15% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default border/Harness Open Source/Light */
-  --figma___radio-button-checked-disabled-dot: 210 6% 60% / 1;
-  /* ✦ Theme/Radio button/Checked/Disabled/Dot/Harness Open Source/Light */
-  --figma___radio-button-checked-disabled-background: 240 100% 12% / 0.05;
-  /* ✦ Theme/Radio button/Checked/Disabled/background/Harness Open Source/Light */
-  --figma___radio-button-checked-disabled-border: 210 6% 60% / 1;
-  /* ✦ Theme/Radio button/Checked/Disabled/border/Harness Open Source/Light */
-  --figma___radio-button-paper: 0 0% 100% / 0.5;
-  /* ✦ Theme/Radio button/Paper/Harness Open Source/Light */
-  --figma___radio-button-unchecked-active-active-border: 210 6% 20% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/Active border/Harness Open Source/Light */
-  --figma___radio-button-unchecked-active-hover-border: 210 6% 20% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/Harness Open Source/Light */
-  --figma___radio-button-unchecked-active-default-background: 0 0% 98% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/default background/Harness Open Source/Light */
-  --figma___radio-button-unchecked-active-default-border: 216 6% 15% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/default border/Harness Open Source/Light */
-  --figma___radio-button-unchecked-disabled-background: 0 0% 0% / 0.05;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/background/Harness Open Source/Light */
-  --figma___radio-button-unchecked-disabled-border: 210 6% 60% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/border/Harness Open Source/Light */
-  --figma___radio-button-border: 240 100% 12% / 0.05;
-  /* ✦ Theme/Radio button/border/Harness Open Source/Light */
-  --figma___secondary-crimson-crimson-1: 340 100% 99% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 1/Harness Open Source/Light */
-  --figma___secondary-crimson-crimson-10: 332 63% 24% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 10/Harness Open Source/Light */
-  --figma___secondary-crimson-crimson-2: 330 100% 98% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 2/Harness Open Source/Light */
-  --figma___secondary-crimson-crimson-3: 332 88% 97% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 3/Harness Open Source/Light */
-  --figma___secondary-crimson-crimson-4: 331 79% 94% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 4/Harness Open Source/Light */
-  --figma___secondary-crimson-crimson-5: 333 73% 91% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 5/Harness Open Source/Light */
-  --figma___secondary-crimson-crimson-6: 333 68% 87% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 6/Harness Open Source/Light */
-  --figma___secondary-crimson-crimson-7: 336 80% 58% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 7/Harness Open Source/Light */
-  --figma___secondary-crimson-crimson-8: 336 71% 53% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 8/Harness Open Source/Light */
-  --figma___secondary-crimson-crimson-9: 336 75% 45% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 9/Harness Open Source/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-1: 340 100% 51% / 0.01;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Open Source/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-10: 336 100% 38% / 0.89;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Open Source/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-11: 332 100% 16% / 0.91;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Open Source/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-2: 330 100% 51% / 0.03;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Open Source/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-3: 332 100% 51% / 0.03;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Open Source/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-4: 331 100% 44% / 0.1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Open Source/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-5: 333 100% 42% / 0.15;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Open Source/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-6: 333 99% 41% / 0.22;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Open Source/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-8: 336 100% 44% / 0.76;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Open Source/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-9: 336 100% 42% / 0.81;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Open Source/Light */
-  --figma___secondary-lime-1: 80 43% 99% / 1;
-  /* ✦ Theme/Secondary/Lime/1/Harness Open Source/Light */
-  --figma___secondary-lime-2: 85 67% 96% / 1;
-  /* ✦ Theme/Secondary/Lime/2/Harness Open Source/Light */
-  --figma___secondary-lime-3: 84 76% 92% / 1;
-  /* ✦ Theme/Secondary/Lime/3/Harness Open Source/Light */
-  --figma___secondary-lime-4: 83 71% 86% / 1;
-  /* ✦ Theme/Secondary/Lime/4/Harness Open Source/Light */
-  --figma___secondary-lime-5: 83 63% 81% / 1;
-  /* ✦ Theme/Secondary/Lime/5/Harness Open Source/Light */
-  --figma___secondary-lime-6: 81 51% 74% / 1;
-  /* ✦ Theme/Secondary/Lime/6/Harness Open Source/Light */
-  --figma___secondary-lime-7: 81 80% 66% / 1;
-  /* ✦ Theme/Secondary/Lime/7/Harness Open Source/Light */
-  --figma___secondary-lime-8: 81 75% 60% / 1;
-  /* ✦ Theme/Secondary/Lime/8/Harness Open Source/Light */
-  --figma___secondary-lime-9: 75 41% 29% / 1;
-  /* ✦ Theme/Secondary/Lime/9/Harness Open Source/Light */
-  --figma___secondary-lime-10: 75 39% 18% / 1;
-  /* ✦ Theme/Secondary/Lime/10/Harness Open Source/Light */
-  --figma___secondary-lime-alpha-1: 80 94% 31% / 0.02;
-  /* ✦ Theme/Secondary/Lime Alpha/1/Harness Open Source/Light */
-  --figma___secondary-lime-alpha-2: 85 99% 40% / 0.06;
-  /* ✦ Theme/Secondary/Lime Alpha/2/Harness Open Source/Light */
-  --figma___secondary-lime-alpha-3: 84 99% 44% / 0.15;
-  /* ✦ Theme/Secondary/Lime Alpha/3/Harness Open Source/Light */
-  --figma___secondary-lime-alpha-4: 83 99% 42% / 0.23;
-  /* ✦ Theme/Secondary/Lime Alpha/4/Harness Open Source/Light */
-  --figma___secondary-lime-alpha-5: 83 100% 39% / 0.31;
-  /* ✦ Theme/Secondary/Lime Alpha/5/Harness Open Source/Light */
-  --figma___secondary-lime-alpha-6: 81 100% 34% / 0.4;
-  /* ✦ Theme/Secondary/Lime Alpha/6/Harness Open Source/Light */
-  --figma___secondary-lime-alpha-7: 81 100% 45% / 0.61;
-  /* ✦ Theme/Secondary/Lime Alpha/7/Harness Open Source/Light */
-  --figma___secondary-lime-alpha-8: 81 100% 43% / 0.7;
-  /* ✦ Theme/Secondary/Lime Alpha/8/Harness Open Source/Light */
-  --figma___secondary-lime-alpha-9: 75 100% 14% / 0.83;
-  /* ✦ Theme/Secondary/Lime Alpha/9/Harness Open Source/Light */
-  --figma___secondary-lime-alpha-10: 76 100% 8% / 0.89;
-  /* ✦ Theme/Secondary/Lime Alpha/10/Harness Open Source/Light */
-  --figma___secondary-purple-1: 300 50% 99% / 1;
-  /* ✦ Theme/Secondary/Purple/1/Harness Open Source/Light */
-  --figma___secondary-purple-2: 276 100% 99% / 1;
-  /* ✦ Theme/Secondary/Purple/2/Harness Open Source/Light */
-  --figma___secondary-purple-3: 277 87% 97% / 1;
-  /* ✦ Theme/Secondary/Purple/3/Harness Open Source/Light */
-  --figma___secondary-purple-4: 274 78% 95% / 1;
-  /* ✦ Theme/Secondary/Purple/4/Harness Open Source/Light */
-  --figma___secondary-purple-5: 276 71% 92% / 1;
-  /* ✦ Theme/Secondary/Purple/5/Harness Open Source/Light */
-  --figma___secondary-purple-6: 274 65% 88% / 1;
-  /* ✦ Theme/Secondary/Purple/6/Harness Open Source/Light */
-  --figma___secondary-purple-7: 272 51% 54% / 1;
-  /* ✦ Theme/Secondary/Purple/7/Harness Open Source/Light */
-  --figma___secondary-purple-8: 272 47% 50% / 1;
-  /* ✦ Theme/Secondary/Purple/8/Harness Open Source/Light */
-  --figma___secondary-purple-9: 272 50% 46% / 1;
-  /* ✦ Theme/Secondary/Purple/9/Harness Open Source/Light */
-  --figma___secondary-purple-10: 270 50% 25% / 1;
-  /* ✦ Theme/Secondary/Purple/10/Harness Open Source/Light */
-  --figma___secondary-purple-alpha-1: 300 94% 35% / 0.01;
-  /* ✦ Theme/Secondary/Purple Alpha/1/Harness Open Source/Light */
-  --figma___secondary-purple-alpha-2: 276 100% 51% / 0.02;
-  /* ✦ Theme/Secondary/Purple Alpha/2/Harness Open Source/Light */
-  --figma___secondary-purple-alpha-3: 277 100% 46% / 0.05;
-  /* ✦ Theme/Secondary/Purple Alpha/3/Harness Open Source/Light */
-  --figma___secondary-purple-alpha-4: 274 98% 44% / 0.09;
-  /* ✦ Theme/Secondary/Purple Alpha/4/Harness Open Source/Light */
-  --figma___secondary-purple-alpha-5: 276 99% 42% / 0.14;
-  /* ✦ Theme/Secondary/Purple Alpha/5/Harness Open Source/Light */
-  --figma___secondary-purple-alpha-6: 275 100% 39% / 0.2;
-  /* ✦ Theme/Secondary/Purple Alpha/6/Harness Open Source/Light */
-  --figma___secondary-purple-alpha-7: 272 100% 34% / 0.69;
-  /* ✦ Theme/Secondary/Purple Alpha/7/Harness Open Source/Light */
-  --figma___secondary-purple-alpha-8: 272 100% 32% / 0.73;
-  /* ✦ Theme/Secondary/Purple Alpha/8/Harness Open Source/Light */
-  --figma___secondary-purple-alpha-9: 273 100% 30% / 0.77;
-  /* ✦ Theme/Secondary/Purple Alpha/9/Harness Open Source/Light */
-  --figma___secondary-purple-alpha-10: 270 100% 14% / 0.88;
-  /* ✦ Theme/Secondary/Purple Alpha/10/Harness Open Source/Light */
-  --figma___secondary-teal-1: 165 67% 99% / 1;
-  /* ✦ Theme/Secondary/Teal/1/Harness Open Source/Light */
-  --figma___secondary-teal-2: 169 65% 97% / 1;
-  /* ✦ Theme/Secondary/Teal/2/Harness Open Source/Light */
-  --figma___secondary-teal-3: 167 60% 94% / 1;
-  /* ✦ Theme/Secondary/Teal/3/Harness Open Source/Light */
-  --figma___secondary-teal-4: 168 52% 90% / 1;
-  /* ✦ Theme/Secondary/Teal/4/Harness Open Source/Light */
-  --figma___secondary-teal-5: 170 47% 85% / 1;
-  /* ✦ Theme/Secondary/Teal/5/Harness Open Source/Light */
-  --figma___secondary-teal-6: 170 43% 78% / 1;
-  /* ✦ Theme/Secondary/Teal/6/Harness Open Source/Light */
-  --figma___secondary-teal-7: 173 80% 36% / 1;
-  /* ✦ Theme/Secondary/Teal/7/Harness Open Source/Light */
-  --figma___secondary-teal-8: 173 83% 33% / 1;
-  /* ✦ Theme/Secondary/Teal/8/Harness Open Source/Light */
-  --figma___secondary-teal-9: 174 91% 25% / 1;
-  /* ✦ Theme/Secondary/Teal/9/Harness Open Source/Light */
-  --figma___secondary-teal-10: 174 65% 15% / 1;
-  /* ✦ Theme/Secondary/Teal/10/Harness Open Source/Light */
-  --figma___secondary-teal-alpha-1: 165 95% 41% / 0.02;
-  /* ✦ Theme/Secondary/Teal Alpha/1/Harness Open Source/Light */
-  --figma___secondary-teal-alpha-2: 169 99% 39% / 0.05;
-  /* ✦ Theme/Secondary/Teal Alpha/2/Harness Open Source/Light */
-  --figma___secondary-teal-alpha-3: 167 98% 38% / 0.09;
-  /* ✦ Theme/Secondary/Teal Alpha/3/Harness Open Source/Light */
-  --figma___secondary-teal-alpha-4: 168 98% 35% / 0.15;
-  /* ✦ Theme/Secondary/Teal Alpha/4/Harness Open Source/Light */
-  --figma___secondary-teal-alpha-5: 170 100% 32% / 0.22;
-  /* ✦ Theme/Secondary/Teal Alpha/5/Harness Open Source/Light */
-  --figma___secondary-teal-alpha-6: 170 100% 30% / 0.31;
-  /* ✦ Theme/Secondary/Teal Alpha/6/Harness Open Source/Light */
-  --figma___secondary-teal-alpha-7: 173 100% 31% / 0.93;
-  /* ✦ Theme/Secondary/Teal Alpha/7/Harness Open Source/Light */
-  --figma___secondary-teal-alpha-8: 173 100% 29% / 0.95;
-  /* ✦ Theme/Secondary/Teal Alpha/8/Harness Open Source/Light */
-  --figma___secondary-teal-alpha-9: 174 100% 23% / 0.98;
-  /* ✦ Theme/Secondary/Teal Alpha/9/Harness Open Source/Light */
-  --figma___secondary-teal-alpha-10: 174 100% 10% / 0.95;
-  /* ✦ Theme/Secondary/Teal Alpha/10/Harness Open Source/Light */
-  --figma___shadow-shadow-button-1: 0 0% 100% / 0.17;
-  /* ✦ Theme/Shadow/Shadow - button/1/Harness Open Source/Light */
-  --figma___shadow-shadow-button-2: 0 0% 100% / 0.07;
-  /* ✦ Theme/Shadow/Shadow - button/2/Harness Open Source/Light */
-  --figma___shadow-shadow-button-3: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow - button/3/Harness Open Source/Light */
-  --figma___shadow-shadow-button-4: 0 0% 0% / 0.08;
-  /* ✦ Theme/Shadow/Shadow - button/4/Harness Open Source/Light */
-  --figma___shadow-shadow-1-1: 0 0% 0% / 0.13;
-  /* ✦ Theme/Shadow/Shadow 1/1/Harness Open Source/Light */
-  --figma___shadow-shadow-2-1: 0 0% 0% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 2/1/Harness Open Source/Light */
-  --figma___shadow-shadow-2-2: 240 100% 12% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 2/2/Harness Open Source/Light */
-  --figma___shadow-shadow-2-3: 240 100% 12% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 2/3/Harness Open Source/Light */
-  --figma___shadow-shadow-3-1: 0 0% 0% / 0.08;
-  /* ✦ Theme/Shadow/Shadow 3/1/Harness Open Source/Light */
-  --figma___shadow-shadow-3-2: 0 0% 0% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 3/2/Harness Open Source/Light */
-  --figma___shadow-shadow-3-3: 240 100% 12% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 3/3/Harness Open Source/Light */
-  --figma___shadow-shadow-4-1: 0 0% 0% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 4/1/Harness Open Source/Light */
-  --figma___shadow-shadow-4-2: 240 100% 12% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 4/2/Harness Open Source/Light */
-  --figma___shadow-shadow-5-1: 0 0% 0% / 0.13;
-  /* ✦ Theme/Shadow/Shadow 5/1/Harness Open Source/Light */
-  --figma___shadow-shadow-5-2: 240 96% 9% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 5/2/Harness Open Source/Light */
-  --figma___shadow-shadow-6-1: 233 96% 9% / 0.17;
-  /* ✦ Theme/Shadow/Shadow 6/1/Harness Open Source/Light */
-  --figma___shadow-shadow-6-2: 233 96% 9% / 0.17;
-  /* ✦ Theme/Shadow/Shadow 6/2/Harness Open Source/Light */
-  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
-  /* ✦ Theme/Shadow/Shadow-button-active/1/Harness Open Source/Light */
-  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
-  /* ✦ Theme/Shadow/Shadow-button-active/2/Harness Open Source/Light */
-  --figma___shadow-shadow-button-active-3: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow-button-active/3/Harness Open Source/Light */
-  --figma___shadow-shadow-button-active-4: 0 0% 0% / 0.08;
-  /* ✦ Theme/Shadow/Shadow-button-active/4/Harness Open Source/Light */
-  --figma___side-nav-container-nav-background: 0 0% 100% / 1;
-  /* ✦ Theme/Side nav/Container/Nav-background/Harness Open Source/Light */
-  --figma___side-nav-container-nav-border: 220 6% 90% / 1;
-  /* ✦ Theme/Side nav/Container/Nav-border/Harness Open Source/Light */
-  --figma___side-nav-module-logo-text: 200 7% 8% / 1;
-  /* ✦ Theme/Side nav/Module Logo Text/Harness Open Source/Light */
-  --figma___side-nav-nav-item-default-icon: 210 6% 40% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Default/Icon/Harness Open Source/Light */
-  --figma___side-nav-nav-item-default-text: 200 5% 12% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Default/Text/Harness Open Source/Light */
-  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
-  /* ✦ Theme/Side nav/Nav-item/Default/default/Harness Open Source/Light */
-  --figma___side-nav-nav-item-hover-background: 0 0% 95% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Background/Harness Open Source/Light */
-  --figma___side-nav-nav-item-hover-icon: 200 5% 12% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/Harness Open Source/Light */
-  --figma___side-nav-nav-item-hover-text: 200 5% 12% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Text/Harness Open Source/Light */
-  --figma___side-nav-nav-item-selected-background: 0 0% 0% / 0.04;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Background/Harness Open Source/Light */
-  --figma___side-nav-nav-item-selected-icon: 200 7% 8% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/Harness Open Source/Light */
-  --figma___side-nav-nav-item-selected-text: 200 7% 8% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Text/Harness Open Source/Light */
-  --figma___side-nav-profile-role: 210 6% 20% / 1;
-  /* ✦ Theme/Side nav/Profile/Role/Harness Open Source/Light */
-  --figma___side-nav-profile-text: 200 7% 8% / 1;
-  /* ✦ Theme/Side nav/Profile/Text/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-default-border: 240 7% 94% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Border/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-default-main-text-icon: 200 7% 8% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-default-scope-name: 210 6% 20% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-hover-border: 210 6% 6% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-hover-main-text-icon: 200 7% 8% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-hover-scope-name: 210 6% 20% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-selected-border: 210 6% 6% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-selected-main-text-icon: 200 7% 8% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-selected-scope-name: 210 6% 20% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/Harness Open Source/Light */
-  --figma___side-nav-separator: 240 7% 94% / 1;
-  /* ✦ Theme/Side nav/Separator/Harness Open Source/Light */
-  --figma___status-colors-error-1: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/1/Harness Open Source/Light */
-  --figma___status-colors-error-2: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/2/Harness Open Source/Light */
-  --figma___status-colors-error-3: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/3/Harness Open Source/Light */
-  --figma___status-colors-error-4: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/4/Harness Open Source/Light */
-  --figma___status-colors-error-5: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/5/Harness Open Source/Light */
-  --figma___status-colors-error-6: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/6/Harness Open Source/Light */
-  --figma___status-colors-error-7: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/7/Harness Open Source/Light */
-  --figma___status-colors-error-8: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/8/Harness Open Source/Light */
-  --figma___status-colors-error-9: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/9/Harness Open Source/Light */
-  --figma___status-colors-error-10: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/10/Harness Open Source/Light */
-  --figma___status-colors-error-alpha-1: 0 100% 71% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/1/Harness Open Source/Light */
-  --figma___status-colors-error-alpha-2: 0 100% 71% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/2/Harness Open Source/Light */
-  --figma___status-colors-error-alpha-3: 0 100% 71% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/3/Harness Open Source/Light */
-  --figma___status-colors-error-alpha-4: 0 100% 71% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/4/Harness Open Source/Light */
-  --figma___status-colors-error-alpha-5: 0 100% 71% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/5/Harness Open Source/Light */
-  --figma___status-colors-error-alpha-6: 0 100% 71% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/6/Harness Open Source/Light */
-  --figma___status-colors-error-alpha-7: 0 100% 71% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/7/Harness Open Source/Light */
-  --figma___status-colors-error-alpha-8: 0 100% 71% / 0.16;
-  /* ✦ Theme/Status colors/Error Alpha/8/Harness Open Source/Light */
-  --figma___status-colors-error-alpha-9: 0 100% 71% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/9/Harness Open Source/Light */
-  --figma___status-colors-error-alpha-10: 0 100% 71% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/10/Harness Open Source/Light */
-  --figma___status-colors-info-1: 210 100% 99% / 1;
-  /* ✦ Theme/Status colors/Info/1/Harness Open Source/Light */
-  --figma___status-colors-info-2: 210 100% 98% / 1;
-  /* ✦ Theme/Status colors/Info/2/Harness Open Source/Light */
-  --figma___status-colors-info-3: 210 100% 96% / 1;
-  /* ✦ Theme/Status colors/Info/3/Harness Open Source/Light */
-  --figma___status-colors-info-4: 210 100% 94% / 1;
-  /* ✦ Theme/Status colors/Info/4/Harness Open Source/Light */
-  --figma___status-colors-info-5: 209 96% 90% / 1;
-  /* ✦ Theme/Status colors/Info/5/Harness Open Source/Light */
-  --figma___status-colors-info-6: 209 82% 85% / 1;
-  /* ✦ Theme/Status colors/Info/6/Harness Open Source/Light */
-  --figma___status-colors-info-7: 214 73% 51% / 1;
-  /* ✦ Theme/Status colors/Info/7/Harness Open Source/Light */
-  --figma___status-colors-info-8: 208 93% 47% / 1;
-  /* ✦ Theme/Status colors/Info/8/Harness Open Source/Light */
-  --figma___status-colors-info-9: 211 90% 42% / 1;
-  /* ✦ Theme/Status colors/Info/9/Harness Open Source/Light */
-  --figma___status-colors-info-10: 216 71% 23% / 1;
-  /* ✦ Theme/Status colors/Info/10/Harness Open Source/Light */
-  --figma___status-colors-info-alpha-1: 210 100% 51% / 0.02;
-  /* ✦ Theme/Status colors/Info Alpha/1/Harness Open Source/Light */
-  --figma___status-colors-info-alpha-2: 210 100% 51% / 0.04;
-  /* ✦ Theme/Status colors/Info Alpha/2/Harness Open Source/Light */
-  --figma___status-colors-info-alpha-3: 210 100% 50% / 0.07;
-  /* ✦ Theme/Status colors/Info Alpha/3/Harness Open Source/Light */
-  --figma___status-colors-info-alpha-4: 210 99% 49% / 0.19;
-  /* ✦ Theme/Status colors/Info Alpha/4/Harness Open Source/Light */
-  --figma___status-colors-info-alpha-5: 209 99% 49% / 0.19;
-  /* ✦ Theme/Status colors/Info Alpha/5/Harness Open Source/Light */
-  --figma___status-colors-info-alpha-6: 209 99% 45% / 0.28;
-  /* ✦ Theme/Status colors/Info Alpha/6/Harness Open Source/Light */
-  --figma___status-colors-info-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/7/Harness Open Source/Light */
-  --figma___status-colors-info-alpha-8: 208 100% 46% / 0.97;
-  /* ✦ Theme/Status colors/Info Alpha/8/Harness Open Source/Light */
-  --figma___status-colors-info-alpha-9: 211 100% 39% / 0.96;
-  /* ✦ Theme/Status colors/Info Alpha/9/Harness Open Source/Light */
-  --figma___status-colors-info-alpha-10: 216 100% 17% / 0.93;
-  /* ✦ Theme/Status colors/Info Alpha/10/Harness Open Source/Light */
-  --figma___status-colors-success-1: 140 60% 99% / 1;
-  /* ✦ Theme/Status colors/Success/1/Harness Open Source/Light */
-  --figma___status-colors-success-2: 138 63% 97% / 1;
-  /* ✦ Theme/Status colors/Success/2/Harness Open Source/Light */
-  --figma___status-colors-success-3: 139 57% 95% / 1;
-  /* ✦ Theme/Status colors/Success/3/Harness Open Source/Light */
-  --figma___status-colors-success-4: 139 48% 91% / 1;
-  /* ✦ Theme/Status colors/Success/4/Harness Open Source/Light */
-  --figma___status-colors-success-5: 141 44% 86% / 1;
-  /* ✦ Theme/Status colors/Success/5/Harness Open Source/Light */
-  --figma___status-colors-success-6: 142 40% 79% / 1;
-  /* ✦ Theme/Status colors/Success/6/Harness Open Source/Light */
-  --figma___status-colors-success-7: 142 72% 29% / 1;
-  /* ✦ Theme/Status colors/Success/7/Harness Open Source/Light */
-  --figma___status-colors-success-8: 152 57% 38% / 1;
-  /* ✦ Theme/Status colors/Success/8/Harness Open Source/Light */
-  --figma___status-colors-success-9: 153 67% 28% / 1;
-  /* ✦ Theme/Status colors/Success/9/Harness Open Source/Light */
-  --figma___status-colors-success-10: 155 40% 16% / 1;
-  /* ✦ Theme/Status colors/Success/10/Harness Open Source/Light */
-  --figma___status-colors-success-alpha-1: 140 95% 39% / 0.02;
-  /* ✦ Theme/Status colors/Success Alpha/1/Harness Open Source/Light */
-  --figma___status-colors-success-alpha-2: 139 98% 37% / 0.09;
-  /* ✦ Theme/Status colors/Success Alpha/2/Harness Open Source/Light */
-  --figma___status-colors-success-alpha-3: 139 98% 37% / 0.09;
-  /* ✦ Theme/Status colors/Success Alpha/3/Harness Open Source/Light */
-  --figma___status-colors-success-alpha-4: 139 99% 33% / 0.13;
-  /* ✦ Theme/Status colors/Success Alpha/4/Harness Open Source/Light */
-  --figma___status-colors-success-alpha-5: 141 100% 30% / 0.2;
-  /* ✦ Theme/Status colors/Success Alpha/5/Harness Open Source/Light */
-  --figma___status-colors-success-alpha-6: 142 99% 29% / 0.29;
-  /* ✦ Theme/Status colors/Success Alpha/6/Harness Open Source/Light */
-  --figma___status-colors-success-alpha-7: 151 100% 28% / 0.81;
-  /* ✦ Theme/Status colors/Success Alpha/7/Harness Open Source/Light */
-  --figma___status-colors-success-alpha-8: 153 100% 26% / 0.84;
-  /* ✦ Theme/Status colors/Success Alpha/8/Harness Open Source/Light */
-  --figma___status-colors-success-alpha-9: 153 100% 21% / 0.91;
-  /* ✦ Theme/Status colors/Success Alpha/9/Harness Open Source/Light */
-  --figma___status-colors-success-alpha-10: 155 100% 7% / 0.9;
-  /* ✦ Theme/Status colors/Success Alpha/10/Harness Open Source/Light */
-  --figma___status-colors-warning-1: 40 60% 99% / 1;
-  /* ✦ Theme/Status colors/Warning/1/Harness Open Source/Light */
-  --figma___status-colors-warning-2: 40 100% 96% / 1;
-  /* ✦ Theme/Status colors/Warning/2/Harness Open Source/Light */
-  --figma___status-colors-warning-3: 45 100% 91% / 1;
-  /* ✦ Theme/Status colors/Warning/3/Harness Open Source/Light */
-  --figma___status-colors-warning-4: 44 100% 86% / 1;
-  /* ✦ Theme/Status colors/Warning/4/Harness Open Source/Light */
-  --figma___status-colors-warning-5: 40 100% 82% / 1;
-  /* ✦ Theme/Status colors/Warning/5/Harness Open Source/Light */
-  --figma___status-colors-warning-6: 39 84% 75% / 1;
-  /* ✦ Theme/Status colors/Warning/6/Harness Open Source/Light */
-  --figma___status-colors-warning-7: 42 100% 62% / 1;
-  /* ✦ Theme/Status colors/Warning/7/Harness Open Source/Light */
-  --figma___status-colors-warning-8: 42 100% 55% / 1;
-  /* ✦ Theme/Status colors/Warning/8/Harness Open Source/Light */
-  --figma___status-colors-warning-9: 25 50% 38% / 1;
-  /* ✦ Theme/Status colors/Warning/9/Harness Open Source/Light */
-  --figma___status-colors-warning-10: 24 40% 22% / 1;
-  /* ✦ Theme/Status colors/Warning/10/Harness Open Source/Light */
-  --figma___status-colors-warning-alpha-1: 40 95% 39% / 0.02;
-  /* ✦ Theme/Status colors/Warning Alpha/1/Harness Open Source/Light */
-  --figma___status-colors-warning-alpha-2: 40 100% 50% / 0.07;
-  /* ✦ Theme/Status colors/Warning Alpha/2/Harness Open Source/Light */
-  --figma___status-colors-warning-alpha-3: 45 100% 50% / 0.19;
-  /* ✦ Theme/Status colors/Warning Alpha/3/Harness Open Source/Light */
-  --figma___status-colors-warning-alpha-4: 44 100% 50% / 0.28;
-  /* ✦ Theme/Status colors/Warning Alpha/4/Harness Open Source/Light */
-  --figma___status-colors-warning-alpha-5: 40 99% 50% / 0.37;
-  /* ✦ Theme/Status colors/Warning Alpha/5/Harness Open Source/Light */
-  --figma___status-colors-warning-alpha-6: 39 100% 46% / 0.45;
-  /* ✦ Theme/Status colors/Warning Alpha/6/Harness Open Source/Light */
-  --figma___status-colors-warning-alpha-7: 42 100% 50% / 0.76;
-  /* ✦ Theme/Status colors/Warning Alpha/7/Harness Open Source/Light */
-  --figma___status-colors-warning-alpha-8: 42 100% 50% / 0.9;
-  /* ✦ Theme/Status colors/Warning Alpha/8/Harness Open Source/Light */
-  --figma___status-colors-warning-alpha-9: 25 100% 24% / 0.81;
-  /* ✦ Theme/Status colors/Warning Alpha/9/Harness Open Source/Light */
-  --figma___status-colors-warning-alpha-10: 24 100% 10% / 0.87;
-  /* ✦ Theme/Status colors/Warning Alpha/10/Harness Open Source/Light */
-  --figma___switch-background: 0 0% 100% / 1;
-  /* ✦ Theme/Switch/Background/Harness Open Source/Light */
-  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/Harness Open Source/Light */
-  --figma___switch-checked-active-background: 200 7% 8% / 1;
-  /* ✦ Theme/Switch/Checked/Active/background/Harness Open Source/Light */
-  --figma___switch-checked-active-border: 210 6% 60% / 0;
-  /* ✦ Theme/Switch/Checked/Active/border/Harness Open Source/Light */
-  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/Harness Open Source/Light */
-  --figma___switch-checked-default-default-background: 200 7% 8% / 1;
-  /* ✦ Theme/Switch/Checked/Default/default background/Harness Open Source/Light */
-  --figma___switch-checked-default-default-border: 210 6% 60% / 0;
-  /* ✦ Theme/Switch/Checked/Default/default border/Harness Open Source/Light */
-  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/Harness Open Source/Light */
-  --figma___switch-checked-disabled-background: 200 7% 8% / 1;
-  /* ✦ Theme/Switch/Checked/Disabled/background/Harness Open Source/Light */
-  --figma___switch-checked-disabled-border: 210 6% 60% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/border/Harness Open Source/Light */
-  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/Harness Open Source/Light */
-  --figma___switch-checked-hover-background: 176 59% 40% / 1;
-  /* ✦ Theme/Switch/Checked/Hover/background/Harness Open Source/Light */
-  --figma___switch-checked-hover-border: 210 6% 60% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/border/Harness Open Source/Light */
-  --figma___switch-paper: 0 0% 100% / 0.5;
-  /* ✦ Theme/Switch/Paper/Harness Open Source/Light */
-  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/Harness Open Source/Light */
-  --figma___switch-unchecked-active-background: 207 6% 70% / 1;
-  /* ✦ Theme/Switch/Unchecked/Active/background/Harness Open Source/Light */
-  --figma___switch-unchecked-active-border: 210 6% 60% / 1;
-  /* ✦ Theme/Switch/Unchecked/Active/border/Harness Open Source/Light */
-  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/Harness Open Source/Light */
-  --figma___switch-unchecked-default-default-background: 210 6% 40% / 1;
-  /* ✦ Theme/Switch/Unchecked/Default/default background/Harness Open Source/Light */
-  --figma___switch-unchecked-default-default-border: 210 6% 60% / 1;
-  /* ✦ Theme/Switch/Unchecked/Default/default border/Harness Open Source/Light */
-  --figma___switch-unchecked-disabled-thumb-thumb-background: 240 13% 95% / 1;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/Harness Open Source/Light */
-  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/Harness Open Source/Light */
-  --figma___switch-unchecked-disabled-background: 0 0% 0% / 0.11;
-  /* ✦ Theme/Switch/Unchecked/Disabled/background/Harness Open Source/Light */
-  --figma___switch-unchecked-disabled-border: 210 6% 60% / 1;
-  /* ✦ Theme/Switch/Unchecked/Disabled/border/Harness Open Source/Light */
-  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/Harness Open Source/Light */
-  --figma___switch-unchecked-hover-background: 210 6% 20% / 1;
-  /* ✦ Theme/Switch/Unchecked/Hover/background/Harness Open Source/Light */
-  --figma___switch-unchecked-hover-border: 210 6% 60% / 1;
-  /* ✦ Theme/Switch/Unchecked/Hover/border/Harness Open Source/Light */
-  --figma___switch-border: 240 100% 12% / 0.05;
-  /* ✦ Theme/Switch/border/Harness Open Source/Light */
-  --figma___tabs-number-active-background: 240 13% 3% / 1;
-  /* ✦ Theme/Tabs/Number/Active/Background/Harness Open Source/Light */
-  --figma___tabs-number-active-text: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Number/Active/text/Harness Open Source/Light */
-  --figma___tabs-number-default-hover-background: 240 6% 80% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/Background/Harness Open Source/Light */
-  --figma___tabs-number-default-hover-text: 200 7% 8% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/text/Harness Open Source/Light */
-  --figma___tabs-pills-active-active: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Active/Harness Open Source/Light */
-  --figma___tabs-pills-active-text: 210 13% 3% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Text/Harness Open Source/Light */
-  --figma___tabs-pills-active-border-grad-1: 219 100% 84% / 0.1;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 1/Harness Open Source/Light */
-  --figma___tabs-pills-active-border-grad-2: 219 100% 84% / 0.05;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 2/Harness Open Source/Light */
-  --figma___tabs-pills-backgrounds: 240 7% 94% / 1;
-  /* ✦ Theme/Tabs/Pills/Backgrounds/Harness Open Source/Light */
-  --figma___tabs-pills-default-background: 240 6% 40% / 0;
-  /* ✦ Theme/Tabs/Pills/Default/Background/Harness Open Source/Light */
-  --figma___tabs-pills-default-text: 240 6% 40% / 1;
-  /* ✦ Theme/Tabs/Pills/Default/Text/Harness Open Source/Light */
-  --figma___tabs-pills-hover-background: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Background/Harness Open Source/Light */
-  --figma___tabs-pills-hover-text: 200 5% 12% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Text/Harness Open Source/Light */
-  --figma___tabs-pills-number-active-background: 200 7% 8% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/Background/Harness Open Source/Light */
-  --figma___tabs-pills-number-active-text: 0 0% 98% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/text/Harness Open Source/Light */
-  --figma___tabs-pills-border-grad-1: 219 100% 84% / 0.07;
-  /* ✦ Theme/Tabs/Pills/border grad 1/Harness Open Source/Light */
-  --figma___tabs-pills-border-grad-2: 219 100% 84% / 0.02;
-  /* ✦ Theme/Tabs/Pills/border grad 2/Harness Open Source/Light */
-  --figma___tabs-primary-active-text: 200 7% 8% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Text/Harness Open Source/Light */
-  --figma___tabs-primary-active-underline: 200 7% 8% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Underline/Harness Open Source/Light */
-  --figma___tabs-primary-border: 272 50% 46% / 1;
-  /* ✦ Theme/Tabs/Primary/Border/Harness Open Source/Light */
-  --figma___tabs-primary-default-background: 240 6% 40% / 0;
-  /* ✦ Theme/Tabs/Primary/Default/Background/Harness Open Source/Light */
-  --figma___tabs-primary-default-text: 210 6% 20% / 1;
-  /* ✦ Theme/Tabs/Primary/Default/Text/Harness Open Source/Light */
-  --figma___tabs-primary-hover-background: 240 93% 11% / 0.08;
-  /* ✦ Theme/Tabs/Primary/Hover/Background/Harness Open Source/Light */
-  --figma___tabs-primary-hover-text: 200 7% 8% / 1;
-  /* ✦ Theme/Tabs/Primary/Hover/Text/Harness Open Source/Light */
-  --figma___tabs-primary-pills-pills: 272 47% 50% / 1;
-  /* ✦ Theme/Tabs/Primary/Pills/Pills/Harness Open Source/Light */
-  --figma___text-disabled: 212 6% 50% / 1;
-  /* ✦ Theme/Text/Disabled/Harness Open Source/Light */
-  --figma___text-links: 216 100% 59% / 1;
-  /* ✦ Theme/Text/Links/Harness Open Source/Light */
-  --figma___text-secondary: 200 5% 12% / 1;
-  /* ✦ Theme/Text/Secondary/Harness Open Source/Light */
-  --figma___text-tertiary: 210 6% 20% / 1;
-  /* ✦ Theme/Text/Tertiary/Harness Open Source/Light */
-  --figma___text-primary: 200 7% 8% / 1;
-  /* ✦ Theme/Text/primary/Harness Open Source/Light */
-  --figma___textfield-assistive-text-primary: 210 6% 20% / 1;
-  /* ✦ Theme/Textfield/Assistive Text/Primary/Harness Open Source/Light */
-  --figma___textfield-background: 0 0% 100% / 0;
-  /* ✦ Theme/Textfield/Background/Harness Open Source/Light */
-  --figma___textfield-input-field-background: 0 0% 98% / 0;
-  /* ✦ Theme/Textfield/Input Field/Background/Harness Open Source/Light */
-  --figma___textfield-input-field-default: 212 6% 50% / 1;
-  /* ✦ Theme/Textfield/Input Field/Default/Harness Open Source/Light */
-  --figma___textfield-input-field-error: 0 80% 65% / 1;
-  /* ✦ Theme/Textfield/Input Field/Error/Harness Open Source/Light */
-  --figma___textfield-input-field-hover: 207 6% 70% / 1;
-  /* ✦ Theme/Textfield/Input Field/Hover/Harness Open Source/Light */
-  --figma___textfield-label-info-icon: 210 6% 20% / 1;
-  /* ✦ Theme/Textfield/Label/Info Icon/Harness Open Source/Light */
-  --figma___textfield-label-link: 206 82% 65% / 1;
-  /* ✦ Theme/Textfield/Label/Link/Harness Open Source/Light */
-  --figma___textfield-label-main: 200 7% 8% / 1;
-  /* ✦ Theme/Textfield/Label/Main/Harness Open Source/Light */
-  --figma___textfield-label-optional: 210 6% 20% / 1;
-  /* ✦ Theme/Textfield/Label/Optional/Harness Open Source/Light */
-  --figma___textfield-pin-soft-background: 240 100% 12% / 0.05;
-  /* ✦ Theme/Textfield/Pin/Soft/Background/Harness Open Source/Light */
-  --figma___textfield-pin-soft-border: 0 0% 0% / 0.17;
-  /* ✦ Theme/Textfield/Pin/Soft/border/Harness Open Source/Light */
-  --figma___textfield-pin-soft-pin: 200 6% 10% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/pin/Harness Open Source/Light */
-  --figma___textfield-pin-surface-background: 220 6% 90% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/Background/Harness Open Source/Light */
-  --figma___textfield-pin-surface-border: 210 6% 40% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/border/Harness Open Source/Light */
-  --figma___textfield-pin-surface-pin: 200 5% 12% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/pin/Harness Open Source/Light */
-  --figma___tooltip-background: 0 0% 100% / 1;
-  /* ✦ Theme/Tooltip/Background/Harness Open Source/Light */
-  --figma___tooltip-body-text: 200 5% 12% / 1;
-  /* ✦ Theme/Tooltip/Body Text/Harness Open Source/Light */
-  --figma___tooltip-dismissable-icon: 200 6% 10% / 1;
-  /* ✦ Theme/Tooltip/Dismissable icon/Harness Open Source/Light */
-  --figma___tooltip-tooltip-title: 200 7% 8% / 1;
-  /* ✦ Theme/Tooltip/Tooltip Title/Harness Open Source/Light */
-  --figma___badges-solid-amber-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Amber/text/Harness Open Source/Light */
-  --figma___badges-solid-blue-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Blue/text/Harness Open Source/Light */
-  --figma___badges-solid-bronze-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Bronze/text/Harness Open Source/Light */
-  --figma___badges-solid-brown-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Brown/text/Harness Open Source/Light */
-  --figma___badges-solid-crimson-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Crimson/text/Harness Open Source/Light */
-  --figma___badges-solid-cyan-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Cyan/text/Harness Open Source/Light */
-  --figma___badges-solid-gold-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Gold/text/Harness Open Source/Light */
-  --figma___badges-solid-grass-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Grass/text/Harness Open Source/Light */
-  --figma___badges-solid-green-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Green/text/Harness Open Source/Light */
-  --figma___badges-solid-indigo-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Indigo/text/Harness Open Source/Light */
-  --figma___badges-solid-iris-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Iris/text/Harness Open Source/Light */
-  --figma___badges-solid-jade-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Jade/text/Harness Open Source/Light */
-  --figma___badges-solid-lime-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Lime/text/Harness Open Source/Light */
-  --figma___badges-solid-mint-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Mint/text/Harness Open Source/Light */
-  --figma___badges-solid-orange-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Orange/text/Harness Open Source/Light */
-  --figma___badges-solid-pink-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Pink/text/Harness Open Source/Light */
-  --figma___badges-solid-plum-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Plum/text/Harness Open Source/Light */
-  --figma___badges-solid-purple-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Purple/text/Harness Open Source/Light */
-  --figma___badges-solid-red-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Red/text/Harness Open Source/Light */
-  --figma___badges-solid-ruby-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Ruby/text/Harness Open Source/Light */
-  --figma___badges-solid-sky-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Sky/text/Harness Open Source/Light */
-  --figma___badges-solid-success-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Success/text/Harness Open Source/Light */
-  --figma___badges-solid-teal-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Teal/text/Harness Open Source/Light */
-  --figma___badges-solid-violet-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Violet/text/Harness Open Source/Light */
-  --figma___badges-solid-yellow-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Yellow/text/Harness Open Source/Light */
-  --figma___badges-solid-accent-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/accent/text/Harness Open Source/Light */
-  --figma___badges-solid-info-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/info/text/Harness Open Source/Light */
-  --figma___badges-solid-warning-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/warning/text/Harness Open Source/Light */
-  --figma___button-solid-error-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Error/Text-primary/Harness Open Source/Light */
-  --figma___button-solid-neutral-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Neutral/Text-primary/Harness Open Source/Light */
-  --figma___button-solid-success-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Success/Text-primary/Harness Open Source/Light */
-  --figma___calendar-selected-date-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Calendar/Selected Date/Text/Harness Open Source/Light */
-  --figma___checkbox-surface-checked-active-check: var(--figma___default-colors-white);
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/Harness Open Source/Light */
-  --figma___checkbox-surface-intermediate-active-check: var(--figma___default-colors-white);
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/Harness Open Source/Light */
-  --figma___radio-button-checked-active-dot: var(--figma___default-colors-white);
-  /* ✦ Theme/Radio button/Checked/Active/Dot/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-default-default: var(--figma___textfield-background);
-  /* ✦ Theme/Side nav/Scope Selector/Default/default/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-hover-default: var(--figma___textfield-background);
-  /* ✦ Theme/Side nav/Scope Selector/Hover/default/Harness Open Source/Light */
-  --figma___side-nav-scope-selector-selected-background: var(--figma___textfield-background);
-  /* ✦ Theme/Side nav/Scope Selector/Selected/background/Harness Open Source/Light */
-  --figma___switch-checked-active-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/Harness Open Source/Light */
-  --figma___switch-checked-default-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/Harness Open Source/Light */
-  --figma___switch-checked-disabled-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/Harness Open Source/Light */
-  --figma___switch-checked-hover-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/Harness Open Source/Light */
-  --figma___switch-unchecked-active-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/Harness Open Source/Light */
-  --figma___switch-unchecked-default-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/Harness Open Source/Light */
-  --figma___switch-unchecked-hover-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-1: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/1/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-2: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/2/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-3: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/3/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-4: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/4/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-5: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/5/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-6: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/6/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-7: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/7/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-8: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/8/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-9: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/9/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-10: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/10/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-alpha-1: 0 100% 71% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/1/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-alpha-2: 0 100% 71% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/2/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-alpha-3: 0 100% 71% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/3/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-alpha-4: 0 100% 71% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/4/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-alpha-5: 0 100% 71% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/5/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-alpha-6: 0 100% 71% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/6/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-alpha-7: 0 100% 71% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/7/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-alpha-8: 0 100% 71% / 0.16; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/8/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-alpha-9: 0 100% 71% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/9/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-alpha-10: 0 100% 71% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/10/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-1: 240 33% 99% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/1/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-2: 223 100% 99% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/2/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-3: 224 100% 97% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/3/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-4: 222 92% 95% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/4/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-5: 225 85% 92% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/5/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-6: 225 78% 82% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/6/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-7: 226 70% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/7/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-8: 226 59% 51% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/8/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-9: 226 55% 45% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/9/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-10: 226 63% 17% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/10/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-alpha-1: 240 93% 26% / 0.01; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/1/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-alpha-2: 223 100% 51% / 0.03; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/2/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-alpha-3: 224 100% 50% / 0.06; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/3/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-alpha-4: 222 98% 48% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/4/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-alpha-5: 225 98% 46% / 0.15; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/5/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-alpha-6: 225 100% 44% / 0.32; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/6/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-alpha-7: 226 100% 41% / 0.76; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/7/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-alpha-8: 226 100% 37% / 0.77; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/8/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-alpha-9: 226 100% 31% / 0.8; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/9/Harness Open Source/Light */
+  --figma___colors-alerts-status-info-alpha-10: 225 100% 14% / 0.88; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/10/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-1: 140 60% 99% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/1/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-2: 138 63% 97% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/2/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-3: 139 57% 95% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/3/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-4: 139 48% 91% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/4/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-5: 141 44% 86% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/5/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-6: 146 38% 69% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/6/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-7: 142 72% 29% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/7/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-8: 152 57% 38% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/8/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-9: 153 67% 28% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/9/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-10: 155 40% 16% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/10/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-alpha-1: 140 95% 39% / 0.02; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/1/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-alpha-2: 139 98% 37% / 0.09; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/2/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-alpha-3: 139 98% 37% / 0.09; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/3/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-alpha-4: 139 99% 33% / 0.13; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/4/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-alpha-5: 151 100% 29% / 0.64; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/5/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-alpha-6: 146 100% 27% / 0.43; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/6/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-alpha-7: 151 100% 28% / 0.81; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/7/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-alpha-8: 153 100% 26% / 0.84; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/8/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-alpha-9: 153 100% 21% / 0.91; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/9/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-alpha-10: 155 100% 7% / 0.9; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/10/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-1: 40 60% 99% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/1/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-2: 40 100% 96% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/2/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-3: 45 100% 91% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/3/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-4: 44 100% 86% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/4/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-5: 40 100% 82% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/5/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-6: 37 67% 68% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/6/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-7: 42 100% 62% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/7/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-8: 42 100% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/8/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-9: 25 50% 38% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/9/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-10: 24 40% 22% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/10/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-alpha-1: 40 95% 39% / 0.02; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/1/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-alpha-2: 40 100% 50% / 0.07; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/2/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-alpha-3: 45 100% 50% / 0.19; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/3/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-alpha-4: 44 100% 50% / 0.28; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/4/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-alpha-5: 40 99% 50% / 0.37; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/5/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-alpha-6: 37 100% 40% / 0.53; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/6/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-alpha-7: 42 100% 50% / 0.76; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/7/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-alpha-8: 42 100% 50% / 0.9; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/8/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-alpha-9: 25 100% 24% / 0.81; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/9/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-alpha-10: 24 100% 10% / 0.87; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/10/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-1: 270 50% 99% / 1; /* ✦ Theme/Colors/Charts/AI Violet/1/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-2: 252 100% 99% / 1; /* ✦ Theme/Colors/Charts/AI Violet/2/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-3: 254 100% 97% / 1; /* ✦ Theme/Colors/Charts/AI Violet/3/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-4: 251 91% 95% / 1; /* ✦ Theme/Colors/Charts/AI Violet/4/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-5: 252 83% 93% / 1; /* ✦ Theme/Colors/Charts/AI Violet/5/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-6: 252 71% 84% / 1; /* ✦ Theme/Colors/Charts/AI Violet/6/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-7: 252 56% 57% / 1; /* ✦ Theme/Colors/Charts/AI Violet/7/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-8: 251 48% 53% / 1; /* ✦ Theme/Colors/Charts/AI Violet/8/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-9: 250 43% 48% / 1; /* ✦ Theme/Colors/Charts/AI Violet/9/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-10: 249 43% 26% / 1; /* ✦ Theme/Colors/Charts/AI Violet/10/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-alpha-1: 270 94% 35% / 0.01; /* ✦ Theme/Colors/Charts/AI Violet Alpha/1/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-alpha-2: 252 100% 51% / 0.02; /* ✦ Theme/Colors/Charts/AI Violet Alpha/2/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-alpha-3: 254 100% 50% / 0.05; /* ✦ Theme/Colors/Charts/AI Violet Alpha/3/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-alpha-4: 251 98% 48% / 0.09; /* ✦ Theme/Colors/Charts/AI Violet Alpha/4/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-alpha-5: 252 99% 46% / 0.13; /* ✦ Theme/Colors/Charts/AI Violet Alpha/5/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-alpha-6: 252 99% 42% / 0.28; /* ✦ Theme/Colors/Charts/AI Violet Alpha/6/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-alpha-7: 252 100% 36% / 0.66; /* ✦ Theme/Colors/Charts/AI Violet Alpha/7/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-alpha-8: 251 100% 32% / 0.69; /* ✦ Theme/Colors/Charts/AI Violet Alpha/8/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-alpha-9: 250 100% 28% / 0.73; /* ✦ Theme/Colors/Charts/AI Violet Alpha/9/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-alpha-10: 249 100% 13% / 0.85; /* ✦ Theme/Colors/Charts/AI Violet Alpha/10/Harness Open Source/Light */
+  --figma___colors-charts-blue-1: 210 100% 99% / 1; /* ✦ Theme/Colors/Charts/Blue/1/Harness Open Source/Light */
+  --figma___colors-charts-blue-2: 210 100% 98% / 1; /* ✦ Theme/Colors/Charts/Blue/2/Harness Open Source/Light */
+  --figma___colors-charts-blue-3: 210 100% 96% / 1; /* ✦ Theme/Colors/Charts/Blue/3/Harness Open Source/Light */
+  --figma___colors-charts-blue-4: 210 100% 94% / 1; /* ✦ Theme/Colors/Charts/Blue/4/Harness Open Source/Light */
+  --figma___colors-charts-blue-5: 209 96% 90% / 1; /* ✦ Theme/Colors/Charts/Blue/5/Harness Open Source/Light */
+  --figma___colors-charts-blue-6: 208 78% 77% / 1; /* ✦ Theme/Colors/Charts/Blue/6/Harness Open Source/Light */
+  --figma___colors-charts-blue-7: 214 73% 51% / 1; /* ✦ Theme/Colors/Charts/Blue/7/Harness Open Source/Light */
+  --figma___colors-charts-blue-8: 208 93% 47% / 1; /* ✦ Theme/Colors/Charts/Blue/8/Harness Open Source/Light */
+  --figma___colors-charts-blue-9: 211 90% 42% / 1; /* ✦ Theme/Colors/Charts/Blue/9/Harness Open Source/Light */
+  --figma___colors-charts-blue-10: 216 71% 23% / 1; /* ✦ Theme/Colors/Charts/Blue/10/Harness Open Source/Light */
+  --figma___colors-charts-blue-alpha-1: 210 100% 51% / 0.02; /* ✦ Theme/Colors/Charts/Blue Alpha/1/Harness Open Source/Light */
+  --figma___colors-charts-blue-alpha-2: 210 100% 51% / 0.04; /* ✦ Theme/Colors/Charts/Blue Alpha/2/Harness Open Source/Light */
+  --figma___colors-charts-blue-alpha-3: 210 100% 50% / 0.07; /* ✦ Theme/Colors/Charts/Blue Alpha/3/Harness Open Source/Light */
+  --figma___colors-charts-blue-alpha-4: 210 99% 49% / 0.19; /* ✦ Theme/Colors/Charts/Blue Alpha/4/Harness Open Source/Light */
+  --figma___colors-charts-blue-alpha-5: 209 99% 45% / 0.28; /* ✦ Theme/Colors/Charts/Blue Alpha/5/Harness Open Source/Light */
+  --figma___colors-charts-blue-alpha-6: 208 100% 44% / 0.41; /* ✦ Theme/Colors/Charts/Blue Alpha/6/Harness Open Source/Light */
+  --figma___colors-charts-blue-alpha-7: 206 100% 50% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/7/Harness Open Source/Light */
+  --figma___colors-charts-blue-alpha-8: 208 100% 46% / 0.97; /* ✦ Theme/Colors/Charts/Blue Alpha/8/Harness Open Source/Light */
+  --figma___colors-charts-blue-alpha-9: 211 100% 39% / 0.96; /* ✦ Theme/Colors/Charts/Blue Alpha/9/Harness Open Source/Light */
+  --figma___colors-charts-blue-alpha-10: 216 100% 17% / 0.93; /* ✦ Theme/Colors/Charts/Blue Alpha/10/Harness Open Source/Light */
+  --figma___colors-charts-indigo-1: 240 33% 99% / 1; /* ✦ Theme/Colors/Charts/Indigo/1/Harness Open Source/Light */
+  --figma___colors-charts-indigo-2: 223 100% 99% / 1; /* ✦ Theme/Colors/Charts/Indigo/2/Harness Open Source/Light */
+  --figma___colors-charts-indigo-3: 224 100% 97% / 1; /* ✦ Theme/Colors/Charts/Indigo/3/Harness Open Source/Light */
+  --figma___colors-charts-indigo-4: 222 92% 95% / 1; /* ✦ Theme/Colors/Charts/Indigo/4/Harness Open Source/Light */
+  --figma___colors-charts-indigo-5: 225 85% 92% / 1; /* ✦ Theme/Colors/Charts/Indigo/5/Harness Open Source/Light */
+  --figma___colors-charts-indigo-6: 225 78% 82% / 1; /* ✦ Theme/Colors/Charts/Indigo/6/Harness Open Source/Light */
+  --figma___colors-charts-indigo-7: 226 70% 55% / 1; /* ✦ Theme/Colors/Charts/Indigo/7/Harness Open Source/Light */
+  --figma___colors-charts-indigo-8: 226 59% 51% / 1; /* ✦ Theme/Colors/Charts/Indigo/8/Harness Open Source/Light */
+  --figma___colors-charts-indigo-9: 226 55% 45% / 1; /* ✦ Theme/Colors/Charts/Indigo/9/Harness Open Source/Light */
+  --figma___colors-charts-indigo-10: 226 63% 17% / 1; /* ✦ Theme/Colors/Charts/Indigo/10/Harness Open Source/Light */
+  --figma___colors-charts-indigo-alpha-1: 240 93% 26% / 0.01; /* ✦ Theme/Colors/Charts/Indigo Alpha/1/Harness Open Source/Light */
+  --figma___colors-charts-indigo-alpha-2: 223 100% 51% / 0.03; /* ✦ Theme/Colors/Charts/Indigo Alpha/2/Harness Open Source/Light */
+  --figma___colors-charts-indigo-alpha-3: 224 100% 50% / 0.06; /* ✦ Theme/Colors/Charts/Indigo Alpha/3/Harness Open Source/Light */
+  --figma___colors-charts-indigo-alpha-4: 222 98% 48% / 0.1; /* ✦ Theme/Colors/Charts/Indigo Alpha/4/Harness Open Source/Light */
+  --figma___colors-charts-indigo-alpha-5: 225 98% 46% / 0.15; /* ✦ Theme/Colors/Charts/Indigo Alpha/5/Harness Open Source/Light */
+  --figma___colors-charts-indigo-alpha-6: 225 100% 44% / 0.32; /* ✦ Theme/Colors/Charts/Indigo Alpha/6/Harness Open Source/Light */
+  --figma___colors-charts-indigo-alpha-7: 226 100% 41% / 0.76; /* ✦ Theme/Colors/Charts/Indigo Alpha/7/Harness Open Source/Light */
+  --figma___colors-charts-indigo-alpha-8: 226 100% 37% / 0.77; /* ✦ Theme/Colors/Charts/Indigo Alpha/8/Harness Open Source/Light */
+  --figma___colors-charts-indigo-alpha-9: 226 100% 31% / 0.8; /* ✦ Theme/Colors/Charts/Indigo Alpha/9/Harness Open Source/Light */
+  --figma___colors-charts-indigo-alpha-10: 225 100% 14% / 0.88; /* ✦ Theme/Colors/Charts/Indigo Alpha/10/Harness Open Source/Light */
+  --figma___colors-charts-mint-1: 168 71% 99% / 1; /* ✦ Theme/Colors/Charts/Mint/1/Harness Open Source/Light */
+  --figma___colors-charts-mint-2: 164 88% 97% / 1; /* ✦ Theme/Colors/Charts/Mint/2/Harness Open Source/Light */
+  --figma___colors-charts-mint-3: 164 79% 93% / 1; /* ✦ Theme/Colors/Charts/Mint/3/Harness Open Source/Light */
+  --figma___colors-charts-mint-4: 165 73% 88% / 1; /* ✦ Theme/Colors/Charts/Mint/4/Harness Open Source/Light */
+  --figma___colors-charts-mint-5: 166 60% 83% / 1; /* ✦ Theme/Colors/Charts/Mint/5/Harness Open Source/Light */
+  --figma___colors-charts-mint-6: 166 44% 67% / 1; /* ✦ Theme/Colors/Charts/Mint/6/Harness Open Source/Light */
+  --figma___colors-charts-mint-7: 176 59% 50% / 1; /* ✦ Theme/Colors/Charts/Mint/7/Harness Open Source/Light */
+  --figma___colors-charts-mint-8: 176 59% 40% / 1; /* ✦ Theme/Colors/Charts/Mint/8/Harness Open Source/Light */
+  --figma___colors-charts-mint-9: 172 50% 31% / 1; /* ✦ Theme/Colors/Charts/Mint/9/Harness Open Source/Light */
+  --figma___colors-charts-mint-10: 171 51% 17% / 1; /* ✦ Theme/Colors/Charts/Mint/10/Harness Open Source/Light */
+  --figma___colors-charts-mint-alpha-1: 168 95% 43% / 0.02; /* ✦ Theme/Colors/Charts/Mint Alpha/1/Harness Open Source/Light */
+  --figma___colors-charts-mint-alpha-2: 164 99% 47% / 0.06; /* ✦ Theme/Colors/Charts/Mint Alpha/2/Harness Open Source/Light */
+  --figma___colors-charts-mint-alpha-3: 164 99% 44% / 0.13; /* ✦ Theme/Colors/Charts/Mint Alpha/3/Harness Open Source/Light */
+  --figma___colors-charts-mint-alpha-4: 165 100% 42% / 0.2; /* ✦ Theme/Colors/Charts/Mint Alpha/4/Harness Open Source/Light */
+  --figma___colors-charts-mint-alpha-5: 166 100% 38% / 0.27; /* ✦ Theme/Colors/Charts/Mint Alpha/5/Harness Open Source/Light */
+  --figma___colors-charts-mint-alpha-6: 166 100% 30% / 0.47; /* ✦ Theme/Colors/Charts/Mint Alpha/6/Harness Open Source/Light */
+  --figma___colors-charts-mint-alpha-7: 167 100% 41% / 0.47; /* ✦ Theme/Colors/Charts/Mint Alpha/7/Harness Open Source/Light */
+  --figma___colors-charts-mint-alpha-8: 167 100% 38% / 0.5; /* ✦ Theme/Colors/Charts/Mint Alpha/8/Harness Open Source/Light */
+  --figma___colors-charts-mint-alpha-9: 172 100% 18% / 0.85; /* ✦ Theme/Colors/Charts/Mint Alpha/9/Harness Open Source/Light */
+  --figma___colors-charts-mint-alpha-10: 171 100% 10% / 0.91; /* ✦ Theme/Colors/Charts/Mint Alpha/10/Harness Open Source/Light */
+  --figma___colors-charts-orange-1: 20 60% 99% / 1; /* ✦ Theme/Colors/Charts/Orange/1/Harness Open Source/Light */
+  --figma___colors-charts-orange-2: 22 100% 98% / 1; /* ✦ Theme/Colors/Charts/Orange/2/Harness Open Source/Light */
+  --figma___colors-charts-orange-3: 34 100% 92% / 1; /* ✦ Theme/Colors/Charts/Orange/3/Harness Open Source/Light */
+  --figma___colors-charts-orange-4: 33 100% 87% / 1; /* ✦ Theme/Colors/Charts/Orange/4/Harness Open Source/Light */
+  --figma___colors-charts-orange-5: 31 100% 82% / 1; /* ✦ Theme/Colors/Charts/Orange/5/Harness Open Source/Light */
+  --figma___colors-charts-orange-6: 21 100% 75% / 1; /* ✦ Theme/Colors/Charts/Orange/6/Harness Open Source/Light */
+  --figma___colors-charts-orange-7: 24 94% 50% / 1; /* ✦ Theme/Colors/Charts/Orange/7/Harness Open Source/Light */
+  --figma___colors-charts-orange-8: 24 100% 46% / 1; /* ✦ Theme/Colors/Charts/Orange/8/Harness Open Source/Light */
+  --figma___colors-charts-orange-9: 16 45% 41% / 1; /* ✦ Theme/Colors/Charts/Orange/9/Harness Open Source/Light */
+  --figma___colors-charts-orange-10: 16 50% 23% / 1; /* ✦ Theme/Colors/Charts/Orange/10/Harness Open Source/Light */
+  --figma___colors-charts-orange-alpha-1: 20 95% 39% / 0.02; /* ✦ Theme/Colors/Charts/Orange Alpha/1/Harness Open Source/Light */
+  --figma___colors-charts-orange-alpha-2: 22 100% 51% / 0.04; /* ✦ Theme/Colors/Charts/Orange Alpha/2/Harness Open Source/Light */
+  --figma___colors-charts-orange-alpha-3: 34 100% 50% / 0.17; /* ✦ Theme/Colors/Charts/Orange Alpha/3/Harness Open Source/Light */
+  --figma___colors-charts-orange-alpha-4: 33 100% 50% / 0.27; /* ✦ Theme/Colors/Charts/Orange Alpha/4/Harness Open Source/Light */
+  --figma___colors-charts-orange-alpha-5: 31 100% 50% / 0.36; /* ✦ Theme/Colors/Charts/Orange Alpha/5/Harness Open Source/Light */
+  --figma___colors-charts-orange-alpha-6: 21 100% 50% / 0.51; /* ✦ Theme/Colors/Charts/Orange Alpha/6/Harness Open Source/Light */
+  --figma___colors-charts-orange-alpha-7: 24 100% 48% / 0.97; /* ✦ Theme/Colors/Charts/Orange Alpha/7/Harness Open Source/Light */
+  --figma___colors-charts-orange-alpha-8: 24 100% 46% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/8/Harness Open Source/Light */
+  --figma___colors-charts-orange-alpha-9: 16 100% 24% / 0.77; /* ✦ Theme/Colors/Charts/Orange Alpha/9/Harness Open Source/Light */
+  --figma___colors-charts-orange-alpha-10: 16 100% 13% / 0.89; /* ✦ Theme/Colors/Charts/Orange Alpha/10/Harness Open Source/Light */
+  --figma___colors-charts-yellow-1: 60 50% 98% / 1; /* ✦ Theme/Colors/Charts/Yellow/1/Harness Open Source/Light */
+  --figma___colors-charts-yellow-2: 52 100% 94% / 1; /* ✦ Theme/Colors/Charts/Yellow/2/Harness Open Source/Light */
+  --figma___colors-charts-yellow-3: 53 100% 89% / 1; /* ✦ Theme/Colors/Charts/Yellow/3/Harness Open Source/Light */
+  --figma___colors-charts-yellow-4: 53 93% 84% / 1; /* ✦ Theme/Colors/Charts/Yellow/4/Harness Open Source/Light */
+  --figma___colors-charts-yellow-5: 52 85% 79% / 1; /* ✦ Theme/Colors/Charts/Yellow/5/Harness Open Source/Light */
+  --figma___colors-charts-yellow-6: 48 59% 64% / 1; /* ✦ Theme/Colors/Charts/Yellow/6/Harness Open Source/Light */
+  --figma___colors-charts-yellow-7: 53 96% 58% / 1; /* ✦ Theme/Colors/Charts/Yellow/7/Harness Open Source/Light */
+  --figma___colors-charts-yellow-8: 52 95% 52% / 1; /* ✦ Theme/Colors/Charts/Yellow/8/Harness Open Source/Light */
+  --figma___colors-charts-yellow-9: 42 50% 31% / 1; /* ✦ Theme/Colors/Charts/Yellow/9/Harness Open Source/Light */
+  --figma___colors-charts-yellow-10: 42 39% 20% / 1; /* ✦ Theme/Colors/Charts/Yellow/10/Harness Open Source/Light */
+  --figma___colors-charts-yellow-alpha-1: 60 50% 98% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/1/Harness Open Source/Light */
+  --figma___colors-charts-yellow-alpha-2: 52 100% 94% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/2/Harness Open Source/Light */
+  --figma___colors-charts-yellow-alpha-3: 53 100% 89% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/3/Harness Open Source/Light */
+  --figma___colors-charts-yellow-alpha-4: 53 93% 84% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/4/Harness Open Source/Light */
+  --figma___colors-charts-yellow-alpha-5: 52 85% 79% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/5/Harness Open Source/Light */
+  --figma___colors-charts-yellow-alpha-6: 48 59% 64% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/6/Harness Open Source/Light */
+  --figma___colors-charts-yellow-alpha-7: 53 96% 58% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/7/Harness Open Source/Light */
+  --figma___colors-charts-yellow-alpha-8: 52 95% 52% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/8/Harness Open Source/Light */
+  --figma___colors-charts-yellow-alpha-9: 42 50% 31% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/9/Harness Open Source/Light */
+  --figma___colors-charts-yellow-alpha-10: 42 39% 20% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/10/Harness Open Source/Light */
+  --figma___colors-default-black-fixed: 210 13% 3% / 1; /* ✦ Theme/Colors/Default/Black (fixed)/Harness Open Source/Light */
+  --figma___colors-default-brand-color: 0 0% 100% / 1; /* ✦ Theme/Colors/Default/Brand Color/Harness Open Source/Light */
+  --figma___colors-default-dark-to-white: 240 13% 3% / 1; /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Light */
+  --figma___colors-default-white-fixed: 0 0% 100% / 1; /* ✦ Theme/Colors/Default/White (fixed)/Harness Open Source/Light */
+  --figma___colors-default-white-to-dark: 0 0% 100% / 1; /* ✦ Theme/Colors/Default/White-to-dark/Harness Open Source/Light */
+  --figma___colors-module-ccm-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CCM/100/Harness Open Source/Light */
+  --figma___colors-module-ccm-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CCM/200/Harness Open Source/Light */
+  --figma___colors-module-ccm-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CCM/300/Harness Open Source/Light */
+  --figma___colors-module-cd-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CD/100/Harness Open Source/Light */
+  --figma___colors-module-cd-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CD/200/Harness Open Source/Light */
+  --figma___colors-module-cd-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CD/300/Harness Open Source/Light */
+  --figma___colors-module-ce-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CE/100/Harness Open Source/Light */
+  --figma___colors-module-ce-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CE/200/Harness Open Source/Light */
+  --figma___colors-module-ce-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CE/300/Harness Open Source/Light */
+  --figma___colors-module-ci-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CI/100/Harness Open Source/Light */
+  --figma___colors-module-ci-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CI/200/Harness Open Source/Light */
+  --figma___colors-module-ci-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CI/300/Harness Open Source/Light */
+  --figma___colors-module-ff-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/FF/100/Harness Open Source/Light */
+  --figma___colors-module-ff-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/FF/200/Harness Open Source/Light */
+  --figma___colors-module-ff-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/FF/300/Harness Open Source/Light */
+  --figma___colors-module-srm-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SRM/100/Harness Open Source/Light */
+  --figma___colors-module-srm-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SRM/200/Harness Open Source/Light */
+  --figma___colors-module-srm-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SRM/300/Harness Open Source/Light */
+  --figma___colors-module-ssca-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SSCA/100/Harness Open Source/Light */
+  --figma___colors-module-ssca-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SSCA/200/Harness Open Source/Light */
+  --figma___colors-module-ssca-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SSCA/300/Harness Open Source/Light */
+  --figma___colors-module-sto-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/STO/100/Harness Open Source/Light */
+  --figma___colors-module-sto-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/STO/200/Harness Open Source/Light */
+  --figma___colors-module-sto-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/STO/300/Harness Open Source/Light */
+  --figma___colors-neutral-gray-1: 0 0% 98% / 1; /* ✦ Theme/Colors/Neutral/Gray/1/Harness Open Source/Light */
+  --figma___colors-neutral-gray-2: 210 7% 94% / 1; /* ✦ Theme/Colors/Neutral/Gray/2/Harness Open Source/Light */
+  --figma___colors-neutral-gray-3: 220 6% 90% / 1; /* ✦ Theme/Colors/Neutral/Gray/3/Harness Open Source/Light */
+  --figma___colors-neutral-gray-4: 240 6% 80% / 1; /* ✦ Theme/Colors/Neutral/Gray/4/Harness Open Source/Light */
+  --figma___colors-neutral-gray-5: 207 6% 70% / 1; /* ✦ Theme/Colors/Neutral/Gray/5/Harness Open Source/Light */
+  --figma___colors-neutral-gray-6: 210 6% 60% / 1; /* ✦ Theme/Colors/Neutral/Gray/6/Harness Open Source/Light */
+  --figma___colors-neutral-gray-7: 212 6% 50% / 1; /* ✦ Theme/Colors/Neutral/Gray/7/Harness Open Source/Light */
+  --figma___colors-neutral-gray-8: 210 6% 40% / 1; /* ✦ Theme/Colors/Neutral/Gray/8/Harness Open Source/Light */
+  --figma___colors-neutral-gray-9: 210 6% 20% / 1; /* ✦ Theme/Colors/Neutral/Gray/9/Harness Open Source/Light */
+  --figma___colors-neutral-gray-10: 216 6% 15% / 1; /* ✦ Theme/Colors/Neutral/Gray/10/Harness Open Source/Light */
+  --figma___colors-neutral-gray-alpha-1: 240 89% 18% / 0.01; /* ✦ Theme/Colors/Neutral/Gray Alpha/1/Harness Open Source/Light */
+  --figma___colors-neutral-gray-alpha-2: 240 89% 18% / 0.02; /* ✦ Theme/Colors/Neutral/Gray Alpha/2/Harness Open Source/Light */
+  --figma___colors-neutral-gray-alpha-3: 240 100% 12% / 0.05; /* ✦ Theme/Colors/Neutral/Gray Alpha/3/Harness Open Source/Light */
+  --figma___colors-neutral-gray-alpha-4: 240 93% 11% / 0.08; /* ✦ Theme/Colors/Neutral/Gray Alpha/4/Harness Open Source/Light */
+  --figma___colors-neutral-gray-alpha-5: 240 100% 9% / 0.11; /* ✦ Theme/Colors/Neutral/Gray Alpha/5/Harness Open Source/Light */
+  --figma___colors-neutral-gray-alpha-6: 240 96% 9% / 0.13; /* ✦ Theme/Colors/Neutral/Gray Alpha/6/Harness Open Source/Light */
+  --figma___colors-neutral-gray-alpha-7: 233 96% 9% / 0.17; /* ✦ Theme/Colors/Neutral/Gray Alpha/7/Harness Open Source/Light */
+  --figma___colors-neutral-gray-alpha-8: 230 100% 9% / 0.28; /* ✦ Theme/Colors/Neutral/Gray Alpha/8/Harness Open Source/Light */
+  --figma___colors-neutral-gray-alpha-9: 232 100% 6% / 0.46; /* ✦ Theme/Colors/Neutral/Gray Alpha/9/Harness Open Source/Light */
+  --figma___colors-neutral-gray-alpha-10: 230 100% 5% / 0.51; /* ✦ Theme/Colors/Neutral/Gray Alpha/10/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-1: 0 0% 98% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/1/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-2: 210 7% 94% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/2/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-3: 220 6% 90% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/3/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-4: 240 6% 80% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/4/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-5: 210 6% 60% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/5/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-6: 210 6% 40% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/6/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-7: 200 7% 8% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/7/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-8: 216 6% 15% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/8/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-9: 210 6% 6% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/9/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-10: 200 7% 8% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/10/Harness Open Source/Light */
+  --figma___colors-primary-primary-alpha-1: 240 89% 18% / 0.01; /* ✦ Theme/Colors/Primary/Primary Alpha/1/Harness Open Source/Light */
+  --figma___colors-primary-primary-alpha-2: 240 89% 18% / 0.02; /* ✦ Theme/Colors/Primary/Primary Alpha/2/Harness Open Source/Light */
+  --figma___colors-primary-primary-alpha-3: 240 100% 12% / 0.05; /* ✦ Theme/Colors/Primary/Primary Alpha/3/Harness Open Source/Light */
+  --figma___colors-primary-primary-alpha-4: 240 93% 11% / 0.08; /* ✦ Theme/Colors/Primary/Primary Alpha/4/Harness Open Source/Light */
+  --figma___colors-primary-primary-alpha-5: 0 0% 0% / 0.13; /* ✦ Theme/Colors/Primary/Primary Alpha/5/Harness Open Source/Light */
+  --figma___colors-primary-primary-alpha-6: 0 0% 0% / 0.27; /* ✦ Theme/Colors/Primary/Primary Alpha/6/Harness Open Source/Light */
+  --figma___colors-primary-primary-alpha-7: 200 7% 8% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/7/Harness Open Source/Light */
+  --figma___colors-primary-primary-alpha-8: 216 6% 15% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/8/Harness Open Source/Light */
+  --figma___colors-primary-primary-alpha-9: 210 6% 6% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/9/Harness Open Source/Light */
+  --figma___colors-primary-primary-alpha-10: 200 7% 8% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/10/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-crimson-1: 340 100% 99% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 1/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-crimson-10: 332 63% 24% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 10/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-crimson-2: 330 100% 98% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 2/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-crimson-3: 332 88% 97% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 3/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-crimson-4: 331 79% 94% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 4/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-crimson-5: 333 73% 91% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 5/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-crimson-6: 335 64% 80% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 6/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-crimson-7: 336 80% 58% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 7/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-crimson-8: 336 71% 53% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 8/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-crimson-9: 336 75% 45% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 9/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-1: 340 100% 51% / 0.01; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-10: 336 100% 38% / 0.89; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-11: 332 100% 16% / 0.91; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-2: 330 100% 51% / 0.03; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-3: 332 100% 51% / 0.03; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-4: 331 100% 44% / 0.1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-5: 333 100% 42% / 0.15; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-6: 335 100% 39% / 0.32; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-8: 336 100% 44% / 0.76; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Open Source/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-9: 336 100% 42% / 0.81; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Open Source/Light */
+  --figma___colors-secondary-lime-1: 80 43% 99% / 1; /* ✦ Theme/Colors/Secondary/Lime/1/Harness Open Source/Light */
+  --figma___colors-secondary-lime-2: 85 67% 96% / 1; /* ✦ Theme/Colors/Secondary/Lime/2/Harness Open Source/Light */
+  --figma___colors-secondary-lime-3: 84 76% 92% / 1; /* ✦ Theme/Colors/Secondary/Lime/3/Harness Open Source/Light */
+  --figma___colors-secondary-lime-4: 83 71% 86% / 1; /* ✦ Theme/Colors/Secondary/Lime/4/Harness Open Source/Light */
+  --figma___colors-secondary-lime-5: 83 63% 81% / 1; /* ✦ Theme/Colors/Secondary/Lime/5/Harness Open Source/Light */
+  --figma___colors-secondary-lime-6: 79 41% 65% / 1; /* ✦ Theme/Colors/Secondary/Lime/6/Harness Open Source/Light */
+  --figma___colors-secondary-lime-7: 81 80% 66% / 1; /* ✦ Theme/Colors/Secondary/Lime/7/Harness Open Source/Light */
+  --figma___colors-secondary-lime-8: 81 75% 60% / 1; /* ✦ Theme/Colors/Secondary/Lime/8/Harness Open Source/Light */
+  --figma___colors-secondary-lime-9: 75 41% 29% / 1; /* ✦ Theme/Colors/Secondary/Lime/9/Harness Open Source/Light */
+  --figma___colors-secondary-lime-10: 75 39% 18% / 1; /* ✦ Theme/Colors/Secondary/Lime/10/Harness Open Source/Light */
+  --figma___colors-secondary-lime-alpha-1: 80 94% 31% / 0.02; /* ✦ Theme/Colors/Secondary/Lime Alpha/1/Harness Open Source/Light */
+  --figma___colors-secondary-lime-alpha-2: 85 99% 40% / 0.06; /* ✦ Theme/Colors/Secondary/Lime Alpha/2/Harness Open Source/Light */
+  --figma___colors-secondary-lime-alpha-3: 84 99% 44% / 0.15; /* ✦ Theme/Colors/Secondary/Lime Alpha/3/Harness Open Source/Light */
+  --figma___colors-secondary-lime-alpha-4: 83 99% 42% / 0.23; /* ✦ Theme/Colors/Secondary/Lime Alpha/4/Harness Open Source/Light */
+  --figma___colors-secondary-lime-alpha-5: 83 100% 39% / 0.31; /* ✦ Theme/Colors/Secondary/Lime Alpha/5/Harness Open Source/Light */
+  --figma___colors-secondary-lime-alpha-6: 81 100% 34% / 0.4; /* ✦ Theme/Colors/Secondary/Lime Alpha/6/Harness Open Source/Light */
+  --figma___colors-secondary-lime-alpha-7: 81 100% 45% / 0.61; /* ✦ Theme/Colors/Secondary/Lime Alpha/7/Harness Open Source/Light */
+  --figma___colors-secondary-lime-alpha-8: 81 100% 43% / 0.7; /* ✦ Theme/Colors/Secondary/Lime Alpha/8/Harness Open Source/Light */
+  --figma___colors-secondary-lime-alpha-9: 75 100% 14% / 0.83; /* ✦ Theme/Colors/Secondary/Lime Alpha/9/Harness Open Source/Light */
+  --figma___colors-secondary-lime-alpha-10: 76 100% 8% / 0.89; /* ✦ Theme/Colors/Secondary/Lime Alpha/10/Harness Open Source/Light */
+  --figma___colors-secondary-purple-1: 300 50% 99% / 1; /* ✦ Theme/Colors/Secondary/Purple/1/Harness Open Source/Light */
+  --figma___colors-secondary-purple-2: 276 100% 99% / 1; /* ✦ Theme/Colors/Secondary/Purple/2/Harness Open Source/Light */
+  --figma___colors-secondary-purple-3: 277 87% 97% / 1; /* ✦ Theme/Colors/Secondary/Purple/3/Harness Open Source/Light */
+  --figma___colors-secondary-purple-4: 274 78% 95% / 1; /* ✦ Theme/Colors/Secondary/Purple/4/Harness Open Source/Light */
+  --figma___colors-secondary-purple-5: 276 71% 92% / 1; /* ✦ Theme/Colors/Secondary/Purple/5/Harness Open Source/Light */
+  --figma___colors-secondary-purple-6: 273 61% 82% / 1; /* ✦ Theme/Colors/Secondary/Purple/6/Harness Open Source/Light */
+  --figma___colors-secondary-purple-7: 272 51% 54% / 1; /* ✦ Theme/Colors/Secondary/Purple/7/Harness Open Source/Light */
+  --figma___colors-secondary-purple-8: 272 47% 50% / 1; /* ✦ Theme/Colors/Secondary/Purple/8/Harness Open Source/Light */
+  --figma___colors-secondary-purple-9: 272 50% 46% / 1; /* ✦ Theme/Colors/Secondary/Purple/9/Harness Open Source/Light */
+  --figma___colors-secondary-purple-10: 270 50% 25% / 1; /* ✦ Theme/Colors/Secondary/Purple/10/Harness Open Source/Light */
+  --figma___colors-secondary-purple-alpha-1: 300 94% 35% / 0.01; /* ✦ Theme/Colors/Secondary/Purple Alpha/1/Harness Open Source/Light */
+  --figma___colors-secondary-purple-alpha-2: 276 100% 51% / 0.02; /* ✦ Theme/Colors/Secondary/Purple Alpha/2/Harness Open Source/Light */
+  --figma___colors-secondary-purple-alpha-3: 277 100% 46% / 0.05; /* ✦ Theme/Colors/Secondary/Purple Alpha/3/Harness Open Source/Light */
+  --figma___colors-secondary-purple-alpha-4: 274 98% 44% / 0.09; /* ✦ Theme/Colors/Secondary/Purple Alpha/4/Harness Open Source/Light */
+  --figma___colors-secondary-purple-alpha-5: 276 99% 42% / 0.14; /* ✦ Theme/Colors/Secondary/Purple Alpha/5/Harness Open Source/Light */
+  --figma___colors-secondary-purple-alpha-6: 273 99% 38% / 0.29; /* ✦ Theme/Colors/Secondary/Purple Alpha/6/Harness Open Source/Light */
+  --figma___colors-secondary-purple-alpha-7: 272 100% 34% / 0.69; /* ✦ Theme/Colors/Secondary/Purple Alpha/7/Harness Open Source/Light */
+  --figma___colors-secondary-purple-alpha-8: 272 100% 32% / 0.73; /* ✦ Theme/Colors/Secondary/Purple Alpha/8/Harness Open Source/Light */
+  --figma___colors-secondary-purple-alpha-9: 273 100% 30% / 0.77; /* ✦ Theme/Colors/Secondary/Purple Alpha/9/Harness Open Source/Light */
+  --figma___colors-secondary-purple-alpha-10: 270 100% 14% / 0.88; /* ✦ Theme/Colors/Secondary/Purple Alpha/10/Harness Open Source/Light */
+  --figma___colors-secondary-teal-1: 165 67% 99% / 1; /* ✦ Theme/Colors/Secondary/Teal/1/Harness Open Source/Light */
+  --figma___colors-secondary-teal-2: 169 65% 97% / 1; /* ✦ Theme/Colors/Secondary/Teal/2/Harness Open Source/Light */
+  --figma___colors-secondary-teal-3: 167 60% 94% / 1; /* ✦ Theme/Colors/Secondary/Teal/3/Harness Open Source/Light */
+  --figma___colors-secondary-teal-4: 168 52% 90% / 1; /* ✦ Theme/Colors/Secondary/Teal/4/Harness Open Source/Light */
+  --figma___colors-secondary-teal-5: 170 47% 85% / 1; /* ✦ Theme/Colors/Secondary/Teal/5/Harness Open Source/Light */
+  --figma___colors-secondary-teal-6: 170 40% 68% / 1; /* ✦ Theme/Colors/Secondary/Teal/6/Harness Open Source/Light */
+  --figma___colors-secondary-teal-7: 173 80% 36% / 1; /* ✦ Theme/Colors/Secondary/Teal/7/Harness Open Source/Light */
+  --figma___colors-secondary-teal-8: 173 83% 33% / 1; /* ✦ Theme/Colors/Secondary/Teal/8/Harness Open Source/Light */
+  --figma___colors-secondary-teal-9: 174 91% 25% / 1; /* ✦ Theme/Colors/Secondary/Teal/9/Harness Open Source/Light */
+  --figma___colors-secondary-teal-10: 174 65% 15% / 1; /* ✦ Theme/Colors/Secondary/Teal/10/Harness Open Source/Light */
+  --figma___colors-secondary-teal-alpha-1: 165 95% 41% / 0.02; /* ✦ Theme/Colors/Secondary/Teal Alpha/1/Harness Open Source/Light */
+  --figma___colors-secondary-teal-alpha-2: 169 99% 39% / 0.05; /* ✦ Theme/Colors/Secondary/Teal Alpha/2/Harness Open Source/Light */
+  --figma___colors-secondary-teal-alpha-3: 167 98% 38% / 0.09; /* ✦ Theme/Colors/Secondary/Teal Alpha/3/Harness Open Source/Light */
+  --figma___colors-secondary-teal-alpha-4: 168 98% 35% / 0.15; /* ✦ Theme/Colors/Secondary/Teal Alpha/4/Harness Open Source/Light */
+  --figma___colors-secondary-teal-alpha-5: 170 100% 32% / 0.22; /* ✦ Theme/Colors/Secondary/Teal Alpha/5/Harness Open Source/Light */
+  --figma___colors-secondary-teal-alpha-6: 170 99% 29% / 0.45; /* ✦ Theme/Colors/Secondary/Teal Alpha/6/Harness Open Source/Light */
+  --figma___colors-secondary-teal-alpha-7: 173 100% 31% / 0.93; /* ✦ Theme/Colors/Secondary/Teal Alpha/7/Harness Open Source/Light */
+  --figma___colors-secondary-teal-alpha-8: 173 100% 29% / 0.95; /* ✦ Theme/Colors/Secondary/Teal Alpha/8/Harness Open Source/Light */
+  --figma___colors-secondary-teal-alpha-9: 174 100% 23% / 0.98; /* ✦ Theme/Colors/Secondary/Teal Alpha/9/Harness Open Source/Light */
+  --figma___colors-secondary-teal-alpha-10: 174 100% 10% / 0.95; /* ✦ Theme/Colors/Secondary/Teal Alpha/10/Harness Open Source/Light */
+  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01; /* ✦ Theme/Overlays/Black Alpha/1/Harness Open Source/Light */
+  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02; /* ✦ Theme/Overlays/Black Alpha/2/Harness Open Source/Light */
+  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05; /* ✦ Theme/Overlays/Black Alpha/3/Harness Open Source/Light */
+  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08; /* ✦ Theme/Overlays/Black Alpha/4/Harness Open Source/Light */
+  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11; /* ✦ Theme/Overlays/Black Alpha/5/Harness Open Source/Light */
+  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13; /* ✦ Theme/Overlays/Black Alpha/6/Harness Open Source/Light */
+  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45; /* ✦ Theme/Overlays/Black Alpha/7/Harness Open Source/Light */
+  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5; /* ✦ Theme/Overlays/Black Alpha/8/Harness Open Source/Light */
+  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61; /* ✦ Theme/Overlays/Black Alpha/9/Harness Open Source/Light */
+  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88; /* ✦ Theme/Overlays/Black Alpha/10/Harness Open Source/Light */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 0; /* ✦ Theme/Overlays/White Alpha/1/Harness Open Source/Light */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01; /* ✦ Theme/Overlays/White Alpha/2/Harness Open Source/Light */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07; /* ✦ Theme/Overlays/White Alpha/3/Harness Open Source/Light */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1; /* ✦ Theme/Overlays/White Alpha/4/Harness Open Source/Light */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13; /* ✦ Theme/Overlays/White Alpha/5/Harness Open Source/Light */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17; /* ✦ Theme/Overlays/White Alpha/6/Harness Open Source/Light */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37; /* ✦ Theme/Overlays/White Alpha/7/Harness Open Source/Light */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46; /* ✦ Theme/Overlays/White Alpha/8/Harness Open Source/Light */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66; /* ✦ Theme/Overlays/White Alpha/9/Harness Open Source/Light */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93; /* ✦ Theme/Overlays/White Alpha/10/Harness Open Source/Light */
+  --figma___semantic-background-backdrop: 230 100% 9% / 0.28; /* ✦ Theme/Semantic/Background/Backdrop/Harness Open Source/Light */
+  --figma___semantic-background-cards-and-rows-default: 0 0% 100% / 0; /* ✦ Theme/Semantic/Background/Cards and Rows/Default/Harness Open Source/Light */
+  --figma___semantic-background-cards-and-rows-hover: 0 0% 0% / 0.03; /* ✦ Theme/Semantic/Background/Cards and Rows/Hover/Harness Open Source/Light */
+  --figma___semantic-background-cards-and-rows-primary-blue-selected: 240 100% 12% / 0.05; /* ✦ Theme/Semantic/Background/Cards and Rows/Primary-blue-selected/Harness Open Source/Light */
+  --figma___semantic-background-cards-and-rows-selected: 0 0% 0% / 0.04; /* ✦ Theme/Semantic/Background/Cards and Rows/Selected/Harness Open Source/Light */
+  --figma___semantic-background-header-page-header: 0 0% 100% / 1; /* ✦ Theme/Semantic/Background/Header/Page Header/Harness Open Source/Light */
+  --figma___semantic-background-header-table-header: 0 0% 98% / 1; /* ✦ Theme/Semantic/Background/Header/Table Header/Harness Open Source/Light */
+  --figma___semantic-background-paper: 0 0% 98% / 1; /* ✦ Theme/Semantic/Background/Paper/Harness Open Source/Light */
+  --figma___semantic-background-primary: 0 0% 98% / 1; /* ✦ Theme/Semantic/Background/Primary/Harness Open Source/Light */
+  --figma___semantic-background-solid: 0 0% 100% / 1; /* ✦ Theme/Semantic/Background/Solid/Harness Open Source/Light */
+  --figma___semantic-border-disabled: 240 93% 11% / 0.08; /* ✦ Theme/Semantic/Border/Disabled/Harness Open Source/Light */
+  --figma___semantic-border-hover: 212 6% 50% / 1; /* ✦ Theme/Semantic/Border/Hover/Harness Open Source/Light */
+  --figma___semantic-border-primary: 240 7% 94% / 1; /* ✦ Theme/Semantic/Border/Primary/Harness Open Source/Light */
+  --figma___semantic-border-secondary: 210 7% 94% / 1; /* ✦ Theme/Semantic/Border/Secondary/Harness Open Source/Light */
+  --figma___semantic-border-selected: 216 6% 15% / 1; /* ✦ Theme/Semantic/Border/Selected/Harness Open Source/Light */
+  --figma___semantic-text-disabled: 212 6% 50% / 1; /* ✦ Theme/Semantic/Text/Disabled/Harness Open Source/Light */
+  --figma___semantic-text-links: 216 100% 59% / 1; /* ✦ Theme/Semantic/Text/Links/Harness Open Source/Light */
+  --figma___semantic-text-secondary: 200 5% 12% / 1; /* ✦ Theme/Semantic/Text/Secondary/Harness Open Source/Light */
+  --figma___semantic-text-tertiary: 210 6% 20% / 1; /* ✦ Theme/Semantic/Text/Tertiary/Harness Open Source/Light */
+  --figma___semantic-text-primary: 200 7% 8% / 1; /* ✦ Theme/Semantic/Text/primary/Harness Open Source/Light */
 }
 
 /* Color variables - dark mode */
 .harness-open-source-dark {
-  --figma___background-backdrop: 0 0% 0% / 0.75;
-  /* ✦ Theme/Background/Backdrop/Harness Open Source/Dark */
-  --figma___background-cards-and-rows-default: 240 5% 12% / 0;
-  /* ✦ Theme/Background/Cards and Rows/Default/Harness Open Source/Dark */
-  --figma___background-cards-and-rows-hover: 200 7% 8% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Hover/Harness Open Source/Dark */
-  --figma___background-cards-and-rows-primary-blue-selected: 240 100% 12% / 0.05;
-  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/Harness Open Source/Dark */
-  --figma___background-cards-and-rows-selected: 210 6% 20% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Selected/Harness Open Source/Dark */
-  --figma___background-header-page-header: 240 6% 6% / 1;
-  /* ✦ Theme/Background/Header/Page Header/Harness Open Source/Dark */
-  --figma___background-header-table-header: 200 7% 8% / 1;
-  /* ✦ Theme/Background/Header/Table Header/Harness Open Source/Dark */
-  --figma___background-paper: 210 6% 6% / 1;
-  /* ✦ Theme/Background/Paper/Harness Open Source/Dark */
-  --figma___background-primary: 210 6% 6% / 1;
-  /* ✦ Theme/Background/Primary/Harness Open Source/Dark */
-  --figma___background-solid: 0 4% 5% / 1;
-  /* ✦ Theme/Background/Solid/Harness Open Source/Dark */
-  --figma___badges-soft-amber-background: 24 100% 50% / 0.1;
-  /* ✦ Theme/Badges/Soft/Amber/background/Harness Open Source/Dark */
-  --figma___badges-soft-amber-text: 43 100% 65% / 1;
-  /* ✦ Theme/Badges/Soft/Amber/text/Harness Open Source/Dark */
-  --figma___badges-soft-blue-background: 216 100% 50% / 0.17;
-  /* ✦ Theme/Badges/Soft/Blue/background/Harness Open Source/Dark */
-  --figma___badges-soft-blue-text: 205 100% 71% / 1;
-  /* ✦ Theme/Badges/Soft/Blue/text/Harness Open Source/Dark */
-  --figma___badges-soft-bronze-background: 17 100% 79% / 0.06;
-  /* ✦ Theme/Badges/Soft/Bronze/background/Harness Open Source/Dark */
-  --figma___badges-soft-bronze-text: 19 100% 89% / 0.81;
-  /* ✦ Theme/Badges/Soft/Bronze/text/Harness Open Source/Dark */
-  --figma___badges-soft-brown-background: 25 99% 68% / 0.07;
-  /* ✦ Theme/Badges/Soft/Brown/background/Harness Open Source/Dark */
-  --figma___badges-soft-brown-text: 28 100% 84% / 0.85;
-  /* ✦ Theme/Badges/Soft/Brown/text/Harness Open Source/Dark */
-  --figma___badges-soft-crimson-background: 335 100% 55% / 0.14;
-  /* ✦ Theme/Badges/Soft/Crimson/background/Harness Open Source/Dark */
-  --figma___badges-soft-crimson-text: 341 100% 76% / 1;
-  /* ✦ Theme/Badges/Soft/Crimson/text/Harness Open Source/Dark */
-  --figma___badges-soft-cyan-background: 197 100% 50% / 0.1;
-  /* ✦ Theme/Badges/Soft/Cyan/background/Harness Open Source/Dark */
-  --figma___badges-soft-cyan-text: 190 100% 56% / 0.95;
-  /* ✦ Theme/Badges/Soft/Cyan/text/Harness Open Source/Dark */
-  --figma___badges-soft-gold-background: 50 100% 77% / 0.05;
-  /* ✦ Theme/Badges/Soft/Gold/background/Harness Open Source/Dark */
-  --figma___badges-soft-gold-text: 35 100% 89% / 0.77;
-  /* ✦ Theme/Badges/Soft/Gold/text/Harness Open Source/Dark */
-  --figma___badges-soft-grass-background: 139 98% 54% / 0.07;
-  /* ✦ Theme/Badges/Soft/Grass/background/Harness Open Source/Dark */
-  --figma___badges-soft-grass-text: 131 100% 77% / 0.8;
-  /* ✦ Theme/Badges/Soft/Grass/text/Harness Open Source/Dark */
-  --figma___badges-soft-green-background: 149 100% 49% / 0.07;
-  /* ✦ Theme/Badges/Soft/Green/background/Harness Open Source/Dark */
-  --figma___badges-soft-green-text: 151 100% 64% / 0.82;
-  /* ✦ Theme/Badges/Soft/Green/text/Harness Open Source/Dark */
-  --figma___badges-soft-indigo-background: 228 100% 57% / 0.18;
-  /* ✦ Theme/Badges/Soft/Indigo/background/Harness Open Source/Dark */
-  --figma___badges-soft-indigo-text: 235 100% 80% / 1;
-  /* ✦ Theme/Badges/Soft/Indigo/text/Harness Open Source/Dark */
-  --figma___badges-soft-iris-background: 244 99% 64% / 0.17;
-  /* ✦ Theme/Badges/Soft/Iris/background/Harness Open Source/Dark */
-  --figma___badges-soft-iris-text: 242 100% 81% / 1;
-  /* ✦ Theme/Badges/Soft/Iris/text/Harness Open Source/Dark */
-  --figma___badges-soft-jade-background: 145 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Soft/Jade/background/Harness Open Source/Dark */
-  --figma___badges-soft-jade-text: 163 99% 56% / 0.83;
-  /* ✦ Theme/Badges/Soft/Jade/text/Harness Open Source/Dark */
-  --figma___badges-soft-lime-background: 89 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Soft/Lime/background/Harness Open Source/Dark */
-  --figma___badges-soft-lime-text: 70 100% 58% / 0.84;
-  /* ✦ Theme/Badges/Soft/Lime/text/Harness Open Source/Dark */
-  --figma___badges-soft-mint-background: 174 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Soft/Mint/background/Harness Open Source/Dark */
-  --figma___badges-soft-mint-text: 167 100% 66% / 0.86;
-  /* ✦ Theme/Badges/Soft/Mint/text/Harness Open Source/Dark */
-  --figma___badges-soft-orange-background: 13 100% 50% / 0.12;
-  /* ✦ Theme/Badges/Soft/Orange/background/Harness Open Source/Dark */
-  --figma___badges-soft-orange-text: 24 100% 70% / 1;
-  /* ✦ Theme/Badges/Soft/Orange/text/Harness Open Source/Dark */
-  --figma___badges-soft-pink-background: 318 99% 56% / 0.14;
-  /* ✦ Theme/Badges/Soft/Pink/background/Harness Open Source/Dark */
-  --figma___badges-soft-pink-text: 325 100% 77% / 0.98;
-  /* ✦ Theme/Badges/Soft/Pink/text/Harness Open Source/Dark */
-  --figma___badges-soft-plum-background: 300 99% 59% / 0.12;
-  /* ✦ Theme/Badges/Soft/Plum/background/Harness Open Source/Dark */
-  --figma___badges-soft-plum-text: 290 100% 80% / 0.91;
-  /* ✦ Theme/Badges/Soft/Plum/text/Harness Open Source/Dark */
-  --figma___badges-soft-purple-background: 282 99% 60% / 0.15;
-  /* ✦ Theme/Badges/Soft/Purple/background/Harness Open Source/Dark */
-  --figma___badges-soft-purple-text: 270 100% 80% / 0.98;
-  /* ✦ Theme/Badges/Soft/Purple/text/Harness Open Source/Dark */
-  --figma___badges-soft-red-background: 353 99% 56% / 0.15;
-  /* ✦ Theme/Badges/Soft/Red/background/Harness Open Source/Dark */
-  --figma___badges-soft-red-text: 358 100% 76% / 1;
-  /* ✦ Theme/Badges/Soft/Red/text/Harness Open Source/Dark */
-  --figma___badges-soft-ruby-background: 348 99% 56% / 0.15;
-  /* ✦ Theme/Badges/Soft/Ruby/background/Harness Open Source/Dark */
-  --figma___badges-soft-ruby-text: 348 100% 76% / 1;
-  /* ✦ Theme/Badges/Soft/Ruby/text/Harness Open Source/Dark */
-  --figma___badges-soft-sky-background: 204 100% 50% / 0.12;
-  /* ✦ Theme/Badges/Soft/Sky/background/Harness Open Source/Dark */
-  --figma___badges-soft-sky-text: 195 100% 66% / 1;
-  /* ✦ Theme/Badges/Soft/Sky/text/Harness Open Source/Dark */
-  --figma___badges-soft-teal-background: 161 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Soft/Teal/background/Harness Open Source/Dark */
-  --figma___badges-soft-teal-text: 170 100% 52% / 0.83;
-  /* ✦ Theme/Badges/Soft/Teal/text/Harness Open Source/Dark */
-  --figma___badges-soft-violet-background: 255 99% 63% / 0.17;
-  /* ✦ Theme/Badges/Soft/Violet/background/Harness Open Source/Dark */
-  --figma___badges-soft-violet-text: 255 100% 80% / 1;
-  /* ✦ Theme/Badges/Soft/Violet/text/Harness Open Source/Dark */
-  --figma___badges-soft-yellow-background: 36 100% 50% / 0.09;
-  /* ✦ Theme/Badges/Soft/Yellow/background/Harness Open Source/Dark */
-  --figma___badges-soft-yellow-text: 55 100% 60% / 1;
-  /* ✦ Theme/Badges/Soft/Yellow/text/Harness Open Source/Dark */
-  --figma___badges-soft-accent-background: 200 6% 10% / 1;
-  /* ✦ Theme/Badges/Soft/accent/background/Harness Open Source/Dark */
-  --figma___badges-soft-accent-text: 220 6% 90% / 1;
-  /* ✦ Theme/Badges/Soft/accent/text/Harness Open Source/Dark */
-  --figma___badges-soft-error-background: 0 80% 65% / 0.1;
-  /* ✦ Theme/Badges/Soft/error/background/Harness Open Source/Dark */
-  --figma___badges-soft-error-text: 0 80% 65% / 0.1;
-  /* ✦ Theme/Badges/Soft/error/text/Harness Open Source/Dark */
-  --figma___badges-soft-info-background: 216 100% 50% / 0.17;
-  /* ✦ Theme/Badges/Soft/info/background/Harness Open Source/Dark */
-  --figma___badges-soft-info-text: 205 100% 71% / 1;
-  /* ✦ Theme/Badges/Soft/info/text/Harness Open Source/Dark */
-  --figma___badges-soft-success-background: 149 100% 49% / 0.07;
-  /* ✦ Theme/Badges/Soft/success/background/Harness Open Source/Dark */
-  --figma___badges-soft-success-text: 151 100% 64% / 0.82;
-  /* ✦ Theme/Badges/Soft/success/text/Harness Open Source/Dark */
-  --figma___badges-soft-warning-background: 34 63% 12% / 1;
-  /* ✦ Theme/Badges/Soft/warning/background/Harness Open Source/Dark */
-  --figma___badges-soft-warning-text: 43 100% 65% / 1;
-  /* ✦ Theme/Badges/Soft/warning/text/Harness Open Source/Dark */
-  --figma___badges-solid-amber-background: 42 100% 62% / 1;
-  /* ✦ Theme/Badges/Solid/Amber/background/Harness Open Source/Dark */
-  --figma___badges-solid-blue-background: 214 73% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Blue/background/Harness Open Source/Dark */
-  --figma___badges-solid-bronze-background: 18 20% 54% / 1;
-  /* ✦ Theme/Badges/Solid/Bronze/background/Harness Open Source/Dark */
-  --figma___badges-solid-brown-background: 28 34% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Brown/background/Harness Open Source/Dark */
-  --figma___badges-solid-crimson-background: 336 80% 58% / 1;
-  /* ✦ Theme/Badges/Solid/Crimson/background/Harness Open Source/Dark */
-  --figma___badges-solid-cyan-background: 190 95% 39% / 1;
-  /* ✦ Theme/Badges/Solid/Cyan/background/Harness Open Source/Dark */
-  --figma___badges-solid-gold-background: 36 20% 49% / 1;
-  /* ✦ Theme/Badges/Solid/Gold/background/Harness Open Source/Dark */
-  --figma___badges-solid-grass-background: 132 59% 33% / 1;
-  /* ✦ Theme/Badges/Solid/Grass/background/Harness Open Source/Dark */
-  --figma___badges-solid-green-background: 142 72% 29% / 1;
-  /* ✦ Theme/Badges/Solid/Green/background/Harness Open Source/Dark */
-  --figma___badges-solid-indigo-background: 226 70% 55% / 1;
-  /* ✦ Theme/Badges/Solid/Indigo/background/Harness Open Source/Dark */
-  --figma___badges-solid-iris-background: 240 60% 60% / 1;
-  /* ✦ Theme/Badges/Solid/Iris/background/Harness Open Source/Dark */
-  --figma___badges-solid-jade-background: 164 60% 40% / 1;
-  /* ✦ Theme/Badges/Solid/Jade/background/Harness Open Source/Dark */
-  --figma___badges-solid-lime-background: 81 80% 66% / 1;
-  /* ✦ Theme/Badges/Solid/Lime/background/Harness Open Source/Dark */
-  --figma___badges-solid-mint-background: 176 59% 50% / 1;
-  /* ✦ Theme/Badges/Solid/Mint/background/Harness Open Source/Dark */
-  --figma___badges-solid-orange-background: 24 94% 50% / 1;
-  /* ✦ Theme/Badges/Solid/Orange/background/Harness Open Source/Dark */
-  --figma___badges-solid-pink-background: 322 65% 55% / 1;
-  /* ✦ Theme/Badges/Solid/Pink/background/Harness Open Source/Dark */
-  --figma___badges-solid-plum-background: 292 45% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Plum/background/Harness Open Source/Dark */
-  --figma___badges-solid-purple-background: 272 51% 54% / 1;
-  /* ✦ Theme/Badges/Solid/Purple/background/Harness Open Source/Dark */
-  --figma___badges-solid-red-background: 358 75% 59% / 1;
-  /* ✦ Theme/Badges/Solid/Red/background/Harness Open Source/Dark */
-  --figma___badges-solid-ruby-background: 348 75% 59% / 1;
-  /* ✦ Theme/Badges/Solid/Ruby/background/Harness Open Source/Dark */
-  --figma___badges-solid-sky-background: 193 98% 74% / 1;
-  /* ✦ Theme/Badges/Solid/Sky/background/Harness Open Source/Dark */
-  --figma___badges-solid-success-background: 142 72% 29% / 1;
-  /* ✦ Theme/Badges/Solid/Success/background/Harness Open Source/Dark */
-  --figma___badges-solid-teal-background: 173 80% 36% / 1;
-  /* ✦ Theme/Badges/Solid/Teal/background/Harness Open Source/Dark */
-  --figma___badges-solid-violet-background: 252 56% 57% / 1;
-  /* ✦ Theme/Badges/Solid/Violet/background/Harness Open Source/Dark */
-  --figma___badges-solid-yellow-background: 53 96% 58% / 1;
-  /* ✦ Theme/Badges/Solid/Yellow/background/Harness Open Source/Dark */
-  --figma___badges-solid-accent-background: 176 59% 50% / 1;
-  /* ✦ Theme/Badges/Solid/accent/background/Harness Open Source/Dark */
-  --figma___badges-solid-info-background: 214 73% 51% / 1;
-  /* ✦ Theme/Badges/Solid/info/background/Harness Open Source/Dark */
-  --figma___badges-solid-warning-background: 43 100% 65% / 1;
-  /* ✦ Theme/Badges/Solid/warning/background/Harness Open Source/Dark */
-  --figma___badges-surface-amber-background: 6 100% 49% / 0.06;
-  /* ✦ Theme/Badges/Surface/Amber/background/Harness Open Source/Dark */
-  --figma___badges-surface-amber-border: 35 100% 57% / 0.38;
-  /* ✦ Theme/Badges/Surface/Amber/border/Harness Open Source/Dark */
-  --figma___badges-surface-amber-text: 43 100% 65% / 1;
-  /* ✦ Theme/Badges/Surface/Amber/text/Harness Open Source/Dark */
-  --figma___badges-surface-blue-background: 227 100% 50% / 0.09;
-  /* ✦ Theme/Badges/Surface/Blue/background/Harness Open Source/Dark */
-  --figma___badges-surface-blue-border: 211 100% 51% / 0.55;
-  /* ✦ Theme/Badges/Surface/Blue/border/Harness Open Source/Dark */
-  --figma___badges-surface-blue-text: 205 100% 71% / 1;
-  /* ✦ Theme/Badges/Surface/Blue/text/Harness Open Source/Dark */
-  --figma___badges-surface-bronze-background: 15 93% 53% / 0.02;
-  /* ✦ Theme/Badges/Surface/Bronze/background/Harness Open Source/Dark */
-  --figma___badges-surface-bronze-border: 17 100% 84% / 0.3;
-  /* ✦ Theme/Badges/Surface/Bronze/border/Harness Open Source/Dark */
-  --figma___badges-surface-bronze-text: 19 100% 89% / 0.81;
-  /* ✦ Theme/Badges/Surface/Bronze/text/Harness Open Source/Dark */
-  --figma___badges-surface-brown-background: 24 100% 50% / 0.03;
-  /* ✦ Theme/Badges/Surface/Brown/background/Harness Open Source/Dark */
-  --figma___badges-surface-brown-border: 28 98% 75% / 0.32;
-  /* ✦ Theme/Badges/Surface/Brown/border/Harness Open Source/Dark */
-  --figma___badges-surface-brown-text: 28 100% 84% / 0.85;
-  /* ✦ Theme/Badges/Surface/Brown/text/Harness Open Source/Dark */
-  --figma___badges-surface-crimson-border: 336 100% 57% / 0.49;
-  /* ✦ Theme/Badges/Surface/Crimson/Border/Harness Open Source/Dark */
-  --figma___badges-surface-crimson-background: 338 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/Crimson/background/Harness Open Source/Dark */
-  --figma___badges-surface-crimson-text: 341 100% 76% / 1;
-  /* ✦ Theme/Badges/Surface/Crimson/text/Harness Open Source/Dark */
-  --figma___badges-surface-cyan-border: 192 100% 57% / 0.35;
-  /* ✦ Theme/Badges/Surface/Cyan/Border/Harness Open Source/Dark */
-  --figma___badges-surface-cyan-background: 207 100% 49% / 0.04;
-  /* ✦ Theme/Badges/Surface/Cyan/background/Harness Open Source/Dark */
-  --figma___badges-surface-cyan-text: 190 100% 56% / 0.95;
-  /* ✦ Theme/Badges/Surface/Cyan/text/Harness Open Source/Dark */
-  --figma___badges-surface-gold-border: 39 97% 85% / 0.27;
-  /* ✦ Theme/Badges/Surface/Gold/Border/Harness Open Source/Dark */
-  --figma___badges-surface-gold-background: 42 100% 50% / 0.01;
-  /* ✦ Theme/Badges/Surface/Gold/background/Harness Open Source/Dark */
-  --figma___badges-surface-gold-text: 35 100% 89% / 0.77;
-  /* ✦ Theme/Badges/Surface/Gold/text/Harness Open Source/Dark */
-  --figma___badges-surface-grass-border: 135 100% 68% / 0.3;
-  /* ✦ Theme/Badges/Surface/Grass/Border/Harness Open Source/Dark */
-  --figma___badges-surface-grass-background: 120 100% 49% / 0.02;
-  /* ✦ Theme/Badges/Surface/Grass/background/Harness Open Source/Dark */
-  --figma___badges-surface-grass-text: 131 100% 77% / 0.8;
-  /* ✦ Theme/Badges/Surface/Grass/text/Harness Open Source/Dark */
-  --figma___badges-surface-green-background: 120 100% 49% / 0.02;
-  /* ✦ Theme/Badges/Surface/Green/background/Harness Open Source/Dark */
-  --figma___badges-surface-green-border: 152 99% 59% / 0.3;
-  /* ✦ Theme/Badges/Surface/Green/border/Harness Open Source/Dark */
-  --figma___badges-surface-green-text: 151 100% 64% / 0.82;
-  /* ✦ Theme/Badges/Surface/Green/text/Harness Open Source/Dark */
-  --figma___badges-surface-indigo-background: 232 100% 50% / 0.09;
-  /* ✦ Theme/Badges/Surface/Indigo/background/Harness Open Source/Dark */
-  --figma___badges-surface-indigo-border: 226 100% 62% / 0.52;
-  /* ✦ Theme/Badges/Surface/Indigo/border/Harness Open Source/Dark */
-  --figma___badges-surface-indigo-text: 235 100% 80% / 1;
-  /* ✦ Theme/Badges/Surface/Indigo/text/Harness Open Source/Dark */
-  --figma___badges-surface-iris-border: 240 100% 71% / 0.49;
-  /* ✦ Theme/Badges/Surface/Iris/Border/Harness Open Source/Dark */
-  --figma___badges-surface-iris-background: 243 100% 55% / 0.09;
-  /* ✦ Theme/Badges/Surface/Iris/background/Harness Open Source/Dark */
-  --figma___badges-surface-iris-text: 242 100% 81% / 1;
-  /* ✦ Theme/Badges/Surface/Iris/text/Harness Open Source/Dark */
-  --figma___badges-surface-jade-border: 159 99% 58% / 0.3;
-  /* ✦ Theme/Badges/Surface/Jade/Border/Harness Open Source/Dark */
-  --figma___badges-surface-jade-background: 120 100% 49% / 0.03;
-  /* ✦ Theme/Badges/Surface/Jade/background/Harness Open Source/Dark */
-  --figma___badges-surface-jade-text: 163 99% 56% / 0.83;
-  /* ✦ Theme/Badges/Surface/Jade/text/Harness Open Source/Dark */
-  --figma___badges-surface-lime-border: 78 100% 61% / 0.28;
-  /* ✦ Theme/Badges/Surface/Lime/Border/Harness Open Source/Dark */
-  --figma___badges-surface-lime-background: 114 100% 49% / 0.02;
-  /* ✦ Theme/Badges/Surface/Lime/background/Harness Open Source/Dark */
-  --figma___badges-surface-lime-text: 70 100% 58% / 0.84;
-  /* ✦ Theme/Badges/Surface/Lime/text/Harness Open Source/Dark */
-  --figma___badges-surface-mint-background: 165 100% 49% / 0.03;
-  /* ✦ Theme/Badges/Surface/Mint/background/Harness Open Source/Dark */
-  --figma___badges-surface-mint-border: 173 100% 55% / 0.31;
-  /* ✦ Theme/Badges/Surface/Mint/border/Harness Open Source/Dark */
-  --figma___badges-surface-mint-text: 167 100% 66% / 0.86;
-  /* ✦ Theme/Badges/Surface/Mint/text/Harness Open Source/Dark */
-  --figma___badges-surface-orange-background: 13 100% 50% / 0.12;
-  /* ✦ Theme/Badges/Surface/Orange/background/Harness Open Source/Dark */
-  --figma___badges-surface-orange-border: 25 100% 51% / 0.44;
-  /* ✦ Theme/Badges/Surface/Orange/border/Harness Open Source/Dark */
-  --figma___badges-surface-orange-text: 24 100% 70% / 1;
-  /* ✦ Theme/Badges/Surface/Orange/text/Harness Open Source/Dark */
-  --figma___badges-surface-pink-background: 319 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/Pink/background/Harness Open Source/Dark */
-  --figma___badges-surface-pink-border: 320 100% 62% / 0.43;
-  /* ✦ Theme/Badges/Surface/Pink/border/Harness Open Source/Dark */
-  --figma___badges-surface-pink-text: 325 100% 77% / 0.98;
-  /* ✦ Theme/Badges/Surface/Pink/text/Harness Open Source/Dark */
-  --figma___badges-surface-plum-background: 300 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Surface/Plum/background/Harness Open Source/Dark */
-  --figma___badges-surface-plum-border: 294 100% 69% / 0.39;
-  /* ✦ Theme/Badges/Surface/Plum/border/Harness Open Source/Dark */
-  --figma___badges-surface-plum-text: 290 100% 80% / 0.91;
-  /* ✦ Theme/Badges/Surface/Plum/text/Harness Open Source/Dark */
-  --figma___badges-surface-purple-background: 283 100% 49% / 0.07;
-  /* ✦ Theme/Badges/Surface/Purple/background/Harness Open Source/Dark */
-  --figma___badges-surface-purple-border: 276 100% 67% / 0.44;
-  /* ✦ Theme/Badges/Surface/Purple/border/Harness Open Source/Dark */
-  --figma___badges-surface-purple-text: 270 100% 80% / 0.98;
-  /* ✦ Theme/Badges/Surface/Purple/text/Harness Open Source/Dark */
-  --figma___badges-surface-red-background: 354 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/Red/background/Harness Open Source/Dark */
-  --figma___badges-surface-red-border: 354 100% 57% / 0.5;
-  /* ✦ Theme/Badges/Surface/Red/border/Harness Open Source/Dark */
-  --figma___badges-surface-red-text: 358 100% 76% / 1;
-  /* ✦ Theme/Badges/Surface/Red/text/Harness Open Source/Dark */
-  --figma___badges-surface-ruby-background: 351 100% 50% / 0.08;
-  /* ✦ Theme/Badges/Surface/Ruby/background/Harness Open Source/Dark */
-  --figma___badges-surface-ruby-border: 348 100% 57% / 0.49;
-  /* ✦ Theme/Badges/Surface/Ruby/border/Harness Open Source/Dark */
-  --figma___badges-surface-ruby-text: 348 100% 76% / 1;
-  /* ✦ Theme/Badges/Surface/Ruby/text/Harness Open Source/Dark */
-  --figma___badges-surface-sky-background: 215 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Surface/Sky/background/Harness Open Source/Dark */
-  --figma___badges-surface-sky-border: 200 100% 59% / 0.4;
-  /* ✦ Theme/Badges/Surface/Sky/border/Harness Open Source/Dark */
-  --figma___badges-surface-sky-text: 195 100% 66% / 1;
-  /* ✦ Theme/Badges/Surface/Sky/text/Harness Open Source/Dark */
-  --figma___badges-surface-teal-background: 141 100% 49% / 0.03;
-  /* ✦ Theme/Badges/Surface/Teal/background/Harness Open Source/Dark */
-  --figma___badges-surface-teal-border: 171 99% 56% / 0.3;
-  /* ✦ Theme/Badges/Surface/Teal/border/Harness Open Source/Dark */
-  --figma___badges-surface-teal-text: 170 100% 52% / 0.83;
-  /* ✦ Theme/Badges/Surface/Teal/text/Harness Open Source/Dark */
-  --figma___badges-surface-violet-background: 255 98% 52% / 0.08;
-  /* ✦ Theme/Badges/Surface/Violet/background/Harness Open Source/Dark */
-  --figma___badges-surface-violet-border: 251 100% 70% / 0.49;
-  /* ✦ Theme/Badges/Surface/Violet/border/Harness Open Source/Dark */
-  --figma___badges-surface-violet-text: 255 100% 80% / 1;
-  /* ✦ Theme/Badges/Surface/Violet/text/Harness Open Source/Dark */
-  --figma___badges-surface-yellow-background: 17 100% 49% / 0.04;
-  /* ✦ Theme/Badges/Surface/Yellow/background/Harness Open Source/Dark */
-  --figma___badges-surface-yellow-border: 47 99% 55% / 0.32;
-  /* ✦ Theme/Badges/Surface/Yellow/border/Harness Open Source/Dark */
-  --figma___badges-surface-yellow-text: 55 100% 60% / 1;
-  /* ✦ Theme/Badges/Surface/Yellow/text/Harness Open Source/Dark */
-  --figma___badges-surface-accent-background: 165 100% 49% / 0.03;
-  /* ✦ Theme/Badges/Surface/accent/background/Harness Open Source/Dark */
-  --figma___badges-surface-accent-border: 173 100% 55% / 0.31;
-  /* ✦ Theme/Badges/Surface/accent/border/Harness Open Source/Dark */
-  --figma___badges-surface-accent-text: 167 100% 66% / 0.86;
-  /* ✦ Theme/Badges/Surface/accent/text/Harness Open Source/Dark */
-  --figma___badges-surface-error-background: 354 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/error/background/Harness Open Source/Dark */
-  --figma___badges-surface-error-border: 354 100% 57% / 0.5;
-  /* ✦ Theme/Badges/Surface/error/border/Harness Open Source/Dark */
-  --figma___badges-surface-error-text: 358 100% 76% / 1;
-  /* ✦ Theme/Badges/Surface/error/text/Harness Open Source/Dark */
-  --figma___badges-surface-info-background: 204 100% 50% / 0.12;
-  /* ✦ Theme/Badges/Surface/info/background/Harness Open Source/Dark */
-  --figma___badges-surface-info-border: 200 100% 59% / 0.4;
-  /* ✦ Theme/Badges/Surface/info/border/Harness Open Source/Dark */
-  --figma___badges-surface-info-text: 195 100% 66% / 1;
-  /* ✦ Theme/Badges/Surface/info/text/Harness Open Source/Dark */
-  --figma___badges-surface-success-background: 120 100% 49% / 0.02;
-  /* ✦ Theme/Badges/Surface/success/background/Harness Open Source/Dark */
-  --figma___badges-surface-success-border: 152 99% 59% / 0.3;
-  /* ✦ Theme/Badges/Surface/success/border/Harness Open Source/Dark */
-  --figma___badges-surface-success-text: 151 100% 64% / 0.82;
-  /* ✦ Theme/Badges/Surface/success/text/Harness Open Source/Dark */
-  --figma___badges-surface-warning-background: 6 100% 49% / 0.06;
-  /* ✦ Theme/Badges/Surface/warning/background/Harness Open Source/Dark */
-  --figma___badges-surface-warning-border: 35 100% 57% / 0.38;
-  /* ✦ Theme/Badges/Surface/warning/border/Harness Open Source/Dark */
-  --figma___badges-surface-warning-text: 43 100% 65% / 1;
-  /* ✦ Theme/Badges/Surface/warning/text/Harness Open Source/Dark */
-  --figma___border-disabled: 224 96% 89% / 0.13;
-  /* ✦ Theme/Border/Disabled/Harness Open Source/Dark */
-  --figma___border-hover: 207 6% 30% / 1;
-  /* ✦ Theme/Border/Hover/Harness Open Source/Dark */
-  --figma___border-primary: 240 6% 10% / 1;
-  /* ✦ Theme/Border/Primary/Harness Open Source/Dark */
-  --figma___border-secondary: 200 5% 12% / 1;
-  /* ✦ Theme/Border/Secondary/Harness Open Source/Dark */
-  --figma___border-selected: 240 7% 94% / 1;
-  /* ✦ Theme/Border/Selected/Harness Open Source/Dark */
-  --figma___breadcrumbs-current: 0 0% 98% / 1;
-  /* ✦ Theme/Breadcrumbs/current/Harness Open Source/Dark */
-  --figma___breadcrumbs-visited: 207 6% 70% / 1;
-  /* ✦ Theme/Breadcrumbs/visited/Harness Open Source/Dark */
-  --figma___button-ghost-accent-active: 172 100% 50% / 0.11;
-  /* ✦ Theme/Button/Ghost/Accent/Active/Harness Open Source/Dark */
-  --figma___button-ghost-accent-active-text: 167 70% 58% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Active text/Harness Open Source/Dark */
-  --figma___button-ghost-accent-hover: 174 100% 50% / 0.07;
-  /* ✦ Theme/Button/Ghost/Accent/Hover/Harness Open Source/Dark */
-  --figma___button-ghost-accent-hover-text: 167 70% 58% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Hover text/Harness Open Source/Dark */
-  --figma___button-ghost-accent-text-disabled: 170 60% 35% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/Harness Open Source/Dark */
-  --figma___button-ghost-accent-text-primary: 167 70% 58% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Text-primary/Harness Open Source/Dark */
-  --figma___button-ghost-error-active: 352 100% 56% / 0.21;
-  /* ✦ Theme/Button/Ghost/Error/Active/Harness Open Source/Dark */
-  --figma___button-ghost-error-active-text: 358 100% 76% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Active Text/Harness Open Source/Dark */
-  --figma___button-ghost-error-hover: 353 99% 56% / 0.15;
-  /* ✦ Theme/Button/Ghost/Error/Hover/Harness Open Source/Dark */
-  --figma___button-ghost-error-hover-text: 358 100% 76% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Hover text/Harness Open Source/Dark */
-  --figma___button-ghost-error-text-disabled: 358 75% 47% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Text-disabled/Harness Open Source/Dark */
-  --figma___button-ghost-error-text-primary: 358 100% 76% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Text-primary/Harness Open Source/Dark */
-  --figma___button-ghost-neutral-active: 224 96% 89% / 0.13;
-  /* ✦ Theme/Button/Ghost/Neutral/Active/Harness Open Source/Dark */
-  --figma___button-ghost-neutral-active-text: 218 7% 70% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Active Text/Harness Open Source/Dark */
-  --figma___button-ghost-neutral-hover: 230 100% 87% / 0.09;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover/Harness Open Source/Dark */
-  --figma___button-ghost-neutral-hover-text: 218 7% 70% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover text/Harness Open Source/Dark */
-  --figma___button-ghost-neutral-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/Harness Open Source/Dark */
-  --figma___button-ghost-neutral-text-primary: 0 0% 98% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/Harness Open Source/Dark */
-  --figma___button-ghost-success-active: 154 100% 50% / 0.11;
-  /* ✦ Theme/Button/Ghost/Success/Active/Harness Open Source/Dark */
-  --figma___button-ghost-success-active-text: 151 65% 54% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Active Text/Harness Open Source/Dark */
-  --figma___button-ghost-success-hover: 149 100% 49% / 0.07;
-  /* ✦ Theme/Button/Ghost/Success/Hover/Harness Open Source/Dark */
-  --figma___button-ghost-success-hover-text: 151 65% 54% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Hover text/Harness Open Source/Dark */
-  --figma___button-ghost-success-text-disabled: 151 100% 63% / 0.5;
-  /* ✦ Theme/Button/Ghost/Success/Text-disabled/Harness Open Source/Dark */
-  --figma___button-ghost-success-text-primary: 151 65% 54% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Text-primary/Harness Open Source/Dark */
-  --figma___button-outline-accent-active: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Outline/Accent/Active/Harness Open Source/Dark */
-  --figma___button-outline-accent-default-border: 0 0% 98% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Default border/Harness Open Source/Dark */
-  --figma___button-outline-accent-disabled-border: 209 95% 92% / 0.24;
-  /* ✦ Theme/Button/Outline/Accent/Disabled Border/Harness Open Source/Dark */
-  --figma___button-outline-accent-hover: 240 89% 18% / 0.02;
-  /* ✦ Theme/Button/Outline/Accent/Hover/Harness Open Source/Dark */
-  --figma___button-outline-accent-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Text-disabled/Harness Open Source/Dark */
-  --figma___button-outline-accent-text-primary: 220 6% 90% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Text-primary/Harness Open Source/Dark */
-  --figma___button-outline-error-active: 0 80% 65% / 0.1;
-  /* ✦ Theme/Button/Outline/Error/Active/Harness Open Source/Dark */
-  --figma___button-outline-error-default-border: 0 80% 65% / 0.16;
-  /* ✦ Theme/Button/Outline/Error/Default - border/Harness Open Source/Dark */
-  --figma___button-outline-error-disabled-border: 0 80% 65% / 0.1;
-  /* ✦ Theme/Button/Outline/Error/Disabled-border/Harness Open Source/Dark */
-  --figma___button-outline-error-hover: 0 80% 65% / 0.1;
-  /* ✦ Theme/Button/Outline/Error/Hover/Harness Open Source/Dark */
-  --figma___button-outline-error-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Outline/Error/Text-disabled/Harness Open Source/Dark */
-  --figma___button-outline-error-text-primary: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Outline/Error/Text-primary/Harness Open Source/Dark */
-  --figma___button-outline-neutral-active: 217 95% 91% / 0.19;
-  /* ✦ Theme/Button/Outline/Neutral/Active/Harness Open Source/Dark */
-  --figma___button-outline-neutral-default-border: 209 95% 92% / 0.24;
-  /* ✦ Theme/Button/Outline/Neutral/Default - border/Harness Open Source/Dark */
-  --figma___button-outline-neutral-disabled-border: 202 88% 93% / 0.33;
-  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/Harness Open Source/Dark */
-  --figma___button-outline-neutral-hover: 217 95% 91% / 0.19;
-  /* ✦ Theme/Button/Outline/Neutral/Hover/Harness Open Source/Dark */
-  --figma___button-outline-neutral-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/Harness Open Source/Dark */
-  --figma___button-outline-neutral-text-primary: 207 6% 70% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Text-primary/Harness Open Source/Dark */
-  --figma___button-outline-success-active: 149 100% 49% / 0.07;
-  /* ✦ Theme/Button/Outline/Success/Active/Harness Open Source/Dark */
-  --figma___button-outline-success-default-border: 152 99% 59% / 0.3;
-  /* ✦ Theme/Button/Outline/Success/Default-border/Harness Open Source/Dark */
-  --figma___button-outline-success-disabled-border: 209 95% 92% / 0.24;
-  /* ✦ Theme/Button/Outline/Success/Disabled - border/Harness Open Source/Dark */
-  --figma___button-outline-success-hover: 120 100% 49% / 0.02;
-  /* ✦ Theme/Button/Outline/Success/Hover/Harness Open Source/Dark */
-  --figma___button-outline-success-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Outline/Success/Text-disabled/Harness Open Source/Dark */
-  --figma___button-outline-success-text-primary: 151 100% 64% / 0.82;
-  /* ✦ Theme/Button/Outline/Success/Text-primary/Harness Open Source/Dark */
-  --figma___button-soft-accent-active: 240 96% 9% / 0.13;
-  /* ✦ Theme/Button/Soft/Accent/Active/Harness Open Source/Dark */
-  --figma___button-soft-accent-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Soft/Accent/Disabled/Harness Open Source/Dark */
-  --figma___button-soft-accent-hover: 240 93% 11% / 0.08;
-  /* ✦ Theme/Button/Soft/Accent/Hover/Harness Open Source/Dark */
-  --figma___button-soft-accent-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Text-disabled/Harness Open Source/Dark */
-  --figma___button-soft-accent-text-primary: 220 6% 90% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Text-primary/Harness Open Source/Dark */
-  --figma___button-soft-accent-default: 202 88% 93% / 0.33;
-  /* ✦ Theme/Button/Soft/Accent/default/Harness Open Source/Dark */
-  --figma___button-soft-error-active: 0 80% 65% / 0.1;
-  /* ✦ Theme/Button/Soft/Error/Active/Harness Open Source/Dark */
-  --figma___button-soft-error-disabled: 0 80% 65% / 0.1;
-  /* ✦ Theme/Button/Soft/Error/Disabled/Harness Open Source/Dark */
-  --figma___button-soft-error-hover: 0 80% 65% / 0.16;
-  /* ✦ Theme/Button/Soft/Error/Hover/Harness Open Source/Dark */
-  --figma___button-soft-error-text-disabled: 354 66% 33% / 1;
-  /* ✦ Theme/Button/Soft/Error/Text-disabled/Harness Open Source/Dark */
-  --figma___button-soft-error-text-primary: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Soft/Error/Text-primary/Harness Open Source/Dark */
-  --figma___button-soft-error-default: 0 80% 65% / 0.1;
-  /* ✦ Theme/Button/Soft/Error/default/Harness Open Source/Dark */
-  --figma___button-soft-neutral-active: 223 100% 91% / 0.16;
-  /* ✦ Theme/Button/Soft/Neutral/Active/Harness Open Source/Dark */
-  --figma___button-soft-neutral-disabled: 230 100% 87% / 0.09;
-  /* ✦ Theme/Button/Soft/Neutral/Disabled/Harness Open Source/Dark */
-  --figma___button-soft-neutral-hover: 224 96% 89% / 0.13;
-  /* ✦ Theme/Button/Soft/Neutral/Hover/Harness Open Source/Dark */
-  --figma___button-soft-neutral-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/Harness Open Source/Dark */
-  --figma___button-soft-neutral-text-primary: 207 6% 70% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Text-primary/Harness Open Source/Dark */
-  --figma___button-soft-neutral-default: 230 100% 87% / 0.09;
-  /* ✦ Theme/Button/Soft/Neutral/default/Harness Open Source/Dark */
-  --figma___button-soft-success-active: 153 99% 53% / 0.15;
-  /* ✦ Theme/Button/Soft/Success/Active/Harness Open Source/Dark */
-  --figma___button-soft-success-disabled: 230 100% 87% / 0.09;
-  /* ✦ Theme/Button/Soft/Success/Disabled/Harness Open Source/Dark */
-  --figma___button-soft-success-hover: 154 100% 50% / 0.11;
-  /* ✦ Theme/Button/Soft/Success/Hover/Harness Open Source/Dark */
-  --figma___button-soft-success-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Soft/Success/Text-disabled/Harness Open Source/Dark */
-  --figma___button-soft-success-text-primary: 151 65% 54% / 1;
-  /* ✦ Theme/Button/Soft/Success/Text-primary/Harness Open Source/Dark */
-  --figma___button-soft-success-default: 149 100% 49% / 0.07;
-  /* ✦ Theme/Button/Soft/Success/default/Harness Open Source/Dark */
-  --figma___button-solid-accent-active: 0 0% 98% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Active/Harness Open Source/Dark */
-  --figma___button-solid-accent-disabled: 240 6% 80% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Disabled/Harness Open Source/Dark */
-  --figma___button-solid-accent-hover: 240 7% 94% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Hover/Harness Open Source/Dark */
-  --figma___button-solid-accent-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Text-disabled/Harness Open Source/Dark */
-  --figma___button-solid-accent-text-primary: 240 13% 3% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Text-primary/Harness Open Source/Dark */
-  --figma___button-solid-accent-default: 0 0% 100% / 1;
-  /* ✦ Theme/Button/Solid/Accent/default/Harness Open Source/Dark */
-  --figma___button-solid-error-active: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Solid/Error/Active/Harness Open Source/Dark */
-  --figma___button-solid-error-disabled: 0 80% 65% / 0.1;
-  /* ✦ Theme/Button/Solid/Error/Disabled/Harness Open Source/Dark */
-  --figma___button-solid-error-hover: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Solid/Error/Hover/Harness Open Source/Dark */
-  --figma___button-solid-error-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Solid/Error/Text-disabled/Harness Open Source/Dark */
-  --figma___button-solid-error-default: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Solid/Error/default/Harness Open Source/Dark */
-  --figma___button-solid-neutral-active: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Active/Harness Open Source/Dark */
-  --figma___button-solid-neutral-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Solid/Neutral/Disabled/Harness Open Source/Dark */
-  --figma___button-solid-neutral-hover: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Hover/Harness Open Source/Dark */
-  --figma___button-solid-neutral-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/Harness Open Source/Dark */
-  --figma___button-solid-neutral-default: 212 6% 50% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/default/Harness Open Source/Dark */
-  --figma___button-solid-success-active: 142 72% 29% / 1;
-  /* ✦ Theme/Button/Solid/Success/Active/Harness Open Source/Dark */
-  --figma___button-solid-success-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Solid/Success/Disabled/Harness Open Source/Dark */
-  --figma___button-solid-success-hover: 151 55% 47% / 1;
-  /* ✦ Theme/Button/Solid/Success/Hover/Harness Open Source/Dark */
-  --figma___button-solid-success-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Solid/Success/Text-disabled/Harness Open Source/Dark */
-  --figma___button-solid-success-default: 142 72% 29% / 1;
-  /* ✦ Theme/Button/Solid/Success/default/Harness Open Source/Dark */
-  --figma___button-surface-accent-active: 0 0% 100% / 0.13;
-  /* ✦ Theme/Button/Surface/Accent/Active/Harness Open Source/Dark */
-  --figma___button-surface-accent-active-border: 0 0% 100% / 0.31;
-  /* ✦ Theme/Button/Surface/Accent/Active border/Harness Open Source/Dark */
-  --figma___button-surface-accent-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Surface/Accent/Disabled/Harness Open Source/Dark */
-  --figma___button-surface-accent-hover: 0 0% 100% / 0.1;
-  /* ✦ Theme/Button/Surface/Accent/Hover/Harness Open Source/Dark */
-  --figma___button-surface-accent-hover-border: 0 0% 100% / 0.31;
-  /* ✦ Theme/Button/Surface/Accent/Hover Border/Harness Open Source/Dark */
-  --figma___button-surface-accent-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Text-disabled/Harness Open Source/Dark */
-  --figma___button-surface-accent-text-primary: 0 0% 98% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Text-primary/Harness Open Source/Dark */
-  --figma___button-surface-accent-default: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Surface/Accent/default/Harness Open Source/Dark */
-  --figma___button-surface-accent-default-border: 0 0% 100% / 0.22;
-  /* ✦ Theme/Button/Surface/Accent/default border/Harness Open Source/Dark */
-  --figma___button-surface-error-active: 0 80% 65% / 0.1;
-  /* ✦ Theme/Button/Surface/Error/Active/Harness Open Source/Dark */
-  --figma___button-surface-error-active-border: 0 80% 65% / 0.16;
-  /* ✦ Theme/Button/Surface/Error/Active border/Harness Open Source/Dark */
-  --figma___button-surface-error-disabled: 353 99% 56% / 0.15;
-  /* ✦ Theme/Button/Surface/Error/Disabled/Harness Open Source/Dark */
-  --figma___button-surface-error-hover: 0 80% 65% / 0.16;
-  /* ✦ Theme/Button/Surface/Error/Hover/Harness Open Source/Dark */
-  --figma___button-surface-error-hover-border: 0 80% 65% / 0.16;
-  /* ✦ Theme/Button/Surface/Error/Hover border/Harness Open Source/Dark */
-  --figma___button-surface-error-text-disabled: 354 66% 33% / 1;
-  /* ✦ Theme/Button/Surface/Error/Text-disabled/Harness Open Source/Dark */
-  --figma___button-surface-error-text-primary: 0 80% 65% / 1;
-  /* ✦ Theme/Button/Surface/Error/Text-primary/Harness Open Source/Dark */
-  --figma___button-surface-error-border: 0 80% 65% / 0.1;
-  /* ✦ Theme/Button/Surface/Error/border/Harness Open Source/Dark */
-  --figma___button-surface-error-default: 0 80% 65% / 0.1;
-  /* ✦ Theme/Button/Surface/Error/default/Harness Open Source/Dark */
-  --figma___button-surface-neutral-active: 223 100% 91% / 0.16;
-  /* ✦ Theme/Button/Surface/Neutral/Active/Harness Open Source/Dark */
-  --figma___button-surface-neutral-disabled: 230 100% 87% / 0.09;
-  /* ✦ Theme/Button/Surface/Neutral/Disabled/Harness Open Source/Dark */
-  --figma___button-surface-neutral-hover: 224 96% 89% / 0.13;
-  /* ✦ Theme/Button/Surface/Neutral/Hover/Harness Open Source/Dark */
-  --figma___button-surface-neutral-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/Harness Open Source/Dark */
-  --figma___button-surface-neutral-text-primary: 0 0% 69% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Text-primary/Harness Open Source/Dark */
-  --figma___button-surface-neutral-border: 209 95% 92% / 0.24;
-  /* ✦ Theme/Button/Surface/Neutral/border/Harness Open Source/Dark */
-  --figma___button-surface-neutral-default: 230 100% 87% / 0.09;
-  /* ✦ Theme/Button/Surface/Neutral/default/Harness Open Source/Dark */
-  --figma___button-surface-success-active: 153 99% 53% / 0.15;
-  /* ✦ Theme/Button/Surface/Success/Active/Harness Open Source/Dark */
-  --figma___button-surface-success-disabled: 230 100% 87% / 0.09;
-  /* ✦ Theme/Button/Surface/Success/Disabled/Harness Open Source/Dark */
-  --figma___button-surface-success-hover: 154 100% 50% / 0.11;
-  /* ✦ Theme/Button/Surface/Success/Hover/Harness Open Source/Dark */
-  --figma___button-surface-success-hover-border: 151 100% 63% / 0.5;
-  /* ✦ Theme/Button/Surface/Success/Hover border/Harness Open Source/Dark */
-  --figma___button-surface-success-text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Button/Surface/Success/Text-disabled/Harness Open Source/Dark */
-  --figma___button-surface-success-text-primary: 151 100% 64% / 0.82;
-  /* ✦ Theme/Button/Surface/Success/Text-primary/Harness Open Source/Dark */
-  --figma___button-surface-success-active-border: 151 100% 63% / 0.5;
-  /* ✦ Theme/Button/Surface/Success/active border/Harness Open Source/Dark */
-  --figma___button-surface-success-default: 149 100% 49% / 0.07;
-  /* ✦ Theme/Button/Surface/Success/default/Harness Open Source/Dark */
-  --figma___button-surface-success-default-border: 155 99% 55% / 0.2;
-  /* ✦ Theme/Button/Surface/Success/default border/Harness Open Source/Dark */
-  --figma___calendar-background: 200 5% 12% / 1;
-  /* ✦ Theme/Calendar/Background/Harness Open Source/Dark */
-  --figma___calendar-selected-date-background: 0 0% 98% / 1;
-  /* ✦ Theme/Calendar/Selected Date/Background/Harness Open Source/Dark */
-  --figma___calendar-selected-range-background: 210 6% 20% / 1;
-  /* ✦ Theme/Calendar/Selected Range/Background/Harness Open Source/Dark */
-  --figma___calendar-selected-range-text: 207 6% 70% / 1;
-  /* ✦ Theme/Calendar/Selected Range/Text/Harness Open Source/Dark */
-  --figma___checkbox-background: 200 5% 12% / 1;
-  /* ✦ Theme/Checkbox/Background/Harness Open Source/Dark */
-  --figma___checkbox-paper: 0 0% 100% / 0.03;
-  /* ✦ Theme/Checkbox/Paper/Harness Open Source/Dark */
-  --figma___checkbox-surface-checked-active-active: 212 6% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/Harness Open Source/Dark */
-  --figma___checkbox-surface-checked-active-hover: 212 6% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/Harness Open Source/Dark */
-  --figma___checkbox-surface-checked-active-default-background: 240 7% 94% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/Harness Open Source/Dark */
-  --figma___checkbox-surface-checked-disabled-check: 212 6% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/Harness Open Source/Dark */
-  --figma___checkbox-surface-checked-disabled-disabled: 210 6% 40% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/Harness Open Source/Dark */
-  --figma___checkbox-surface-checked-disabled-border: 207 6% 30% / 0;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/Harness Open Source/Dark */
-  --figma___checkbox-surface-intermediate-active-active-border: 240 6% 80% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/Harness Open Source/Dark */
-  --figma___checkbox-surface-intermediate-active-hover-border: 240 6% 80% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/Harness Open Source/Dark */
-  --figma___checkbox-surface-intermediate-active-default-background: 164 99% 44% / 0;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/Harness Open Source/Dark */
-  --figma___checkbox-surface-intermediate-active-default-border: 240 7% 94% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/Harness Open Source/Dark */
-  --figma___checkbox-surface-intermediate-disabled-check: 212 6% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/Harness Open Source/Dark */
-  --figma___checkbox-surface-intermediate-disabled-disabled: 0 0% 0% / 0;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/Harness Open Source/Dark */
-  --figma___checkbox-surface-intermediate-disabled-border: 212 6% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/Harness Open Source/Dark */
-  --figma___checkbox-surface-unchecked-active-active-border: 240 6% 80% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/Harness Open Source/Dark */
-  --figma___checkbox-surface-unchecked-active-hover-border: 240 6% 80% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/Harness Open Source/Dark */
-  --figma___checkbox-surface-unchecked-active-default-background: 210 6% 6% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/Harness Open Source/Dark */
-  --figma___checkbox-surface-unchecked-active-default-border: 240 7% 94% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/Harness Open Source/Dark */
-  --figma___checkbox-surface-unchecked-disabled-disabled: 210 6% 60% / 0;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/Harness Open Source/Dark */
-  --figma___checkbox-surface-unchecked-disabled-border: 212 6% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/Harness Open Source/Dark */
-  --figma___checkbox-border: 230 100% 87% / 0.09;
-  /* ✦ Theme/Checkbox/border/Harness Open Source/Dark */
-  --figma___default-colors-black: 210 13% 3% / 1;
-  /* ✦ Theme/Default colors/black/Harness Open Source/Dark */
-  --figma___default-colors-dark-to-white: 0 0% 100% / 1;
-  /* ✦ Theme/Default colors/dark-to-white/Harness Open Source/Dark */
-  --figma___default-colors-white: 0 0% 100% / 1;
-  /* ✦ Theme/Default colors/white/Harness Open Source/Dark */
-  --figma___default-colors-white-to-dark: 240 13% 3% / 1;
-  /* ✦ Theme/Default colors/white-to-dark/Harness Open Source/Dark */
-  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
-  /* ✦ Theme/Dropdown/Dropdown Item/Default/Harness Open Source/Dark */
-  --figma___dropdown-dropdown-item-hover: 200 6% 10% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Hover/Harness Open Source/Dark */
-  --figma___dropdown-dropdown-item-selected: 200 6% 10% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Selected/Harness Open Source/Dark */
-  --figma___dropdown-text-shortcut-text-selected: 212 6% 50% / 1;
-  /* ✦ Theme/Dropdown/Text/Shortcut text selected/Harness Open Source/Dark */
-  --figma___dropdown-text-text-selected: 0 0% 98% / 1;
-  /* ✦ Theme/Dropdown/Text/Text Selected/Harness Open Source/Dark */
-  --figma___dropdown-text-hover: 207 6% 70% / 1;
-  /* ✦ Theme/Dropdown/Text/hover/Harness Open Source/Dark */
-  --figma___dropdown-background: 200 5% 12% / 1;
-  /* ✦ Theme/Dropdown/background/Harness Open Source/Dark */
-  --figma___dropdown-border: 240 6% 10% / 1;
-  /* ✦ Theme/Dropdown/border/Harness Open Source/Dark */
-  --figma___dropdown-separator: 216 6% 15% / 1;
-  /* ✦ Theme/Dropdown/separator/Harness Open Source/Dark */
-  --figma___filter-active: 210 6% 20% / 1;
-  /* ✦ Theme/Filter/Active/Harness Open Source/Dark */
-  --figma___filter-default: 216 6% 15% / 1;
-  /* ✦ Theme/Filter/Default/Harness Open Source/Dark */
-  --figma___filter-hover: 210 6% 20% / 1;
-  /* ✦ Theme/Filter/Hover/Harness Open Source/Dark */
-  --figma___inline-alert-banner-customisable: 240 7% 11% / 1;
-  /* ✦ Theme/Inline Alert Banner/Customisable/Harness Open Source/Dark */
-  --figma___inline-alert-banner-error: 353 99% 56% / 0.15;
-  /* ✦ Theme/Inline Alert Banner/Error/Harness Open Source/Dark */
-  --figma___inline-alert-banner-info: 214 58% 16% / 1;
-  /* ✦ Theme/Inline Alert Banner/Info/Harness Open Source/Dark */
-  --figma___inline-alert-banner-reminder: 36 80% 8% / 1;
-  /* ✦ Theme/Inline Alert Banner/Reminder/Harness Open Source/Dark */
-  --figma___inline-alert-banner-success: 155 38% 11% / 1;
-  /* ✦ Theme/Inline Alert Banner/Success/Harness Open Source/Dark */
-  --figma___inline-alert-banner-warning: 26 68% 12% / 1;
-  /* ✦ Theme/Inline Alert Banner/Warning/Harness Open Source/Dark */
-  --figma___modal-background: 200 5% 12% / 1;
-  /* ✦ Theme/Modal/Background/Harness Open Source/Dark */
-  --figma___modal-paper: 0 0% 100% / 0.03;
-  /* ✦ Theme/Modal/Paper/Harness Open Source/Dark */
-  --figma___modal-border: 230 100% 87% / 0.09;
-  /* ✦ Theme/Modal/border/Harness Open Source/Dark */
-  --figma___neutral-color-gray-1: 200 7% 8% / 1;
-  /* ✦ Theme/Neutral color/Gray/1/Harness Open Source/Dark */
-  --figma___neutral-color-gray-2: 210 6% 6% / 1;
-  /* ✦ Theme/Neutral color/Gray/2/Harness Open Source/Dark */
-  --figma___neutral-color-gray-3: 200 6% 10% / 1;
-  /* ✦ Theme/Neutral color/Gray/3/Harness Open Source/Dark */
-  --figma___neutral-color-gray-4: 200 5% 12% / 1;
-  /* ✦ Theme/Neutral color/Gray/4/Harness Open Source/Dark */
-  --figma___neutral-color-gray-5: 216 6% 15% / 1;
-  /* ✦ Theme/Neutral color/Gray/5/Harness Open Source/Dark */
-  --figma___neutral-color-gray-6: 210 6% 20% / 1;
-  /* ✦ Theme/Neutral color/Gray/6/Harness Open Source/Dark */
-  --figma___neutral-color-gray-7: 207 6% 30% / 1;
-  /* ✦ Theme/Neutral color/Gray/7/Harness Open Source/Dark */
-  --figma___neutral-color-gray-8: 210 6% 40% / 1;
-  /* ✦ Theme/Neutral color/Gray/8/Harness Open Source/Dark */
-  --figma___neutral-color-gray-9: 212 6% 50% / 1;
-  /* ✦ Theme/Neutral color/Gray/9/Harness Open Source/Dark */
-  --figma___neutral-color-gray-10: 240 7% 94% / 1;
-  /* ✦ Theme/Neutral color/Gray/10/Harness Open Source/Dark */
-  --figma___neutral-color-gray-alpha-1: 240 93% 53% / 0.01;
-  /* ✦ Theme/Neutral color/Gray Alpha/1/Harness Open Source/Dark */
-  --figma___neutral-color-gray-alpha-2: 240 93% 73% / 0.03;
-  /* ✦ Theme/Neutral color/Gray Alpha/2/Harness Open Source/Dark */
-  --figma___neutral-color-gray-alpha-3: 230 100% 87% / 0.09;
-  /* ✦ Theme/Neutral color/Gray Alpha/3/Harness Open Source/Dark */
-  --figma___neutral-color-gray-alpha-4: 224 96% 89% / 0.13;
-  /* ✦ Theme/Neutral color/Gray Alpha/4/Harness Open Source/Dark */
-  --figma___neutral-color-gray-alpha-5: 223 100% 91% / 0.16;
-  /* ✦ Theme/Neutral color/Gray Alpha/5/Harness Open Source/Dark */
-  --figma___neutral-color-gray-alpha-6: 217 95% 91% / 0.19;
-  /* ✦ Theme/Neutral color/Gray Alpha/6/Harness Open Source/Dark */
-  --figma___neutral-color-gray-alpha-7: 209 95% 92% / 0.24;
-  /* ✦ Theme/Neutral color/Gray Alpha/7/Harness Open Source/Dark */
-  --figma___neutral-color-gray-alpha-8: 202 88% 93% / 0.33;
-  /* ✦ Theme/Neutral color/Gray Alpha/8/Harness Open Source/Dark */
-  --figma___neutral-color-gray-alpha-9: 219 100% 93% / 0.41;
-  /* ✦ Theme/Neutral color/Gray Alpha/9/Harness Open Source/Dark */
-  --figma___neutral-color-gray-alpha-10: 218 100% 95% / 0.49;
-  /* ✦ Theme/Neutral color/Gray Alpha/10/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-1: 252 19% 10% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/1/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-2: 255 30% 13% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/2/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-3: 255 34% 18% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/3/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-4: 252 35% 22% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/4/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-5: 253 35% 25% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/5/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-6: 253 37% 30% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/6/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-7: 252 56% 57% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/7/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-8: 253 63% 64% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/8/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-9: 255 100% 80% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/9/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-10: 249 94% 93% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/10/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-alpha-1: 240 100% 49% / 0.03;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/1/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-alpha-2: 255 98% 52% / 0.08;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/2/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-alpha-3: 255 99% 63% / 0.17;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/3/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-alpha-4: 252 99% 66% / 0.23;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/4/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-alpha-5: 252 99% 67% / 0.28;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/5/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-alpha-6: 253 100% 68% / 0.35;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/6/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-alpha-7: 252 100% 70% / 0.79;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/7/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-alpha-8: 253 100% 74% / 0.85;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/8/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-alpha-9: 255 100% 80% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/9/Harness Open Source/Dark */
-  --figma___other-colors-ai-violet-alpha-10: 249 100% 94% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/10/Harness Open Source/Dark */
-  --figma___other-colors-blue-1: 212 36% 9% / 1;
-  /* ✦ Theme/Other Colors/Blue/1/Harness Open Source/Dark */
-  --figma___other-colors-blue-2: 216 50% 12% / 1;
-  /* ✦ Theme/Other Colors/Blue/2/Harness Open Source/Dark */
-  --figma___other-colors-blue-3: 214 58% 16% / 1;
-  /* ✦ Theme/Other Colors/Blue/3/Harness Open Source/Dark */
-  --figma___other-colors-blue-4: 214 65% 18% / 1;
-  /* ✦ Theme/Other Colors/Blue/4/Harness Open Source/Dark */
-  --figma___other-colors-blue-5: 213 67% 21% / 1;
-  /* ✦ Theme/Other Colors/Blue/5/Harness Open Source/Dark */
-  --figma___other-colors-blue-6: 212 72% 25% / 1;
-  /* ✦ Theme/Other Colors/Blue/6/Harness Open Source/Dark */
-  --figma___other-colors-blue-7: 214 73% 51% / 1;
-  /* ✦ Theme/Other Colors/Blue/7/Harness Open Source/Dark */
-  --figma___other-colors-blue-8: 206 100% 62% / 1;
-  /* ✦ Theme/Other Colors/Blue/8/Harness Open Source/Dark */
-  --figma___other-colors-blue-9: 205 100% 71% / 1;
-  /* ✦ Theme/Other Colors/Blue/9/Harness Open Source/Dark */
-  --figma___other-colors-blue-10: 206 100% 88% / 1;
-  /* ✦ Theme/Other Colors/Blue/10/Harness Open Source/Dark */
-  --figma___other-colors-blue-alpha-1: 240 100% 49% / 0.04;
-  /* ✦ Theme/Other Colors/Blue Alpha/1/Harness Open Source/Dark */
-  --figma___other-colors-blue-alpha-2: 227 100% 50% / 0.09;
-  /* ✦ Theme/Other Colors/Blue Alpha/2/Harness Open Source/Dark */
-  --figma___other-colors-blue-alpha-3: 216 100% 50% / 0.17;
-  /* ✦ Theme/Other Colors/Blue Alpha/3/Harness Open Source/Dark */
-  --figma___other-colors-blue-alpha-4: 214 100% 50% / 0.23;
-  /* ✦ Theme/Other Colors/Blue Alpha/4/Harness Open Source/Dark */
-  --figma___other-colors-blue-alpha-5: 212 100% 52% / 0.38;
-  /* ✦ Theme/Other Colors/Blue Alpha/5/Harness Open Source/Dark */
-  --figma___other-colors-blue-alpha-6: 212 100% 52% / 0.38;
-  /* ✦ Theme/Other Colors/Blue Alpha/6/Harness Open Source/Dark */
-  --figma___other-colors-blue-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/7/Harness Open Source/Dark */
-  --figma___other-colors-blue-alpha-8: 206 100% 62% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/8/Harness Open Source/Dark */
-  --figma___other-colors-blue-alpha-9: 205 100% 71% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/9/Harness Open Source/Dark */
-  --figma___other-colors-blue-alpha-10: 206 100% 88% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/10/Harness Open Source/Dark */
-  --figma___other-colors-indigo-1: 226 25% 10% / 1;
-  /* ✦ Theme/Other Colors/Indigo/1/Harness Open Source/Dark */
-  --figma___other-colors-indigo-2: 230 36% 13% / 1;
-  /* ✦ Theme/Other Colors/Indigo/2/Harness Open Source/Dark */
-  --figma___other-colors-indigo-3: 228 43% 18% / 1;
-  /* ✦ Theme/Other Colors/Indigo/3/Harness Open Source/Dark */
-  --figma___other-colors-indigo-4: 228 45% 21% / 1;
-  /* ✦ Theme/Other Colors/Indigo/4/Harness Open Source/Dark */
-  --figma___other-colors-indigo-5: 227 48% 24% / 1;
-  /* ✦ Theme/Other Colors/Indigo/5/Harness Open Source/Dark */
-  --figma___other-colors-indigo-6: 225 51% 29% / 1;
-  /* ✦ Theme/Other Colors/Indigo/6/Harness Open Source/Dark */
-  --figma___other-colors-indigo-7: 226 70% 55% / 1;
-  /* ✦ Theme/Other Colors/Indigo/7/Harness Open Source/Dark */
-  --figma___other-colors-indigo-8: 230 74% 63% / 1;
-  /* ✦ Theme/Other Colors/Indigo/8/Harness Open Source/Dark */
-  --figma___other-colors-indigo-9: 235 100% 80% / 1;
-  /* ✦ Theme/Other Colors/Indigo/9/Harness Open Source/Dark */
-  --figma___other-colors-indigo-10: 236 94% 93% / 1;
-  /* ✦ Theme/Other Colors/Indigo/10/Harness Open Source/Dark */
-  --figma___other-colors-indigo-alpha-1: 240 100% 49% / 0.04;
-  /* ✦ Theme/Other Colors/Indigo Alpha/1/Harness Open Source/Dark */
-  --figma___other-colors-indigo-alpha-2: 232 100% 50% / 0.09;
-  /* ✦ Theme/Other Colors/Indigo Alpha/2/Harness Open Source/Dark */
-  --figma___other-colors-indigo-alpha-3: 228 100% 57% / 0.18;
-  /* ✦ Theme/Other Colors/Indigo Alpha/3/Harness Open Source/Dark */
-  --figma___other-colors-indigo-alpha-4: 228 99% 59% / 0.24;
-  /* ✦ Theme/Other Colors/Indigo Alpha/4/Harness Open Source/Dark */
-  --figma___other-colors-indigo-alpha-5: 227 99% 60% / 0.29;
-  /* ✦ Theme/Other Colors/Indigo Alpha/5/Harness Open Source/Dark */
-  --figma___other-colors-indigo-alpha-6: 225 100% 61% / 0.37;
-  /* ✦ Theme/Other Colors/Indigo Alpha/6/Harness Open Source/Dark */
-  --figma___other-colors-indigo-alpha-7: 226 100% 63% / 0.85;
-  /* ✦ Theme/Other Colors/Indigo Alpha/7/Harness Open Source/Dark */
-  --figma___other-colors-indigo-alpha-8: 230 100% 70% / 0.9;
-  /* ✦ Theme/Other Colors/Indigo Alpha/8/Harness Open Source/Dark */
-  --figma___other-colors-indigo-alpha-9: 235 100% 80% / 1;
-  /* ✦ Theme/Other Colors/Indigo Alpha/9/Harness Open Source/Dark */
-  --figma___other-colors-indigo-alpha-10: 236 100% 94% / 1;
-  /* ✦ Theme/Other Colors/Indigo Alpha/10/Harness Open Source/Dark */
-  --figma___other-colors-mint-1: 173 52% 6% / 1;
-  /* ✦ Theme/Other Colors/Mint/1/Harness Open Source/Dark */
-  --figma___other-colors-mint-2: 174 51% 8% / 1;
-  /* ✦ Theme/Other Colors/Mint/2/Harness Open Source/Dark */
-  --figma___other-colors-mint-3: 176 52% 11% / 1;
-  /* ✦ Theme/Other Colors/Mint/3/Harness Open Source/Dark */
-  --figma___other-colors-mint-4: 173 56% 13% / 1;
-  /* ✦ Theme/Other Colors/Mint/4/Harness Open Source/Dark */
-  --figma___other-colors-mint-5: 173 57% 15% / 1;
-  /* ✦ Theme/Other Colors/Mint/5/Harness Open Source/Dark */
-  --figma___other-colors-mint-6: 173 58% 18% / 1;
-  /* ✦ Theme/Other Colors/Mint/6/Harness Open Source/Dark */
-  --figma___other-colors-mint-7: 176 59% 50% / 1;
-  /* ✦ Theme/Other Colors/Mint/7/Harness Open Source/Dark */
-  --figma___other-colors-mint-8: 176 59% 60% / 1;
-  /* ✦ Theme/Other Colors/Mint/8/Harness Open Source/Dark */
-  --figma___other-colors-mint-9: 167 70% 58% / 1;
-  /* ✦ Theme/Other Colors/Mint/9/Harness Open Source/Dark */
-  --figma___other-colors-mint-10: 175 60% 65% / 1;
-  /* ✦ Theme/Other Colors/Mint/10/Harness Open Source/Dark */
-  --figma___other-colors-mint-alpha-1: 120 100% 44% / 0;
-  /* ✦ Theme/Other Colors/Mint Alpha/1/Harness Open Source/Dark */
-  --figma___other-colors-mint-alpha-2: 165 100% 49% / 0.03;
-  /* ✦ Theme/Other Colors/Mint Alpha/2/Harness Open Source/Dark */
-  --figma___other-colors-mint-alpha-3: 174 100% 50% / 0.07;
-  /* ✦ Theme/Other Colors/Mint Alpha/3/Harness Open Source/Dark */
-  --figma___other-colors-mint-alpha-4: 172 100% 50% / 0.11;
-  /* ✦ Theme/Other Colors/Mint Alpha/4/Harness Open Source/Dark */
-  --figma___other-colors-mint-alpha-5: 172 100% 50% / 0.15;
-  /* ✦ Theme/Other Colors/Mint Alpha/5/Harness Open Source/Dark */
-  --figma___other-colors-mint-alpha-6: 173 100% 50% / 0.21;
-  /* ✦ Theme/Other Colors/Mint Alpha/6/Harness Open Source/Dark */
-  --figma___other-colors-mint-alpha-7: 167 100% 78% / 0.91;
-  /* ✦ Theme/Other Colors/Mint Alpha/7/Harness Open Source/Dark */
-  --figma___other-colors-mint-alpha-8: 163 100% 81% / 0.95;
-  /* ✦ Theme/Other Colors/Mint Alpha/8/Harness Open Source/Dark */
-  --figma___other-colors-mint-alpha-9: 167 100% 66% / 0.86;
-  /* ✦ Theme/Other Colors/Mint Alpha/9/Harness Open Source/Dark */
-  --figma___other-colors-mint-alpha-10: 155 100% 90% / 0.96;
-  /* ✦ Theme/Other Colors/Mint Alpha/10/Harness Open Source/Dark */
-  --figma___other-colors-orange-1: 29 68% 7% / 1;
-  /* ✦ Theme/Other Colors/Orange/1/Harness Open Source/Dark */
-  --figma___other-colors-orange-2: 29 81% 8% / 1;
-  /* ✦ Theme/Other Colors/Orange/2/Harness Open Source/Dark */
-  --figma___other-colors-orange-3: 26 68% 12% / 1;
-  /* ✦ Theme/Other Colors/Orange/3/Harness Open Source/Dark */
-  --figma___other-colors-orange-4: 25 66% 15% / 1;
-  /* ✦ Theme/Other Colors/Orange/4/Harness Open Source/Dark */
-  --figma___other-colors-orange-5: 25 65% 18% / 1;
-  /* ✦ Theme/Other Colors/Orange/5/Harness Open Source/Dark */
-  --figma___other-colors-orange-6: 25 66% 22% / 1;
-  /* ✦ Theme/Other Colors/Orange/6/Harness Open Source/Dark */
-  --figma___other-colors-orange-7: 24 94% 50% / 1;
-  /* ✦ Theme/Other Colors/Orange/7/Harness Open Source/Dark */
-  --figma___other-colors-orange-8: 24 100% 58% / 1;
-  /* ✦ Theme/Other Colors/Orange/8/Harness Open Source/Dark */
-  --figma___other-colors-orange-9: 24 100% 70% / 1;
-  /* ✦ Theme/Other Colors/Orange/9/Harness Open Source/Dark */
-  --figma___other-colors-orange-10: 30 100% 88% / 1;
-  /* ✦ Theme/Other Colors/Orange/10/Harness Open Source/Dark */
-  --figma___other-colors-orange-alpha-1: 0 100% 49% / 0.03;
-  /* ✦ Theme/Other Colors/Orange Alpha/1/Harness Open Source/Dark */
-  --figma___other-colors-orange-alpha-2: 0 100% 50% / 0.06;
-  /* ✦ Theme/Other Colors/Orange Alpha/2/Harness Open Source/Dark */
-  --figma___other-colors-orange-alpha-3: 13 100% 50% / 0.12;
-  /* ✦ Theme/Other Colors/Orange Alpha/3/Harness Open Source/Dark */
-  --figma___other-colors-orange-alpha-4: 20 100% 50% / 0.17;
-  /* ✦ Theme/Other Colors/Orange Alpha/4/Harness Open Source/Dark */
-  --figma___other-colors-orange-alpha-5: 24 100% 50% / 0.22;
-  /* ✦ Theme/Other Colors/Orange Alpha/5/Harness Open Source/Dark */
-  --figma___other-colors-orange-alpha-6: 25 100% 51% / 0.3;
-  /* ✦ Theme/Other Colors/Orange Alpha/6/Harness Open Source/Dark */
-  --figma___other-colors-orange-alpha-7: 24 100% 51% / 0.97;
-  /* ✦ Theme/Other Colors/Orange Alpha/7/Harness Open Source/Dark */
-  --figma___other-colors-orange-alpha-8: 24 100% 58% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/8/Harness Open Source/Dark */
-  --figma___other-colors-orange-alpha-9: 24 100% 70% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/9/Harness Open Source/Dark */
-  --figma___other-colors-orange-alpha-10: 30 100% 88% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/10/Harness Open Source/Dark */
-  --figma___other-colors-yellow-1: 45 100% 5% / 1;
-  /* ✦ Theme/Other Colors/Yellow/1/Harness Open Source/Dark */
-  --figma___other-colors-yellow-2: 44 79% 7% / 1;
-  /* ✦ Theme/Other Colors/Yellow/2/Harness Open Source/Dark */
-  --figma___other-colors-yellow-3: 44 63% 11% / 1;
-  /* ✦ Theme/Other Colors/Yellow/3/Harness Open Source/Dark */
-  --figma___other-colors-yellow-4: 44 58% 13% / 1;
-  /* ✦ Theme/Other Colors/Yellow/4/Harness Open Source/Dark */
-  --figma___other-colors-yellow-5: 45 56% 15% / 1;
-  /* ✦ Theme/Other Colors/Yellow/5/Harness Open Source/Dark */
-  --figma___other-colors-yellow-6: 46 57% 18% / 1;
-  /* ✦ Theme/Other Colors/Yellow/6/Harness Open Source/Dark */
-  --figma___other-colors-yellow-7: 53 96% 58% / 1;
-  /* ✦ Theme/Other Colors/Yellow/7/Harness Open Source/Dark */
-  --figma___other-colors-yellow-8: 53 96% 67% / 1;
-  /* ✦ Theme/Other Colors/Yellow/8/Harness Open Source/Dark */
-  --figma___other-colors-yellow-9: 55 100% 60% / 1;
-  /* ✦ Theme/Other Colors/Yellow/9/Harness Open Source/Dark */
-  --figma___other-colors-yellow-10: 53 100% 84% / 1;
-  /* ✦ Theme/Other Colors/Yellow/10/Harness Open Source/Dark */
-  --figma___other-colors-yellow-alpha-1: 45 100% 5% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/1/Harness Open Source/Dark */
-  --figma___other-colors-yellow-alpha-2: 44 79% 7% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/2/Harness Open Source/Dark */
-  --figma___other-colors-yellow-alpha-3: 44 63% 11% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/3/Harness Open Source/Dark */
-  --figma___other-colors-yellow-alpha-4: 44 58% 13% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/4/Harness Open Source/Dark */
-  --figma___other-colors-yellow-alpha-5: 45 56% 15% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/5/Harness Open Source/Dark */
-  --figma___other-colors-yellow-alpha-6: 46 57% 18% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/6/Harness Open Source/Dark */
-  --figma___other-colors-yellow-alpha-7: 53 96% 58% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/7/Harness Open Source/Dark */
-  --figma___other-colors-yellow-alpha-8: 53 96% 67% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/8/Harness Open Source/Dark */
-  --figma___other-colors-yellow-alpha-9: 55 100% 60% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/9/Harness Open Source/Dark */
-  --figma___other-colors-yellow-alpha-10: 53 100% 84% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/10/Harness Open Source/Dark */
-  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01;
-  /* ✦ Theme/Overlays/Black Alpha/1/Harness Open Source/Dark */
-  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02;
-  /* ✦ Theme/Overlays/Black Alpha/2/Harness Open Source/Dark */
-  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05;
-  /* ✦ Theme/Overlays/Black Alpha/3/Harness Open Source/Dark */
-  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08;
-  /* ✦ Theme/Overlays/Black Alpha/4/Harness Open Source/Dark */
-  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11;
-  /* ✦ Theme/Overlays/Black Alpha/5/Harness Open Source/Dark */
-  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13;
-  /* ✦ Theme/Overlays/Black Alpha/6/Harness Open Source/Dark */
-  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45;
-  /* ✦ Theme/Overlays/Black Alpha/7/Harness Open Source/Dark */
-  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5;
-  /* ✦ Theme/Overlays/Black Alpha/8/Harness Open Source/Dark */
-  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61;
-  /* ✦ Theme/Overlays/Black Alpha/9/Harness Open Source/Dark */
-  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88;
-  /* ✦ Theme/Overlays/Black Alpha/10/Harness Open Source/Dark */
-  --figma___overlays-white-alpha-1: 0 0% 100% / 0;
-  /* ✦ Theme/Overlays/White Alpha/1/Harness Open Source/Dark */
-  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01;
-  /* ✦ Theme/Overlays/White Alpha/2/Harness Open Source/Dark */
-  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07;
-  /* ✦ Theme/Overlays/White Alpha/3/Harness Open Source/Dark */
-  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1;
-  /* ✦ Theme/Overlays/White Alpha/4/Harness Open Source/Dark */
-  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13;
-  /* ✦ Theme/Overlays/White Alpha/5/Harness Open Source/Dark */
-  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17;
-  /* ✦ Theme/Overlays/White Alpha/6/Harness Open Source/Dark */
-  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37;
-  /* ✦ Theme/Overlays/White Alpha/7/Harness Open Source/Dark */
-  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46;
-  /* ✦ Theme/Overlays/White Alpha/8/Harness Open Source/Dark */
-  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66;
-  /* ✦ Theme/Overlays/White Alpha/9/Harness Open Source/Dark */
-  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93;
-  /* ✦ Theme/Overlays/White Alpha/10/Harness Open Source/Dark */
-  --figma___pagination-active-background: 216 6% 15% / 1;
-  /* ✦ Theme/Pagination/Active/Background/Harness Open Source/Dark */
-  --figma___pagination-active-border: 210 6% 20% / 1;
-  /* ✦ Theme/Pagination/Active/Border/Harness Open Source/Dark */
-  --figma___pagination-active-text: 0 0% 98% / 1;
-  /* ✦ Theme/Pagination/Active/Text/Harness Open Source/Dark */
-  --figma___pagination-background: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Background/Harness Open Source/Dark */
-  --figma___pagination-default-background: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Default/Background/Harness Open Source/Dark */
-  --figma___pagination-default-border: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Default/Border/Harness Open Source/Dark */
-  --figma___pagination-default-text: 0 0% 98% / 1;
-  /* ✦ Theme/Pagination/Default/Text/Harness Open Source/Dark */
-  --figma___pagination-hover-background: 216 6% 15% / 1;
-  /* ✦ Theme/Pagination/Hover/Background/Harness Open Source/Dark */
-  --figma___pagination-hover-border: 210 6% 20% / 1;
-  /* ✦ Theme/Pagination/Hover/Border/Harness Open Source/Dark */
-  --figma___pagination-hover-text: 207 6% 70% / 1;
-  /* ✦ Theme/Pagination/Hover/Text/Harness Open Source/Dark */
-  --figma___pagination-pagination-shadow-1: 0 0% 0% / 0;
-  /* ✦ Theme/Pagination/Pagination shadow/1/Harness Open Source/Dark */
-  --figma___pagination-pagination-shadow-2: 240 100% 12% / 0;
-  /* ✦ Theme/Pagination/Pagination shadow/2/Harness Open Source/Dark */
-  --figma___primary-color-primary-accent-1: 200 7% 8% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/1/Harness Open Source/Dark */
-  --figma___primary-color-primary-accent-2: 210 6% 6% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/2/Harness Open Source/Dark */
-  --figma___primary-color-primary-accent-3: 200 6% 10% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/3/Harness Open Source/Dark */
-  --figma___primary-color-primary-accent-4: 200 5% 12% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/4/Harness Open Source/Dark */
-  --figma___primary-color-primary-accent-5: 210 6% 20% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/5/Harness Open Source/Dark */
-  --figma___primary-color-primary-accent-6: 210 6% 40% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/6/Harness Open Source/Dark */
-  --figma___primary-color-primary-accent-7: 0 0% 98% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/7/Harness Open Source/Dark */
-  --figma___primary-color-primary-accent-8: 240 7% 94% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/8/Harness Open Source/Dark */
-  --figma___primary-color-primary-accent-9: 220 6% 90% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/9/Harness Open Source/Dark */
-  --figma___primary-color-primary-accent-10: 0 0% 98% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/10/Harness Open Source/Dark */
-  --figma___primary-color-primary-alpha-1: 240 89% 18% / 0.01;
-  /* ✦ Theme/Primary Color/Primary Alpha/1/Harness Open Source/Dark */
-  --figma___primary-color-primary-alpha-2: 240 89% 18% / 0.02;
-  /* ✦ Theme/Primary Color/Primary Alpha/2/Harness Open Source/Dark */
-  --figma___primary-color-primary-alpha-3: 240 100% 12% / 0.05;
-  /* ✦ Theme/Primary Color/Primary Alpha/3/Harness Open Source/Dark */
-  --figma___primary-color-primary-alpha-4: 240 93% 11% / 0.08;
-  /* ✦ Theme/Primary Color/Primary Alpha/4/Harness Open Source/Dark */
-  --figma___primary-color-primary-alpha-5: 240 96% 9% / 0.13;
-  /* ✦ Theme/Primary Color/Primary Alpha/5/Harness Open Source/Dark */
-  --figma___primary-color-primary-alpha-6: 230 100% 9% / 0.28;
-  /* ✦ Theme/Primary Color/Primary Alpha/6/Harness Open Source/Dark */
-  --figma___primary-color-primary-alpha-7: 0 0% 98% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/7/Harness Open Source/Dark */
-  --figma___primary-color-primary-alpha-8: 240 7% 94% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/8/Harness Open Source/Dark */
-  --figma___primary-color-primary-alpha-9: 220 6% 90% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/9/Harness Open Source/Dark */
-  --figma___primary-color-primary-alpha-10: 0 0% 98% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/10/Harness Open Source/Dark */
-  --figma___radio-button-background: 200 5% 12% / 1;
-  /* ✦ Theme/Radio button/Background/Harness Open Source/Dark */
-  --figma___radio-button-checked-active-active-border: 212 6% 50% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active Border/Harness Open Source/Dark */
-  --figma___radio-button-checked-active-active-background: 212 6% 50% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active background/Harness Open Source/Dark */
-  --figma___radio-button-checked-active-hover-background: 212 6% 50% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover background/Harness Open Source/Dark */
-  --figma___radio-button-checked-active-hover-border: 212 6% 50% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover border/Harness Open Source/Dark */
-  --figma___radio-button-checked-active-default-background: 240 7% 94% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default background/Harness Open Source/Dark */
-  --figma___radio-button-checked-active-default-border: 240 7% 94% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default border/Harness Open Source/Dark */
-  --figma___radio-button-checked-disabled-dot: 210 6% 20% / 1;
-  /* ✦ Theme/Radio button/Checked/Disabled/Dot/Harness Open Source/Dark */
-  --figma___radio-button-checked-disabled-background: 240 100% 12% / 0.05;
-  /* ✦ Theme/Radio button/Checked/Disabled/background/Harness Open Source/Dark */
-  --figma___radio-button-checked-disabled-border: 210 6% 20% / 1;
-  /* ✦ Theme/Radio button/Checked/Disabled/border/Harness Open Source/Dark */
-  --figma___radio-button-paper: 0 0% 100% / 0.03;
-  /* ✦ Theme/Radio button/Paper/Harness Open Source/Dark */
-  --figma___radio-button-unchecked-active-active-border: 212 6% 50% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/Active border/Harness Open Source/Dark */
-  --figma___radio-button-unchecked-active-hover-border: 212 6% 50% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/Harness Open Source/Dark */
-  --figma___radio-button-unchecked-active-default-background: 210 6% 6% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/default background/Harness Open Source/Dark */
-  --figma___radio-button-unchecked-active-default-border: 240 7% 94% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/default border/Harness Open Source/Dark */
-  --figma___radio-button-unchecked-disabled-background: 0 0% 100% / 0.07;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/background/Harness Open Source/Dark */
-  --figma___radio-button-unchecked-disabled-border: 210 6% 20% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/border/Harness Open Source/Dark */
-  --figma___radio-button-border: 230 100% 87% / 0.09;
-  /* ✦ Theme/Radio button/border/Harness Open Source/Dark */
-  --figma___secondary-crimson-crimson-1: 333 18% 10% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 1/Harness Open Source/Dark */
-  --figma___secondary-crimson-crimson-10: 330 91% 91% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 10/Harness Open Source/Dark */
-  --figma___secondary-crimson-crimson-2: 336 32% 12% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 2/Harness Open Source/Dark */
-  --figma___secondary-crimson-crimson-3: 335 41% 16% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 3/Harness Open Source/Dark */
-  --figma___secondary-crimson-crimson-4: 336 45% 18% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 4/Harness Open Source/Dark */
-  --figma___secondary-crimson-crimson-5: 336 49% 21% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 5/Harness Open Source/Dark */
-  --figma___secondary-crimson-crimson-6: 336 54% 25% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 6/Harness Open Source/Dark */
-  --figma___secondary-crimson-crimson-7: 336 80% 58% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 7/Harness Open Source/Dark */
-  --figma___secondary-crimson-crimson-8: 339 87% 67% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 8/Harness Open Source/Dark */
-  --figma___secondary-crimson-crimson-9: 341 100% 76% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 9/Harness Open Source/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-1: 354 100% 49% / 0.02;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Open Source/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-10: 341 100% 76% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Open Source/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-11: 329 100% 92% / 0.99;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Open Source/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-2: 338 100% 50% / 0.07;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Open Source/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-3: 335 100% 55% / 0.14;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Open Source/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-4: 336 99% 56% / 0.19;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Open Source/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-5: 336 100% 58% / 0.25;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Open Source/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-6: 336 99% 58% / 0.33;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Open Source/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-8: 336 100% 63% / 0.9;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Open Source/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-9: 339 100% 70% / 0.95;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Open Source/Dark */
-  --figma___secondary-lime-1: 74 55% 6% / 1;
-  /* ✦ Theme/Secondary/Lime/1/Harness Open Source/Dark */
-  --figma___secondary-lime-2: 78 41% 8% / 1;
-  /* ✦ Theme/Secondary/Lime/2/Harness Open Source/Dark */
-  --figma___secondary-lime-3: 82 39% 11% / 1;
-  /* ✦ Theme/Secondary/Lime/3/Harness Open Source/Dark */
-  --figma___secondary-lime-4: 82 40% 13% / 1;
-  /* ✦ Theme/Secondary/Lime/4/Harness Open Source/Dark */
-  --figma___secondary-lime-5: 81 41% 15% / 1;
-  /* ✦ Theme/Secondary/Lime/5/Harness Open Source/Dark */
-  --figma___secondary-lime-6: 80 43% 18% / 1;
-  /* ✦ Theme/Secondary/Lime/6/Harness Open Source/Dark */
-  --figma___secondary-lime-7: 81 80% 66% / 1;
-  /* ✦ Theme/Secondary/Lime/7/Harness Open Source/Dark */
-  --figma___secondary-lime-8: 75 85% 60% / 1;
-  /* ✦ Theme/Secondary/Lime/8/Harness Open Source/Dark */
-  --figma___secondary-lime-9: 70 70% 50% / 1;
-  /* ✦ Theme/Secondary/Lime/9/Harness Open Source/Dark */
-  --figma___secondary-lime-10: 80 79% 85% / 1;
-  /* ✦ Theme/Secondary/Lime/10/Harness Open Source/Dark */
-  --figma___secondary-lime-alpha-1: 75 100% 5% / 0.71;
-  /* ✦ Theme/Secondary/Lime Alpha/1/Harness Open Source/Dark */
-  --figma___secondary-lime-alpha-2: 114 100% 49% / 0.02;
-  /* ✦ Theme/Secondary/Lime Alpha/2/Harness Open Source/Dark */
-  --figma___secondary-lime-alpha-3: 89 100% 50% / 0.06;
-  /* ✦ Theme/Secondary/Lime Alpha/3/Harness Open Source/Dark */
-  --figma___secondary-lime-alpha-4: 84 100% 50% / 0.1;
-  /* ✦ Theme/Secondary/Lime Alpha/4/Harness Open Source/Dark */
-  --figma___secondary-lime-alpha-5: 81 99% 53% / 0.14;
-  /* ✦ Theme/Secondary/Lime Alpha/5/Harness Open Source/Dark */
-  --figma___secondary-lime-alpha-6: 80 99% 58% / 0.19;
-  /* ✦ Theme/Secondary/Lime Alpha/6/Harness Open Source/Dark */
-  --figma___secondary-lime-alpha-7: 81 100% 71% / 0.93;
-  /* ✦ Theme/Secondary/Lime Alpha/7/Harness Open Source/Dark */
-  --figma___secondary-lime-alpha-8: 75 100% 64% / 0.94;
-  /* ✦ Theme/Secondary/Lime Alpha/8/Harness Open Source/Dark */
-  --figma___secondary-lime-alpha-9: 70 100% 58% / 0.84;
-  /* ✦ Theme/Secondary/Lime Alpha/9/Harness Open Source/Dark */
-  --figma___secondary-lime-alpha-10: 80 100% 88% / 0.97;
-  /* ✦ Theme/Secondary/Lime Alpha/10/Harness Open Source/Dark */
-  --figma___secondary-purple-1: 287 18% 10% / 1;
-  /* ✦ Theme/Secondary/Purple/1/Harness Open Source/Dark */
-  --figma___secondary-purple-2: 284 31% 12% / 1;
-  /* ✦ Theme/Secondary/Purple/2/Harness Open Source/Dark */
-  --figma___secondary-purple-3: 282 35% 17% / 1;
-  /* ✦ Theme/Secondary/Purple/3/Harness Open Source/Dark */
-  --figma___secondary-purple-4: 281 37% 20% / 1;
-  /* ✦ Theme/Secondary/Purple/4/Harness Open Source/Dark */
-  --figma___secondary-purple-5: 280 38% 23% / 1;
-  /* ✦ Theme/Secondary/Purple/5/Harness Open Source/Dark */
-  --figma___secondary-purple-6: 278 40% 27% / 1;
-  /* ✦ Theme/Secondary/Purple/6/Harness Open Source/Dark */
-  --figma___secondary-purple-7: 272 51% 54% / 1;
-  /* ✦ Theme/Secondary/Purple/7/Harness Open Source/Dark */
-  --figma___secondary-purple-8: 271 58% 61% / 1;
-  /* ✦ Theme/Secondary/Purple/8/Harness Open Source/Dark */
-  --figma___secondary-purple-9: 270 89% 78% / 1;
-  /* ✦ Theme/Secondary/Purple/9/Harness Open Source/Dark */
-  --figma___secondary-purple-10: 275 77% 92% / 1;
-  /* ✦ Theme/Secondary/Purple/10/Harness Open Source/Dark */
-  --figma___secondary-purple-alpha-1: 278 100% 49% / 0.02;
-  /* ✦ Theme/Secondary/Purple Alpha/1/Harness Open Source/Dark */
-  --figma___secondary-purple-alpha-2: 283 100% 49% / 0.07;
-  /* ✦ Theme/Secondary/Purple Alpha/2/Harness Open Source/Dark */
-  --figma___secondary-purple-alpha-3: 282 99% 60% / 0.15;
-  /* ✦ Theme/Secondary/Purple Alpha/3/Harness Open Source/Dark */
-  --figma___secondary-purple-alpha-4: 281 99% 62% / 0.2;
-  /* ✦ Theme/Secondary/Purple Alpha/4/Harness Open Source/Dark */
-  --figma___secondary-purple-alpha-5: 280 100% 64% / 0.25;
-  /* ✦ Theme/Secondary/Purple Alpha/5/Harness Open Source/Dark */
-  --figma___secondary-purple-alpha-6: 278 99% 66% / 0.32;
-  /* ✦ Theme/Secondary/Purple Alpha/6/Harness Open Source/Dark */
-  --figma___secondary-purple-alpha-7: 272 100% 69% / 0.75;
-  /* ✦ Theme/Secondary/Purple Alpha/7/Harness Open Source/Dark */
-  --figma___secondary-purple-alpha-8: 271 100% 73% / 0.82;
-  /* ✦ Theme/Secondary/Purple Alpha/8/Harness Open Source/Dark */
-  --figma___secondary-purple-alpha-9: 270 100% 80% / 0.98;
-  /* ✦ Theme/Secondary/Purple Alpha/9/Harness Open Source/Dark */
-  --figma___secondary-purple-alpha-10: 275 100% 93% / 0.98;
-  /* ✦ Theme/Secondary/Purple Alpha/10/Harness Open Source/Dark */
-  --figma___secondary-teal-1: 166 49% 7% / 1;
-  /* ✦ Theme/Secondary/Teal/1/Harness Open Source/Dark */
-  --figma___secondary-teal-2: 166 55% 8% / 1;
-  /* ✦ Theme/Secondary/Teal/2/Harness Open Source/Dark */
-  --figma___secondary-teal-3: 167 52% 11% / 1;
-  /* ✦ Theme/Secondary/Teal/3/Harness Open Source/Dark */
-  --figma___secondary-teal-4: 169 53% 13% / 1;
-  /* ✦ Theme/Secondary/Teal/4/Harness Open Source/Dark */
-  --figma___secondary-teal-5: 168 53% 15% / 1;
-  /* ✦ Theme/Secondary/Teal/5/Harness Open Source/Dark */
-  --figma___secondary-teal-6: 169 52% 18% / 1;
-  /* ✦ Theme/Secondary/Teal/6/Harness Open Source/Dark */
-  --figma___secondary-teal-7: 173 80% 36% / 1;
-  /* ✦ Theme/Secondary/Teal/7/Harness Open Source/Dark */
-  --figma___secondary-teal-8: 172 90% 39% / 1;
-  /* ✦ Theme/Secondary/Teal/8/Harness Open Source/Dark */
-  --figma___secondary-teal-9: 170 90% 45% / 1;
-  /* ✦ Theme/Secondary/Teal/9/Harness Open Source/Dark */
-  --figma___secondary-teal-10: 163 69% 81% / 1;
-  /* ✦ Theme/Secondary/Teal/10/Harness Open Source/Dark */
-  --figma___secondary-teal-alpha-1: 120 100% 48% / 0.01;
-  /* ✦ Theme/Secondary/Teal Alpha/1/Harness Open Source/Dark */
-  --figma___secondary-teal-alpha-2: 141 100% 49% / 0.03;
-  /* ✦ Theme/Secondary/Teal Alpha/2/Harness Open Source/Dark */
-  --figma___secondary-teal-alpha-3: 161 100% 50% / 0.07;
-  /* ✦ Theme/Secondary/Teal Alpha/3/Harness Open Source/Dark */
-  --figma___secondary-teal-alpha-4: 167 100% 50% / 0.11;
-  /* ✦ Theme/Secondary/Teal Alpha/4/Harness Open Source/Dark */
-  --figma___secondary-teal-alpha-5: 167 100% 50% / 0.15;
-  /* ✦ Theme/Secondary/Teal Alpha/5/Harness Open Source/Dark */
-  --figma___secondary-teal-alpha-6: 169 99% 53% / 0.2;
-  /* ✦ Theme/Secondary/Teal Alpha/6/Harness Open Source/Dark */
-  --figma___secondary-teal-alpha-7: 173 100% 53% / 0.61;
-  /* ✦ Theme/Secondary/Teal Alpha/7/Harness Open Source/Dark */
-  --figma___secondary-teal-alpha-8: 172 100% 51% / 0.71;
-  /* ✦ Theme/Secondary/Teal Alpha/8/Harness Open Source/Dark */
-  --figma___secondary-teal-alpha-9: 170 100% 52% / 0.83;
-  /* ✦ Theme/Secondary/Teal Alpha/9/Harness Open Source/Dark */
-  --figma___secondary-teal-alpha-10: 163 100% 86% / 0.94;
-  /* ✦ Theme/Secondary/Teal Alpha/10/Harness Open Source/Dark */
-  --figma___shadow-shadow-button-1: 0 0% 100% / 0.17;
-  /* ✦ Theme/Shadow/Shadow - button/1/Harness Open Source/Dark */
-  --figma___shadow-shadow-button-2: 0 0% 100% / 0.07;
-  /* ✦ Theme/Shadow/Shadow - button/2/Harness Open Source/Dark */
-  --figma___shadow-shadow-button-3: 0 0% 100% / 0.27;
-  /* ✦ Theme/Shadow/Shadow - button/3/Harness Open Source/Dark */
-  --figma___shadow-shadow-button-4: 0 0% 100% / 0.11;
-  /* ✦ Theme/Shadow/Shadow - button/4/Harness Open Source/Dark */
-  --figma___shadow-shadow-1-1: 0 0% 0% / 0.03;
-  /* ✦ Theme/Shadow/Shadow 1/1/Harness Open Source/Dark */
-  --figma___shadow-shadow-2-1: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 2/1/Harness Open Source/Dark */
-  --figma___shadow-shadow-2-2: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 2/2/Harness Open Source/Dark */
-  --figma___shadow-shadow-2-3: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 2/3/Harness Open Source/Dark */
-  --figma___shadow-shadow-3-1: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 3/1/Harness Open Source/Dark */
-  --figma___shadow-shadow-3-2: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow 3/2/Harness Open Source/Dark */
-  --figma___shadow-shadow-3-3: 0 0% 0% / 0.11;
-  /* ✦ Theme/Shadow/Shadow 3/3/Harness Open Source/Dark */
-  --figma___shadow-shadow-4-1: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow 4/1/Harness Open Source/Dark */
-  --figma___shadow-shadow-4-2: 0 0% 0% / 0.17;
-  /* ✦ Theme/Shadow/Shadow 4/2/Harness Open Source/Dark */
-  --figma___shadow-shadow-5-1: 0 0% 0% / 0.5;
-  /* ✦ Theme/Shadow/Shadow 5/1/Harness Open Source/Dark */
-  --figma___shadow-shadow-5-2: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow 5/2/Harness Open Source/Dark */
-  --figma___shadow-shadow-6-1: 0 0% 0% / 0.88;
-  /* ✦ Theme/Shadow/Shadow 6/1/Harness Open Source/Dark */
-  --figma___shadow-shadow-6-2: 0 0% 0% / 0.61;
-  /* ✦ Theme/Shadow/Shadow 6/2/Harness Open Source/Dark */
-  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
-  /* ✦ Theme/Shadow/Shadow-button-active/1/Harness Open Source/Dark */
-  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
-  /* ✦ Theme/Shadow/Shadow-button-active/2/Harness Open Source/Dark */
-  --figma___shadow-shadow-button-active-3: 0 0% 100% / 0.27;
-  /* ✦ Theme/Shadow/Shadow-button-active/3/Harness Open Source/Dark */
-  --figma___shadow-shadow-button-active-4: 0 0% 100% / 0.11;
-  /* ✦ Theme/Shadow/Shadow-button-active/4/Harness Open Source/Dark */
-  --figma___side-nav-container-nav-background: 210 13% 3% / 1;
-  /* ✦ Theme/Side nav/Container/Nav-background/Harness Open Source/Dark */
-  --figma___side-nav-container-nav-border: 200 6% 10% / 1;
-  /* ✦ Theme/Side nav/Container/Nav-border/Harness Open Source/Dark */
-  --figma___side-nav-module-logo-text: 0 0% 98% / 1;
-  /* ✦ Theme/Side nav/Module Logo Text/Harness Open Source/Dark */
-  --figma___side-nav-nav-item-default-icon: 210 6% 40% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Default/Icon/Harness Open Source/Dark */
-  --figma___side-nav-nav-item-default-text: 207 6% 70% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Default/Text/Harness Open Source/Dark */
-  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
-  /* ✦ Theme/Side nav/Nav-item/Default/default/Harness Open Source/Dark */
-  --figma___side-nav-nav-item-hover-background: 210 6% 20% / 0.15;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Background/Harness Open Source/Dark */
-  --figma___side-nav-nav-item-hover-icon: 207 6% 70% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/Harness Open Source/Dark */
-  --figma___side-nav-nav-item-hover-text: 207 6% 70% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Text/Harness Open Source/Dark */
-  --figma___side-nav-nav-item-selected-background: 200 6% 10% / 0;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Background/Harness Open Source/Dark */
-  --figma___side-nav-nav-item-selected-icon: 0 0% 98% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/Harness Open Source/Dark */
-  --figma___side-nav-nav-item-selected-text: 0 0% 98% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Text/Harness Open Source/Dark */
-  --figma___side-nav-profile-role: 212 6% 50% / 1;
-  /* ✦ Theme/Side nav/Profile/Role/Harness Open Source/Dark */
-  --figma___side-nav-profile-text: 0 0% 98% / 1;
-  /* ✦ Theme/Side nav/Profile/Text/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-default-border: 240 6% 10% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Border/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-default-main-text-icon: 0 0% 98% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-default-scope-name: 212 6% 50% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-hover-border: 220 6% 90% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-hover-main-text-icon: 0 0% 98% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-hover-scope-name: 212 6% 50% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-selected-border: 220 6% 90% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-selected-main-text-icon: 0 0% 98% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-selected-scope-name: 212 6% 50% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/Harness Open Source/Dark */
-  --figma___side-nav-separator: 240 6% 10% / 1;
-  /* ✦ Theme/Side nav/Separator/Harness Open Source/Dark */
-  --figma___status-colors-error-1: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/1/Harness Open Source/Dark */
-  --figma___status-colors-error-2: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/2/Harness Open Source/Dark */
-  --figma___status-colors-error-3: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/3/Harness Open Source/Dark */
-  --figma___status-colors-error-4: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/4/Harness Open Source/Dark */
-  --figma___status-colors-error-5: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/5/Harness Open Source/Dark */
-  --figma___status-colors-error-6: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/6/Harness Open Source/Dark */
-  --figma___status-colors-error-7: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/7/Harness Open Source/Dark */
-  --figma___status-colors-error-8: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/8/Harness Open Source/Dark */
-  --figma___status-colors-error-9: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/9/Harness Open Source/Dark */
-  --figma___status-colors-error-10: 0 80% 65% / 1;
-  /* ✦ Theme/Status colors/Error/10/Harness Open Source/Dark */
-  --figma___status-colors-error-alpha-1: 0 80% 65% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/1/Harness Open Source/Dark */
-  --figma___status-colors-error-alpha-2: 0 80% 65% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/2/Harness Open Source/Dark */
-  --figma___status-colors-error-alpha-3: 0 80% 65% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/3/Harness Open Source/Dark */
-  --figma___status-colors-error-alpha-4: 0 80% 65% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/4/Harness Open Source/Dark */
-  --figma___status-colors-error-alpha-5: 0 80% 65% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/5/Harness Open Source/Dark */
-  --figma___status-colors-error-alpha-6: 0 80% 65% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/6/Harness Open Source/Dark */
-  --figma___status-colors-error-alpha-7: 0 80% 65% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/7/Harness Open Source/Dark */
-  --figma___status-colors-error-alpha-8: 0 80% 65% / 0.16;
-  /* ✦ Theme/Status colors/Error Alpha/8/Harness Open Source/Dark */
-  --figma___status-colors-error-alpha-9: 0 80% 65% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/9/Harness Open Source/Dark */
-  --figma___status-colors-error-alpha-10: 0 80% 65% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/10/Harness Open Source/Dark */
-  --figma___status-colors-info-1: 212 36% 9% / 1;
-  /* ✦ Theme/Status colors/Info/1/Harness Open Source/Dark */
-  --figma___status-colors-info-2: 216 50% 12% / 1;
-  /* ✦ Theme/Status colors/Info/2/Harness Open Source/Dark */
-  --figma___status-colors-info-3: 214 58% 16% / 1;
-  /* ✦ Theme/Status colors/Info/3/Harness Open Source/Dark */
-  --figma___status-colors-info-4: 214 65% 18% / 1;
-  /* ✦ Theme/Status colors/Info/4/Harness Open Source/Dark */
-  --figma___status-colors-info-5: 213 67% 21% / 1;
-  /* ✦ Theme/Status colors/Info/5/Harness Open Source/Dark */
-  --figma___status-colors-info-6: 212 72% 25% / 1;
-  /* ✦ Theme/Status colors/Info/6/Harness Open Source/Dark */
-  --figma___status-colors-info-7: 214 73% 51% / 1;
-  /* ✦ Theme/Status colors/Info/7/Harness Open Source/Dark */
-  --figma___status-colors-info-8: 206 100% 62% / 1;
-  /* ✦ Theme/Status colors/Info/8/Harness Open Source/Dark */
-  --figma___status-colors-info-9: 205 100% 71% / 1;
-  /* ✦ Theme/Status colors/Info/9/Harness Open Source/Dark */
-  --figma___status-colors-info-10: 206 100% 88% / 1;
-  /* ✦ Theme/Status colors/Info/10/Harness Open Source/Dark */
-  --figma___status-colors-info-alpha-1: 240 100% 49% / 0.04;
-  /* ✦ Theme/Status colors/Info Alpha/1/Harness Open Source/Dark */
-  --figma___status-colors-info-alpha-2: 227 100% 50% / 0.09;
-  /* ✦ Theme/Status colors/Info Alpha/2/Harness Open Source/Dark */
-  --figma___status-colors-info-alpha-3: 216 100% 50% / 0.17;
-  /* ✦ Theme/Status colors/Info Alpha/3/Harness Open Source/Dark */
-  --figma___status-colors-info-alpha-4: 214 100% 50% / 0.23;
-  /* ✦ Theme/Status colors/Info Alpha/4/Harness Open Source/Dark */
-  --figma___status-colors-info-alpha-5: 213 100% 51% / 0.29;
-  /* ✦ Theme/Status colors/Info Alpha/5/Harness Open Source/Dark */
-  --figma___status-colors-info-alpha-6: 212 100% 52% / 0.38;
-  /* ✦ Theme/Status colors/Info Alpha/6/Harness Open Source/Dark */
-  --figma___status-colors-info-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/7/Harness Open Source/Dark */
-  --figma___status-colors-info-alpha-8: 206 100% 62% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/8/Harness Open Source/Dark */
-  --figma___status-colors-info-alpha-9: 205 100% 71% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/9/Harness Open Source/Dark */
-  --figma___status-colors-info-alpha-10: 206 100% 88% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/10/Harness Open Source/Dark */
-  --figma___status-colors-success-1: 145 32% 7% / 1;
-  /* ✦ Theme/Status colors/Success/1/Harness Open Source/Dark */
-  --figma___status-colors-success-2: 154 32% 9% / 1;
-  /* ✦ Theme/Status colors/Success/2/Harness Open Source/Dark */
-  --figma___status-colors-success-3: 155 38% 11% / 1;
-  /* ✦ Theme/Status colors/Success/3/Harness Open Source/Dark */
-  --figma___status-colors-success-4: 155 42% 14% / 1;
-  /* ✦ Theme/Status colors/Success/4/Harness Open Source/Dark */
-  --figma___status-colors-success-5: 153 43% 16% / 1;
-  /* ✦ Theme/Status colors/Success/5/Harness Open Source/Dark */
-  --figma___status-colors-success-6: 155 47% 19% / 1;
-  /* ✦ Theme/Status colors/Success/6/Harness Open Source/Dark */
-  --figma___status-colors-success-7: 142 72% 29% / 1;
-  /* ✦ Theme/Status colors/Success/7/Harness Open Source/Dark */
-  --figma___status-colors-success-8: 151 55% 47% / 1;
-  /* ✦ Theme/Status colors/Success/8/Harness Open Source/Dark */
-  --figma___status-colors-success-9: 151 65% 54% / 1;
-  /* ✦ Theme/Status colors/Success/9/Harness Open Source/Dark */
-  --figma___status-colors-success-10: 144 70% 82% / 1;
-  /* ✦ Theme/Status colors/Success/10/Harness Open Source/Dark */
-  --figma___status-colors-success-alpha-1: 120 100% 44% / 0;
-  /* ✦ Theme/Status colors/Success Alpha/1/Harness Open Source/Dark */
-  --figma___status-colors-success-alpha-2: 120 100% 49% / 0.02;
-  /* ✦ Theme/Status colors/Success Alpha/2/Harness Open Source/Dark */
-  --figma___status-colors-success-alpha-3: 149 100% 49% / 0.07;
-  /* ✦ Theme/Status colors/Success Alpha/3/Harness Open Source/Dark */
-  --figma___status-colors-success-alpha-4: 154 100% 50% / 0.11;
-  /* ✦ Theme/Status colors/Success Alpha/4/Harness Open Source/Dark */
-  --figma___status-colors-success-alpha-5: 153 99% 53% / 0.15;
-  /* ✦ Theme/Status colors/Success Alpha/5/Harness Open Source/Dark */
-  --figma___status-colors-success-alpha-6: 155 99% 55% / 0.2;
-  /* ✦ Theme/Status colors/Success Alpha/6/Harness Open Source/Dark */
-  --figma___status-colors-success-alpha-7: 151 100% 62% / 0.61;
-  /* ✦ Theme/Status colors/Success Alpha/7/Harness Open Source/Dark */
-  --figma___status-colors-success-alpha-8: 151 100% 63% / 0.7;
-  /* ✦ Theme/Status colors/Success Alpha/8/Harness Open Source/Dark */
-  --figma___status-colors-success-alpha-9: 151 100% 64% / 0.82;
-  /* ✦ Theme/Status colors/Success Alpha/9/Harness Open Source/Dark */
-  --figma___status-colors-success-alpha-10: 144 100% 87% / 0.94;
-  /* ✦ Theme/Status colors/Success Alpha/10/Harness Open Source/Dark */
-  --figma___status-colors-warning-1: 37 100% 6% / 1;
-  /* ✦ Theme/Status colors/Warning/1/Harness Open Source/Dark */
-  --figma___status-colors-warning-2: 36 80% 8% / 1;
-  /* ✦ Theme/Status colors/Warning/2/Harness Open Source/Dark */
-  --figma___status-colors-warning-3: 34 63% 12% / 1;
-  /* ✦ Theme/Status colors/Warning/3/Harness Open Source/Dark */
-  --figma___status-colors-warning-4: 34 58% 14% / 1;
-  /* ✦ Theme/Status colors/Warning/4/Harness Open Source/Dark */
-  --figma___status-colors-warning-5: 34 58% 17% / 1;
-  /* ✦ Theme/Status colors/Warning/5/Harness Open Source/Dark */
-  --figma___status-colors-warning-6: 34 58% 21% / 1;
-  /* ✦ Theme/Status colors/Warning/6/Harness Open Source/Dark */
-  --figma___status-colors-warning-7: 42 100% 62% / 1;
-  /* ✦ Theme/Status colors/Warning/7/Harness Open Source/Dark */
-  --figma___status-colors-warning-8: 43 100% 64% / 1;
-  /* ✦ Theme/Status colors/Warning/8/Harness Open Source/Dark */
-  --figma___status-colors-warning-9: 43 100% 65% / 1;
-  /* ✦ Theme/Status colors/Warning/9/Harness Open Source/Dark */
-  --figma___status-colors-warning-10: 41 100% 85% / 1;
-  /* ✦ Theme/Status colors/Warning/10/Harness Open Source/Dark */
-  --figma___status-colors-warning-alpha-1: 0 100% 49% / 0.03;
-  /* ✦ Theme/Status colors/Warning Alpha/1/Harness Open Source/Dark */
-  --figma___status-colors-warning-alpha-2: 6 100% 49% / 0.06;
-  /* ✦ Theme/Status colors/Warning Alpha/2/Harness Open Source/Dark */
-  --figma___status-colors-warning-alpha-3: 24 100% 50% / 0.1;
-  /* ✦ Theme/Status colors/Warning Alpha/3/Harness Open Source/Dark */
-  --figma___status-colors-warning-alpha-4: 30 100% 50% / 0.14;
-  /* ✦ Theme/Status colors/Warning Alpha/4/Harness Open Source/Dark */
-  --figma___status-colors-warning-alpha-5: 33 100% 50% / 0.19;
-  /* ✦ Theme/Status colors/Warning Alpha/5/Harness Open Source/Dark */
-  --figma___status-colors-warning-alpha-6: 34 100% 53% / 0.26;
-  /* ✦ Theme/Status colors/Warning Alpha/6/Harness Open Source/Dark */
-  --figma___status-colors-warning-alpha-7: 42 100% 62% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/7/Harness Open Source/Dark */
-  --figma___status-colors-warning-alpha-8: 43 100% 64% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/8/Harness Open Source/Dark */
-  --figma___status-colors-warning-alpha-9: 43 100% 65% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/9/Harness Open Source/Dark */
-  --figma___status-colors-warning-alpha-10: 41 100% 85% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/10/Harness Open Source/Dark */
-  --figma___switch-background: 200 5% 12% / 1;
-  /* ✦ Theme/Switch/Background/Harness Open Source/Dark */
-  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/Harness Open Source/Dark */
-  --figma___switch-checked-active-background: 0 0% 98% / 1;
-  /* ✦ Theme/Switch/Checked/Active/background/Harness Open Source/Dark */
-  --figma___switch-checked-active-border: 210 6% 60% / 0;
-  /* ✦ Theme/Switch/Checked/Active/border/Harness Open Source/Dark */
-  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/Harness Open Source/Dark */
-  --figma___switch-checked-default-default-background: 0 0% 98% / 1;
-  /* ✦ Theme/Switch/Checked/Default/default background/Harness Open Source/Dark */
-  --figma___switch-checked-default-default-border: 210 6% 60% / 0;
-  /* ✦ Theme/Switch/Checked/Default/default border/Harness Open Source/Dark */
-  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/Harness Open Source/Dark */
-  --figma___switch-checked-disabled-background: 0 0% 98% / 1;
-  /* ✦ Theme/Switch/Checked/Disabled/background/Harness Open Source/Dark */
-  --figma___switch-checked-disabled-border: 210 6% 60% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/border/Harness Open Source/Dark */
-  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/Harness Open Source/Dark */
-  --figma___switch-checked-hover-background: 176 59% 60% / 1;
-  /* ✦ Theme/Switch/Checked/Hover/background/Harness Open Source/Dark */
-  --figma___switch-checked-hover-border: 210 6% 60% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/border/Harness Open Source/Dark */
-  --figma___switch-paper: 0 0% 100% / 0.03;
-  /* ✦ Theme/Switch/Paper/Harness Open Source/Dark */
-  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/Harness Open Source/Dark */
-  --figma___switch-unchecked-active-background: 216 6% 15% / 1;
-  /* ✦ Theme/Switch/Unchecked/Active/background/Harness Open Source/Dark */
-  --figma___switch-unchecked-active-border: 210 6% 20% / 1;
-  /* ✦ Theme/Switch/Unchecked/Active/border/Harness Open Source/Dark */
-  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/Harness Open Source/Dark */
-  --figma___switch-unchecked-default-default-background: 210 6% 40% / 1;
-  /* ✦ Theme/Switch/Unchecked/Default/default background/Harness Open Source/Dark */
-  --figma___switch-unchecked-default-default-border: 210 6% 20% / 1;
-  /* ✦ Theme/Switch/Unchecked/Default/default border/Harness Open Source/Dark */
-  --figma___switch-unchecked-disabled-thumb-thumb-background: 230 7% 16% / 1;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/Harness Open Source/Dark */
-  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/Harness Open Source/Dark */
-  --figma___switch-unchecked-disabled-background: 240 100% 9% / 0.11;
-  /* ✦ Theme/Switch/Unchecked/Disabled/background/Harness Open Source/Dark */
-  --figma___switch-unchecked-disabled-border: 210 6% 20% / 1;
-  /* ✦ Theme/Switch/Unchecked/Disabled/border/Harness Open Source/Dark */
-  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/Harness Open Source/Dark */
-  --figma___switch-unchecked-hover-background: 212 6% 50% / 1;
-  /* ✦ Theme/Switch/Unchecked/Hover/background/Harness Open Source/Dark */
-  --figma___switch-unchecked-hover-border: 210 6% 20% / 1;
-  /* ✦ Theme/Switch/Unchecked/Hover/border/Harness Open Source/Dark */
-  --figma___switch-border: 230 100% 87% / 0.09;
-  /* ✦ Theme/Switch/border/Harness Open Source/Dark */
-  --figma___tabs-number-active-background: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Number/Active/Background/Harness Open Source/Dark */
-  --figma___tabs-number-active-text: 240 13% 3% / 1;
-  /* ✦ Theme/Tabs/Number/Active/text/Harness Open Source/Dark */
-  --figma___tabs-number-default-hover-background: 200 5% 12% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/Background/Harness Open Source/Dark */
-  --figma___tabs-number-default-hover-text: 0 0% 98% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/text/Harness Open Source/Dark */
-  --figma___tabs-pills-active-active: 240 13% 3% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Active/Harness Open Source/Dark */
-  --figma___tabs-pills-active-text: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Text/Harness Open Source/Dark */
-  --figma___tabs-pills-active-border-grad-1: 219 100% 84% / 0.05;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 1/Harness Open Source/Dark */
-  --figma___tabs-pills-active-border-grad-2: 219 100% 84% / 0.1;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 2/Harness Open Source/Dark */
-  --figma___tabs-pills-backgrounds: 240 6% 10% / 1;
-  /* ✦ Theme/Tabs/Pills/Backgrounds/Harness Open Source/Dark */
-  --figma___tabs-pills-default-background: 240 6% 40% / 0;
-  /* ✦ Theme/Tabs/Pills/Default/Background/Harness Open Source/Dark */
-  --figma___tabs-pills-default-text: 240 6% 60% / 1;
-  /* ✦ Theme/Tabs/Pills/Default/Text/Harness Open Source/Dark */
-  --figma___tabs-pills-hover-background: 240 13% 3% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Background/Harness Open Source/Dark */
-  --figma___tabs-pills-hover-text: 207 6% 70% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Text/Harness Open Source/Dark */
-  --figma___tabs-pills-number-active-background: 0 0% 98% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/Background/Harness Open Source/Dark */
-  --figma___tabs-pills-number-active-text: 200 7% 8% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/text/Harness Open Source/Dark */
-  --figma___tabs-pills-border-grad-1: 219 100% 84% / 0.07;
-  /* ✦ Theme/Tabs/Pills/border grad 1/Harness Open Source/Dark */
-  --figma___tabs-pills-border-grad-2: 219 100% 84% / 0.02;
-  /* ✦ Theme/Tabs/Pills/border grad 2/Harness Open Source/Dark */
-  --figma___tabs-primary-active-text: 0 0% 98% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Text/Harness Open Source/Dark */
-  --figma___tabs-primary-active-underline: 0 0% 98% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Underline/Harness Open Source/Dark */
-  --figma___tabs-primary-border: 270 89% 78% / 1;
-  /* ✦ Theme/Tabs/Primary/Border/Harness Open Source/Dark */
-  --figma___tabs-primary-default-background: 240 6% 40% / 0;
-  /* ✦ Theme/Tabs/Primary/Default/Background/Harness Open Source/Dark */
-  --figma___tabs-primary-default-text: 212 6% 50% / 1;
-  /* ✦ Theme/Tabs/Primary/Default/Text/Harness Open Source/Dark */
-  --figma___tabs-primary-hover-background: 240 93% 11% / 0.08;
-  /* ✦ Theme/Tabs/Primary/Hover/Background/Harness Open Source/Dark */
-  --figma___tabs-primary-hover-text: 0 0% 98% / 1;
-  /* ✦ Theme/Tabs/Primary/Hover/Text/Harness Open Source/Dark */
-  --figma___tabs-primary-pills-pills: 271 58% 61% / 1;
-  /* ✦ Theme/Tabs/Primary/Pills/Pills/Harness Open Source/Dark */
-  --figma___text-disabled: 207 6% 30% / 1;
-  /* ✦ Theme/Text/Disabled/Harness Open Source/Dark */
-  --figma___text-links: 216 100% 59% / 1;
-  /* ✦ Theme/Text/Links/Harness Open Source/Dark */
-  --figma___text-secondary: 207 6% 70% / 1;
-  /* ✦ Theme/Text/Secondary/Harness Open Source/Dark */
-  --figma___text-tertiary: 212 6% 50% / 1;
-  /* ✦ Theme/Text/Tertiary/Harness Open Source/Dark */
-  --figma___text-primary: 0 0% 98% / 1;
-  /* ✦ Theme/Text/primary/Harness Open Source/Dark */
-  --figma___textfield-assistive-text-primary: 212 6% 50% / 1;
-  /* ✦ Theme/Textfield/Assistive Text/Primary/Harness Open Source/Dark */
-  --figma___textfield-background: 0 0% 100% / 0;
-  /* ✦ Theme/Textfield/Background/Harness Open Source/Dark */
-  --figma___textfield-input-field-background: 0 0% 98% / 0;
-  /* ✦ Theme/Textfield/Input Field/Background/Harness Open Source/Dark */
-  --figma___textfield-input-field-default: 207 6% 30% / 1;
-  /* ✦ Theme/Textfield/Input Field/Default/Harness Open Source/Dark */
-  --figma___textfield-input-field-error: 0 80% 65% / 1;
-  /* ✦ Theme/Textfield/Input Field/Error/Harness Open Source/Dark */
-  --figma___textfield-input-field-hover: 216 6% 15% / 1;
-  /* ✦ Theme/Textfield/Input Field/Hover/Harness Open Source/Dark */
-  --figma___textfield-label-info-icon: 212 6% 50% / 1;
-  /* ✦ Theme/Textfield/Label/Info Icon/Harness Open Source/Dark */
-  --figma___textfield-label-link: 211 85% 48% / 1;
-  /* ✦ Theme/Textfield/Label/Link/Harness Open Source/Dark */
-  --figma___textfield-label-main: 0 0% 98% / 1;
-  /* ✦ Theme/Textfield/Label/Main/Harness Open Source/Dark */
-  --figma___textfield-label-optional: 212 6% 50% / 1;
-  /* ✦ Theme/Textfield/Label/Optional/Harness Open Source/Dark */
-  --figma___textfield-pin-soft-background: 240 100% 12% / 0.05;
-  /* ✦ Theme/Textfield/Pin/Soft/Background/Harness Open Source/Dark */
-  --figma___textfield-pin-soft-border: 233 96% 9% / 0.17;
-  /* ✦ Theme/Textfield/Pin/Soft/border/Harness Open Source/Dark */
-  --figma___textfield-pin-soft-pin: 240 6% 80% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/pin/Harness Open Source/Dark */
-  --figma___textfield-pin-surface-background: 200 6% 10% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/Background/Harness Open Source/Dark */
-  --figma___textfield-pin-surface-border: 210 6% 40% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/border/Harness Open Source/Dark */
-  --figma___textfield-pin-surface-pin: 207 6% 70% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/pin/Harness Open Source/Dark */
-  --figma___tooltip-background: 200 5% 12% / 1;
-  /* ✦ Theme/Tooltip/Background/Harness Open Source/Dark */
-  --figma___tooltip-body-text: 207 6% 70% / 1;
-  /* ✦ Theme/Tooltip/Body Text/Harness Open Source/Dark */
-  --figma___tooltip-dismissable-icon: 240 6% 80% / 1;
-  /* ✦ Theme/Tooltip/Dismissable icon/Harness Open Source/Dark */
-  --figma___tooltip-tooltip-title: 0 0% 98% / 1;
-  /* ✦ Theme/Tooltip/Tooltip Title/Harness Open Source/Dark */
-  --figma___badges-solid-amber-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Amber/text/Harness Open Source/Dark */
-  --figma___badges-solid-blue-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Blue/text/Harness Open Source/Dark */
-  --figma___badges-solid-bronze-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Bronze/text/Harness Open Source/Dark */
-  --figma___badges-solid-brown-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Brown/text/Harness Open Source/Dark */
-  --figma___badges-solid-crimson-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Crimson/text/Harness Open Source/Dark */
-  --figma___badges-solid-cyan-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Cyan/text/Harness Open Source/Dark */
-  --figma___badges-solid-gold-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Gold/text/Harness Open Source/Dark */
-  --figma___badges-solid-grass-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Grass/text/Harness Open Source/Dark */
-  --figma___badges-solid-green-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Green/text/Harness Open Source/Dark */
-  --figma___badges-solid-indigo-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Indigo/text/Harness Open Source/Dark */
-  --figma___badges-solid-iris-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Iris/text/Harness Open Source/Dark */
-  --figma___badges-solid-jade-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Jade/text/Harness Open Source/Dark */
-  --figma___badges-solid-lime-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Lime/text/Harness Open Source/Dark */
-  --figma___badges-solid-mint-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Mint/text/Harness Open Source/Dark */
-  --figma___badges-solid-orange-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Orange/text/Harness Open Source/Dark */
-  --figma___badges-solid-pink-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Pink/text/Harness Open Source/Dark */
-  --figma___badges-solid-plum-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Plum/text/Harness Open Source/Dark */
-  --figma___badges-solid-purple-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Purple/text/Harness Open Source/Dark */
-  --figma___badges-solid-red-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Red/text/Harness Open Source/Dark */
-  --figma___badges-solid-ruby-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Ruby/text/Harness Open Source/Dark */
-  --figma___badges-solid-sky-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Sky/text/Harness Open Source/Dark */
-  --figma___badges-solid-success-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Success/text/Harness Open Source/Dark */
-  --figma___badges-solid-teal-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Teal/text/Harness Open Source/Dark */
-  --figma___badges-solid-violet-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Violet/text/Harness Open Source/Dark */
-  --figma___badges-solid-yellow-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Yellow/text/Harness Open Source/Dark */
-  --figma___badges-solid-accent-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/accent/text/Harness Open Source/Dark */
-  --figma___badges-solid-info-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/info/text/Harness Open Source/Dark */
-  --figma___badges-solid-warning-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/warning/text/Harness Open Source/Dark */
-  --figma___button-solid-error-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Error/Text-primary/Harness Open Source/Dark */
-  --figma___button-solid-neutral-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Neutral/Text-primary/Harness Open Source/Dark */
-  --figma___button-solid-success-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Success/Text-primary/Harness Open Source/Dark */
-  --figma___calendar-selected-date-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Calendar/Selected Date/Text/Harness Open Source/Dark */
-  --figma___checkbox-surface-checked-active-check: var(--figma___default-colors-white);
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/Harness Open Source/Dark */
-  --figma___checkbox-surface-intermediate-active-check: var(--figma___default-colors-white);
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/Harness Open Source/Dark */
-  --figma___radio-button-checked-active-dot: var(--figma___default-colors-white);
-  /* ✦ Theme/Radio button/Checked/Active/Dot/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-default-default: var(--figma___textfield-background);
-  /* ✦ Theme/Side nav/Scope Selector/Default/default/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-hover-default: var(--figma___textfield-background);
-  /* ✦ Theme/Side nav/Scope Selector/Hover/default/Harness Open Source/Dark */
-  --figma___side-nav-scope-selector-selected-background: var(--figma___textfield-background);
-  /* ✦ Theme/Side nav/Scope Selector/Selected/background/Harness Open Source/Dark */
-  --figma___switch-checked-active-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/Harness Open Source/Dark */
-  --figma___switch-checked-default-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/Harness Open Source/Dark */
-  --figma___switch-checked-disabled-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/Harness Open Source/Dark */
-  --figma___switch-checked-hover-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/Harness Open Source/Dark */
-  --figma___switch-unchecked-active-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/Harness Open Source/Dark */
-  --figma___switch-unchecked-default-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/Harness Open Source/Dark */
-  --figma___switch-unchecked-hover-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-1: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/1/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-2: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/2/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-3: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/3/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-4: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/4/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-5: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/5/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-6: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/6/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-7: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/7/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-8: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/8/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-9: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/9/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-10: 0 80% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/10/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-alpha-1: 0 80% 65% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/1/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-alpha-2: 0 80% 65% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/2/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-alpha-3: 0 80% 65% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/3/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-alpha-4: 0 80% 65% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/4/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-alpha-5: 0 80% 65% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/5/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-alpha-6: 0 80% 65% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/6/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-alpha-7: 0 80% 65% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/7/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-alpha-8: 0 80% 65% / 0.16; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/8/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-alpha-9: 0 80% 65% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/9/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-alpha-10: 0 80% 65% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/10/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-1: 226 25% 10% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/1/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-2: 230 36% 13% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/2/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-3: 228 43% 18% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/3/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-4: 228 45% 21% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/4/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-5: 227 48% 24% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/5/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-6: 226 53% 37% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/6/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-7: 226 70% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/7/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-8: 230 74% 63% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/8/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-9: 235 100% 80% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/9/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-10: 236 94% 93% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/10/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-alpha-1: 240 100% 49% / 0.04; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/1/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-alpha-2: 232 100% 50% / 0.09; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/2/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-alpha-3: 228 100% 57% / 0.18; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/3/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-alpha-4: 228 99% 59% / 0.24; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/4/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-alpha-5: 227 99% 60% / 0.29; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/5/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-alpha-6: 226 100% 62% / 0.52; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/6/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-alpha-7: 226 100% 63% / 0.85; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/7/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-alpha-8: 230 100% 70% / 0.9; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/8/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-alpha-9: 235 100% 80% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/9/Harness Open Source/Dark */
+  --figma___colors-alerts-status-info-alpha-10: 236 100% 94% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/10/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-1: 145 32% 7% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/1/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-2: 154 32% 9% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/2/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-3: 155 38% 11% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/3/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-4: 155 42% 14% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/4/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-5: 153 43% 16% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/5/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-6: 152 50% 25% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/6/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-7: 142 72% 29% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/7/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-8: 151 55% 47% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/8/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-9: 151 65% 54% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/9/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-10: 144 70% 82% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/10/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-alpha-1: 120 100% 44% / 0; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/1/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-alpha-2: 120 100% 49% / 0.02; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/2/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-alpha-3: 149 100% 49% / 0.07; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/3/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-alpha-4: 154 100% 50% / 0.11; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/4/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-alpha-5: 151 100% 63% / 0.5; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/5/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-alpha-6: 152 99% 59% / 0.3; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/6/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-alpha-7: 151 100% 62% / 0.61; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/7/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-alpha-8: 151 100% 63% / 0.7; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/8/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-alpha-9: 151 100% 64% / 0.82; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/9/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-alpha-10: 144 100% 87% / 0.94; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/10/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-1: 37 100% 6% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/1/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-2: 36 80% 8% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/2/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-3: 34 63% 12% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/3/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-4: 34 58% 14% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/4/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-5: 34 58% 17% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/5/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-6: 35 59% 27% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/6/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-7: 42 100% 62% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/7/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-8: 43 100% 64% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/8/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-9: 43 100% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/9/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-10: 41 100% 85% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/10/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-alpha-1: 0 100% 49% / 0.03; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/1/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-alpha-2: 6 100% 49% / 0.06; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/2/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-alpha-3: 24 100% 50% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/3/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-alpha-4: 30 100% 50% / 0.14; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/4/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-alpha-5: 33 100% 50% / 0.19; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/5/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-alpha-6: 35 100% 57% / 0.38; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/6/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-alpha-7: 42 100% 62% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/7/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-alpha-8: 43 100% 64% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/8/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-alpha-9: 43 100% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/9/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-alpha-10: 41 100% 85% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/10/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-1: 252 19% 10% / 1; /* ✦ Theme/Colors/Charts/AI Violet/1/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-2: 255 30% 13% / 1; /* ✦ Theme/Colors/Charts/AI Violet/2/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-3: 255 34% 18% / 1; /* ✦ Theme/Colors/Charts/AI Violet/3/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-4: 252 35% 22% / 1; /* ✦ Theme/Colors/Charts/AI Violet/4/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-5: 253 35% 25% / 1; /* ✦ Theme/Colors/Charts/AI Violet/5/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-6: 251 38% 39% / 1; /* ✦ Theme/Colors/Charts/AI Violet/6/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-7: 252 56% 57% / 1; /* ✦ Theme/Colors/Charts/AI Violet/7/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-8: 253 63% 64% / 1; /* ✦ Theme/Colors/Charts/AI Violet/8/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-9: 255 100% 80% / 1; /* ✦ Theme/Colors/Charts/AI Violet/9/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-10: 249 94% 93% / 1; /* ✦ Theme/Colors/Charts/AI Violet/10/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-alpha-1: 240 100% 49% / 0.03; /* ✦ Theme/Colors/Charts/AI Violet Alpha/1/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-alpha-2: 255 98% 52% / 0.08; /* ✦ Theme/Colors/Charts/AI Violet Alpha/2/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-alpha-3: 255 99% 63% / 0.17; /* ✦ Theme/Colors/Charts/AI Violet Alpha/3/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-alpha-4: 252 99% 66% / 0.23; /* ✦ Theme/Colors/Charts/AI Violet Alpha/4/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-alpha-5: 252 99% 67% / 0.28; /* ✦ Theme/Colors/Charts/AI Violet Alpha/5/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-alpha-6: 251 100% 70% / 0.49; /* ✦ Theme/Colors/Charts/AI Violet Alpha/6/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-alpha-7: 252 100% 70% / 0.79; /* ✦ Theme/Colors/Charts/AI Violet Alpha/7/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-alpha-8: 253 100% 74% / 0.85; /* ✦ Theme/Colors/Charts/AI Violet Alpha/8/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-alpha-9: 255 100% 80% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/9/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-alpha-10: 249 100% 94% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/10/Harness Open Source/Dark */
+  --figma___colors-charts-blue-1: 212 36% 9% / 1; /* ✦ Theme/Colors/Charts/Blue/1/Harness Open Source/Dark */
+  --figma___colors-charts-blue-2: 216 50% 12% / 1; /* ✦ Theme/Colors/Charts/Blue/2/Harness Open Source/Dark */
+  --figma___colors-charts-blue-3: 214 58% 16% / 1; /* ✦ Theme/Colors/Charts/Blue/3/Harness Open Source/Dark */
+  --figma___colors-charts-blue-4: 214 65% 18% / 1; /* ✦ Theme/Colors/Charts/Blue/4/Harness Open Source/Dark */
+  --figma___colors-charts-blue-5: 213 67% 21% / 1; /* ✦ Theme/Colors/Charts/Blue/5/Harness Open Source/Dark */
+  --figma___colors-charts-blue-6: 211 82% 32% / 1; /* ✦ Theme/Colors/Charts/Blue/6/Harness Open Source/Dark */
+  --figma___colors-charts-blue-7: 214 73% 51% / 1; /* ✦ Theme/Colors/Charts/Blue/7/Harness Open Source/Dark */
+  --figma___colors-charts-blue-8: 206 100% 62% / 1; /* ✦ Theme/Colors/Charts/Blue/8/Harness Open Source/Dark */
+  --figma___colors-charts-blue-9: 205 100% 71% / 1; /* ✦ Theme/Colors/Charts/Blue/9/Harness Open Source/Dark */
+  --figma___colors-charts-blue-10: 206 100% 88% / 1; /* ✦ Theme/Colors/Charts/Blue/10/Harness Open Source/Dark */
+  --figma___colors-charts-blue-alpha-1: 240 100% 49% / 0.04; /* ✦ Theme/Colors/Charts/Blue Alpha/1/Harness Open Source/Dark */
+  --figma___colors-charts-blue-alpha-2: 227 100% 50% / 0.09; /* ✦ Theme/Colors/Charts/Blue Alpha/2/Harness Open Source/Dark */
+  --figma___colors-charts-blue-alpha-3: 216 100% 50% / 0.17; /* ✦ Theme/Colors/Charts/Blue Alpha/3/Harness Open Source/Dark */
+  --figma___colors-charts-blue-alpha-4: 214 100% 50% / 0.23; /* ✦ Theme/Colors/Charts/Blue Alpha/4/Harness Open Source/Dark */
+  --figma___colors-charts-blue-alpha-5: 212 100% 52% / 0.38; /* ✦ Theme/Colors/Charts/Blue Alpha/5/Harness Open Source/Dark */
+  --figma___colors-charts-blue-alpha-6: 211 100% 51% / 0.55; /* ✦ Theme/Colors/Charts/Blue Alpha/6/Harness Open Source/Dark */
+  --figma___colors-charts-blue-alpha-7: 206 100% 50% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/7/Harness Open Source/Dark */
+  --figma___colors-charts-blue-alpha-8: 206 100% 62% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/8/Harness Open Source/Dark */
+  --figma___colors-charts-blue-alpha-9: 205 100% 71% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/9/Harness Open Source/Dark */
+  --figma___colors-charts-blue-alpha-10: 206 100% 88% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/10/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-1: 226 25% 10% / 1; /* ✦ Theme/Colors/Charts/Indigo/1/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-2: 230 36% 13% / 1; /* ✦ Theme/Colors/Charts/Indigo/2/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-3: 228 43% 18% / 1; /* ✦ Theme/Colors/Charts/Indigo/3/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-4: 228 45% 21% / 1; /* ✦ Theme/Colors/Charts/Indigo/4/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-5: 227 48% 24% / 1; /* ✦ Theme/Colors/Charts/Indigo/5/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-6: 226 53% 37% / 1; /* ✦ Theme/Colors/Charts/Indigo/6/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-7: 226 70% 55% / 1; /* ✦ Theme/Colors/Charts/Indigo/7/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-8: 230 74% 63% / 1; /* ✦ Theme/Colors/Charts/Indigo/8/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-9: 235 100% 80% / 1; /* ✦ Theme/Colors/Charts/Indigo/9/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-10: 236 94% 93% / 1; /* ✦ Theme/Colors/Charts/Indigo/10/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-alpha-1: 240 100% 49% / 0.04; /* ✦ Theme/Colors/Charts/Indigo Alpha/1/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-alpha-2: 232 100% 50% / 0.09; /* ✦ Theme/Colors/Charts/Indigo Alpha/2/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-alpha-3: 228 100% 57% / 0.18; /* ✦ Theme/Colors/Charts/Indigo Alpha/3/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-alpha-4: 228 99% 59% / 0.24; /* ✦ Theme/Colors/Charts/Indigo Alpha/4/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-alpha-5: 227 99% 60% / 0.29; /* ✦ Theme/Colors/Charts/Indigo Alpha/5/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-alpha-6: 226 100% 62% / 0.52; /* ✦ Theme/Colors/Charts/Indigo Alpha/6/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-alpha-7: 226 100% 63% / 0.85; /* ✦ Theme/Colors/Charts/Indigo Alpha/7/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-alpha-8: 230 100% 70% / 0.9; /* ✦ Theme/Colors/Charts/Indigo Alpha/8/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-alpha-9: 235 100% 80% / 1; /* ✦ Theme/Colors/Charts/Indigo Alpha/9/Harness Open Source/Dark */
+  --figma___colors-charts-indigo-alpha-10: 236 100% 94% / 1; /* ✦ Theme/Colors/Charts/Indigo Alpha/10/Harness Open Source/Dark */
+  --figma___colors-charts-mint-1: 173 52% 6% / 1; /* ✦ Theme/Colors/Charts/Mint/1/Harness Open Source/Dark */
+  --figma___colors-charts-mint-2: 174 51% 8% / 1; /* ✦ Theme/Colors/Charts/Mint/2/Harness Open Source/Dark */
+  --figma___colors-charts-mint-3: 176 52% 11% / 1; /* ✦ Theme/Colors/Charts/Mint/3/Harness Open Source/Dark */
+  --figma___colors-charts-mint-4: 173 56% 13% / 1; /* ✦ Theme/Colors/Charts/Mint/4/Harness Open Source/Dark */
+  --figma___colors-charts-mint-5: 173 57% 15% / 1; /* ✦ Theme/Colors/Charts/Mint/5/Harness Open Source/Dark */
+  --figma___colors-charts-mint-6: 173 60% 24% / 1; /* ✦ Theme/Colors/Charts/Mint/6/Harness Open Source/Dark */
+  --figma___colors-charts-mint-7: 176 59% 50% / 1; /* ✦ Theme/Colors/Charts/Mint/7/Harness Open Source/Dark */
+  --figma___colors-charts-mint-8: 176 59% 60% / 1; /* ✦ Theme/Colors/Charts/Mint/8/Harness Open Source/Dark */
+  --figma___colors-charts-mint-9: 167 70% 58% / 1; /* ✦ Theme/Colors/Charts/Mint/9/Harness Open Source/Dark */
+  --figma___colors-charts-mint-10: 175 60% 65% / 1; /* ✦ Theme/Colors/Charts/Mint/10/Harness Open Source/Dark */
+  --figma___colors-charts-mint-alpha-1: 120 100% 44% / 0; /* ✦ Theme/Colors/Charts/Mint Alpha/1/Harness Open Source/Dark */
+  --figma___colors-charts-mint-alpha-2: 165 100% 49% / 0.03; /* ✦ Theme/Colors/Charts/Mint Alpha/2/Harness Open Source/Dark */
+  --figma___colors-charts-mint-alpha-3: 174 100% 50% / 0.07; /* ✦ Theme/Colors/Charts/Mint Alpha/3/Harness Open Source/Dark */
+  --figma___colors-charts-mint-alpha-4: 172 100% 50% / 0.11; /* ✦ Theme/Colors/Charts/Mint Alpha/4/Harness Open Source/Dark */
+  --figma___colors-charts-mint-alpha-5: 172 100% 50% / 0.15; /* ✦ Theme/Colors/Charts/Mint Alpha/5/Harness Open Source/Dark */
+  --figma___colors-charts-mint-alpha-6: 173 100% 55% / 0.31; /* ✦ Theme/Colors/Charts/Mint Alpha/6/Harness Open Source/Dark */
+  --figma___colors-charts-mint-alpha-7: 167 100% 78% / 0.91; /* ✦ Theme/Colors/Charts/Mint Alpha/7/Harness Open Source/Dark */
+  --figma___colors-charts-mint-alpha-8: 163 100% 81% / 0.95; /* ✦ Theme/Colors/Charts/Mint Alpha/8/Harness Open Source/Dark */
+  --figma___colors-charts-mint-alpha-9: 167 100% 66% / 0.86; /* ✦ Theme/Colors/Charts/Mint Alpha/9/Harness Open Source/Dark */
+  --figma___colors-charts-mint-alpha-10: 155 100% 90% / 0.96; /* ✦ Theme/Colors/Charts/Mint Alpha/10/Harness Open Source/Dark */
+  --figma___colors-charts-orange-1: 29 68% 7% / 1; /* ✦ Theme/Colors/Charts/Orange/1/Harness Open Source/Dark */
+  --figma___colors-charts-orange-2: 29 81% 8% / 1; /* ✦ Theme/Colors/Charts/Orange/2/Harness Open Source/Dark */
+  --figma___colors-charts-orange-3: 26 68% 12% / 1; /* ✦ Theme/Colors/Charts/Orange/3/Harness Open Source/Dark */
+  --figma___colors-charts-orange-4: 25 66% 15% / 1; /* ✦ Theme/Colors/Charts/Orange/4/Harness Open Source/Dark */
+  --figma___colors-charts-orange-5: 25 65% 18% / 1; /* ✦ Theme/Colors/Charts/Orange/5/Harness Open Source/Dark */
+  --figma___colors-charts-orange-6: 25 68% 29% / 1; /* ✦ Theme/Colors/Charts/Orange/6/Harness Open Source/Dark */
+  --figma___colors-charts-orange-7: 24 94% 50% / 1; /* ✦ Theme/Colors/Charts/Orange/7/Harness Open Source/Dark */
+  --figma___colors-charts-orange-8: 24 100% 58% / 1; /* ✦ Theme/Colors/Charts/Orange/8/Harness Open Source/Dark */
+  --figma___colors-charts-orange-9: 24 100% 70% / 1; /* ✦ Theme/Colors/Charts/Orange/9/Harness Open Source/Dark */
+  --figma___colors-charts-orange-10: 30 100% 88% / 1; /* ✦ Theme/Colors/Charts/Orange/10/Harness Open Source/Dark */
+  --figma___colors-charts-orange-alpha-1: 0 100% 49% / 0.03; /* ✦ Theme/Colors/Charts/Orange Alpha/1/Harness Open Source/Dark */
+  --figma___colors-charts-orange-alpha-2: 0 100% 50% / 0.06; /* ✦ Theme/Colors/Charts/Orange Alpha/2/Harness Open Source/Dark */
+  --figma___colors-charts-orange-alpha-3: 13 100% 50% / 0.12; /* ✦ Theme/Colors/Charts/Orange Alpha/3/Harness Open Source/Dark */
+  --figma___colors-charts-orange-alpha-4: 20 100% 50% / 0.17; /* ✦ Theme/Colors/Charts/Orange Alpha/4/Harness Open Source/Dark */
+  --figma___colors-charts-orange-alpha-5: 24 100% 50% / 0.22; /* ✦ Theme/Colors/Charts/Orange Alpha/5/Harness Open Source/Dark */
+  --figma___colors-charts-orange-alpha-6: 25 100% 51% / 0.44; /* ✦ Theme/Colors/Charts/Orange Alpha/6/Harness Open Source/Dark */
+  --figma___colors-charts-orange-alpha-7: 24 100% 51% / 0.97; /* ✦ Theme/Colors/Charts/Orange Alpha/7/Harness Open Source/Dark */
+  --figma___colors-charts-orange-alpha-8: 24 100% 58% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/8/Harness Open Source/Dark */
+  --figma___colors-charts-orange-alpha-9: 24 100% 70% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/9/Harness Open Source/Dark */
+  --figma___colors-charts-orange-alpha-10: 30 100% 88% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/10/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-1: 45 100% 5% / 1; /* ✦ Theme/Colors/Charts/Yellow/1/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-2: 44 79% 7% / 1; /* ✦ Theme/Colors/Charts/Yellow/2/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-3: 44 63% 11% / 1; /* ✦ Theme/Colors/Charts/Yellow/3/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-4: 44 58% 13% / 1; /* ✦ Theme/Colors/Charts/Yellow/4/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-5: 45 56% 15% / 1; /* ✦ Theme/Colors/Charts/Yellow/5/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-6: 47 59% 24% / 1; /* ✦ Theme/Colors/Charts/Yellow/6/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-7: 53 96% 58% / 1; /* ✦ Theme/Colors/Charts/Yellow/7/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-8: 53 96% 67% / 1; /* ✦ Theme/Colors/Charts/Yellow/8/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-9: 55 100% 60% / 1; /* ✦ Theme/Colors/Charts/Yellow/9/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-10: 53 100% 84% / 1; /* ✦ Theme/Colors/Charts/Yellow/10/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-alpha-1: 45 100% 5% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/1/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-alpha-2: 44 79% 7% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/2/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-alpha-3: 44 63% 11% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/3/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-alpha-4: 44 58% 13% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/4/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-alpha-5: 45 56% 15% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/5/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-alpha-6: 47 59% 24% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/6/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-alpha-7: 53 96% 58% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/7/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-alpha-8: 53 96% 67% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/8/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-alpha-9: 55 100% 60% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/9/Harness Open Source/Dark */
+  --figma___colors-charts-yellow-alpha-10: 53 100% 84% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/10/Harness Open Source/Dark */
+  --figma___colors-default-black-fixed: 210 13% 3% / 1; /* ✦ Theme/Colors/Default/Black (fixed)/Harness Open Source/Dark */
+  --figma___colors-default-brand-color: 0 0% 100% / 1; /* ✦ Theme/Colors/Default/Brand Color/Harness Open Source/Dark */
+  --figma___colors-default-dark-to-white: 0 0% 100% / 1; /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Dark */
+  --figma___colors-default-white-fixed: 0 0% 100% / 1; /* ✦ Theme/Colors/Default/White (fixed)/Harness Open Source/Dark */
+  --figma___colors-default-white-to-dark: 240 13% 3% / 1; /* ✦ Theme/Colors/Default/White-to-dark/Harness Open Source/Dark */
+  --figma___colors-module-ccm-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CCM/100/Harness Open Source/Dark */
+  --figma___colors-module-ccm-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CCM/200/Harness Open Source/Dark */
+  --figma___colors-module-ccm-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CCM/300/Harness Open Source/Dark */
+  --figma___colors-module-cd-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CD/100/Harness Open Source/Dark */
+  --figma___colors-module-cd-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CD/200/Harness Open Source/Dark */
+  --figma___colors-module-cd-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CD/300/Harness Open Source/Dark */
+  --figma___colors-module-ce-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CE/100/Harness Open Source/Dark */
+  --figma___colors-module-ce-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CE/200/Harness Open Source/Dark */
+  --figma___colors-module-ce-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CE/300/Harness Open Source/Dark */
+  --figma___colors-module-ci-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CI/100/Harness Open Source/Dark */
+  --figma___colors-module-ci-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CI/200/Harness Open Source/Dark */
+  --figma___colors-module-ci-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/CI/300/Harness Open Source/Dark */
+  --figma___colors-module-ff-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/FF/100/Harness Open Source/Dark */
+  --figma___colors-module-ff-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/FF/200/Harness Open Source/Dark */
+  --figma___colors-module-ff-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/FF/300/Harness Open Source/Dark */
+  --figma___colors-module-srm-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SRM/100/Harness Open Source/Dark */
+  --figma___colors-module-srm-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SRM/200/Harness Open Source/Dark */
+  --figma___colors-module-srm-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SRM/300/Harness Open Source/Dark */
+  --figma___colors-module-ssca-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SSCA/100/Harness Open Source/Dark */
+  --figma___colors-module-ssca-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SSCA/200/Harness Open Source/Dark */
+  --figma___colors-module-ssca-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/SSCA/300/Harness Open Source/Dark */
+  --figma___colors-module-sto-100: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/STO/100/Harness Open Source/Dark */
+  --figma___colors-module-sto-200: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/STO/200/Harness Open Source/Dark */
+  --figma___colors-module-sto-300: 0 0% 100% / 1; /* ✦ Theme/Colors/Module/STO/300/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-1: 200 7% 8% / 1; /* ✦ Theme/Colors/Neutral/Gray/1/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-2: 210 6% 6% / 1; /* ✦ Theme/Colors/Neutral/Gray/2/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-3: 200 6% 10% / 1; /* ✦ Theme/Colors/Neutral/Gray/3/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-4: 200 5% 12% / 1; /* ✦ Theme/Colors/Neutral/Gray/4/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-5: 216 6% 15% / 1; /* ✦ Theme/Colors/Neutral/Gray/5/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-6: 210 6% 20% / 1; /* ✦ Theme/Colors/Neutral/Gray/6/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-7: 207 6% 30% / 1; /* ✦ Theme/Colors/Neutral/Gray/7/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-8: 210 6% 40% / 1; /* ✦ Theme/Colors/Neutral/Gray/8/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-9: 212 6% 50% / 1; /* ✦ Theme/Colors/Neutral/Gray/9/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-10: 240 7% 94% / 1; /* ✦ Theme/Colors/Neutral/Gray/10/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-alpha-1: 240 93% 53% / 0.01; /* ✦ Theme/Colors/Neutral/Gray Alpha/1/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-alpha-2: 240 93% 73% / 0.03; /* ✦ Theme/Colors/Neutral/Gray Alpha/2/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-alpha-3: 230 100% 87% / 0.09; /* ✦ Theme/Colors/Neutral/Gray Alpha/3/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-alpha-4: 224 96% 89% / 0.13; /* ✦ Theme/Colors/Neutral/Gray Alpha/4/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-alpha-5: 223 100% 91% / 0.16; /* ✦ Theme/Colors/Neutral/Gray Alpha/5/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-alpha-6: 217 95% 91% / 0.19; /* ✦ Theme/Colors/Neutral/Gray Alpha/6/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-alpha-7: 209 95% 92% / 0.24; /* ✦ Theme/Colors/Neutral/Gray Alpha/7/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-alpha-8: 202 88% 93% / 0.33; /* ✦ Theme/Colors/Neutral/Gray Alpha/8/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-alpha-9: 219 100% 93% / 0.41; /* ✦ Theme/Colors/Neutral/Gray Alpha/9/Harness Open Source/Dark */
+  --figma___colors-neutral-gray-alpha-10: 218 100% 95% / 0.49; /* ✦ Theme/Colors/Neutral/Gray Alpha/10/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-1: 200 7% 8% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/1/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-2: 210 6% 6% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/2/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-3: 200 6% 10% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/3/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-4: 200 5% 12% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/4/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-5: 210 6% 20% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/5/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-6: 210 6% 40% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/6/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-7: 0 0% 98% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/7/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-8: 240 7% 94% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/8/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-9: 220 6% 90% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/9/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-10: 0 0% 98% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/10/Harness Open Source/Dark */
+  --figma___colors-primary-primary-alpha-1: 240 89% 18% / 0.01; /* ✦ Theme/Colors/Primary/Primary Alpha/1/Harness Open Source/Dark */
+  --figma___colors-primary-primary-alpha-2: 240 89% 18% / 0.02; /* ✦ Theme/Colors/Primary/Primary Alpha/2/Harness Open Source/Dark */
+  --figma___colors-primary-primary-alpha-3: 240 100% 12% / 0.05; /* ✦ Theme/Colors/Primary/Primary Alpha/3/Harness Open Source/Dark */
+  --figma___colors-primary-primary-alpha-4: 240 93% 11% / 0.08; /* ✦ Theme/Colors/Primary/Primary Alpha/4/Harness Open Source/Dark */
+  --figma___colors-primary-primary-alpha-5: 240 96% 9% / 0.13; /* ✦ Theme/Colors/Primary/Primary Alpha/5/Harness Open Source/Dark */
+  --figma___colors-primary-primary-alpha-6: 230 100% 9% / 0.28; /* ✦ Theme/Colors/Primary/Primary Alpha/6/Harness Open Source/Dark */
+  --figma___colors-primary-primary-alpha-7: 0 0% 98% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/7/Harness Open Source/Dark */
+  --figma___colors-primary-primary-alpha-8: 240 7% 94% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/8/Harness Open Source/Dark */
+  --figma___colors-primary-primary-alpha-9: 220 6% 90% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/9/Harness Open Source/Dark */
+  --figma___colors-primary-primary-alpha-10: 0 0% 98% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/10/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-crimson-1: 333 18% 10% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 1/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-crimson-10: 330 91% 91% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 10/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-crimson-2: 336 32% 12% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 2/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-crimson-3: 335 41% 16% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 3/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-crimson-4: 336 45% 18% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 4/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-crimson-5: 336 49% 21% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 5/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-crimson-6: 336 63% 33% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 6/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-crimson-7: 336 80% 58% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 7/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-crimson-8: 339 87% 67% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 8/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-crimson-9: 341 100% 76% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 9/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-1: 354 100% 49% / 0.02; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-10: 341 100% 76% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-11: 329 100% 92% / 0.99; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-2: 338 100% 50% / 0.07; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-3: 335 100% 55% / 0.14; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-4: 336 99% 56% / 0.19; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-5: 336 100% 58% / 0.25; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-6: 336 100% 57% / 0.49; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-8: 336 100% 63% / 0.9; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Open Source/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-9: 339 100% 70% / 0.95; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-1: 74 55% 6% / 1; /* ✦ Theme/Colors/Secondary/Lime/1/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-2: 78 41% 8% / 1; /* ✦ Theme/Colors/Secondary/Lime/2/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-3: 82 39% 11% / 1; /* ✦ Theme/Colors/Secondary/Lime/3/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-4: 82 40% 13% / 1; /* ✦ Theme/Colors/Secondary/Lime/4/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-5: 81 41% 15% / 1; /* ✦ Theme/Colors/Secondary/Lime/5/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-6: 78 46% 24% / 1; /* ✦ Theme/Colors/Secondary/Lime/6/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-7: 81 80% 66% / 1; /* ✦ Theme/Colors/Secondary/Lime/7/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-8: 75 85% 60% / 1; /* ✦ Theme/Colors/Secondary/Lime/8/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-9: 70 70% 50% / 1; /* ✦ Theme/Colors/Secondary/Lime/9/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-10: 80 79% 85% / 1; /* ✦ Theme/Colors/Secondary/Lime/10/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-alpha-1: 75 100% 5% / 0.71; /* ✦ Theme/Colors/Secondary/Lime Alpha/1/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-alpha-2: 114 100% 49% / 0.02; /* ✦ Theme/Colors/Secondary/Lime Alpha/2/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-alpha-3: 89 100% 50% / 0.06; /* ✦ Theme/Colors/Secondary/Lime Alpha/3/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-alpha-4: 84 100% 50% / 0.1; /* ✦ Theme/Colors/Secondary/Lime Alpha/4/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-alpha-5: 81 99% 53% / 0.14; /* ✦ Theme/Colors/Secondary/Lime Alpha/5/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-alpha-6: 80 99% 58% / 0.19; /* ✦ Theme/Colors/Secondary/Lime Alpha/6/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-alpha-7: 81 100% 71% / 0.93; /* ✦ Theme/Colors/Secondary/Lime Alpha/7/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-alpha-8: 75 100% 64% / 0.94; /* ✦ Theme/Colors/Secondary/Lime Alpha/8/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-alpha-9: 70 100% 58% / 0.84; /* ✦ Theme/Colors/Secondary/Lime Alpha/9/Harness Open Source/Dark */
+  --figma___colors-secondary-lime-alpha-10: 80 100% 88% / 0.97; /* ✦ Theme/Colors/Secondary/Lime Alpha/10/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-1: 287 18% 10% / 1; /* ✦ Theme/Colors/Secondary/Purple/1/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-2: 284 31% 12% / 1; /* ✦ Theme/Colors/Secondary/Purple/2/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-3: 282 35% 17% / 1; /* ✦ Theme/Colors/Secondary/Purple/3/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-4: 281 37% 20% / 1; /* ✦ Theme/Colors/Secondary/Purple/4/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-5: 280 38% 23% / 1; /* ✦ Theme/Colors/Secondary/Purple/5/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-6: 276 41% 35% / 1; /* ✦ Theme/Colors/Secondary/Purple/6/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-7: 272 51% 54% / 1; /* ✦ Theme/Colors/Secondary/Purple/7/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-8: 271 58% 61% / 1; /* ✦ Theme/Colors/Secondary/Purple/8/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-9: 270 89% 78% / 1; /* ✦ Theme/Colors/Secondary/Purple/9/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-10: 275 77% 92% / 1; /* ✦ Theme/Colors/Secondary/Purple/10/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-alpha-1: 278 100% 49% / 0.02; /* ✦ Theme/Colors/Secondary/Purple Alpha/1/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-alpha-2: 283 100% 49% / 0.07; /* ✦ Theme/Colors/Secondary/Purple Alpha/2/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-alpha-3: 282 99% 60% / 0.15; /* ✦ Theme/Colors/Secondary/Purple Alpha/3/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-alpha-4: 281 99% 62% / 0.2; /* ✦ Theme/Colors/Secondary/Purple Alpha/4/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-alpha-5: 280 100% 64% / 0.25; /* ✦ Theme/Colors/Secondary/Purple Alpha/5/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-alpha-6: 276 100% 67% / 0.44; /* ✦ Theme/Colors/Secondary/Purple Alpha/6/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-alpha-7: 272 100% 69% / 0.75; /* ✦ Theme/Colors/Secondary/Purple Alpha/7/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-alpha-8: 271 100% 73% / 0.82; /* ✦ Theme/Colors/Secondary/Purple Alpha/8/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-alpha-9: 270 100% 80% / 0.98; /* ✦ Theme/Colors/Secondary/Purple Alpha/9/Harness Open Source/Dark */
+  --figma___colors-secondary-purple-alpha-10: 275 100% 93% / 0.98; /* ✦ Theme/Colors/Secondary/Purple Alpha/10/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-1: 166 49% 7% / 1; /* ✦ Theme/Colors/Secondary/Teal/1/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-2: 166 55% 8% / 1; /* ✦ Theme/Colors/Secondary/Teal/2/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-3: 167 52% 11% / 1; /* ✦ Theme/Colors/Secondary/Teal/3/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-4: 169 53% 13% / 1; /* ✦ Theme/Colors/Secondary/Teal/4/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-5: 168 53% 15% / 1; /* ✦ Theme/Colors/Secondary/Teal/5/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-6: 171 55% 24% / 1; /* ✦ Theme/Colors/Secondary/Teal/6/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-7: 173 80% 36% / 1; /* ✦ Theme/Colors/Secondary/Teal/7/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-8: 172 90% 39% / 1; /* ✦ Theme/Colors/Secondary/Teal/8/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-9: 170 90% 45% / 1; /* ✦ Theme/Colors/Secondary/Teal/9/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-10: 163 69% 81% / 1; /* ✦ Theme/Colors/Secondary/Teal/10/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-alpha-1: 120 100% 48% / 0.01; /* ✦ Theme/Colors/Secondary/Teal Alpha/1/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-alpha-2: 141 100% 49% / 0.03; /* ✦ Theme/Colors/Secondary/Teal Alpha/2/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-alpha-3: 161 100% 50% / 0.07; /* ✦ Theme/Colors/Secondary/Teal Alpha/3/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-alpha-4: 167 100% 50% / 0.11; /* ✦ Theme/Colors/Secondary/Teal Alpha/4/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-alpha-5: 167 100% 50% / 0.15; /* ✦ Theme/Colors/Secondary/Teal Alpha/5/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-alpha-6: 171 99% 56% / 0.3; /* ✦ Theme/Colors/Secondary/Teal Alpha/6/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-alpha-7: 173 100% 53% / 0.61; /* ✦ Theme/Colors/Secondary/Teal Alpha/7/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-alpha-8: 172 100% 51% / 0.71; /* ✦ Theme/Colors/Secondary/Teal Alpha/8/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-alpha-9: 170 100% 52% / 0.83; /* ✦ Theme/Colors/Secondary/Teal Alpha/9/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-alpha-10: 163 100% 86% / 0.94; /* ✦ Theme/Colors/Secondary/Teal Alpha/10/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01; /* ✦ Theme/Overlays/Black Alpha/1/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02; /* ✦ Theme/Overlays/Black Alpha/2/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05; /* ✦ Theme/Overlays/Black Alpha/3/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08; /* ✦ Theme/Overlays/Black Alpha/4/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11; /* ✦ Theme/Overlays/Black Alpha/5/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13; /* ✦ Theme/Overlays/Black Alpha/6/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45; /* ✦ Theme/Overlays/Black Alpha/7/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5; /* ✦ Theme/Overlays/Black Alpha/8/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61; /* ✦ Theme/Overlays/Black Alpha/9/Harness Open Source/Dark */
+  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88; /* ✦ Theme/Overlays/Black Alpha/10/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 0; /* ✦ Theme/Overlays/White Alpha/1/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01; /* ✦ Theme/Overlays/White Alpha/2/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07; /* ✦ Theme/Overlays/White Alpha/3/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1; /* ✦ Theme/Overlays/White Alpha/4/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13; /* ✦ Theme/Overlays/White Alpha/5/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17; /* ✦ Theme/Overlays/White Alpha/6/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37; /* ✦ Theme/Overlays/White Alpha/7/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46; /* ✦ Theme/Overlays/White Alpha/8/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66; /* ✦ Theme/Overlays/White Alpha/9/Harness Open Source/Dark */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93; /* ✦ Theme/Overlays/White Alpha/10/Harness Open Source/Dark */
+  --figma___semantic-background-backdrop: 0 0% 0% / 0.75; /* ✦ Theme/Semantic/Background/Backdrop/Harness Open Source/Dark */
+  --figma___semantic-background-cards-and-rows-default: 240 5% 12% / 0; /* ✦ Theme/Semantic/Background/Cards and Rows/Default/Harness Open Source/Dark */
+  --figma___semantic-background-cards-and-rows-hover: 200 7% 8% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Hover/Harness Open Source/Dark */
+  --figma___semantic-background-cards-and-rows-primary-blue-selected: 240 100% 12% / 0.05; /* ✦ Theme/Semantic/Background/Cards and Rows/Primary-blue-selected/Harness Open Source/Dark */
+  --figma___semantic-background-cards-and-rows-selected: 210 6% 20% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Selected/Harness Open Source/Dark */
+  --figma___semantic-background-header-page-header: 240 6% 6% / 1; /* ✦ Theme/Semantic/Background/Header/Page Header/Harness Open Source/Dark */
+  --figma___semantic-background-header-table-header: 200 7% 8% / 1; /* ✦ Theme/Semantic/Background/Header/Table Header/Harness Open Source/Dark */
+  --figma___semantic-background-paper: 210 6% 6% / 1; /* ✦ Theme/Semantic/Background/Paper/Harness Open Source/Dark */
+  --figma___semantic-background-primary: 210 6% 6% / 1; /* ✦ Theme/Semantic/Background/Primary/Harness Open Source/Dark */
+  --figma___semantic-background-solid: 0 4% 5% / 1; /* ✦ Theme/Semantic/Background/Solid/Harness Open Source/Dark */
+  --figma___semantic-border-disabled: 224 96% 89% / 0.13; /* ✦ Theme/Semantic/Border/Disabled/Harness Open Source/Dark */
+  --figma___semantic-border-hover: 207 6% 30% / 1; /* ✦ Theme/Semantic/Border/Hover/Harness Open Source/Dark */
+  --figma___semantic-border-primary: 240 6% 10% / 1; /* ✦ Theme/Semantic/Border/Primary/Harness Open Source/Dark */
+  --figma___semantic-border-secondary: 200 5% 12% / 1; /* ✦ Theme/Semantic/Border/Secondary/Harness Open Source/Dark */
+  --figma___semantic-border-selected: 240 7% 94% / 1; /* ✦ Theme/Semantic/Border/Selected/Harness Open Source/Dark */
+  --figma___semantic-text-disabled: 207 6% 30% / 1; /* ✦ Theme/Semantic/Text/Disabled/Harness Open Source/Dark */
+  --figma___semantic-text-links: 216 100% 59% / 1; /* ✦ Theme/Semantic/Text/Links/Harness Open Source/Dark */
+  --figma___semantic-text-secondary: 207 6% 70% / 1; /* ✦ Theme/Semantic/Text/Secondary/Harness Open Source/Dark */
+  --figma___semantic-text-tertiary: 212 6% 50% / 1; /* ✦ Theme/Semantic/Text/Tertiary/Harness Open Source/Dark */
+  --figma___semantic-text-primary: 0 0% 98% / 1; /* ✦ Theme/Semantic/Text/primary/Harness Open Source/Dark */
 }

--- a/packages/canary/src/style-tokens/themes/harness-theme.css
+++ b/packages/canary/src/style-tokens/themes/harness-theme.css
@@ -1,3767 +1,804 @@
 /* Non color variables */
 :root {
-  --figma___badges-badge-radius: 4px;
-  /* ✦ Theme/Badges/badge-radius/Harness Theme/Mode 1 */
-  --figma___grids-extra-large-1920-col: 12px;
-  /* ✦ Theme/Grids/Extra Large (> 1920)/Col/Harness Theme/Mode 1 */
-  --figma___grids-extra-large-1920-gutters: 20px;
-  /* ✦ Theme/Grids/Extra Large (> 1920)/Gutters/Harness Theme/Mode 1 */
-  --figma___grids-extra-large-1920-width: 138px;
-  /* ✦ Theme/Grids/Extra Large (> 1920)/Width/Harness Theme/Mode 1 */
-  --figma___grids-extra-small-0-to-480-col: 2px;
-  /* ✦ Theme/Grids/Extra Small (0 to 480)/Col/Harness Theme/Mode 1 */
-  --figma___grids-extra-small-0-to-480-gutters: 16px;
-  /* ✦ Theme/Grids/Extra Small (0 to 480)/Gutters/Harness Theme/Mode 1 */
-  --figma___grids-extra-small-0-to-480-margins: 16px;
-  /* ✦ Theme/Grids/Extra Small (0 to 480)/Margins/Harness Theme/Mode 1 */
-  --figma___grids-large-1280-to-1920-col: 12px;
-  /* ✦ Theme/Grids/Large (1280 to 1920)/Col/Harness Theme/Mode 1 */
-  --figma___grids-large-1280-to-1920-gutters: 20px;
-  /* ✦ Theme/Grids/Large (1280 to 1920)/Gutters/Harness Theme/Mode 1 */
-  --figma___grids-large-1280-to-1920-margins: 24px;
-  /* ✦ Theme/Grids/Large (1280 to 1920)/Margins/Harness Theme/Mode 1 */
-  --figma___grids-medium-576-to-1279-col: 8px;
-  /* ✦ Theme/Grids/Medium (576 to 1279)/Col/Harness Theme/Mode 1 */
-  --figma___grids-medium-576-to-1279-gutters: 16px;
-  /* ✦ Theme/Grids/Medium (576 to 1279)/Gutters/Harness Theme/Mode 1 */
-  --figma___grids-medium-576-to-1279-margins: 24px;
-  /* ✦ Theme/Grids/Medium (576 to 1279)/Margins/Harness Theme/Mode 1 */
-  --figma___grids-small-480-to-575-col: 4px;
-  /* ✦ Theme/Grids/Small (480 to 575)/Col/Harness Theme/Mode 1 */
-  --figma___grids-small-480-to-575-gutters: 16px;
-  /* ✦ Theme/Grids/Small (480 to 575)/Gutters/Harness Theme/Mode 1 */
-  --figma___grids-small-480-to-575-margins: 24px;
-  /* ✦ Theme/Grids/Small (480 to 575)/Margins/Harness Theme/Mode 1 */
-  --figma___height-button-height-1: 24px;
-  /* ✦ Theme/Height/button-height-1/Harness Theme/Mode 1 */
-  --figma___height-button-height-2: 32px;
-  /* ✦ Theme/Height/button-height-2/Harness Theme/Mode 1 */
-  --figma___height-button-height-3: 40px;
-  /* ✦ Theme/Height/button-height-3/Harness Theme/Mode 1 */
-  --figma___height-button-height-4: 48px;
-  /* ✦ Theme/Height/button-height-4/Harness Theme/Mode 1 */
-  --figma___height-menu-item-height-1: 24px;
-  /* ✦ Theme/Height/menu-item-height-1/Harness Theme/Mode 1 */
-  --figma___height-menu-item-height-2: 32px;
-  /* ✦ Theme/Height/menu-item-height-2/Harness Theme/Mode 1 */
-  --figma___height-table-cell-min-height-1: 36px;
-  /* ✦ Theme/Height/table-cell-min-height-1/Harness Theme/Mode 1 */
-  --figma___height-table-cell-min-height-2: 44px;
-  /* ✦ Theme/Height/table-cell-min-height-2/Harness Theme/Mode 1 */
-  --figma___height-table-cell-min-height-3: 48px;
-  /* ✦ Theme/Height/table-cell-min-height-3/Harness Theme/Mode 1 */
-  --figma___padding-main-content-padding: 12px;
-  /* ✦ Theme/Padding/Main content padding/Harness Theme/Mode 1 */
-  --figma___padding-table-cell-padding-1: 8px;
-  /* ✦ Theme/Padding/table-cell-padding-1/Harness Theme/Mode 1 */
-  --figma___padding-table-cell-padding-2: 12px;
-  /* ✦ Theme/Padding/table-cell-padding-2/Harness Theme/Mode 1 */
-  --figma___padding-table-cell-padding-3: 16px;
-  /* ✦ Theme/Padding/table-cell-padding-3/Harness Theme/Mode 1 */
-  --figma___pagination-active-border-radius: 6px;
-  /* ✦ Theme/Pagination/Active/Border-radius/Harness Theme/Mode 1 */
-  --figma___pagination-border-radius: 0px;
-  /* ✦ Theme/Pagination/Border-radius/Harness Theme/Mode 1 */
-  --figma___pagination-default-border-radius: 4px;
-  /* ✦ Theme/Pagination/Default/Border-radius/Harness Theme/Mode 1 */
-  --figma___pagination-gap: 0px;
-  /* ✦ Theme/Pagination/Gap/Harness Theme/Mode 1 */
-  --figma___pagination-hover-border-radius: 4px;
-  /* ✦ Theme/Pagination/Hover/Border-radius/Harness Theme/Mode 1 */
-  --figma___radius-1: 3px;
-  /* ✦ Theme/Radius/1/Harness Theme/Mode 1 */
-  --figma___radius-2: 4px;
-  /* ✦ Theme/Radius/2/Harness Theme/Mode 1 */
-  --figma___radius-3: 6px;
-  /* ✦ Theme/Radius/3/Harness Theme/Mode 1 */
-  --figma___radius-4: 8px;
-  /* ✦ Theme/Radius/4/Harness Theme/Mode 1 */
-  --figma___radius-5: 12px;
-  /* ✦ Theme/Radius/5/Harness Theme/Mode 1 */
-  --figma___radius-6: 16px;
-  /* ✦ Theme/Radius/6/Harness Theme/Mode 1 */
-  --figma___radius-1-max: 3px;
-  /* ✦ Theme/Radius/1-max/Harness Theme/Mode 1 */
-  --figma___radius-2-max: 4px;
-  /* ✦ Theme/Radius/2-max/Harness Theme/Mode 1 */
-  --figma___radius-3-max: 6px;
-  /* ✦ Theme/Radius/3-max/Harness Theme/Mode 1 */
-  --figma___radius-4-max: 8px;
-  /* ✦ Theme/Radius/4-max/Harness Theme/Mode 1 */
-  --figma___radius-5-max: 12px;
-  /* ✦ Theme/Radius/5-max/Harness Theme/Mode 1 */
-  --figma___radius-6-max: 16px;
-  /* ✦ Theme/Radius/6-max/Harness Theme/Mode 1 */
-  --figma___radius-main-content-radius: 8px;
-  /* ✦ Theme/Radius/Main content radius/Harness Theme/Mode 1 */
-  --figma___radius-full: 9999px;
-  /* ✦ Theme/Radius/full/Harness Theme/Mode 1 */
-  --figma___space-1: 4px;
-  /* ✦ Theme/Space/1/Harness Theme/Mode 1 */
-  --figma___space-2: 8px;
-  /* ✦ Theme/Space/2/Harness Theme/Mode 1 */
-  --figma___space-3: 12px;
-  /* ✦ Theme/Space/3/Harness Theme/Mode 1 */
-  --figma___space-4: 16px;
-  /* ✦ Theme/Space/4/Harness Theme/Mode 1 */
-  --figma___space-5: 24px;
-  /* ✦ Theme/Space/5/Harness Theme/Mode 1 */
-  --figma___space-6: 32px;
-  /* ✦ Theme/Space/6/Harness Theme/Mode 1 */
-  --figma___space-7: 40px;
-  /* ✦ Theme/Space/7/Harness Theme/Mode 1 */
-  --figma___space-8: 48px;
-  /* ✦ Theme/Space/8/Harness Theme/Mode 1 */
-  --figma___space-9: 64px;
-  /* ✦ Theme/Space/9/Harness Theme/Mode 1 */
-  --figma___switch-thumb-size-1: 12px;
-  /* ✦ Theme/Switch/Thumb Size/1/Harness Theme/Mode 1 */
-  --figma___switch-thumb-size-2: 16px;
-  /* ✦ Theme/Switch/Thumb Size/2/Harness Theme/Mode 1 */
-  --figma___switch-thumb-size-3: 20px;
-  /* ✦ Theme/Switch/Thumb Size/3/Harness Theme/Mode 1 */
-  --figma___tabs-pills-border-radius: 8px;
-  /* ✦ Theme/Tabs/Pills/border-radius/Harness Theme/Mode 1 */
-  --figma___tabs-pills-padding: 4px;
-  /* ✦ Theme/Tabs/Pills/padding/Harness Theme/Mode 1 */
-  --figma___tabs-pills-pill-border-radius: 4px;
-  /* ✦ Theme/Tabs/Pills/pill border radius/Harness Theme/Mode 1 */
-  --figma___textfield-assistive-text-assistive-text: 12px;
-  /* ✦ Theme/Textfield/Assistive Text/Assistive Text/Harness Theme/Mode 1 */
-  --figma___textfield-gap: 4px;
-  /* ✦ Theme/Textfield/Gap/Harness Theme/Mode 1 */
-  --figma___textfield-input-field-textfield-height: 32px;
-  /* ✦ Theme/Textfield/Input Field/Textfield Height/Harness Theme/Mode 1 */
+  --figma___component-pagination-border-radius: 0px; /* ✦ Theme/Component/Pagination/Border-radius/Harness Theme/Mode 1 */
+  --figma___component-pagination-gap: 0px; /* ✦ Theme/Component/Pagination/Gap/Harness Theme/Mode 1 */
+  --figma___component-switch-thumb-size-1: 12px; /* ✦ Theme/Component/Switch/Thumb Size/1/Harness Theme/Mode 1 */
+  --figma___component-switch-thumb-size-2: 16px; /* ✦ Theme/Component/Switch/Thumb Size/2/Harness Theme/Mode 1 */
+  --figma___component-switch-thumb-size-3: 20px; /* ✦ Theme/Component/Switch/Thumb Size/3/Harness Theme/Mode 1 */
+  --figma___component-textfield-gap: 4px; /* ✦ Theme/Component/Textfield/Gap/Harness Theme/Mode 1 */
+  --figma___padding-main-content-padding: 12px; /* ✦ Theme/Padding/Main content padding/Harness Theme/Mode 1 */
+  --figma___radius-1: 3px; /* ✦ Theme/Radius/1/Harness Theme/Mode 1 */
+  --figma___radius-2: 4px; /* ✦ Theme/Radius/2/Harness Theme/Mode 1 */
+  --figma___radius-3: 6px; /* ✦ Theme/Radius/3/Harness Theme/Mode 1 */
+  --figma___radius-4: 8px; /* ✦ Theme/Radius/4/Harness Theme/Mode 1 */
+  --figma___radius-5: 12px; /* ✦ Theme/Radius/5/Harness Theme/Mode 1 */
+  --figma___radius-6: 16px; /* ✦ Theme/Radius/6/Harness Theme/Mode 1 */
+  --figma___radius-main-content-radius: 8px; /* ✦ Theme/Radius/Main content radius/Harness Theme/Mode 1 */
+  --figma___radius-full: 9999px; /* ✦ Theme/Radius/full/Harness Theme/Mode 1 */
 }
 
 /* Color variables - light mode */
 .harness-theme-light {
-  --figma___background-backdrop: 230 100% 9% / 0.28;
-  /* ✦ Theme/Background/Backdrop/Harness Theme/Light */
-  --figma___background-cards-and-rows-default: 0 0% 100% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Default/Harness Theme/Light */
-  --figma___background-cards-and-rows-hover: 0 0% 95% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Hover/Harness Theme/Light */
-  --figma___background-cards-and-rows-primary-blue-selected: 210 100% 50% / 0.07;
-  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/Harness Theme/Light */
-  --figma___background-cards-and-rows-selected: 0 0% 95% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Selected/Harness Theme/Light */
-  --figma___background-header-page-header: 0 0% 100% / 1;
-  /* ✦ Theme/Background/Header/Page Header/Harness Theme/Light */
-  --figma___background-header-table-header: 0 0% 99% / 1;
-  /* ✦ Theme/Background/Header/Table Header/Harness Theme/Light */
-  --figma___background-paper: 0 0% 98% / 1;
-  /* ✦ Theme/Background/Paper/Harness Theme/Light */
-  --figma___background-primary: 0 0% 93% / 1;
-  /* ✦ Theme/Background/Primary/Harness Theme/Light */
-  --figma___background-solid: 0 0% 100% / 1;
-  /* ✦ Theme/Background/Solid/Harness Theme/Light */
-  --figma___badges-soft-amber-background: 45 100% 50% / 0.19;
-  /* ✦ Theme/Badges/Soft/Amber/background/Harness Theme/Light */
-  --figma___badges-soft-amber-text: 25 100% 24% / 0.81;
-  /* ✦ Theme/Badges/Soft/Amber/text/Harness Theme/Light */
-  --figma___badges-soft-blue-background: 210 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Soft/Blue/background/Harness Theme/Light */
-  --figma___badges-soft-blue-text: 211 100% 39% / 0.96;
-  /* ✦ Theme/Badges/Soft/Blue/text/Harness Theme/Light */
-  --figma___badges-soft-bronze-background: 18 99% 30% / 0.07;
-  /* ✦ Theme/Badges/Soft/Bronze/background/Harness Theme/Light */
-  --figma___badges-soft-bronze-text: 15 100% 12% / 0.67;
-  /* ✦ Theme/Badges/Soft/Bronze/text/Harness Theme/Light */
-  --figma___badges-soft-brown-background: 30 98% 34% / 0.08;
-  /* ✦ Theme/Badges/Soft/Brown/background/Harness Theme/Light */
-  --figma___badges-soft-brown-text: 24 100% 16% / 0.73;
-  /* ✦ Theme/Badges/Soft/Brown/text/Harness Theme/Light */
-  --figma___badges-soft-crimson-background: 332 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Soft/Crimson/background/Harness Theme/Light */
-  --figma___badges-soft-crimson-text: 336 100% 38% / 0.89;
-  /* ✦ Theme/Badges/Soft/Crimson/text/Harness Theme/Light */
-  --figma___badges-soft-cyan-background: 186 98% 42% / 0.09;
-  /* ✦ Theme/Badges/Soft/Cyan/background/Harness Theme/Light */
-  --figma___badges-soft-cyan-text: 192 100% 28% / 0.95;
-  /* ✦ Theme/Badges/Soft/Cyan/text/Harness Theme/Light */
-  --figma___badges-soft-gold-background: 45 97% 28% / 0.09;
-  /* ✦ Theme/Badges/Soft/Gold/background/Harness Theme/Light */
-  --figma___badges-soft-gold-text: 36 100% 11% / 0.71;
-  /* ✦ Theme/Badges/Soft/Gold/text/Harness Theme/Light */
-  --figma___badges-soft-grass-background: 120 98% 35% / 0.08;
-  /* ✦ Theme/Badges/Soft/Grass/background/Harness Theme/Light */
-  --figma___badges-soft-grass-text: 133 100% 19% / 0.84;
-  /* ✦ Theme/Badges/Soft/Grass/text/Harness Theme/Light */
-  --figma___badges-soft-green-background: 139 98% 37% / 0.09;
-  /* ✦ Theme/Badges/Soft/Green/background/Harness Theme/Light */
-  --figma___badges-soft-green-text: 153 100% 21% / 0.91;
-  /* ✦ Theme/Badges/Soft/Green/text/Harness Theme/Light */
-  --figma___badges-soft-indigo-background: 224 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Soft/Indigo/background/Harness Theme/Light */
-  --figma___badges-soft-indigo-text: 226 100% 31% / 0.8;
-  /* ✦ Theme/Badges/Soft/Indigo/text/Harness Theme/Light */
-  --figma___badges-soft-iris-background: 240 100% 51% / 0.05;
-  /* ✦ Theme/Badges/Soft/Iris/background/Harness Theme/Light */
-  --figma___badges-soft-iris-text: 240 100% 34% / 0.72;
-  /* ✦ Theme/Badges/Soft/Iris/text/Harness Theme/Light */
-  --figma___badges-soft-jade-background: 150 100% 41% / 0.11;
-  /* ✦ Theme/Badges/Soft/Jade/background/Harness Theme/Light */
-  --figma___badges-soft-jade-text: 163 100% 21% / 0.9;
-  /* ✦ Theme/Badges/Soft/Jade/text/Harness Theme/Light */
-  --figma___badges-soft-lime-background: 84 99% 44% / 0.15;
-  /* ✦ Theme/Badges/Soft/Lime/background/Harness Theme/Light */
-  --figma___badges-soft-lime-text: 75 100% 14% / 0.83;
-  /* ✦ Theme/Badges/Soft/Lime/text/Harness Theme/Light */
-  --figma___badges-soft-mint-background: 164 99% 44% / 0.13;
-  /* ✦ Theme/Badges/Soft/Mint/background/Harness Theme/Light */
-  --figma___badges-soft-mint-text: 172 100% 18% / 0.85;
-  /* ✦ Theme/Badges/Soft/Mint/text/Harness Theme/Light */
-  --figma___badges-soft-orange-background: 34 100% 50% / 0.17;
-  /* ✦ Theme/Badges/Soft/Orange/background/Harness Theme/Light */
-  --figma___badges-soft-orange-text: 16 100% 24% / 0.77;
-  /* ✦ Theme/Badges/Soft/Orange/text/Harness Theme/Light */
-  --figma___badges-soft-pink-background: 323 99% 47% / 0.07;
-  /* ✦ Theme/Badges/Soft/Pink/background/Harness Theme/Light */
-  --figma___badges-soft-pink-text: 322 100% 37% / 0.89;
-  /* ✦ Theme/Badges/Soft/Pink/text/Harness Theme/Light */
-  --figma___badges-soft-plum-background: 300 99% 41% / 0.06;
-  /* ✦ Theme/Badges/Soft/Plum/background/Harness Theme/Light */
-  --figma___badges-soft-plum-text: 292 100% 31% / 0.83;
-  /* ✦ Theme/Badges/Soft/Plum/text/Harness Theme/Light */
-  --figma___badges-soft-purple-background: 277 100% 46% / 0.05;
-  /* ✦ Theme/Badges/Soft/Purple/background/Harness Theme/Light */
-  --figma___badges-soft-purple-text: 273 100% 30% / 0.77;
-  /* ✦ Theme/Badges/Soft/Purple/text/Harness Theme/Light */
-  --figma___badges-soft-red-background: 0 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Soft/Red/background/Harness Theme/Light */
-  --figma___badges-soft-red-text: 358 100% 37% / 0.84;
-  /* ✦ Theme/Badges/Soft/Red/text/Harness Theme/Light */
-  --figma___badges-soft-ruby-background: 344 100% 47% / 0.06;
-  /* ✦ Theme/Badges/Soft/Ruby/background/Harness Theme/Light */
-  --figma___badges-soft-ruby-text: 345 100% 38% / 0.86;
-  /* ✦ Theme/Badges/Soft/Ruby/text/Harness Theme/Light */
-  --figma___badges-soft-sky-background: 192 100% 50% / 0.11;
-  /* ✦ Theme/Badges/Soft/Sky/background/Harness Theme/Light */
-  --figma___badges-soft-sky-text: 200 100% 25% / 0.86;
-  /* ✦ Theme/Badges/Soft/Sky/text/Harness Theme/Light */
-  --figma___badges-soft-teal-background: 167 98% 38% / 0.09;
-  /* ✦ Theme/Badges/Soft/Teal/background/Harness Theme/Light */
-  --figma___badges-soft-teal-text: 174 100% 23% / 0.98;
-  /* ✦ Theme/Badges/Soft/Teal/text/Harness Theme/Light */
-  --figma___badges-soft-violet-background: 254 100% 50% / 0.05;
-  /* ✦ Theme/Badges/Soft/Violet/background/Harness Theme/Light */
-  --figma___badges-soft-violet-text: 250 100% 28% / 0.73;
-  /* ✦ Theme/Badges/Soft/Violet/text/Harness Theme/Light */
-  --figma___badges-soft-yellow-background: 53 100% 50% / 0.22;
-  /* ✦ Theme/Badges/Soft/Yellow/background/Harness Theme/Light */
-  --figma___badges-soft-yellow-text: 42 100% 18% / 0.84;
-  /* ✦ Theme/Badges/Soft/Yellow/text/Harness Theme/Light */
-  --figma___badges-soft-accent-background: 210 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Soft/accent/background/Harness Theme/Light */
-  --figma___badges-soft-accent-text: 211 100% 39% / 0.96;
-  /* ✦ Theme/Badges/Soft/accent/text/Harness Theme/Light */
-  --figma___badges-soft-error-background: 0 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Soft/error/background/Harness Theme/Light */
-  --figma___badges-soft-error-text: 358 65% 47% / 1;
-  /* ✦ Theme/Badges/Soft/error/text/Harness Theme/Light */
-  --figma___badges-soft-info-background: 210 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Soft/info/background/Harness Theme/Light */
-  --figma___badges-soft-info-text: 211 90% 42% / 1;
-  /* ✦ Theme/Badges/Soft/info/text/Harness Theme/Light */
-  --figma___badges-soft-success-background: 139 98% 37% / 0.09;
-  /* ✦ Theme/Badges/Soft/success/background/Harness Theme/Light */
-  --figma___badges-soft-success-text: 153 67% 28% / 1;
-  /* ✦ Theme/Badges/Soft/success/text/Harness Theme/Light */
-  --figma___badges-soft-warning-background: 45 100% 91% / 1;
-  /* ✦ Theme/Badges/Soft/warning/background/Harness Theme/Light */
-  --figma___badges-soft-warning-text: 25 50% 38% / 1;
-  /* ✦ Theme/Badges/Soft/warning/text/Harness Theme/Light */
-  --figma___badges-solid-amber-background: 42 100% 62% / 1;
-  /* ✦ Theme/Badges/Solid/Amber/background/Harness Theme/Light */
-  --figma___badges-solid-blue-background: 214 73% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Blue/background/Harness Theme/Light */
-  --figma___badges-solid-bronze-background: 18 20% 54% / 1;
-  /* ✦ Theme/Badges/Solid/Bronze/background/Harness Theme/Light */
-  --figma___badges-solid-brown-background: 28 34% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Brown/background/Harness Theme/Light */
-  --figma___badges-solid-crimson-background: 336 80% 58% / 1;
-  /* ✦ Theme/Badges/Solid/Crimson/background/Harness Theme/Light */
-  --figma___badges-solid-cyan-background: 190 95% 39% / 1;
-  /* ✦ Theme/Badges/Solid/Cyan/background/Harness Theme/Light */
-  --figma___badges-solid-gold-background: 36 20% 49% / 1;
-  /* ✦ Theme/Badges/Solid/Gold/background/Harness Theme/Light */
-  --figma___badges-solid-grass-background: 132 59% 33% / 1;
-  /* ✦ Theme/Badges/Solid/Grass/background/Harness Theme/Light */
-  --figma___badges-solid-green-background: 142 72% 29% / 1;
-  /* ✦ Theme/Badges/Solid/Green/background/Harness Theme/Light */
-  --figma___badges-solid-indigo-background: 226 70% 55% / 1;
-  /* ✦ Theme/Badges/Solid/Indigo/background/Harness Theme/Light */
-  --figma___badges-solid-iris-background: 240 60% 60% / 1;
-  /* ✦ Theme/Badges/Solid/Iris/background/Harness Theme/Light */
-  --figma___badges-solid-jade-background: 164 60% 40% / 1;
-  /* ✦ Theme/Badges/Solid/Jade/background/Harness Theme/Light */
-  --figma___badges-solid-lime-background: 81 80% 66% / 1;
-  /* ✦ Theme/Badges/Solid/Lime/background/Harness Theme/Light */
-  --figma___badges-solid-mint-background: 167 70% 72% / 1;
-  /* ✦ Theme/Badges/Solid/Mint/background/Harness Theme/Light */
-  --figma___badges-solid-orange-background: 16 45% 41% / 1;
-  /* ✦ Theme/Badges/Solid/Orange/background/Harness Theme/Light */
-  --figma___badges-solid-pink-background: 322 65% 55% / 1;
-  /* ✦ Theme/Badges/Solid/Pink/background/Harness Theme/Light */
-  --figma___badges-solid-plum-background: 292 45% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Plum/background/Harness Theme/Light */
-  --figma___badges-solid-purple-background: 272 51% 54% / 1;
-  /* ✦ Theme/Badges/Solid/Purple/background/Harness Theme/Light */
-  --figma___badges-solid-red-background: 358 75% 59% / 1;
-  /* ✦ Theme/Badges/Solid/Red/background/Harness Theme/Light */
-  --figma___badges-solid-ruby-background: 348 75% 59% / 1;
-  /* ✦ Theme/Badges/Solid/Ruby/background/Harness Theme/Light */
-  --figma___badges-solid-sky-background: 193 98% 74% / 1;
-  /* ✦ Theme/Badges/Solid/Sky/background/Harness Theme/Light */
-  --figma___badges-solid-success-background: 142 72% 29% / 1;
-  /* ✦ Theme/Badges/Solid/Success/background/Harness Theme/Light */
-  --figma___badges-solid-teal-background: 173 80% 36% / 1;
-  /* ✦ Theme/Badges/Solid/Teal/background/Harness Theme/Light */
-  --figma___badges-solid-violet-background: 252 56% 57% / 1;
-  /* ✦ Theme/Badges/Solid/Violet/background/Harness Theme/Light */
-  --figma___badges-solid-yellow-background: 53 96% 58% / 1;
-  /* ✦ Theme/Badges/Solid/Yellow/background/Harness Theme/Light */
-  --figma___badges-solid-accent-background: 214 73% 51% / 1;
-  /* ✦ Theme/Badges/Solid/accent/background/Harness Theme/Light */
-  --figma___badges-solid-info-background: 214 73% 51% / 1;
-  /* ✦ Theme/Badges/Solid/info/background/Harness Theme/Light */
-  --figma___badges-solid-warning-background: 42 100% 62% / 1;
-  /* ✦ Theme/Badges/Solid/warning/background/Harness Theme/Light */
-  --figma___badges-surface-amber-background: 40 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/Amber/background/Harness Theme/Light */
-  --figma___badges-surface-amber-border: 37 100% 40% / 0.53;
-  /* ✦ Theme/Badges/Surface/Amber/border/Harness Theme/Light */
-  --figma___badges-surface-amber-text: 25 100% 24% / 0.81;
-  /* ✦ Theme/Badges/Surface/Amber/text/Harness Theme/Light */
-  --figma___badges-surface-blue-background: 210 100% 51% / 0.04;
-  /* ✦ Theme/Badges/Surface/Blue/background/Harness Theme/Light */
-  --figma___badges-surface-blue-border: 208 100% 44% / 0.41;
-  /* ✦ Theme/Badges/Surface/Blue/border/Harness Theme/Light */
-  --figma___badges-surface-blue-text: 211 100% 39% / 0.96;
-  /* ✦ Theme/Badges/Surface/Blue/text/Harness Theme/Light */
-  --figma___badges-surface-bronze-background: 17 95% 40% / 0.04;
-  /* ✦ Theme/Badges/Surface/Bronze/background/Harness Theme/Light */
-  --figma___badges-surface-bronze-border: 18 100% 22% / 0.31;
-  /* ✦ Theme/Badges/Surface/Bronze/border/Harness Theme/Light */
-  --figma___badges-surface-bronze-text: 15 100% 12% / 0.67;
-  /* ✦ Theme/Badges/Surface/Bronze/text/Harness Theme/Light */
-  --figma___badges-surface-brown-background: 30 94% 35% / 0.04;
-  /* ✦ Theme/Badges/Surface/Brown/background/Harness Theme/Light */
-  --figma___badges-surface-brown-border: 29 100% 34% / 0.41;
-  /* ✦ Theme/Badges/Surface/Brown/border/Harness Theme/Light */
-  --figma___badges-surface-brown-text: 24 100% 16% / 0.73;
-  /* ✦ Theme/Badges/Surface/Brown/text/Harness Theme/Light */
-  --figma___badges-surface-crimson-border: 335 100% 39% / 0.32;
-  /* ✦ Theme/Badges/Surface/Crimson/Border/Harness Theme/Light */
-  --figma___badges-surface-crimson-background: 330 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Crimson/background/Harness Theme/Light */
-  --figma___badges-surface-crimson-text: 336 100% 38% / 0.89;
-  /* ✦ Theme/Badges/Surface/Crimson/text/Harness Theme/Light */
-  --figma___badges-surface-cyan-border: 189 100% 35% / 0.48;
-  /* ✦ Theme/Badges/Surface/Cyan/Border/Harness Theme/Light */
-  --figma___badges-surface-cyan-background: 186 100% 42% / 0.05;
-  /* ✦ Theme/Badges/Surface/Cyan/background/Harness Theme/Light */
-  --figma___badges-surface-cyan-text: 192 100% 28% / 0.95;
-  /* ✦ Theme/Badges/Surface/Cyan/text/Harness Theme/Light */
-  --figma___badges-surface-gold-border: 38 100% 22% / 0.36;
-  /* ✦ Theme/Badges/Surface/Gold/Border/Harness Theme/Light */
-  --figma___badges-surface-gold-background: 47 100% 35% / 0.05;
-  /* ✦ Theme/Badges/Surface/Gold/background/Harness Theme/Light */
-  --figma___badges-surface-gold-text: 36 100% 11% / 0.71;
-  /* ✦ Theme/Badges/Surface/Gold/text/Harness Theme/Light */
-  --figma___badges-surface-grass-border: 125 100% 27% / 0.41;
-  /* ✦ Theme/Badges/Surface/Grass/Border/Harness Theme/Light */
-  --figma___badges-surface-grass-background: 120 95% 39% / 0.05;
-  /* ✦ Theme/Badges/Surface/Grass/background/Harness Theme/Light */
-  --figma___badges-surface-grass-text: 133 100% 19% / 0.84;
-  /* ✦ Theme/Badges/Surface/Grass/text/Harness Theme/Light */
-  --figma___badges-surface-green-background: 139 98% 37% / 0.09;
-  /* ✦ Theme/Badges/Surface/Green/background/Harness Theme/Light */
-  --figma___badges-surface-green-border: 146 100% 27% / 0.43;
-  /* ✦ Theme/Badges/Surface/Green/border/Harness Theme/Light */
-  --figma___badges-surface-green-text: 153 100% 21% / 0.91;
-  /* ✦ Theme/Badges/Surface/Green/text/Harness Theme/Light */
-  --figma___badges-surface-indigo-background: 223 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Indigo/background/Harness Theme/Light */
-  --figma___badges-surface-indigo-border: 225 100% 44% / 0.32;
-  /* ✦ Theme/Badges/Surface/Indigo/border/Harness Theme/Light */
-  --figma___badges-surface-indigo-text: 226 100% 31% / 0.8;
-  /* ✦ Theme/Badges/Surface/Indigo/text/Harness Theme/Light */
-  --figma___badges-surface-iris-border: 239 100% 43% / 0.27;
-  /* ✦ Theme/Badges/Surface/Iris/Border/Harness Theme/Light */
-  --figma___badges-surface-iris-background: 240 100% 51% / 0.02;
-  /* ✦ Theme/Badges/Surface/Iris/background/Harness Theme/Light */
-  --figma___badges-surface-iris-text: 240 100% 34% / 0.72;
-  /* ✦ Theme/Badges/Surface/Iris/text/Harness Theme/Light */
-  --figma___badges-surface-jade-border: 159 100% 29% / 0.44;
-  /* ✦ Theme/Badges/Surface/Jade/Border/Harness Theme/Light */
-  --figma___badges-surface-jade-background: 150 99% 44% / 0.06;
-  /* ✦ Theme/Badges/Surface/Jade/background/Harness Theme/Light */
-  --figma___badges-surface-jade-text: 163 100% 21% / 0.9;
-  /* ✦ Theme/Badges/Surface/Jade/text/Harness Theme/Light */
-  --figma___badges-surface-lime-border: 79 100% 29% / 0.5;
-  /* ✦ Theme/Badges/Surface/Lime/Border/Harness Theme/Light */
-  --figma___badges-surface-lime-background: 85 99% 40% / 0.06;
-  /* ✦ Theme/Badges/Surface/Lime/background/Harness Theme/Light */
-  --figma___badges-surface-lime-text: 75 100% 14% / 0.83;
-  /* ✦ Theme/Badges/Surface/Lime/text/Harness Theme/Light */
-  --figma___badges-surface-mint-background: 164 99% 47% / 0.06;
-  /* ✦ Theme/Badges/Surface/Mint/background/Harness Theme/Light */
-  --figma___badges-surface-mint-border: 166 100% 30% / 0.47;
-  /* ✦ Theme/Badges/Surface/Mint/border/Harness Theme/Light */
-  --figma___badges-surface-mint-text: 172 100% 18% / 0.85;
-  /* ✦ Theme/Badges/Surface/Mint/text/Harness Theme/Light */
-  --figma___badges-surface-orange-background: 22 100% 51% / 0.04;
-  /* ✦ Theme/Badges/Surface/Orange/background/Harness Theme/Light */
-  --figma___badges-surface-orange-border: 21 100% 50% / 0.51;
-  /* ✦ Theme/Badges/Surface/Orange/border/Harness Theme/Light */
-  --figma___badges-surface-orange-text: 16 100% 24% / 0.77;
-  /* ✦ Theme/Badges/Surface/Orange/text/Harness Theme/Light */
-  --figma___badges-surface-pink-background: 323 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Pink/background/Harness Theme/Light */
-  --figma___badges-surface-pink-border: 323 100% 38% / 0.32;
-  /* ✦ Theme/Badges/Surface/Pink/border/Harness Theme/Light */
-  --figma___badges-surface-pink-text: 322 100% 37% / 0.89;
-  /* ✦ Theme/Badges/Surface/Pink/text/Harness Theme/Light */
-  --figma___badges-surface-plum-background: 300 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Plum/background/Harness Theme/Light */
-  --figma___badges-surface-plum-border: 295 100% 33% / 0.31;
-  /* ✦ Theme/Badges/Surface/Plum/border/Harness Theme/Light */
-  --figma___badges-surface-plum-text: 292 100% 31% / 0.83;
-  /* ✦ Theme/Badges/Surface/Plum/text/Harness Theme/Light */
-  --figma___badges-surface-purple-background: 276 100% 51% / 0.02;
-  /* ✦ Theme/Badges/Surface/Purple/background/Harness Theme/Light */
-  --figma___badges-surface-purple-border: 273 99% 38% / 0.29;
-  /* ✦ Theme/Badges/Surface/Purple/border/Harness Theme/Light */
-  --figma___badges-surface-purple-text: 273 100% 30% / 0.77;
-  /* ✦ Theme/Badges/Surface/Purple/text/Harness Theme/Light */
-  --figma___badges-surface-red-background: 0 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Red/background/Harness Theme/Light */
-  --figma___badges-surface-red-border: 359 100% 43% / 0.32;
-  /* ✦ Theme/Badges/Surface/Red/border/Harness Theme/Light */
-  --figma___badges-surface-red-text: 358 100% 37% / 0.84;
-  /* ✦ Theme/Badges/Surface/Red/text/Harness Theme/Light */
-  --figma___badges-surface-ruby-background: 345 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/Ruby/background/Harness Theme/Light */
-  --figma___badges-surface-ruby-border: 348 100% 39% / 0.31;
-  /* ✦ Theme/Badges/Surface/Ruby/border/Harness Theme/Light */
-  --figma___badges-surface-ruby-text: 345 100% 38% / 0.86;
-  /* ✦ Theme/Badges/Surface/Ruby/text/Harness Theme/Light */
-  --figma___badges-surface-sky-background: 193 100% 50% / 0.05;
-  /* ✦ Theme/Badges/Surface/Sky/background/Harness Theme/Light */
-  --figma___badges-surface-sky-border: 194 100% 38% / 0.49;
-  /* ✦ Theme/Badges/Surface/Sky/border/Harness Theme/Light */
-  --figma___badges-surface-sky-text: 200 100% 25% / 0.86;
-  /* ✦ Theme/Badges/Surface/Sky/text/Harness Theme/Light */
-  --figma___badges-surface-teal-background: 169 99% 39% / 0.05;
-  /* ✦ Theme/Badges/Surface/Teal/background/Harness Theme/Light */
-  --figma___badges-surface-teal-border: 170 99% 29% / 0.45;
-  /* ✦ Theme/Badges/Surface/Teal/border/Harness Theme/Light */
-  --figma___badges-surface-teal-text: 174 100% 23% / 0.98;
-  /* ✦ Theme/Badges/Surface/Teal/text/Harness Theme/Light */
-  --figma___badges-surface-violet-background: 252 100% 51% / 0.02;
-  /* ✦ Theme/Badges/Surface/Violet/background/Harness Theme/Light */
-  --figma___badges-surface-violet-border: 252 99% 42% / 0.28;
-  /* ✦ Theme/Badges/Surface/Violet/border/Harness Theme/Light */
-  --figma___badges-surface-violet-text: 250 100% 28% / 0.73;
-  /* ✦ Theme/Badges/Surface/Violet/text/Harness Theme/Light */
-  --figma___badges-surface-yellow-background: 52 100% 50% / 0.12;
-  /* ✦ Theme/Badges/Surface/Yellow/background/Harness Theme/Light */
-  --figma___badges-surface-yellow-border: 48 100% 37% / 0.57;
-  /* ✦ Theme/Badges/Surface/Yellow/border/Harness Theme/Light */
-  --figma___badges-surface-yellow-text: 42 100% 18% / 0.84;
-  /* ✦ Theme/Badges/Surface/Yellow/text/Harness Theme/Light */
-  --figma___badges-surface-accent-background: 210 100% 51% / 0.04;
-  /* ✦ Theme/Badges/Surface/accent/background/Harness Theme/Light */
-  --figma___badges-surface-accent-border: 208 100% 44% / 0.41;
-  /* ✦ Theme/Badges/Surface/accent/border/Harness Theme/Light */
-  --figma___badges-surface-accent-text: 208 100% 44% / 0.41;
-  /* ✦ Theme/Badges/Surface/accent/text/Harness Theme/Light */
-  --figma___badges-surface-error-background: 0 100% 51% / 0.03;
-  /* ✦ Theme/Badges/Surface/error/background/Harness Theme/Light */
-  --figma___badges-surface-error-border: 359 100% 43% / 0.32;
-  /* ✦ Theme/Badges/Surface/error/border/Harness Theme/Light */
-  --figma___badges-surface-error-text: 358 100% 37% / 0.84;
-  /* ✦ Theme/Badges/Surface/error/text/Harness Theme/Light */
-  --figma___badges-surface-info-background: 192 100% 50% / 0.11;
-  /* ✦ Theme/Badges/Surface/info/background/Harness Theme/Light */
-  --figma___badges-surface-info-border: 194 100% 38% / 0.49;
-  /* ✦ Theme/Badges/Surface/info/border/Harness Theme/Light */
-  --figma___badges-surface-info-text: 200 100% 25% / 0.86;
-  /* ✦ Theme/Badges/Surface/info/text/Harness Theme/Light */
-  --figma___badges-surface-success-background: 150 99% 44% / 0.06;
-  /* ✦ Theme/Badges/Surface/success/background/Harness Theme/Light */
-  --figma___badges-surface-success-border: 159 100% 29% / 0.44;
-  /* ✦ Theme/Badges/Surface/success/border/Harness Theme/Light */
-  --figma___badges-surface-success-text: 163 100% 21% / 0.9;
-  /* ✦ Theme/Badges/Surface/success/text/Harness Theme/Light */
-  --figma___badges-surface-warning-background: 40 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/warning/background/Harness Theme/Light */
-  --figma___badges-surface-warning-border: 37 100% 40% / 0.53;
-  /* ✦ Theme/Badges/Surface/warning/border/Harness Theme/Light */
-  --figma___badges-surface-warning-text: 25 100% 24% / 0.81;
-  /* ✦ Theme/Badges/Surface/warning/text/Harness Theme/Light */
-  --figma___border-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Border/Disabled/Harness Theme/Light */
-  --figma___border-hover: 0 0% 83% / 1;
-  /* ✦ Theme/Border/Hover/Harness Theme/Light */
-  --figma___border-primary: 0 0% 0% / 0.08;
-  /* ✦ Theme/Border/Primary/Harness Theme/Light */
-  --figma___border-secondary: 0 0% 95% / 1;
-  /* ✦ Theme/Border/Secondary/Harness Theme/Light */
-  --figma___border-selected: 208 93% 47% / 1;
-  /* ✦ Theme/Border/Selected/Harness Theme/Light */
-  --figma___breadcrumbs-current: 0 0% 13% / 1;
-  /* ✦ Theme/Breadcrumbs/current/Harness Theme/Light */
-  --figma___breadcrumbs-visited: 0 0% 39% / 1;
-  /* ✦ Theme/Breadcrumbs/visited/Harness Theme/Light */
-  --figma___button-ghost-accent-active: 210 99% 49% / 0.19;
-  /* ✦ Theme/Button/Ghost/Accent/Active/Harness Theme/Light */
-  --figma___button-ghost-accent-active-text: 211 90% 42% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Active text/Harness Theme/Light */
-  --figma___button-ghost-accent-hover: 210 100% 50% / 0.07;
-  /* ✦ Theme/Button/Ghost/Accent/Hover/Harness Theme/Light */
-  --figma___button-ghost-accent-hover-text: 211 90% 42% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Hover text/Harness Theme/Light */
-  --figma___button-ghost-accent-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/Harness Theme/Light */
-  --figma___button-ghost-accent-text-primary: 211 90% 42% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Text-primary/Harness Theme/Light */
-  --figma___button-ghost-error-active: 0 100% 50% / 0.1;
-  /* ✦ Theme/Button/Ghost/Error/Active/Harness Theme/Light */
-  --figma___button-ghost-error-active-text: 358 65% 47% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Active Text/Harness Theme/Light */
-  --figma___button-ghost-error-hover: 0 100% 50% / 0.06;
-  /* ✦ Theme/Button/Ghost/Error/Hover/Harness Theme/Light */
-  --figma___button-ghost-error-hover-text: 358 65% 47% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Hover text/Harness Theme/Light */
-  --figma___button-ghost-error-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Ghost/Error/Text-disabled/Harness Theme/Light */
-  --figma___button-ghost-error-text-primary: 358 65% 47% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Text-primary/Harness Theme/Light */
-  --figma___button-ghost-neutral-active: 0 0% 0% / 0.08;
-  /* ✦ Theme/Button/Ghost/Neutral/Active/Harness Theme/Light */
-  --figma___button-ghost-neutral-active-text: 0 0% 39% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Active Text/Harness Theme/Light */
-  --figma___button-ghost-neutral-hover: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover/Harness Theme/Light */
-  --figma___button-ghost-neutral-hover-text: 0 0% 39% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover text/Harness Theme/Light */
-  --figma___button-ghost-neutral-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/Harness Theme/Light */
-  --figma___button-ghost-neutral-text-primary: 0 0% 39% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/Harness Theme/Light */
-  --figma___button-ghost-success-active: 139 99% 33% / 0.13;
-  /* ✦ Theme/Button/Ghost/Success/Active/Harness Theme/Light */
-  --figma___button-ghost-success-active-text: 153 67% 28% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Active Text/Harness Theme/Light */
-  --figma___button-ghost-success-hover: 139 98% 37% / 0.09;
-  /* ✦ Theme/Button/Ghost/Success/Hover/Harness Theme/Light */
-  --figma___button-ghost-success-hover-text: 153 67% 28% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Hover text/Harness Theme/Light */
-  --figma___button-ghost-success-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Ghost/Success/Text-disabled/Harness Theme/Light */
-  --figma___button-ghost-success-text-primary: 153 67% 28% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Text-primary/Harness Theme/Light */
-  --figma___button-outline-accent-active: 210 100% 50% / 0.07;
-  /* ✦ Theme/Button/Outline/Accent/Active/Harness Theme/Light */
-  --figma___button-outline-accent-default-border: 206 100% 50% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Default border/Harness Theme/Light */
-  --figma___button-outline-accent-disabled-border: 0 0% 0% / 0.13;
-  /* ✦ Theme/Button/Outline/Accent/Disabled Border/Harness Theme/Light */
-  --figma___button-outline-accent-hover: 210 100% 51% / 0.04;
-  /* ✦ Theme/Button/Outline/Accent/Hover/Harness Theme/Light */
-  --figma___button-outline-accent-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Outline/Accent/Text-disabled/Harness Theme/Light */
-  --figma___button-outline-accent-text-primary: 211 90% 42% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Text-primary/Harness Theme/Light */
-  --figma___button-outline-error-active: 0 100% 50% / 0.06;
-  /* ✦ Theme/Button/Outline/Error/Active/Harness Theme/Light */
-  --figma___button-outline-error-default-border: 358 100% 43% / 0.72;
-  /* ✦ Theme/Button/Outline/Error/Default - border/Harness Theme/Light */
-  --figma___button-outline-error-disabled-border: 0 0% 0% / 0.13;
-  /* ✦ Theme/Button/Outline/Error/Disabled-border/Harness Theme/Light */
-  --figma___button-outline-error-hover: 0 100% 51% / 0.03;
-  /* ✦ Theme/Button/Outline/Error/Hover/Harness Theme/Light */
-  --figma___button-outline-error-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Outline/Error/Text-disabled/Harness Theme/Light */
-  --figma___button-outline-error-text-primary: 358 65% 47% / 1;
-  /* ✦ Theme/Button/Outline/Error/Text-primary/Harness Theme/Light */
-  --figma___button-outline-neutral-active: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Outline/Neutral/Active/Harness Theme/Light */
-  --figma___button-outline-neutral-default-border: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Outline/Neutral/Default - border/Harness Theme/Light */
-  --figma___button-outline-neutral-disabled-border: 0 0% 0% / 0.13;
-  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/Harness Theme/Light */
-  --figma___button-outline-neutral-hover: 240 89% 18% / 0.02;
-  /* ✦ Theme/Button/Outline/Neutral/Hover/Harness Theme/Light */
-  --figma___button-outline-neutral-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/Harness Theme/Light */
-  --figma___button-outline-neutral-text-primary: 0 0% 39% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Text-primary/Harness Theme/Light */
-  --figma___button-outline-success-active: 139 98% 37% / 0.09;
-  /* ✦ Theme/Button/Outline/Success/Active/Harness Theme/Light */
-  --figma___button-outline-success-default-border: 151 100% 28% / 0.81;
-  /* ✦ Theme/Button/Outline/Success/Default-border/Harness Theme/Light */
-  --figma___button-outline-success-disabled-border: 0 0% 0% / 0.13;
-  /* ✦ Theme/Button/Outline/Success/Disabled - border/Harness Theme/Light */
-  --figma___button-outline-success-hover: 139 98% 37% / 0.09;
-  /* ✦ Theme/Button/Outline/Success/Hover/Harness Theme/Light */
-  --figma___button-outline-success-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Outline/Success/Text-disabled/Harness Theme/Light */
-  --figma___button-outline-success-text-primary: 153 67% 28% / 1;
-  /* ✦ Theme/Button/Outline/Success/Text-primary/Harness Theme/Light */
-  --figma___button-soft-accent-active: 209 99% 49% / 0.19;
-  /* ✦ Theme/Button/Soft/Accent/Active/Harness Theme/Light */
-  --figma___button-soft-accent-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Soft/Accent/Disabled/Harness Theme/Light */
-  --figma___button-soft-accent-hover: 210 99% 49% / 0.19;
-  /* ✦ Theme/Button/Soft/Accent/Hover/Harness Theme/Light */
-  --figma___button-soft-accent-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Soft/Accent/Text-disabled/Harness Theme/Light */
-  --figma___button-soft-accent-text-primary: 211 90% 42% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Text-primary/Harness Theme/Light */
-  --figma___button-soft-accent-default: 210 100% 50% / 0.07;
-  /* ✦ Theme/Button/Soft/Accent/default/Harness Theme/Light */
-  --figma___button-soft-error-active: 0 100% 47% / 0.15;
-  /* ✦ Theme/Button/Soft/Error/Active/Harness Theme/Light */
-  --figma___button-soft-error-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Soft/Error/Disabled/Harness Theme/Light */
-  --figma___button-soft-error-hover: 0 100% 50% / 0.1;
-  /* ✦ Theme/Button/Soft/Error/Hover/Harness Theme/Light */
-  --figma___button-soft-error-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Soft/Error/Text-disabled/Harness Theme/Light */
-  --figma___button-soft-error-text-primary: 358 65% 47% / 1;
-  /* ✦ Theme/Button/Soft/Error/Text-primary/Harness Theme/Light */
-  --figma___button-soft-error-default: 0 100% 50% / 0.06;
-  /* ✦ Theme/Button/Soft/Error/default/Harness Theme/Light */
-  --figma___button-soft-neutral-active: 0 0% 0% / 0.11;
-  /* ✦ Theme/Button/Soft/Neutral/Active/Harness Theme/Light */
-  --figma___button-soft-neutral-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Soft/Neutral/Disabled/Harness Theme/Light */
-  --figma___button-soft-neutral-hover: 0 0% 0% / 0.08;
-  /* ✦ Theme/Button/Soft/Neutral/Hover/Harness Theme/Light */
-  --figma___button-soft-neutral-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/Harness Theme/Light */
-  --figma___button-soft-neutral-text-primary: 0 0% 39% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Text-primary/Harness Theme/Light */
-  --figma___button-soft-neutral-default: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Soft/Neutral/default/Harness Theme/Light */
-  --figma___button-soft-success-active: 141 100% 30% / 0.2;
-  /* ✦ Theme/Button/Soft/Success/Active/Harness Theme/Light */
-  --figma___button-soft-success-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Soft/Success/Disabled/Harness Theme/Light */
-  --figma___button-soft-success-hover: 139 99% 33% / 0.13;
-  /* ✦ Theme/Button/Soft/Success/Hover/Harness Theme/Light */
-  --figma___button-soft-success-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Soft/Success/Text-disabled/Harness Theme/Light */
-  --figma___button-soft-success-text-primary: 153 100% 21% / 0.91;
-  /* ✦ Theme/Button/Soft/Success/Text-primary/Harness Theme/Light */
-  --figma___button-soft-success-default: 139 98% 37% / 0.09;
-  /* ✦ Theme/Button/Soft/Success/default/Harness Theme/Light */
-  --figma___button-solid-accent-active: 214 73% 51% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Active/Harness Theme/Light */
-  --figma___button-solid-accent-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Solid/Accent/Disabled/Harness Theme/Light */
-  --figma___button-solid-accent-hover: 208 93% 47% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Hover/Harness Theme/Light */
-  --figma___button-solid-accent-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Solid/Accent/Text-disabled/Harness Theme/Light */
-  --figma___button-solid-accent-default: 214 73% 51% / 1;
-  /* ✦ Theme/Button/Solid/Accent/default/Harness Theme/Light */
-  --figma___button-solid-error-active: 358 75% 59% / 1;
-  /* ✦ Theme/Button/Solid/Error/Active/Harness Theme/Light */
-  --figma___button-solid-error-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Solid/Error/Disabled/Harness Theme/Light */
-  --figma___button-solid-error-hover: 358 67% 55% / 1;
-  /* ✦ Theme/Button/Solid/Error/Hover/Harness Theme/Light */
-  --figma___button-solid-error-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Solid/Error/Text-disabled/Harness Theme/Light */
-  --figma___button-solid-error-default: 358 75% 59% / 1;
-  /* ✦ Theme/Button/Solid/Error/default/Harness Theme/Light */
-  --figma___button-solid-neutral-active: 0 0% 55% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Active/Harness Theme/Light */
-  --figma___button-solid-neutral-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Solid/Neutral/Disabled/Harness Theme/Light */
-  --figma___button-solid-neutral-hover: 0 0% 50% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Hover/Harness Theme/Light */
-  --figma___button-solid-neutral-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/Harness Theme/Light */
-  --figma___button-solid-neutral-default: 0 0% 55% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/default/Harness Theme/Light */
-  --figma___button-solid-success-active: 142 72% 29% / 1;
-  /* ✦ Theme/Button/Solid/Success/Active/Harness Theme/Light */
-  --figma___button-solid-success-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Solid/Success/Disabled/Harness Theme/Light */
-  --figma___button-solid-success-hover: 152 57% 38% / 1;
-  /* ✦ Theme/Button/Solid/Success/Hover/Harness Theme/Light */
-  --figma___button-solid-success-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Solid/Success/Text-disabled/Harness Theme/Light */
-  --figma___button-solid-success-default: 142 72% 29% / 1;
-  /* ✦ Theme/Button/Solid/Success/default/Harness Theme/Light */
-  --figma___button-surface-accent-active: 209 99% 49% / 0.19;
-  /* ✦ Theme/Button/Surface/Accent/Active/Harness Theme/Light */
-  --figma___button-surface-accent-active-border: 206 100% 45% / 0.63;
-  /* ✦ Theme/Button/Surface/Accent/Active border/Harness Theme/Light */
-  --figma___button-surface-accent-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Surface/Accent/Disabled/Harness Theme/Light */
-  --figma___button-surface-accent-hover: 210 99% 49% / 0.19;
-  /* ✦ Theme/Button/Surface/Accent/Hover/Harness Theme/Light */
-  --figma___button-surface-accent-hover-border: 206 100% 45% / 0.63;
-  /* ✦ Theme/Button/Surface/Accent/Hover Border/Harness Theme/Light */
-  --figma___button-surface-accent-text-disabled: 231 10% 75% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Text-disabled/Harness Theme/Light */
-  --figma___button-surface-accent-text-primary: 211 90% 42% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Text-primary/Harness Theme/Light */
-  --figma___button-surface-accent-default: 210 100% 50% / 0.07;
-  /* ✦ Theme/Button/Surface/Accent/default/Harness Theme/Light */
-  --figma___button-surface-accent-default-border: 208 100% 44% / 0.41;
-  /* ✦ Theme/Button/Surface/Accent/default border/Harness Theme/Light */
-  --figma___button-surface-error-active: 0 100% 47% / 0.15;
-  /* ✦ Theme/Button/Surface/Error/Active/Harness Theme/Light */
-  --figma___button-surface-error-active-border: 358 100% 40% / 0.76;
-  /* ✦ Theme/Button/Surface/Error/Active border/Harness Theme/Light */
-  --figma___button-surface-error-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Surface/Error/Disabled/Harness Theme/Light */
-  --figma___button-surface-error-hover: 0 100% 50% / 0.1;
-  /* ✦ Theme/Button/Surface/Error/Hover/Harness Theme/Light */
-  --figma___button-surface-error-hover-border: 358 100% 40% / 0.76;
-  /* ✦ Theme/Button/Surface/Error/Hover border/Harness Theme/Light */
-  --figma___button-surface-error-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Surface/Error/Text-disabled/Harness Theme/Light */
-  --figma___button-surface-error-text-primary: 358 65% 47% / 1;
-  /* ✦ Theme/Button/Surface/Error/Text-primary/Harness Theme/Light */
-  --figma___button-surface-error-border: 0 99% 45% / 0.22;
-  /* ✦ Theme/Button/Surface/Error/border/Harness Theme/Light */
-  --figma___button-surface-error-default: 0 100% 50% / 0.06;
-  /* ✦ Theme/Button/Surface/Error/default/Harness Theme/Light */
-  --figma___button-surface-neutral-active: 240 100% 9% / 0.11;
-  /* ✦ Theme/Button/Surface/Neutral/Active/Harness Theme/Light */
-  --figma___button-surface-neutral-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Surface/Neutral/Disabled/Harness Theme/Light */
-  --figma___button-surface-neutral-hover: 240 93% 11% / 0.08;
-  /* ✦ Theme/Button/Surface/Neutral/Hover/Harness Theme/Light */
-  --figma___button-surface-neutral-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/Harness Theme/Light */
-  --figma___button-surface-neutral-text-primary: 220 6% 40% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Text-primary/Harness Theme/Light */
-  --figma___button-surface-neutral-border: 233 96% 9% / 0.17;
-  /* ✦ Theme/Button/Surface/Neutral/border/Harness Theme/Light */
-  --figma___button-surface-neutral-default: 240 100% 12% / 0.05;
-  /* ✦ Theme/Button/Surface/Neutral/default/Harness Theme/Light */
-  --figma___button-surface-success-active: 141 100% 30% / 0.2;
-  /* ✦ Theme/Button/Surface/Success/Active/Harness Theme/Light */
-  --figma___button-surface-success-disabled: 0 0% 0% / 0.05;
-  /* ✦ Theme/Button/Surface/Success/Disabled/Harness Theme/Light */
-  --figma___button-surface-success-hover: 139 99% 33% / 0.13;
-  /* ✦ Theme/Button/Surface/Success/Hover/Harness Theme/Light */
-  --figma___button-surface-success-hover-border: 153 100% 26% / 0.84;
-  /* ✦ Theme/Button/Surface/Success/Hover border/Harness Theme/Light */
-  --figma___button-surface-success-text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Button/Surface/Success/Text-disabled/Harness Theme/Light */
-  --figma___button-surface-success-text-primary: 153 67% 28% / 1;
-  /* ✦ Theme/Button/Surface/Success/Text-primary/Harness Theme/Light */
-  --figma___button-surface-success-active-border: 153 100% 26% / 0.84;
-  /* ✦ Theme/Button/Surface/Success/active border/Harness Theme/Light */
-  --figma___button-surface-success-default: 139 98% 37% / 0.09;
-  /* ✦ Theme/Button/Surface/Success/default/Harness Theme/Light */
-  --figma___button-surface-success-default-border: 142 99% 29% / 0.29;
-  /* ✦ Theme/Button/Surface/Success/default border/Harness Theme/Light */
-  --figma___calendar-background: 240 20% 98% / 1;
-  /* ✦ Theme/Calendar/Background/Harness Theme/Light */
-  --figma___calendar-selected-date-background: 214 73% 51% / 1;
-  /* ✦ Theme/Calendar/Selected Date/Background/Harness Theme/Light */
-  --figma___calendar-selected-range-background: 210 100% 50% / 0.07;
-  /* ✦ Theme/Calendar/Selected Range/Background/Harness Theme/Light */
-  --figma___calendar-selected-range-text: 211 100% 39% / 0.96;
-  /* ✦ Theme/Calendar/Selected Range/Text/Harness Theme/Light */
-  --figma___checkbox-background: 0 0% 100% / 0.8;
-  /* ✦ Theme/Checkbox/Background/Harness Theme/Light */
-  --figma___checkbox-paper: 0 0% 100% / 1;
-  /* ✦ Theme/Checkbox/Paper/Harness Theme/Light */
-  --figma___checkbox-surface-checked-active-active: 208 93% 47% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/Harness Theme/Light */
-  --figma___checkbox-surface-checked-active-hover: 208 93% 47% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/Harness Theme/Light */
-  --figma___checkbox-surface-checked-active-default-background: 214 73% 51% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/Harness Theme/Light */
-  --figma___checkbox-surface-checked-disabled-check: 240 96% 9% / 0.13;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/Harness Theme/Light */
-  --figma___checkbox-surface-checked-disabled-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/Harness Theme/Light */
-  --figma___checkbox-surface-checked-disabled-border: 240 96% 9% / 0.13;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/Harness Theme/Light */
-  --figma___checkbox-surface-intermediate-active-active-border: 206 100% 45% / 0.63;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/Harness Theme/Light */
-  --figma___checkbox-surface-intermediate-active-check: 211 100% 39% / 0.96;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/Harness Theme/Light */
-  --figma___checkbox-surface-intermediate-active-hover-border: 208 100% 44% / 0.41;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/Harness Theme/Light */
-  --figma___checkbox-surface-intermediate-active-default-background: 210 100% 50% / 0.07;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/Harness Theme/Light */
-  --figma___checkbox-surface-intermediate-active-default-border: 209 99% 45% / 0.28;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/Harness Theme/Light */
-  --figma___checkbox-surface-intermediate-disabled-check: 240 96% 9% / 0.13;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/Harness Theme/Light */
-  --figma___checkbox-surface-intermediate-disabled-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/Harness Theme/Light */
-  --figma___checkbox-surface-intermediate-disabled-border: 240 96% 9% / 0.13;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/Harness Theme/Light */
-  --figma___checkbox-surface-unchecked-active-active-border: 230 100% 9% / 0.28;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/Harness Theme/Light */
-  --figma___checkbox-surface-unchecked-active-hover-border: 233 96% 9% / 0.17;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/Harness Theme/Light */
-  --figma___checkbox-surface-unchecked-active-default-background: 0 0% 98% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/Harness Theme/Light */
-  --figma___checkbox-surface-unchecked-active-default-border: 240 96% 9% / 0.13;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/Harness Theme/Light */
-  --figma___checkbox-surface-unchecked-disabled-disabled: 240 100% 12% / 0.05;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/Harness Theme/Light */
-  --figma___checkbox-surface-unchecked-disabled-border: 240 96% 9% / 0.13;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/Harness Theme/Light */
-  --figma___checkbox-border: 0 0% 0% / 0.05;
-  /* ✦ Theme/Checkbox/border/Harness Theme/Light */
-  --figma___default-colors-black: 0 0% 0% / 1;
-  /* ✦ Theme/Default colors/black/Harness Theme/Light */
-  --figma___default-colors-dark-to-white: 0 0% 13% / 1;
-  /* ✦ Theme/Default colors/dark-to-white/Harness Theme/Light */
-  --figma___default-colors-white: 0 0% 100% / 1;
-  /* ✦ Theme/Default colors/white/Harness Theme/Light */
-  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
-  /* ✦ Theme/Dropdown/Dropdown Item/Default/Harness Theme/Light */
-  --figma___dropdown-dropdown-item-hover: 240 13% 95% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Hover/Harness Theme/Light */
-  --figma___dropdown-dropdown-item-selected: 240 13% 95% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Selected/Harness Theme/Light */
-  --figma___dropdown-text-shortcut-text-selected: 0 0% 0% / 0.5;
-  /* ✦ Theme/Dropdown/Text/Shortcut text selected/Harness Theme/Light */
-  --figma___dropdown-text-text-selected: 0 0% 13% / 1;
-  /* ✦ Theme/Dropdown/Text/Text Selected/Harness Theme/Light */
-  --figma___dropdown-text-hover: 0 0% 39% / 1;
-  /* ✦ Theme/Dropdown/Text/hover/Harness Theme/Light */
-  --figma___dropdown-background: 240 20% 98% / 1;
-  /* ✦ Theme/Dropdown/background/Harness Theme/Light */
-  --figma___dropdown-border: 240 100% 12% / 0.05;
-  /* ✦ Theme/Dropdown/border/Harness Theme/Light */
-  --figma___dropdown-separator: 240 100% 12% / 0.05;
-  /* ✦ Theme/Dropdown/separator/Harness Theme/Light */
-  --figma___filter-active: 240 100% 12% / 0.05;
-  /* ✦ Theme/Filter/Active/Harness Theme/Light */
-  --figma___filter-hover: 240 100% 12% / 0.05;
-  /* ✦ Theme/Filter/Hover/Harness Theme/Light */
-  --figma___inline-alert-banner-customisable: 240 20% 98% / 1;
-  /* ✦ Theme/Inline Alert Banner/Customisable/Harness Theme/Light */
-  --figma___inline-alert-banner-error: 0 100% 97% / 1;
-  /* ✦ Theme/Inline Alert Banner/Error/Harness Theme/Light */
-  --figma___inline-alert-banner-info: 210 100% 50% / 0.07;
-  /* ✦ Theme/Inline Alert Banner/Info/Harness Theme/Light */
-  --figma___inline-alert-banner-reminder: 40 100% 96% / 1;
-  /* ✦ Theme/Inline Alert Banner/Reminder/Harness Theme/Light */
-  --figma___inline-alert-banner-success: 150 69% 94% / 1;
-  /* ✦ Theme/Inline Alert Banner/Success/Harness Theme/Light */
-  --figma___inline-alert-banner-warning: 34 100% 92% / 1;
-  /* ✦ Theme/Inline Alert Banner/Warning/Harness Theme/Light */
-  --figma___modal-background: 0 0% 100% / 0.8;
-  /* ✦ Theme/Modal/Background/Harness Theme/Light */
-  --figma___modal-paper: 0 0% 100% / 1;
-  /* ✦ Theme/Modal/Paper/Harness Theme/Light */
-  --figma___modal-border: 0 0% 0% / 0.05;
-  /* ✦ Theme/Modal/border/Harness Theme/Light */
-  --figma___neutral-color-gray-1: 0 0% 99% / 1;
-  /* ✦ Theme/Neutral color/Gray/1/Harness Theme/Light */
-  --figma___neutral-color-gray-2: 0 0% 98% / 1;
-  /* ✦ Theme/Neutral color/Gray/2/Harness Theme/Light */
-  --figma___neutral-color-gray-3: 0 0% 95% / 1;
-  /* ✦ Theme/Neutral color/Gray/3/Harness Theme/Light */
-  --figma___neutral-color-gray-4: 0 0% 92% / 1;
-  /* ✦ Theme/Neutral color/Gray/4/Harness Theme/Light */
-  --figma___neutral-color-gray-5: 0 0% 89% / 1;
-  /* ✦ Theme/Neutral color/Gray/5/Harness Theme/Light */
-  --figma___neutral-color-gray-6: 0 0% 87% / 1;
-  /* ✦ Theme/Neutral color/Gray/6/Harness Theme/Light */
-  --figma___neutral-color-gray-7: 0 0% 55% / 1;
-  /* ✦ Theme/Neutral color/Gray/7/Harness Theme/Light */
-  --figma___neutral-color-gray-8: 0 0% 50% / 1;
-  /* ✦ Theme/Neutral color/Gray/8/Harness Theme/Light */
-  --figma___neutral-color-gray-9: 0 0% 39% / 1;
-  /* ✦ Theme/Neutral color/Gray/9/Harness Theme/Light */
-  --figma___neutral-color-gray-10: 0 0% 13% / 1;
-  /* ✦ Theme/Neutral color/Gray/10/Harness Theme/Light */
-  --figma___neutral-color-gray-alpha-1: 0 0% 0% / 0.01;
-  /* ✦ Theme/Neutral color/Gray Alpha/1/Harness Theme/Light */
-  --figma___neutral-color-gray-alpha-2: 240 89% 18% / 0.02;
-  /* ✦ Theme/Neutral color/Gray Alpha/2/Harness Theme/Light */
-  --figma___neutral-color-gray-alpha-3: 0 0% 0% / 0.05;
-  /* ✦ Theme/Neutral color/Gray Alpha/3/Harness Theme/Light */
-  --figma___neutral-color-gray-alpha-4: 0 0% 0% / 0.08;
-  /* ✦ Theme/Neutral color/Gray Alpha/4/Harness Theme/Light */
-  --figma___neutral-color-gray-alpha-5: 0 0% 0% / 0.11;
-  /* ✦ Theme/Neutral color/Gray Alpha/5/Harness Theme/Light */
-  --figma___neutral-color-gray-alpha-6: 0 0% 0% / 0.13;
-  /* ✦ Theme/Neutral color/Gray Alpha/6/Harness Theme/Light */
-  --figma___neutral-color-gray-alpha-7: 0 0% 0% / 0.45;
-  /* ✦ Theme/Neutral color/Gray Alpha/7/Harness Theme/Light */
-  --figma___neutral-color-gray-alpha-8: 0 0% 0% / 0.5;
-  /* ✦ Theme/Neutral color/Gray Alpha/8/Harness Theme/Light */
-  --figma___neutral-color-gray-alpha-9: 0 0% 0% / 0.61;
-  /* ✦ Theme/Neutral color/Gray Alpha/9/Harness Theme/Light */
-  --figma___neutral-color-gray-alpha-10: 0 0% 0% / 0.88;
-  /* ✦ Theme/Neutral color/Gray Alpha/10/Harness Theme/Light */
-  --figma___other-colors-ai-violet-1: 270 50% 99% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/1/Harness Theme/Light */
-  --figma___other-colors-ai-violet-2: 252 100% 99% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/2/Harness Theme/Light */
-  --figma___other-colors-ai-violet-3: 254 100% 97% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/3/Harness Theme/Light */
-  --figma___other-colors-ai-violet-4: 251 91% 95% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/4/Harness Theme/Light */
-  --figma___other-colors-ai-violet-5: 252 83% 93% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/5/Harness Theme/Light */
-  --figma___other-colors-ai-violet-6: 251 78% 89% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/6/Harness Theme/Light */
-  --figma___other-colors-ai-violet-7: 252 56% 57% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/7/Harness Theme/Light */
-  --figma___other-colors-ai-violet-8: 251 48% 53% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/8/Harness Theme/Light */
-  --figma___other-colors-ai-violet-9: 250 43% 48% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/9/Harness Theme/Light */
-  --figma___other-colors-ai-violet-10: 249 43% 26% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/10/Harness Theme/Light */
-  --figma___other-colors-ai-violet-alpha-1: 270 94% 35% / 0.01;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/1/Harness Theme/Light */
-  --figma___other-colors-ai-violet-alpha-2: 252 100% 51% / 0.02;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/2/Harness Theme/Light */
-  --figma___other-colors-ai-violet-alpha-3: 254 100% 50% / 0.05;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/3/Harness Theme/Light */
-  --figma___other-colors-ai-violet-alpha-4: 251 98% 48% / 0.09;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/4/Harness Theme/Light */
-  --figma___other-colors-ai-violet-alpha-5: 252 99% 46% / 0.13;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/5/Harness Theme/Light */
-  --figma___other-colors-ai-violet-alpha-6: 251 99% 44% / 0.19;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/6/Harness Theme/Light */
-  --figma___other-colors-ai-violet-alpha-7: 252 100% 36% / 0.66;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/7/Harness Theme/Light */
-  --figma___other-colors-ai-violet-alpha-8: 251 100% 32% / 0.69;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/8/Harness Theme/Light */
-  --figma___other-colors-ai-violet-alpha-9: 250 100% 28% / 0.73;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/9/Harness Theme/Light */
-  --figma___other-colors-ai-violet-alpha-10: 249 100% 13% / 0.85;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/10/Harness Theme/Light */
-  --figma___other-colors-blue-1: 210 100% 99% / 1;
-  /* ✦ Theme/Other Colors/Blue/1/Harness Theme/Light */
-  --figma___other-colors-blue-2: 210 100% 98% / 1;
-  /* ✦ Theme/Other Colors/Blue/2/Harness Theme/Light */
-  --figma___other-colors-blue-3: 210 100% 96% / 1;
-  /* ✦ Theme/Other Colors/Blue/3/Harness Theme/Light */
-  --figma___other-colors-blue-4: 210 100% 94% / 1;
-  /* ✦ Theme/Other Colors/Blue/4/Harness Theme/Light */
-  --figma___other-colors-blue-5: 209 96% 90% / 1;
-  /* ✦ Theme/Other Colors/Blue/5/Harness Theme/Light */
-  --figma___other-colors-blue-6: 209 82% 85% / 1;
-  /* ✦ Theme/Other Colors/Blue/6/Harness Theme/Light */
-  --figma___other-colors-blue-7: 214 73% 51% / 1;
-  /* ✦ Theme/Other Colors/Blue/7/Harness Theme/Light */
-  --figma___other-colors-blue-8: 208 93% 47% / 1;
-  /* ✦ Theme/Other Colors/Blue/8/Harness Theme/Light */
-  --figma___other-colors-blue-9: 211 90% 42% / 1;
-  /* ✦ Theme/Other Colors/Blue/9/Harness Theme/Light */
-  --figma___other-colors-blue-10: 216 71% 23% / 1;
-  /* ✦ Theme/Other Colors/Blue/10/Harness Theme/Light */
-  --figma___other-colors-blue-alpha-1: 210 100% 51% / 0.02;
-  /* ✦ Theme/Other Colors/Blue Alpha/1/Harness Theme/Light */
-  --figma___other-colors-blue-alpha-2: 210 100% 51% / 0.04;
-  /* ✦ Theme/Other Colors/Blue Alpha/2/Harness Theme/Light */
-  --figma___other-colors-blue-alpha-3: 210 100% 50% / 0.07;
-  /* ✦ Theme/Other Colors/Blue Alpha/3/Harness Theme/Light */
-  --figma___other-colors-blue-alpha-4: 210 99% 49% / 0.19;
-  /* ✦ Theme/Other Colors/Blue Alpha/4/Harness Theme/Light */
-  --figma___other-colors-blue-alpha-5: 209 99% 49% / 0.19;
-  /* ✦ Theme/Other Colors/Blue Alpha/5/Harness Theme/Light */
-  --figma___other-colors-blue-alpha-6: 209 99% 45% / 0.28;
-  /* ✦ Theme/Other Colors/Blue Alpha/6/Harness Theme/Light */
-  --figma___other-colors-blue-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/7/Harness Theme/Light */
-  --figma___other-colors-blue-alpha-8: 208 100% 46% / 0.97;
-  /* ✦ Theme/Other Colors/Blue Alpha/8/Harness Theme/Light */
-  --figma___other-colors-blue-alpha-9: 211 100% 39% / 0.96;
-  /* ✦ Theme/Other Colors/Blue Alpha/9/Harness Theme/Light */
-  --figma___other-colors-blue-alpha-10: 216 100% 17% / 0.93;
-  /* ✦ Theme/Other Colors/Blue Alpha/10/Harness Theme/Light */
-  --figma___other-colors-indigo-1: 240 33% 99% / 1;
-  /* ✦ Theme/Other Colors/Indigo/1/Harness Theme/Light */
-  --figma___other-colors-indigo-2: 223 100% 99% / 1;
-  /* ✦ Theme/Other Colors/Indigo/2/Harness Theme/Light */
-  --figma___other-colors-indigo-3: 224 100% 97% / 1;
-  /* ✦ Theme/Other Colors/Indigo/3/Harness Theme/Light */
-  --figma___other-colors-indigo-4: 222 92% 95% / 1;
-  /* ✦ Theme/Other Colors/Indigo/4/Harness Theme/Light */
-  --figma___other-colors-indigo-5: 225 85% 92% / 1;
-  /* ✦ Theme/Other Colors/Indigo/5/Harness Theme/Light */
-  --figma___other-colors-indigo-6: 224 81% 88% / 1;
-  /* ✦ Theme/Other Colors/Indigo/6/Harness Theme/Light */
-  --figma___other-colors-indigo-7: 226 70% 55% / 1;
-  /* ✦ Theme/Other Colors/Indigo/7/Harness Theme/Light */
-  --figma___other-colors-indigo-8: 226 59% 51% / 1;
-  /* ✦ Theme/Other Colors/Indigo/8/Harness Theme/Light */
-  --figma___other-colors-indigo-9: 226 55% 45% / 1;
-  /* ✦ Theme/Other Colors/Indigo/9/Harness Theme/Light */
-  --figma___other-colors-indigo-10: 226 63% 17% / 1;
-  /* ✦ Theme/Other Colors/Indigo/10/Harness Theme/Light */
-  --figma___other-colors-indigo-alpha-1: 240 93% 26% / 0.01;
-  /* ✦ Theme/Other Colors/Indigo Alpha/1/Harness Theme/Light */
-  --figma___other-colors-indigo-alpha-2: 223 100% 51% / 0.03;
-  /* ✦ Theme/Other Colors/Indigo Alpha/2/Harness Theme/Light */
-  --figma___other-colors-indigo-alpha-3: 224 100% 50% / 0.06;
-  /* ✦ Theme/Other Colors/Indigo Alpha/3/Harness Theme/Light */
-  --figma___other-colors-indigo-alpha-4: 222 98% 48% / 0.1;
-  /* ✦ Theme/Other Colors/Indigo Alpha/4/Harness Theme/Light */
-  --figma___other-colors-indigo-alpha-5: 225 98% 46% / 0.15;
-  /* ✦ Theme/Other Colors/Indigo Alpha/5/Harness Theme/Light */
-  --figma___other-colors-indigo-alpha-6: 224 99% 45% / 0.22;
-  /* ✦ Theme/Other Colors/Indigo Alpha/6/Harness Theme/Light */
-  --figma___other-colors-indigo-alpha-7: 226 100% 41% / 0.76;
-  /* ✦ Theme/Other Colors/Indigo Alpha/7/Harness Theme/Light */
-  --figma___other-colors-indigo-alpha-8: 226 100% 37% / 0.77;
-  /* ✦ Theme/Other Colors/Indigo Alpha/8/Harness Theme/Light */
-  --figma___other-colors-indigo-alpha-9: 226 100% 31% / 0.8;
-  /* ✦ Theme/Other Colors/Indigo Alpha/9/Harness Theme/Light */
-  --figma___other-colors-indigo-alpha-10: 225 100% 14% / 0.88;
-  /* ✦ Theme/Other Colors/Indigo Alpha/10/Harness Theme/Light */
-  --figma___other-colors-mint-1: 168 71% 99% / 1;
-  /* ✦ Theme/Other Colors/Mint/1/Harness Theme/Light */
-  --figma___other-colors-mint-2: 164 88% 97% / 1;
-  /* ✦ Theme/Other Colors/Mint/2/Harness Theme/Light */
-  --figma___other-colors-mint-3: 164 79% 93% / 1;
-  /* ✦ Theme/Other Colors/Mint/3/Harness Theme/Light */
-  --figma___other-colors-mint-4: 165 73% 88% / 1;
-  /* ✦ Theme/Other Colors/Mint/4/Harness Theme/Light */
-  --figma___other-colors-mint-5: 166 60% 83% / 1;
-  /* ✦ Theme/Other Colors/Mint/5/Harness Theme/Light */
-  --figma___other-colors-mint-6: 166 50% 77% / 1;
-  /* ✦ Theme/Other Colors/Mint/6/Harness Theme/Light */
-  --figma___other-colors-mint-7: 167 70% 72% / 1;
-  /* ✦ Theme/Other Colors/Mint/7/Harness Theme/Light */
-  --figma___other-colors-mint-8: 167 62% 69% / 1;
-  /* ✦ Theme/Other Colors/Mint/8/Harness Theme/Light */
-  --figma___other-colors-mint-9: 172 50% 31% / 1;
-  /* ✦ Theme/Other Colors/Mint/9/Harness Theme/Light */
-  --figma___other-colors-mint-10: 171 51% 17% / 1;
-  /* ✦ Theme/Other Colors/Mint/10/Harness Theme/Light */
-  --figma___other-colors-mint-alpha-1: 168 95% 43% / 0.02;
-  /* ✦ Theme/Other Colors/Mint Alpha/1/Harness Theme/Light */
-  --figma___other-colors-mint-alpha-2: 164 99% 47% / 0.06;
-  /* ✦ Theme/Other Colors/Mint Alpha/2/Harness Theme/Light */
-  --figma___other-colors-mint-alpha-3: 164 99% 44% / 0.13;
-  /* ✦ Theme/Other Colors/Mint Alpha/3/Harness Theme/Light */
-  --figma___other-colors-mint-alpha-4: 165 100% 42% / 0.2;
-  /* ✦ Theme/Other Colors/Mint Alpha/4/Harness Theme/Light */
-  --figma___other-colors-mint-alpha-5: 166 100% 38% / 0.27;
-  /* ✦ Theme/Other Colors/Mint Alpha/5/Harness Theme/Light */
-  --figma___other-colors-mint-alpha-6: 166 99% 33% / 0.35;
-  /* ✦ Theme/Other Colors/Mint Alpha/6/Harness Theme/Light */
-  --figma___other-colors-mint-alpha-7: 167 100% 41% / 0.47;
-  /* ✦ Theme/Other Colors/Mint Alpha/7/Harness Theme/Light */
-  --figma___other-colors-mint-alpha-8: 167 100% 38% / 0.5;
-  /* ✦ Theme/Other Colors/Mint Alpha/8/Harness Theme/Light */
-  --figma___other-colors-mint-alpha-9: 172 100% 18% / 0.85;
-  /* ✦ Theme/Other Colors/Mint Alpha/9/Harness Theme/Light */
-  --figma___other-colors-mint-alpha-10: 171 100% 10% / 0.91;
-  /* ✦ Theme/Other Colors/Mint Alpha/10/Harness Theme/Light */
-  --figma___other-colors-orange-1: 20 60% 99% / 1;
-  /* ✦ Theme/Other Colors/Orange/1/Harness Theme/Light */
-  --figma___other-colors-orange-2: 22 100% 98% / 1;
-  /* ✦ Theme/Other Colors/Orange/2/Harness Theme/Light */
-  --figma___other-colors-orange-3: 34 100% 92% / 1;
-  /* ✦ Theme/Other Colors/Orange/3/Harness Theme/Light */
-  --figma___other-colors-orange-4: 33 100% 87% / 1;
-  /* ✦ Theme/Other Colors/Orange/4/Harness Theme/Light */
-  --figma___other-colors-orange-5: 31 100% 82% / 1;
-  /* ✦ Theme/Other Colors/Orange/5/Harness Theme/Light */
-  --figma___other-colors-orange-6: 27 100% 78% / 1;
-  /* ✦ Theme/Other Colors/Orange/6/Harness Theme/Light */
-  --figma___other-colors-orange-7: 24 94% 50% / 1;
-  /* ✦ Theme/Other Colors/Orange/7/Harness Theme/Light */
-  --figma___other-colors-orange-8: 24 100% 46% / 1;
-  /* ✦ Theme/Other Colors/Orange/8/Harness Theme/Light */
-  --figma___other-colors-orange-9: 16 45% 41% / 1;
-  /* ✦ Theme/Other Colors/Orange/9/Harness Theme/Light */
-  --figma___other-colors-orange-10: 16 50% 23% / 1;
-  /* ✦ Theme/Other Colors/Orange/10/Harness Theme/Light */
-  --figma___other-colors-orange-alpha-1: 20 95% 39% / 0.02;
-  /* ✦ Theme/Other Colors/Orange Alpha/1/Harness Theme/Light */
-  --figma___other-colors-orange-alpha-2: 22 100% 51% / 0.04;
-  /* ✦ Theme/Other Colors/Orange Alpha/2/Harness Theme/Light */
-  --figma___other-colors-orange-alpha-3: 34 100% 50% / 0.17;
-  /* ✦ Theme/Other Colors/Orange Alpha/3/Harness Theme/Light */
-  --figma___other-colors-orange-alpha-4: 33 100% 50% / 0.27;
-  /* ✦ Theme/Other Colors/Orange Alpha/4/Harness Theme/Light */
-  --figma___other-colors-orange-alpha-5: 31 100% 50% / 0.36;
-  /* ✦ Theme/Other Colors/Orange Alpha/5/Harness Theme/Light */
-  --figma___other-colors-orange-alpha-6: 27 100% 50% / 0.43;
-  /* ✦ Theme/Other Colors/Orange Alpha/6/Harness Theme/Light */
-  --figma___other-colors-orange-alpha-7: 24 100% 48% / 0.97;
-  /* ✦ Theme/Other Colors/Orange Alpha/7/Harness Theme/Light */
-  --figma___other-colors-orange-alpha-8: 24 100% 46% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/8/Harness Theme/Light */
-  --figma___other-colors-orange-alpha-9: 16 100% 24% / 0.77;
-  /* ✦ Theme/Other Colors/Orange Alpha/9/Harness Theme/Light */
-  --figma___other-colors-orange-alpha-10: 16 100% 13% / 0.89;
-  /* ✦ Theme/Other Colors/Orange Alpha/10/Harness Theme/Light */
-  --figma___other-colors-yellow-1: 60 50% 98% / 1;
-  /* ✦ Theme/Other Colors/Yellow/1/Harness Theme/Light */
-  --figma___other-colors-yellow-2: 52 100% 94% / 1;
-  /* ✦ Theme/Other Colors/Yellow/2/Harness Theme/Light */
-  --figma___other-colors-yellow-3: 53 100% 89% / 1;
-  /* ✦ Theme/Other Colors/Yellow/3/Harness Theme/Light */
-  --figma___other-colors-yellow-4: 53 93% 84% / 1;
-  /* ✦ Theme/Other Colors/Yellow/4/Harness Theme/Light */
-  --figma___other-colors-yellow-5: 52 85% 79% / 1;
-  /* ✦ Theme/Other Colors/Yellow/5/Harness Theme/Light */
-  --figma___other-colors-yellow-6: 51 73% 72% / 1;
-  /* ✦ Theme/Other Colors/Yellow/6/Harness Theme/Light */
-  --figma___other-colors-yellow-7: 53 96% 58% / 1;
-  /* ✦ Theme/Other Colors/Yellow/7/Harness Theme/Light */
-  --figma___other-colors-yellow-8: 52 95% 52% / 1;
-  /* ✦ Theme/Other Colors/Yellow/8/Harness Theme/Light */
-  --figma___other-colors-yellow-9: 42 50% 31% / 1;
-  /* ✦ Theme/Other Colors/Yellow/9/Harness Theme/Light */
-  --figma___other-colors-yellow-10: 42 39% 20% / 1;
-  /* ✦ Theme/Other Colors/Yellow/10/Harness Theme/Light */
-  --figma___other-colors-yellow-alpha-1: 60 94% 35% / 0.02;
-  /* ✦ Theme/Other Colors/Yellow Alpha/1/Harness Theme/Light */
-  --figma___other-colors-yellow-alpha-2: 52 100% 50% / 0.12;
-  /* ✦ Theme/Other Colors/Yellow Alpha/2/Harness Theme/Light */
-  --figma___other-colors-yellow-alpha-3: 53 100% 50% / 0.22;
-  /* ✦ Theme/Other Colors/Yellow Alpha/3/Harness Theme/Light */
-  --figma___other-colors-yellow-alpha-4: 53 100% 48% / 0.31;
-  /* ✦ Theme/Other Colors/Yellow Alpha/4/Harness Theme/Light */
-  --figma___other-colors-yellow-alpha-5: 52 99% 46% / 0.39;
-  /* ✦ Theme/Other Colors/Yellow Alpha/5/Harness Theme/Light */
-  --figma___other-colors-yellow-alpha-6: 51 100% 42% / 0.48;
-  /* ✦ Theme/Other Colors/Yellow Alpha/6/Harness Theme/Light */
-  --figma___other-colors-yellow-alpha-7: 53 100% 49% / 0.82;
-  /* ✦ Theme/Other Colors/Yellow Alpha/7/Harness Theme/Light */
-  --figma___other-colors-yellow-alpha-8: 52 100% 49% / 0.94;
-  /* ✦ Theme/Other Colors/Yellow Alpha/8/Harness Theme/Light */
-  --figma___other-colors-yellow-alpha-9: 42 100% 18% / 0.84;
-  /* ✦ Theme/Other Colors/Yellow Alpha/9/Harness Theme/Light */
-  --figma___other-colors-yellow-alpha-10: 42 100% 9% / 0.88;
-  /* ✦ Theme/Other Colors/Yellow Alpha/10/Harness Theme/Light */
-  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01;
-  /* ✦ Theme/Overlays/Black Alpha/1/Harness Theme/Light */
-  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02;
-  /* ✦ Theme/Overlays/Black Alpha/2/Harness Theme/Light */
-  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05;
-  /* ✦ Theme/Overlays/Black Alpha/3/Harness Theme/Light */
-  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08;
-  /* ✦ Theme/Overlays/Black Alpha/4/Harness Theme/Light */
-  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11;
-  /* ✦ Theme/Overlays/Black Alpha/5/Harness Theme/Light */
-  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13;
-  /* ✦ Theme/Overlays/Black Alpha/6/Harness Theme/Light */
-  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45;
-  /* ✦ Theme/Overlays/Black Alpha/7/Harness Theme/Light */
-  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5;
-  /* ✦ Theme/Overlays/Black Alpha/8/Harness Theme/Light */
-  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61;
-  /* ✦ Theme/Overlays/Black Alpha/9/Harness Theme/Light */
-  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88;
-  /* ✦ Theme/Overlays/Black Alpha/10/Harness Theme/Light */
-  --figma___overlays-white-alpha-1: 0 0% 100% / 0;
-  /* ✦ Theme/Overlays/White Alpha/1/Harness Theme/Light */
-  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01;
-  /* ✦ Theme/Overlays/White Alpha/2/Harness Theme/Light */
-  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07;
-  /* ✦ Theme/Overlays/White Alpha/3/Harness Theme/Light */
-  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1;
-  /* ✦ Theme/Overlays/White Alpha/4/Harness Theme/Light */
-  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13;
-  /* ✦ Theme/Overlays/White Alpha/5/Harness Theme/Light */
-  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17;
-  /* ✦ Theme/Overlays/White Alpha/6/Harness Theme/Light */
-  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37;
-  /* ✦ Theme/Overlays/White Alpha/7/Harness Theme/Light */
-  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46;
-  /* ✦ Theme/Overlays/White Alpha/8/Harness Theme/Light */
-  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66;
-  /* ✦ Theme/Overlays/White Alpha/9/Harness Theme/Light */
-  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93;
-  /* ✦ Theme/Overlays/White Alpha/10/Harness Theme/Light */
-  --figma___pagination-active-background: 214 73% 51% / 1;
-  /* ✦ Theme/Pagination/Active/Background/Harness Theme/Light */
-  --figma___pagination-active-border: 214 73% 51% / 1;
-  /* ✦ Theme/Pagination/Active/Border/Harness Theme/Light */
-  --figma___pagination-background: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Background/Harness Theme/Light */
-  --figma___pagination-default-background: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Default/Background/Harness Theme/Light */
-  --figma___pagination-default-border: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Default/Border/Harness Theme/Light */
-  --figma___pagination-default-text: 0 0% 0% / 0.5;
-  /* ✦ Theme/Pagination/Default/Text/Harness Theme/Light */
-  --figma___pagination-hover-background: 240 100% 12% / 0.05;
-  /* ✦ Theme/Pagination/Hover/Background/Harness Theme/Light */
-  --figma___pagination-hover-border: 0 0% 95% / 1;
-  /* ✦ Theme/Pagination/Hover/Border/Harness Theme/Light */
-  --figma___pagination-hover-text: 211 90% 42% / 1;
-  /* ✦ Theme/Pagination/Hover/Text/Harness Theme/Light */
-  --figma___pagination-pagination-shadow-1: 0 0% 0% / 0;
-  /* ✦ Theme/Pagination/Pagination shadow/1/Harness Theme/Light */
-  --figma___pagination-pagination-shadow-2: 240 100% 12% / 0;
-  /* ✦ Theme/Pagination/Pagination shadow/2/Harness Theme/Light */
-  --figma___primary-color-primary-accent-1: 210 100% 99% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/1/Harness Theme/Light */
-  --figma___primary-color-primary-accent-2: 210 100% 98% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/2/Harness Theme/Light */
-  --figma___primary-color-primary-accent-3: 210 100% 96% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/3/Harness Theme/Light */
-  --figma___primary-color-primary-accent-4: 210 100% 94% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/4/Harness Theme/Light */
-  --figma___primary-color-primary-accent-5: 209 96% 90% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/5/Harness Theme/Light */
-  --figma___primary-color-primary-accent-6: 209 82% 85% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/6/Harness Theme/Light */
-  --figma___primary-color-primary-accent-7: 214 73% 51% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/7/Harness Theme/Light */
-  --figma___primary-color-primary-accent-8: 208 93% 47% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/8/Harness Theme/Light */
-  --figma___primary-color-primary-accent-9: 211 90% 42% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/9/Harness Theme/Light */
-  --figma___primary-color-primary-accent-10: 216 71% 23% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/10/Harness Theme/Light */
-  --figma___primary-color-primary-alpha-1: 210 100% 51% / 0.02;
-  /* ✦ Theme/Primary Color/Primary Alpha/1/Harness Theme/Light */
-  --figma___primary-color-primary-alpha-2: 210 100% 51% / 0.04;
-  /* ✦ Theme/Primary Color/Primary Alpha/2/Harness Theme/Light */
-  --figma___primary-color-primary-alpha-3: 210 100% 50% / 0.07;
-  /* ✦ Theme/Primary Color/Primary Alpha/3/Harness Theme/Light */
-  --figma___primary-color-primary-alpha-4: 210 99% 49% / 0.19;
-  /* ✦ Theme/Primary Color/Primary Alpha/4/Harness Theme/Light */
-  --figma___primary-color-primary-alpha-5: 209 99% 49% / 0.19;
-  /* ✦ Theme/Primary Color/Primary Alpha/5/Harness Theme/Light */
-  --figma___primary-color-primary-alpha-6: 209 99% 45% / 0.28;
-  /* ✦ Theme/Primary Color/Primary Alpha/6/Harness Theme/Light */
-  --figma___primary-color-primary-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/7/Harness Theme/Light */
-  --figma___primary-color-primary-alpha-8: 208 100% 46% / 0.97;
-  /* ✦ Theme/Primary Color/Primary Alpha/8/Harness Theme/Light */
-  --figma___primary-color-primary-alpha-9: 211 100% 39% / 0.96;
-  /* ✦ Theme/Primary Color/Primary Alpha/9/Harness Theme/Light */
-  --figma___primary-color-primary-alpha-10: 216 100% 17% / 0.93;
-  /* ✦ Theme/Primary Color/Primary Alpha/10/Harness Theme/Light */
-  --figma___radio-button-background: 0 0% 100% / 0.8;
-  /* ✦ Theme/Radio button/Background/Harness Theme/Light */
-  --figma___radio-button-checked-active-active-border: 214 73% 51% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active Border/Harness Theme/Light */
-  --figma___radio-button-checked-active-active-background: 214 73% 51% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active background/Harness Theme/Light */
-  --figma___radio-button-checked-active-hover-background: 208 93% 47% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover background/Harness Theme/Light */
-  --figma___radio-button-checked-active-hover-border: 208 93% 47% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover border/Harness Theme/Light */
-  --figma___radio-button-checked-active-default-background: 214 73% 51% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default background/Harness Theme/Light */
-  --figma___radio-button-checked-active-default-border: 214 73% 51% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default border/Harness Theme/Light */
-  --figma___radio-button-checked-disabled-dot: 0 0% 0% / 0.27;
-  /* ✦ Theme/Radio button/Checked/Disabled/Dot/Harness Theme/Light */
-  --figma___radio-button-checked-disabled-background: 0 0% 0% / 0.05;
-  /* ✦ Theme/Radio button/Checked/Disabled/background/Harness Theme/Light */
-  --figma___radio-button-checked-disabled-border: 0 0% 0% / 0.13;
-  /* ✦ Theme/Radio button/Checked/Disabled/border/Harness Theme/Light */
-  --figma___radio-button-paper: 0 0% 100% / 1;
-  /* ✦ Theme/Radio button/Paper/Harness Theme/Light */
-  --figma___radio-button-unchecked-active-active-border: 0 0% 0% / 0.45;
-  /* ✦ Theme/Radio button/Unchecked/Active/Active border/Harness Theme/Light */
-  --figma___radio-button-unchecked-active-hover-border: 0 0% 0% / 0.27;
-  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/Harness Theme/Light */
-  --figma___radio-button-unchecked-active-default-background: 0 0% 0% / 0.05;
-  /* ✦ Theme/Radio button/Unchecked/Active/default background/Harness Theme/Light */
-  --figma___radio-button-unchecked-active-default-border: 0 0% 0% / 0.17;
-  /* ✦ Theme/Radio button/Unchecked/Active/default border/Harness Theme/Light */
-  --figma___radio-button-unchecked-disabled-background: 0 0% 0% / 0.05;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/background/Harness Theme/Light */
-  --figma___radio-button-unchecked-disabled-border: 0 0% 0% / 0.13;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/border/Harness Theme/Light */
-  --figma___radio-button-border: 0 0% 0% / 0.05;
-  /* ✦ Theme/Radio button/border/Harness Theme/Light */
-  --figma___secondary-crimson-crimson-1: 340 100% 99% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 1/Harness Theme/Light */
-  --figma___secondary-crimson-crimson-10: 332 63% 24% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 10/Harness Theme/Light */
-  --figma___secondary-crimson-crimson-2: 330 100% 98% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 2/Harness Theme/Light */
-  --figma___secondary-crimson-crimson-3: 332 88% 97% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 3/Harness Theme/Light */
-  --figma___secondary-crimson-crimson-4: 331 79% 94% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 4/Harness Theme/Light */
-  --figma___secondary-crimson-crimson-5: 333 73% 91% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 5/Harness Theme/Light */
-  --figma___secondary-crimson-crimson-6: 333 68% 87% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 6/Harness Theme/Light */
-  --figma___secondary-crimson-crimson-7: 336 80% 58% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 7/Harness Theme/Light */
-  --figma___secondary-crimson-crimson-8: 336 71% 53% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 8/Harness Theme/Light */
-  --figma___secondary-crimson-crimson-9: 336 75% 45% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 9/Harness Theme/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-1: 340 100% 51% / 0.01;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Theme/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-10: 336 100% 38% / 0.89;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Theme/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-11: 332 100% 16% / 0.91;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Theme/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-2: 330 100% 51% / 0.03;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Theme/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-3: 332 100% 51% / 0.03;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Theme/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-4: 331 100% 44% / 0.1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Theme/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-5: 333 100% 42% / 0.15;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Theme/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-6: 333 99% 41% / 0.22;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Theme/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-8: 336 100% 44% / 0.76;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Theme/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-9: 336 100% 42% / 0.81;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Theme/Light */
-  --figma___secondary-lime-1: 80 43% 99% / 1;
-  /* ✦ Theme/Secondary/Lime/1/Harness Theme/Light */
-  --figma___secondary-lime-2: 85 67% 96% / 1;
-  /* ✦ Theme/Secondary/Lime/2/Harness Theme/Light */
-  --figma___secondary-lime-3: 84 76% 92% / 1;
-  /* ✦ Theme/Secondary/Lime/3/Harness Theme/Light */
-  --figma___secondary-lime-4: 83 71% 86% / 1;
-  /* ✦ Theme/Secondary/Lime/4/Harness Theme/Light */
-  --figma___secondary-lime-5: 83 63% 81% / 1;
-  /* ✦ Theme/Secondary/Lime/5/Harness Theme/Light */
-  --figma___secondary-lime-6: 81 51% 74% / 1;
-  /* ✦ Theme/Secondary/Lime/6/Harness Theme/Light */
-  --figma___secondary-lime-7: 81 80% 66% / 1;
-  /* ✦ Theme/Secondary/Lime/7/Harness Theme/Light */
-  --figma___secondary-lime-8: 81 75% 60% / 1;
-  /* ✦ Theme/Secondary/Lime/8/Harness Theme/Light */
-  --figma___secondary-lime-9: 75 41% 29% / 1;
-  /* ✦ Theme/Secondary/Lime/9/Harness Theme/Light */
-  --figma___secondary-lime-10: 75 39% 18% / 1;
-  /* ✦ Theme/Secondary/Lime/10/Harness Theme/Light */
-  --figma___secondary-lime-alpha-1: 80 94% 31% / 0.02;
-  /* ✦ Theme/Secondary/Lime Alpha/1/Harness Theme/Light */
-  --figma___secondary-lime-alpha-2: 85 99% 40% / 0.06;
-  /* ✦ Theme/Secondary/Lime Alpha/2/Harness Theme/Light */
-  --figma___secondary-lime-alpha-3: 84 99% 44% / 0.15;
-  /* ✦ Theme/Secondary/Lime Alpha/3/Harness Theme/Light */
-  --figma___secondary-lime-alpha-4: 83 99% 42% / 0.23;
-  /* ✦ Theme/Secondary/Lime Alpha/4/Harness Theme/Light */
-  --figma___secondary-lime-alpha-5: 83 100% 39% / 0.31;
-  /* ✦ Theme/Secondary/Lime Alpha/5/Harness Theme/Light */
-  --figma___secondary-lime-alpha-6: 81 100% 34% / 0.4;
-  /* ✦ Theme/Secondary/Lime Alpha/6/Harness Theme/Light */
-  --figma___secondary-lime-alpha-7: 81 100% 45% / 0.61;
-  /* ✦ Theme/Secondary/Lime Alpha/7/Harness Theme/Light */
-  --figma___secondary-lime-alpha-8: 81 100% 43% / 0.7;
-  /* ✦ Theme/Secondary/Lime Alpha/8/Harness Theme/Light */
-  --figma___secondary-lime-alpha-9: 75 100% 14% / 0.83;
-  /* ✦ Theme/Secondary/Lime Alpha/9/Harness Theme/Light */
-  --figma___secondary-lime-alpha-10: 76 100% 8% / 0.89;
-  /* ✦ Theme/Secondary/Lime Alpha/10/Harness Theme/Light */
-  --figma___secondary-purple-1: 300 50% 99% / 1;
-  /* ✦ Theme/Secondary/Purple/1/Harness Theme/Light */
-  --figma___secondary-purple-2: 276 100% 99% / 1;
-  /* ✦ Theme/Secondary/Purple/2/Harness Theme/Light */
-  --figma___secondary-purple-3: 277 87% 97% / 1;
-  /* ✦ Theme/Secondary/Purple/3/Harness Theme/Light */
-  --figma___secondary-purple-4: 274 78% 95% / 1;
-  /* ✦ Theme/Secondary/Purple/4/Harness Theme/Light */
-  --figma___secondary-purple-5: 276 71% 92% / 1;
-  /* ✦ Theme/Secondary/Purple/5/Harness Theme/Light */
-  --figma___secondary-purple-6: 274 65% 88% / 1;
-  /* ✦ Theme/Secondary/Purple/6/Harness Theme/Light */
-  --figma___secondary-purple-7: 272 51% 54% / 1;
-  /* ✦ Theme/Secondary/Purple/7/Harness Theme/Light */
-  --figma___secondary-purple-8: 272 47% 50% / 1;
-  /* ✦ Theme/Secondary/Purple/8/Harness Theme/Light */
-  --figma___secondary-purple-9: 272 50% 46% / 1;
-  /* ✦ Theme/Secondary/Purple/9/Harness Theme/Light */
-  --figma___secondary-purple-10: 270 50% 25% / 1;
-  /* ✦ Theme/Secondary/Purple/10/Harness Theme/Light */
-  --figma___secondary-purple-alpha-1: 300 94% 35% / 0.01;
-  /* ✦ Theme/Secondary/Purple Alpha/1/Harness Theme/Light */
-  --figma___secondary-purple-alpha-2: 276 100% 51% / 0.02;
-  /* ✦ Theme/Secondary/Purple Alpha/2/Harness Theme/Light */
-  --figma___secondary-purple-alpha-3: 277 100% 46% / 0.05;
-  /* ✦ Theme/Secondary/Purple Alpha/3/Harness Theme/Light */
-  --figma___secondary-purple-alpha-4: 274 98% 44% / 0.09;
-  /* ✦ Theme/Secondary/Purple Alpha/4/Harness Theme/Light */
-  --figma___secondary-purple-alpha-5: 276 99% 42% / 0.14;
-  /* ✦ Theme/Secondary/Purple Alpha/5/Harness Theme/Light */
-  --figma___secondary-purple-alpha-6: 275 100% 39% / 0.2;
-  /* ✦ Theme/Secondary/Purple Alpha/6/Harness Theme/Light */
-  --figma___secondary-purple-alpha-7: 272 100% 34% / 0.69;
-  /* ✦ Theme/Secondary/Purple Alpha/7/Harness Theme/Light */
-  --figma___secondary-purple-alpha-8: 272 100% 32% / 0.73;
-  /* ✦ Theme/Secondary/Purple Alpha/8/Harness Theme/Light */
-  --figma___secondary-purple-alpha-9: 273 100% 30% / 0.77;
-  /* ✦ Theme/Secondary/Purple Alpha/9/Harness Theme/Light */
-  --figma___secondary-purple-alpha-10: 270 100% 14% / 0.88;
-  /* ✦ Theme/Secondary/Purple Alpha/10/Harness Theme/Light */
-  --figma___secondary-teal-1: 165 67% 99% / 1;
-  /* ✦ Theme/Secondary/Teal/1/Harness Theme/Light */
-  --figma___secondary-teal-2: 169 65% 97% / 1;
-  /* ✦ Theme/Secondary/Teal/2/Harness Theme/Light */
-  --figma___secondary-teal-3: 167 60% 94% / 1;
-  /* ✦ Theme/Secondary/Teal/3/Harness Theme/Light */
-  --figma___secondary-teal-4: 168 52% 90% / 1;
-  /* ✦ Theme/Secondary/Teal/4/Harness Theme/Light */
-  --figma___secondary-teal-5: 170 47% 85% / 1;
-  /* ✦ Theme/Secondary/Teal/5/Harness Theme/Light */
-  --figma___secondary-teal-6: 170 43% 78% / 1;
-  /* ✦ Theme/Secondary/Teal/6/Harness Theme/Light */
-  --figma___secondary-teal-7: 173 80% 36% / 1;
-  /* ✦ Theme/Secondary/Teal/7/Harness Theme/Light */
-  --figma___secondary-teal-8: 173 83% 33% / 1;
-  /* ✦ Theme/Secondary/Teal/8/Harness Theme/Light */
-  --figma___secondary-teal-9: 174 91% 25% / 1;
-  /* ✦ Theme/Secondary/Teal/9/Harness Theme/Light */
-  --figma___secondary-teal-10: 174 65% 15% / 1;
-  /* ✦ Theme/Secondary/Teal/10/Harness Theme/Light */
-  --figma___secondary-teal-alpha-1: 165 95% 41% / 0.02;
-  /* ✦ Theme/Secondary/Teal Alpha/1/Harness Theme/Light */
-  --figma___secondary-teal-alpha-2: 169 99% 39% / 0.05;
-  /* ✦ Theme/Secondary/Teal Alpha/2/Harness Theme/Light */
-  --figma___secondary-teal-alpha-3: 167 98% 38% / 0.09;
-  /* ✦ Theme/Secondary/Teal Alpha/3/Harness Theme/Light */
-  --figma___secondary-teal-alpha-4: 168 98% 35% / 0.15;
-  /* ✦ Theme/Secondary/Teal Alpha/4/Harness Theme/Light */
-  --figma___secondary-teal-alpha-5: 170 100% 32% / 0.22;
-  /* ✦ Theme/Secondary/Teal Alpha/5/Harness Theme/Light */
-  --figma___secondary-teal-alpha-6: 170 100% 30% / 0.31;
-  /* ✦ Theme/Secondary/Teal Alpha/6/Harness Theme/Light */
-  --figma___secondary-teal-alpha-7: 173 100% 31% / 0.93;
-  /* ✦ Theme/Secondary/Teal Alpha/7/Harness Theme/Light */
-  --figma___secondary-teal-alpha-8: 173 100% 29% / 0.95;
-  /* ✦ Theme/Secondary/Teal Alpha/8/Harness Theme/Light */
-  --figma___secondary-teal-alpha-9: 174 100% 23% / 0.98;
-  /* ✦ Theme/Secondary/Teal Alpha/9/Harness Theme/Light */
-  --figma___secondary-teal-alpha-10: 174 100% 10% / 0.95;
-  /* ✦ Theme/Secondary/Teal Alpha/10/Harness Theme/Light */
-  --figma___shadow-shadow-button-1: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow - button/1/Harness Theme/Light */
-  --figma___shadow-shadow-button-2: 0 0% 100% / 0.31;
-  /* ✦ Theme/Shadow/Shadow - button/2/Harness Theme/Light */
-  --figma___shadow-shadow-button-3: 0 0% 100% / 0.46;
-  /* ✦ Theme/Shadow/Shadow - button/3/Harness Theme/Light */
-  --figma___shadow-shadow-button-4: 0 0% 100% / 0;
-  /* ✦ Theme/Shadow/Shadow - button/4/Harness Theme/Light */
-  --figma___shadow-shadow-1-1: 0 0% 0% / 0.13;
-  /* ✦ Theme/Shadow/Shadow 1/1/Harness Theme/Light */
-  --figma___shadow-shadow-2-1: 0 0% 0% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 2/1/Harness Theme/Light */
-  --figma___shadow-shadow-2-2: 240 100% 12% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 2/2/Harness Theme/Light */
-  --figma___shadow-shadow-2-3: 240 100% 12% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 2/3/Harness Theme/Light */
-  --figma___shadow-shadow-3-1: 0 0% 0% / 0.08;
-  /* ✦ Theme/Shadow/Shadow 3/1/Harness Theme/Light */
-  --figma___shadow-shadow-3-2: 0 0% 0% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 3/2/Harness Theme/Light */
-  --figma___shadow-shadow-3-3: 240 100% 12% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 3/3/Harness Theme/Light */
-  --figma___shadow-shadow-4-1: 0 0% 0% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 4/1/Harness Theme/Light */
-  --figma___shadow-shadow-4-2: 240 100% 12% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 4/2/Harness Theme/Light */
-  --figma___shadow-shadow-5-1: 0 0% 0% / 0.13;
-  /* ✦ Theme/Shadow/Shadow 5/1/Harness Theme/Light */
-  --figma___shadow-shadow-5-2: 240 96% 9% / 0.05;
-  /* ✦ Theme/Shadow/Shadow 5/2/Harness Theme/Light */
-  --figma___shadow-shadow-6-1: 233 96% 9% / 0.17;
-  /* ✦ Theme/Shadow/Shadow 6/1/Harness Theme/Light */
-  --figma___shadow-shadow-6-2: 233 96% 9% / 0.17;
-  /* ✦ Theme/Shadow/Shadow 6/2/Harness Theme/Light */
-  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
-  /* ✦ Theme/Shadow/Shadow-button-active/1/Harness Theme/Light */
-  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
-  /* ✦ Theme/Shadow/Shadow-button-active/2/Harness Theme/Light */
-  --figma___shadow-shadow-button-active-3: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow-button-active/3/Harness Theme/Light */
-  --figma___shadow-shadow-button-active-4: 0 0% 0% / 0.08;
-  /* ✦ Theme/Shadow/Shadow-button-active/4/Harness Theme/Light */
-  --figma___side-nav-container-nav-background: 0 0% 93% / 1;
-  /* ✦ Theme/Side nav/Container/Nav-background/Harness Theme/Light */
-  --figma___side-nav-container-nav-border: 0 0% 100% / 0;
-  /* ✦ Theme/Side nav/Container/Nav-border/Harness Theme/Light */
-  --figma___side-nav-module-logo-text: 0 0% 13% / 1;
-  /* ✦ Theme/Side nav/Module Logo Text/Harness Theme/Light */
-  --figma___side-nav-nav-item-default-icon: 0 0% 0% / 0.5;
-  /* ✦ Theme/Side nav/Nav-item/Default/Icon/Harness Theme/Light */
-  --figma___side-nav-nav-item-default-text: 0 0% 39% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Default/Text/Harness Theme/Light */
-  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
-  /* ✦ Theme/Side nav/Nav-item/Default/default/Harness Theme/Light */
-  --figma___side-nav-nav-item-hover-background: 0 0% 95% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Background/Harness Theme/Light */
-  --figma___side-nav-nav-item-hover-icon: 0 0% 39% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/Harness Theme/Light */
-  --figma___side-nav-nav-item-hover-text: 0 0% 39% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Text/Harness Theme/Light */
-  --figma___side-nav-nav-item-selected-background: 0 0% 95% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Background/Harness Theme/Light */
-  --figma___side-nav-nav-item-selected-icon: 0 0% 13% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/Harness Theme/Light */
-  --figma___side-nav-nav-item-selected-text: 0 0% 13% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Text/Harness Theme/Light */
-  --figma___side-nav-profile-role: 0 0% 0% / 0.5;
-  /* ✦ Theme/Side nav/Profile/Role/Harness Theme/Light */
-  --figma___side-nav-profile-text: 0 0% 13% / 1;
-  /* ✦ Theme/Side nav/Profile/Text/Harness Theme/Light */
-  --figma___side-nav-scope-selector-default-border: 0 0% 0% / 0.08;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Border/Harness Theme/Light */
-  --figma___side-nav-scope-selector-default-main-text-icon: 0 0% 13% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/Harness Theme/Light */
-  --figma___side-nav-scope-selector-default-scope-name: 0 0% 0% / 0.5;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/Harness Theme/Light */
-  --figma___side-nav-scope-selector-default-default: 0 0% 100% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/default/Harness Theme/Light */
-  --figma___side-nav-scope-selector-hover-border: 211 100% 39% / 0.96;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/Harness Theme/Light */
-  --figma___side-nav-scope-selector-hover-main-text-icon: 0 0% 13% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/Harness Theme/Light */
-  --figma___side-nav-scope-selector-hover-scope-name: 0 0% 0% / 0.5;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/Harness Theme/Light */
-  --figma___side-nav-scope-selector-hover-default: 0 0% 100% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/default/Harness Theme/Light */
-  --figma___side-nav-scope-selector-selected-border: 211 100% 39% / 0.96;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/Harness Theme/Light */
-  --figma___side-nav-scope-selector-selected-main-text-icon: 0 0% 13% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/Harness Theme/Light */
-  --figma___side-nav-scope-selector-selected-scope-name: 0 0% 0% / 0.5;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/Harness Theme/Light */
-  --figma___side-nav-scope-selector-selected-background: 0 0% 100% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/background/Harness Theme/Light */
-  --figma___side-nav-separator: 0 0% 0% / 0.08;
-  /* ✦ Theme/Side nav/Separator/Harness Theme/Light */
-  --figma___status-colors-error-1: 0 100% 99% / 1;
-  /* ✦ Theme/Status colors/Error/1/Harness Theme/Light */
-  --figma___status-colors-error-2: 0 100% 98% / 1;
-  /* ✦ Theme/Status colors/Error/2/Harness Theme/Light */
-  --figma___status-colors-error-3: 0 100% 97% / 1;
-  /* ✦ Theme/Status colors/Error/3/Harness Theme/Light */
-  --figma___status-colors-error-4: 0 100% 95% / 1;
-  /* ✦ Theme/Status colors/Error/4/Harness Theme/Light */
-  --figma___status-colors-error-5: 0 90% 92% / 1;
-  /* ✦ Theme/Status colors/Error/5/Harness Theme/Light */
-  --figma___status-colors-error-6: 0 81% 88% / 1;
-  /* ✦ Theme/Status colors/Error/6/Harness Theme/Light */
-  --figma___status-colors-error-7: 358 75% 59% / 1;
-  /* ✦ Theme/Status colors/Error/7/Harness Theme/Light */
-  --figma___status-colors-error-8: 358 67% 55% / 1;
-  /* ✦ Theme/Status colors/Error/8/Harness Theme/Light */
-  --figma___status-colors-error-9: 358 65% 47% / 1;
-  /* ✦ Theme/Status colors/Error/9/Harness Theme/Light */
-  --figma___status-colors-error-10: 351 63% 24% / 1;
-  /* ✦ Theme/Status colors/Error/10/Harness Theme/Light */
-  --figma___status-colors-error-alpha-1: 0 100% 51% / 0.01;
-  /* ✦ Theme/Status colors/Error Alpha/1/Harness Theme/Light */
-  --figma___status-colors-error-alpha-2: 0 100% 51% / 0.03;
-  /* ✦ Theme/Status colors/Error Alpha/2/Harness Theme/Light */
-  --figma___status-colors-error-alpha-3: 0 100% 50% / 0.06;
-  /* ✦ Theme/Status colors/Error Alpha/3/Harness Theme/Light */
-  --figma___status-colors-error-alpha-4: 0 100% 50% / 0.1;
-  /* ✦ Theme/Status colors/Error Alpha/4/Harness Theme/Light */
-  --figma___status-colors-error-alpha-5: 0 100% 47% / 0.15;
-  /* ✦ Theme/Status colors/Error Alpha/5/Harness Theme/Light */
-  --figma___status-colors-error-alpha-6: 0 99% 45% / 0.22;
-  /* ✦ Theme/Status colors/Error Alpha/6/Harness Theme/Light */
-  --figma___status-colors-error-alpha-7: 358 100% 43% / 0.72;
-  /* ✦ Theme/Status colors/Error Alpha/7/Harness Theme/Light */
-  --figma___status-colors-error-alpha-8: 358 100% 40% / 0.76;
-  /* ✦ Theme/Status colors/Error Alpha/8/Harness Theme/Light */
-  --figma___status-colors-error-alpha-9: 358 100% 37% / 0.84;
-  /* ✦ Theme/Status colors/Error Alpha/9/Harness Theme/Light */
-  --figma___status-colors-error-alpha-10: 351 100% 17% / 0.91;
-  /* ✦ Theme/Status colors/Error Alpha/10/Harness Theme/Light */
-  --figma___status-colors-info-1: 210 100% 99% / 1;
-  /* ✦ Theme/Status colors/Info/1/Harness Theme/Light */
-  --figma___status-colors-info-2: 210 100% 98% / 1;
-  /* ✦ Theme/Status colors/Info/2/Harness Theme/Light */
-  --figma___status-colors-info-3: 210 100% 96% / 1;
-  /* ✦ Theme/Status colors/Info/3/Harness Theme/Light */
-  --figma___status-colors-info-4: 210 100% 94% / 1;
-  /* ✦ Theme/Status colors/Info/4/Harness Theme/Light */
-  --figma___status-colors-info-5: 209 96% 90% / 1;
-  /* ✦ Theme/Status colors/Info/5/Harness Theme/Light */
-  --figma___status-colors-info-6: 209 82% 85% / 1;
-  /* ✦ Theme/Status colors/Info/6/Harness Theme/Light */
-  --figma___status-colors-info-7: 214 73% 51% / 1;
-  /* ✦ Theme/Status colors/Info/7/Harness Theme/Light */
-  --figma___status-colors-info-8: 208 93% 47% / 1;
-  /* ✦ Theme/Status colors/Info/8/Harness Theme/Light */
-  --figma___status-colors-info-9: 211 90% 42% / 1;
-  /* ✦ Theme/Status colors/Info/9/Harness Theme/Light */
-  --figma___status-colors-info-10: 216 71% 23% / 1;
-  /* ✦ Theme/Status colors/Info/10/Harness Theme/Light */
-  --figma___status-colors-info-alpha-1: 210 100% 51% / 0.02;
-  /* ✦ Theme/Status colors/Info Alpha/1/Harness Theme/Light */
-  --figma___status-colors-info-alpha-2: 210 100% 51% / 0.04;
-  /* ✦ Theme/Status colors/Info Alpha/2/Harness Theme/Light */
-  --figma___status-colors-info-alpha-3: 210 100% 50% / 0.07;
-  /* ✦ Theme/Status colors/Info Alpha/3/Harness Theme/Light */
-  --figma___status-colors-info-alpha-4: 210 99% 49% / 0.19;
-  /* ✦ Theme/Status colors/Info Alpha/4/Harness Theme/Light */
-  --figma___status-colors-info-alpha-5: 209 99% 49% / 0.19;
-  /* ✦ Theme/Status colors/Info Alpha/5/Harness Theme/Light */
-  --figma___status-colors-info-alpha-6: 209 99% 45% / 0.28;
-  /* ✦ Theme/Status colors/Info Alpha/6/Harness Theme/Light */
-  --figma___status-colors-info-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/7/Harness Theme/Light */
-  --figma___status-colors-info-alpha-8: 208 100% 46% / 0.97;
-  /* ✦ Theme/Status colors/Info Alpha/8/Harness Theme/Light */
-  --figma___status-colors-info-alpha-9: 211 100% 39% / 0.96;
-  /* ✦ Theme/Status colors/Info Alpha/9/Harness Theme/Light */
-  --figma___status-colors-info-alpha-10: 216 100% 17% / 0.93;
-  /* ✦ Theme/Status colors/Info Alpha/10/Harness Theme/Light */
-  --figma___status-colors-success-1: 140 60% 99% / 1;
-  /* ✦ Theme/Status colors/Success/1/Harness Theme/Light */
-  --figma___status-colors-success-2: 138 63% 97% / 1;
-  /* ✦ Theme/Status colors/Success/2/Harness Theme/Light */
-  --figma___status-colors-success-3: 139 57% 95% / 1;
-  /* ✦ Theme/Status colors/Success/3/Harness Theme/Light */
-  --figma___status-colors-success-4: 139 48% 91% / 1;
-  /* ✦ Theme/Status colors/Success/4/Harness Theme/Light */
-  --figma___status-colors-success-5: 141 44% 86% / 1;
-  /* ✦ Theme/Status colors/Success/5/Harness Theme/Light */
-  --figma___status-colors-success-6: 142 40% 79% / 1;
-  /* ✦ Theme/Status colors/Success/6/Harness Theme/Light */
-  --figma___status-colors-success-7: 142 72% 29% / 1;
-  /* ✦ Theme/Status colors/Success/7/Harness Theme/Light */
-  --figma___status-colors-success-8: 152 57% 38% / 1;
-  /* ✦ Theme/Status colors/Success/8/Harness Theme/Light */
-  --figma___status-colors-success-9: 153 67% 28% / 1;
-  /* ✦ Theme/Status colors/Success/9/Harness Theme/Light */
-  --figma___status-colors-success-10: 155 40% 16% / 1;
-  /* ✦ Theme/Status colors/Success/10/Harness Theme/Light */
-  --figma___status-colors-success-alpha-1: 140 95% 39% / 0.02;
-  /* ✦ Theme/Status colors/Success Alpha/1/Harness Theme/Light */
-  --figma___status-colors-success-alpha-2: 139 98% 37% / 0.09;
-  /* ✦ Theme/Status colors/Success Alpha/2/Harness Theme/Light */
-  --figma___status-colors-success-alpha-3: 139 98% 37% / 0.09;
-  /* ✦ Theme/Status colors/Success Alpha/3/Harness Theme/Light */
-  --figma___status-colors-success-alpha-4: 139 99% 33% / 0.13;
-  /* ✦ Theme/Status colors/Success Alpha/4/Harness Theme/Light */
-  --figma___status-colors-success-alpha-5: 141 100% 30% / 0.2;
-  /* ✦ Theme/Status colors/Success Alpha/5/Harness Theme/Light */
-  --figma___status-colors-success-alpha-6: 142 99% 29% / 0.29;
-  /* ✦ Theme/Status colors/Success Alpha/6/Harness Theme/Light */
-  --figma___status-colors-success-alpha-7: 151 100% 28% / 0.81;
-  /* ✦ Theme/Status colors/Success Alpha/7/Harness Theme/Light */
-  --figma___status-colors-success-alpha-8: 153 100% 26% / 0.84;
-  /* ✦ Theme/Status colors/Success Alpha/8/Harness Theme/Light */
-  --figma___status-colors-success-alpha-9: 153 100% 21% / 0.91;
-  /* ✦ Theme/Status colors/Success Alpha/9/Harness Theme/Light */
-  --figma___status-colors-success-alpha-10: 155 100% 7% / 0.9;
-  /* ✦ Theme/Status colors/Success Alpha/10/Harness Theme/Light */
-  --figma___status-colors-warning-1: 40 60% 99% / 1;
-  /* ✦ Theme/Status colors/Warning/1/Harness Theme/Light */
-  --figma___status-colors-warning-2: 40 100% 96% / 1;
-  /* ✦ Theme/Status colors/Warning/2/Harness Theme/Light */
-  --figma___status-colors-warning-3: 45 100% 91% / 1;
-  /* ✦ Theme/Status colors/Warning/3/Harness Theme/Light */
-  --figma___status-colors-warning-4: 44 100% 86% / 1;
-  /* ✦ Theme/Status colors/Warning/4/Harness Theme/Light */
-  --figma___status-colors-warning-5: 40 100% 82% / 1;
-  /* ✦ Theme/Status colors/Warning/5/Harness Theme/Light */
-  --figma___status-colors-warning-6: 39 84% 75% / 1;
-  /* ✦ Theme/Status colors/Warning/6/Harness Theme/Light */
-  --figma___status-colors-warning-7: 42 100% 62% / 1;
-  /* ✦ Theme/Status colors/Warning/7/Harness Theme/Light */
-  --figma___status-colors-warning-8: 42 100% 55% / 1;
-  /* ✦ Theme/Status colors/Warning/8/Harness Theme/Light */
-  --figma___status-colors-warning-9: 25 50% 38% / 1;
-  /* ✦ Theme/Status colors/Warning/9/Harness Theme/Light */
-  --figma___status-colors-warning-10: 24 40% 22% / 1;
-  /* ✦ Theme/Status colors/Warning/10/Harness Theme/Light */
-  --figma___status-colors-warning-alpha-1: 40 95% 39% / 0.02;
-  /* ✦ Theme/Status colors/Warning Alpha/1/Harness Theme/Light */
-  --figma___status-colors-warning-alpha-2: 40 100% 50% / 0.07;
-  /* ✦ Theme/Status colors/Warning Alpha/2/Harness Theme/Light */
-  --figma___status-colors-warning-alpha-3: 45 100% 50% / 0.19;
-  /* ✦ Theme/Status colors/Warning Alpha/3/Harness Theme/Light */
-  --figma___status-colors-warning-alpha-4: 44 100% 50% / 0.28;
-  /* ✦ Theme/Status colors/Warning Alpha/4/Harness Theme/Light */
-  --figma___status-colors-warning-alpha-5: 40 99% 50% / 0.37;
-  /* ✦ Theme/Status colors/Warning Alpha/5/Harness Theme/Light */
-  --figma___status-colors-warning-alpha-6: 39 100% 46% / 0.45;
-  /* ✦ Theme/Status colors/Warning Alpha/6/Harness Theme/Light */
-  --figma___status-colors-warning-alpha-7: 42 100% 50% / 0.76;
-  /* ✦ Theme/Status colors/Warning Alpha/7/Harness Theme/Light */
-  --figma___status-colors-warning-alpha-8: 42 100% 50% / 0.9;
-  /* ✦ Theme/Status colors/Warning Alpha/8/Harness Theme/Light */
-  --figma___status-colors-warning-alpha-9: 25 100% 24% / 0.81;
-  /* ✦ Theme/Status colors/Warning Alpha/9/Harness Theme/Light */
-  --figma___status-colors-warning-alpha-10: 24 100% 10% / 0.87;
-  /* ✦ Theme/Status colors/Warning Alpha/10/Harness Theme/Light */
-  --figma___switch-background: 0 0% 100% / 0.8;
-  /* ✦ Theme/Switch/Background/Harness Theme/Light */
-  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/Harness Theme/Light */
-  --figma___switch-checked-active-background: 214 73% 51% / 1;
-  /* ✦ Theme/Switch/Checked/Active/background/Harness Theme/Light */
-  --figma___switch-checked-active-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Checked/Active/border/Harness Theme/Light */
-  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/Harness Theme/Light */
-  --figma___switch-checked-default-default-background: 214 73% 51% / 1;
-  /* ✦ Theme/Switch/Checked/Default/default background/Harness Theme/Light */
-  --figma___switch-checked-default-default-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Checked/Default/default border/Harness Theme/Light */
-  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/Harness Theme/Light */
-  --figma___switch-checked-disabled-background: 206 100% 50% / 1;
-  /* ✦ Theme/Switch/Checked/Disabled/background/Harness Theme/Light */
-  --figma___switch-checked-disabled-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/border/Harness Theme/Light */
-  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/Harness Theme/Light */
-  --figma___switch-checked-hover-background: 208 93% 47% / 1;
-  /* ✦ Theme/Switch/Checked/Hover/background/Harness Theme/Light */
-  --figma___switch-checked-hover-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/border/Harness Theme/Light */
-  --figma___switch-paper: 0 0% 100% / 1;
-  /* ✦ Theme/Switch/Paper/Harness Theme/Light */
-  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/Harness Theme/Light */
-  --figma___switch-unchecked-active-background: 0 0% 0% / 0.11;
-  /* ✦ Theme/Switch/Unchecked/Active/background/Harness Theme/Light */
-  --figma___switch-unchecked-active-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Unchecked/Active/border/Harness Theme/Light */
-  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/Harness Theme/Light */
-  --figma___switch-unchecked-default-default-background: 240 100% 12% / 0.05;
-  /* ✦ Theme/Switch/Unchecked/Default/default background/Harness Theme/Light */
-  --figma___switch-unchecked-default-default-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Unchecked/Default/default border/Harness Theme/Light */
-  --figma___switch-unchecked-disabled-thumb-thumb-background: 0 0% 0% / 0.05;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/Harness Theme/Light */
-  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/Harness Theme/Light */
-  --figma___switch-unchecked-disabled-background: 0 0% 95% / 1;
-  /* ✦ Theme/Switch/Unchecked/Disabled/background/Harness Theme/Light */
-  --figma___switch-unchecked-disabled-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Unchecked/Disabled/border/Harness Theme/Light */
-  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/Harness Theme/Light */
-  --figma___switch-unchecked-hover-background: 240 93% 11% / 0.08;
-  /* ✦ Theme/Switch/Unchecked/Hover/background/Harness Theme/Light */
-  --figma___switch-unchecked-hover-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Unchecked/Hover/border/Harness Theme/Light */
-  --figma___switch-border: 0 0% 0% / 0.05;
-  /* ✦ Theme/Switch/border/Harness Theme/Light */
-  --figma___tabs-number-active-background: 0 0% 13% / 1;
-  /* ✦ Theme/Tabs/Number/Active/Background/Harness Theme/Light */
-  --figma___tabs-number-active-text: 0 0% 13% / 1;
-  /* ✦ Theme/Tabs/Number/Active/text/Harness Theme/Light */
-  --figma___tabs-number-default-hover-background: 0 0% 89% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/Background/Harness Theme/Light */
-  --figma___tabs-number-default-hover-text: 0 0% 13% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/text/Harness Theme/Light */
-  --figma___tabs-pills-active-active: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Active/Harness Theme/Light */
-  --figma___tabs-pills-active-text: 0 0% 13% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Text/Harness Theme/Light */
-  --figma___tabs-pills-active-border-grad-1: 0 0% 0% / 0.08;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 1/Harness Theme/Light */
-  --figma___tabs-pills-active-border-grad-2: 0 0% 0% / 0.08;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 2/Harness Theme/Light */
-  --figma___tabs-pills-backgrounds: 210 100% 51% / 0.02;
-  /* ✦ Theme/Tabs/Pills/Backgrounds/Harness Theme/Light */
-  --figma___tabs-pills-default-background: 230 100% 5% / 0;
-  /* ✦ Theme/Tabs/Pills/Default/Background/Harness Theme/Light */
-  --figma___tabs-pills-default-text: 0 0% 0% / 0.5;
-  /* ✦ Theme/Tabs/Pills/Default/Text/Harness Theme/Light */
-  --figma___tabs-pills-hover-background: 0 0% 92% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Background/Harness Theme/Light */
-  --figma___tabs-pills-hover-text: 0 0% 39% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Text/Harness Theme/Light */
-  --figma___tabs-pills-number-active-background: 0 0% 13% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/Background/Harness Theme/Light */
-  --figma___tabs-pills-number-active-text: 0 0% 99% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/text/Harness Theme/Light */
-  --figma___tabs-pills-border-grad-1: 0 0% 0% / 0.08;
-  /* ✦ Theme/Tabs/Pills/border grad 1/Harness Theme/Light */
-  --figma___tabs-pills-border-grad-2: 0 0% 0% / 0.08;
-  /* ✦ Theme/Tabs/Pills/border grad 2/Harness Theme/Light */
-  --figma___tabs-primary-active-text: 0 0% 13% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Text/Harness Theme/Light */
-  --figma___tabs-primary-active-underline: 206 82% 65% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Underline/Harness Theme/Light */
-  --figma___tabs-primary-border: 211 100% 39% / 0.96;
-  /* ✦ Theme/Tabs/Primary/Border/Harness Theme/Light */
-  --figma___tabs-primary-default-background: 230 100% 5% / 0;
-  /* ✦ Theme/Tabs/Primary/Default/Background/Harness Theme/Light */
-  --figma___tabs-primary-default-text: 0 0% 0% / 0.5;
-  /* ✦ Theme/Tabs/Primary/Default/Text/Harness Theme/Light */
-  --figma___tabs-primary-hover-background: 0 0% 0% / 0.08;
-  /* ✦ Theme/Tabs/Primary/Hover/Background/Harness Theme/Light */
-  --figma___tabs-primary-hover-text: 0 0% 13% / 1;
-  /* ✦ Theme/Tabs/Primary/Hover/Text/Harness Theme/Light */
-  --figma___tabs-primary-pills-pills: 214 73% 51% / 1;
-  /* ✦ Theme/Tabs/Primary/Pills/Pills/Harness Theme/Light */
-  --figma___text-disabled: 0 0% 0% / 0.45;
-  /* ✦ Theme/Text/Disabled/Harness Theme/Light */
-  --figma___text-links: 211 90% 42% / 1;
-  /* ✦ Theme/Text/Links/Harness Theme/Light */
-  --figma___text-secondary: 0 0% 39% / 1;
-  /* ✦ Theme/Text/Secondary/Harness Theme/Light */
-  --figma___text-tertiary: 0 0% 0% / 0.5;
-  /* ✦ Theme/Text/Tertiary/Harness Theme/Light */
-  --figma___text-primary: 0 0% 13% / 1;
-  /* ✦ Theme/Text/primary/Harness Theme/Light */
-  --figma___textfield-assistive-text-primary: 0 0% 0% / 0.5;
-  /* ✦ Theme/Textfield/Assistive Text/Primary/Harness Theme/Light */
-  --figma___textfield-background: 0 0% 100% / 1;
-  /* ✦ Theme/Textfield/Background/Harness Theme/Light */
-  --figma___textfield-input-field-background: 0 0% 100% / 1;
-  /* ✦ Theme/Textfield/Input Field/Background/Harness Theme/Light */
-  --figma___textfield-input-field-default: 0 0% 0% / 0.08;
-  /* ✦ Theme/Textfield/Input Field/Default/Harness Theme/Light */
-  --figma___textfield-input-field-error: 358 75% 59% / 1;
-  /* ✦ Theme/Textfield/Input Field/Error/Harness Theme/Light */
-  --figma___textfield-input-field-hover: 208 93% 47% / 1;
-  /* ✦ Theme/Textfield/Input Field/Hover/Harness Theme/Light */
-  --figma___textfield-label-info-icon: 211 100% 39% / 0.96;
-  /* ✦ Theme/Textfield/Label/Info Icon/Harness Theme/Light */
-  --figma___textfield-label-link: 211 100% 39% / 0.96;
-  /* ✦ Theme/Textfield/Label/Link/Harness Theme/Light */
-  --figma___textfield-label-main: 0 0% 39% / 1;
-  /* ✦ Theme/Textfield/Label/Main/Harness Theme/Light */
-  --figma___textfield-label-optional: 0 0% 0% / 0.5;
-  /* ✦ Theme/Textfield/Label/Optional/Harness Theme/Light */
-  --figma___textfield-pin-soft-background: 210 100% 98% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/Background/Harness Theme/Light */
-  --figma___textfield-pin-soft-border: 209 96% 90% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/border/Harness Theme/Light */
-  --figma___textfield-pin-soft-pin: 211 100% 39% / 0.96;
-  /* ✦ Theme/Textfield/Pin/Soft/pin/Harness Theme/Light */
-  --figma___textfield-pin-surface-background: 0 0% 98% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/Background/Harness Theme/Light */
-  --figma___textfield-pin-surface-border: 0 0% 89% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/border/Harness Theme/Light */
-  --figma___textfield-pin-surface-pin: 211 100% 39% / 0.96;
-  /* ✦ Theme/Textfield/Pin/Surface/pin/Harness Theme/Light */
-  --figma___tooltip-background: 240 13% 95% / 1;
-  /* ✦ Theme/Tooltip/Background/Harness Theme/Light */
-  --figma___tooltip-body-text: 0 0% 39% / 1;
-  /* ✦ Theme/Tooltip/Body Text/Harness Theme/Light */
-  --figma___tooltip-dismissable-icon: 0 0% 39% / 1;
-  /* ✦ Theme/Tooltip/Dismissable icon/Harness Theme/Light */
-  --figma___tooltip-tooltip-title: 0 0% 13% / 1;
-  /* ✦ Theme/Tooltip/Tooltip Title/Harness Theme/Light */
-  --figma___badges-solid-amber-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Amber/text/Harness Theme/Light */
-  --figma___badges-solid-blue-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Blue/text/Harness Theme/Light */
-  --figma___badges-solid-bronze-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Bronze/text/Harness Theme/Light */
-  --figma___badges-solid-brown-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Brown/text/Harness Theme/Light */
-  --figma___badges-solid-crimson-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Crimson/text/Harness Theme/Light */
-  --figma___badges-solid-cyan-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Cyan/text/Harness Theme/Light */
-  --figma___badges-solid-gold-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Gold/text/Harness Theme/Light */
-  --figma___badges-solid-grass-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Grass/text/Harness Theme/Light */
-  --figma___badges-solid-green-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Green/text/Harness Theme/Light */
-  --figma___badges-solid-indigo-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Indigo/text/Harness Theme/Light */
-  --figma___badges-solid-iris-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Iris/text/Harness Theme/Light */
-  --figma___badges-solid-jade-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Jade/text/Harness Theme/Light */
-  --figma___badges-solid-lime-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Lime/text/Harness Theme/Light */
-  --figma___badges-solid-mint-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Mint/text/Harness Theme/Light */
-  --figma___badges-solid-orange-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Orange/text/Harness Theme/Light */
-  --figma___badges-solid-pink-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Pink/text/Harness Theme/Light */
-  --figma___badges-solid-plum-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Plum/text/Harness Theme/Light */
-  --figma___badges-solid-purple-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Purple/text/Harness Theme/Light */
-  --figma___badges-solid-red-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Red/text/Harness Theme/Light */
-  --figma___badges-solid-ruby-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Ruby/text/Harness Theme/Light */
-  --figma___badges-solid-sky-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Sky/text/Harness Theme/Light */
-  --figma___badges-solid-success-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Success/text/Harness Theme/Light */
-  --figma___badges-solid-teal-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Teal/text/Harness Theme/Light */
-  --figma___badges-solid-violet-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Violet/text/Harness Theme/Light */
-  --figma___badges-solid-yellow-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Yellow/text/Harness Theme/Light */
-  --figma___badges-solid-accent-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/accent/text/Harness Theme/Light */
-  --figma___badges-solid-info-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/info/text/Harness Theme/Light */
-  --figma___badges-solid-warning-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/warning/text/Harness Theme/Light */
-  --figma___button-solid-accent-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Accent/Text-primary/Harness Theme/Light */
-  --figma___button-solid-error-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Error/Text-primary/Harness Theme/Light */
-  --figma___button-solid-neutral-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Neutral/Text-primary/Harness Theme/Light */
-  --figma___button-solid-success-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Success/Text-primary/Harness Theme/Light */
-  --figma___calendar-selected-date-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Calendar/Selected Date/Text/Harness Theme/Light */
-  --figma___checkbox-surface-checked-active-check: var(--figma___default-colors-white);
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/Harness Theme/Light */
-  --figma___default-colors-white-to-dark: var(--figma___default-colors-white);
-  /* ✦ Theme/Default colors/white-to-dark/Harness Theme/Light */
-  --figma___filter-default: var(--figma___default-colors-white);
-  /* ✦ Theme/Filter/Default/Harness Theme/Light */
-  --figma___pagination-active-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Pagination/Active/Text/Harness Theme/Light */
-  --figma___radio-button-checked-active-dot: var(--figma___default-colors-white);
-  /* ✦ Theme/Radio button/Checked/Active/Dot/Harness Theme/Light */
-  --figma___switch-checked-active-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/Harness Theme/Light */
-  --figma___switch-checked-default-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/Harness Theme/Light */
-  --figma___switch-checked-disabled-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/Harness Theme/Light */
-  --figma___switch-checked-hover-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/Harness Theme/Light */
-  --figma___switch-unchecked-active-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/Harness Theme/Light */
-  --figma___switch-unchecked-default-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/Harness Theme/Light */
-  --figma___switch-unchecked-hover-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/Harness Theme/Light */
+  --figma___colors-alerts-status-error-1: 0 100% 99% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/1/Harness Theme/Light */
+  --figma___colors-alerts-status-error-2: 0 100% 98% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/2/Harness Theme/Light */
+  --figma___colors-alerts-status-error-3: 0 100% 97% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/3/Harness Theme/Light */
+  --figma___colors-alerts-status-error-4: 0 100% 95% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/4/Harness Theme/Light */
+  --figma___colors-alerts-status-error-5: 0 90% 92% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/5/Harness Theme/Light */
+  --figma___colors-alerts-status-error-6: 359 74% 82% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/6/Harness Theme/Light */
+  --figma___colors-alerts-status-error-7: 358 75% 59% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/7/Harness Theme/Light */
+  --figma___colors-alerts-status-error-8: 358 67% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/8/Harness Theme/Light */
+  --figma___colors-alerts-status-error-9: 358 65% 47% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/9/Harness Theme/Light */
+  --figma___colors-alerts-status-error-10: 351 63% 24% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/10/Harness Theme/Light */
+  --figma___colors-alerts-status-error-alpha-1: 0 100% 51% / 0.01; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/1/Harness Theme/Light */
+  --figma___colors-alerts-status-error-alpha-2: 0 100% 51% / 0.03; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/2/Harness Theme/Light */
+  --figma___colors-alerts-status-error-alpha-3: 0 100% 50% / 0.06; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/3/Harness Theme/Light */
+  --figma___colors-alerts-status-error-alpha-4: 0 100% 50% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/4/Harness Theme/Light */
+  --figma___colors-alerts-status-error-alpha-5: 0 100% 47% / 0.15; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/5/Harness Theme/Light */
+  --figma___colors-alerts-status-error-alpha-6: 359 100% 43% / 0.32; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/6/Harness Theme/Light */
+  --figma___colors-alerts-status-error-alpha-7: 358 100% 43% / 0.72; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/7/Harness Theme/Light */
+  --figma___colors-alerts-status-error-alpha-8: 358 100% 40% / 0.76; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/8/Harness Theme/Light */
+  --figma___colors-alerts-status-error-alpha-9: 358 100% 37% / 0.84; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/9/Harness Theme/Light */
+  --figma___colors-alerts-status-error-alpha-10: 351 100% 17% / 0.91; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/10/Harness Theme/Light */
+  --figma___colors-alerts-status-info-1: 240 33% 99% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/1/Harness Theme/Light */
+  --figma___colors-alerts-status-info-2: 223 100% 99% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/2/Harness Theme/Light */
+  --figma___colors-alerts-status-info-3: 224 100% 97% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/3/Harness Theme/Light */
+  --figma___colors-alerts-status-info-4: 222 92% 95% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/4/Harness Theme/Light */
+  --figma___colors-alerts-status-info-5: 225 85% 92% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/5/Harness Theme/Light */
+  --figma___colors-alerts-status-info-6: 225 78% 82% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/6/Harness Theme/Light */
+  --figma___colors-alerts-status-info-7: 226 70% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/7/Harness Theme/Light */
+  --figma___colors-alerts-status-info-8: 226 59% 51% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/8/Harness Theme/Light */
+  --figma___colors-alerts-status-info-9: 226 55% 45% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/9/Harness Theme/Light */
+  --figma___colors-alerts-status-info-10: 226 63% 17% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/10/Harness Theme/Light */
+  --figma___colors-alerts-status-info-alpha-1: 240 93% 26% / 0.01; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/1/Harness Theme/Light */
+  --figma___colors-alerts-status-info-alpha-2: 223 100% 51% / 0.03; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/2/Harness Theme/Light */
+  --figma___colors-alerts-status-info-alpha-3: 224 100% 50% / 0.06; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/3/Harness Theme/Light */
+  --figma___colors-alerts-status-info-alpha-4: 222 98% 48% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/4/Harness Theme/Light */
+  --figma___colors-alerts-status-info-alpha-5: 225 98% 46% / 0.15; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/5/Harness Theme/Light */
+  --figma___colors-alerts-status-info-alpha-6: 225 100% 44% / 0.32; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/6/Harness Theme/Light */
+  --figma___colors-alerts-status-info-alpha-7: 226 100% 41% / 0.76; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/7/Harness Theme/Light */
+  --figma___colors-alerts-status-info-alpha-8: 226 100% 37% / 0.77; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/8/Harness Theme/Light */
+  --figma___colors-alerts-status-info-alpha-9: 226 100% 31% / 0.8; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/9/Harness Theme/Light */
+  --figma___colors-alerts-status-info-alpha-10: 225 100% 14% / 0.88; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/10/Harness Theme/Light */
+  --figma___colors-alerts-status-success-1: 140 60% 99% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/1/Harness Theme/Light */
+  --figma___colors-alerts-status-success-2: 138 63% 97% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/2/Harness Theme/Light */
+  --figma___colors-alerts-status-success-3: 139 57% 95% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/3/Harness Theme/Light */
+  --figma___colors-alerts-status-success-4: 139 48% 91% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/4/Harness Theme/Light */
+  --figma___colors-alerts-status-success-5: 141 44% 86% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/5/Harness Theme/Light */
+  --figma___colors-alerts-status-success-6: 146 38% 69% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/6/Harness Theme/Light */
+  --figma___colors-alerts-status-success-7: 142 72% 29% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/7/Harness Theme/Light */
+  --figma___colors-alerts-status-success-8: 152 57% 38% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/8/Harness Theme/Light */
+  --figma___colors-alerts-status-success-9: 153 67% 28% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/9/Harness Theme/Light */
+  --figma___colors-alerts-status-success-10: 155 40% 16% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/10/Harness Theme/Light */
+  --figma___colors-alerts-status-success-alpha-1: 140 95% 39% / 0.02; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/1/Harness Theme/Light */
+  --figma___colors-alerts-status-success-alpha-2: 139 98% 37% / 0.09; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/2/Harness Theme/Light */
+  --figma___colors-alerts-status-success-alpha-3: 139 98% 37% / 0.09; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/3/Harness Theme/Light */
+  --figma___colors-alerts-status-success-alpha-4: 139 99% 33% / 0.13; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/4/Harness Theme/Light */
+  --figma___colors-alerts-status-success-alpha-5: 141 100% 30% / 0.2; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/5/Harness Theme/Light */
+  --figma___colors-alerts-status-success-alpha-6: 146 100% 27% / 0.43; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/6/Harness Theme/Light */
+  --figma___colors-alerts-status-success-alpha-7: 151 100% 28% / 0.81; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/7/Harness Theme/Light */
+  --figma___colors-alerts-status-success-alpha-8: 153 100% 26% / 0.84; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/8/Harness Theme/Light */
+  --figma___colors-alerts-status-success-alpha-9: 153 100% 21% / 0.91; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/9/Harness Theme/Light */
+  --figma___colors-alerts-status-success-alpha-10: 155 100% 7% / 0.9; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/10/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-1: 40 60% 99% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/1/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-2: 40 100% 96% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/2/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-3: 45 100% 91% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/3/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-4: 44 100% 86% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/4/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-5: 40 100% 82% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/5/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-6: 37 67% 68% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/6/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-7: 42 100% 62% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/7/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-8: 42 100% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/8/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-9: 25 50% 38% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/9/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-10: 24 40% 22% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/10/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-alpha-1: 40 95% 39% / 0.02; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/1/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-alpha-2: 40 100% 50% / 0.07; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/2/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-alpha-3: 45 100% 50% / 0.19; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/3/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-alpha-4: 44 100% 50% / 0.28; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/4/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-alpha-5: 40 99% 50% / 0.37; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/5/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-alpha-6: 37 100% 40% / 0.53; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/6/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-alpha-7: 42 100% 50% / 0.76; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/7/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-alpha-8: 42 100% 50% / 0.9; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/8/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-alpha-9: 25 100% 24% / 0.81; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/9/Harness Theme/Light */
+  --figma___colors-alerts-status-warning-alpha-10: 24 100% 10% / 0.87; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/10/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-1: 270 50% 99% / 1; /* ✦ Theme/Colors/Charts/AI Violet/1/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-2: 252 100% 99% / 1; /* ✦ Theme/Colors/Charts/AI Violet/2/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-3: 254 100% 97% / 1; /* ✦ Theme/Colors/Charts/AI Violet/3/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-4: 251 91% 95% / 1; /* ✦ Theme/Colors/Charts/AI Violet/4/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-5: 252 83% 93% / 1; /* ✦ Theme/Colors/Charts/AI Violet/5/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-6: 252 71% 84% / 1; /* ✦ Theme/Colors/Charts/AI Violet/6/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-7: 252 56% 57% / 1; /* ✦ Theme/Colors/Charts/AI Violet/7/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-8: 251 48% 53% / 1; /* ✦ Theme/Colors/Charts/AI Violet/8/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-9: 250 43% 48% / 1; /* ✦ Theme/Colors/Charts/AI Violet/9/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-10: 249 43% 26% / 1; /* ✦ Theme/Colors/Charts/AI Violet/10/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-alpha-1: 270 94% 35% / 0.01; /* ✦ Theme/Colors/Charts/AI Violet Alpha/1/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-alpha-2: 252 100% 51% / 0.02; /* ✦ Theme/Colors/Charts/AI Violet Alpha/2/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-alpha-3: 254 100% 50% / 0.05; /* ✦ Theme/Colors/Charts/AI Violet Alpha/3/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-alpha-4: 251 98% 48% / 0.09; /* ✦ Theme/Colors/Charts/AI Violet Alpha/4/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-alpha-5: 252 99% 46% / 0.13; /* ✦ Theme/Colors/Charts/AI Violet Alpha/5/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-alpha-6: 252 99% 42% / 0.28; /* ✦ Theme/Colors/Charts/AI Violet Alpha/6/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-alpha-7: 252 100% 36% / 0.66; /* ✦ Theme/Colors/Charts/AI Violet Alpha/7/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-alpha-8: 251 100% 32% / 0.69; /* ✦ Theme/Colors/Charts/AI Violet Alpha/8/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-alpha-9: 250 100% 28% / 0.73; /* ✦ Theme/Colors/Charts/AI Violet Alpha/9/Harness Theme/Light */
+  --figma___colors-charts-ai-violet-alpha-10: 249 100% 13% / 0.85; /* ✦ Theme/Colors/Charts/AI Violet Alpha/10/Harness Theme/Light */
+  --figma___colors-charts-blue-1: 210 100% 99% / 1; /* ✦ Theme/Colors/Charts/Blue/1/Harness Theme/Light */
+  --figma___colors-charts-blue-2: 210 100% 98% / 1; /* ✦ Theme/Colors/Charts/Blue/2/Harness Theme/Light */
+  --figma___colors-charts-blue-3: 210 100% 96% / 1; /* ✦ Theme/Colors/Charts/Blue/3/Harness Theme/Light */
+  --figma___colors-charts-blue-4: 210 100% 94% / 1; /* ✦ Theme/Colors/Charts/Blue/4/Harness Theme/Light */
+  --figma___colors-charts-blue-5: 209 96% 90% / 1; /* ✦ Theme/Colors/Charts/Blue/5/Harness Theme/Light */
+  --figma___colors-charts-blue-6: 208 78% 77% / 1; /* ✦ Theme/Colors/Charts/Blue/6/Harness Theme/Light */
+  --figma___colors-charts-blue-7: 214 73% 51% / 1; /* ✦ Theme/Colors/Charts/Blue/7/Harness Theme/Light */
+  --figma___colors-charts-blue-8: 208 93% 47% / 1; /* ✦ Theme/Colors/Charts/Blue/8/Harness Theme/Light */
+  --figma___colors-charts-blue-9: 211 90% 42% / 1; /* ✦ Theme/Colors/Charts/Blue/9/Harness Theme/Light */
+  --figma___colors-charts-blue-10: 216 71% 23% / 1; /* ✦ Theme/Colors/Charts/Blue/10/Harness Theme/Light */
+  --figma___colors-charts-blue-alpha-1: 210 100% 51% / 0.02; /* ✦ Theme/Colors/Charts/Blue Alpha/1/Harness Theme/Light */
+  --figma___colors-charts-blue-alpha-2: 210 100% 51% / 0.04; /* ✦ Theme/Colors/Charts/Blue Alpha/2/Harness Theme/Light */
+  --figma___colors-charts-blue-alpha-3: 210 100% 50% / 0.07; /* ✦ Theme/Colors/Charts/Blue Alpha/3/Harness Theme/Light */
+  --figma___colors-charts-blue-alpha-4: 210 99% 49% / 0.19; /* ✦ Theme/Colors/Charts/Blue Alpha/4/Harness Theme/Light */
+  --figma___colors-charts-blue-alpha-5: 209 99% 49% / 0.19; /* ✦ Theme/Colors/Charts/Blue Alpha/5/Harness Theme/Light */
+  --figma___colors-charts-blue-alpha-6: 208 100% 44% / 0.41; /* ✦ Theme/Colors/Charts/Blue Alpha/6/Harness Theme/Light */
+  --figma___colors-charts-blue-alpha-7: 206 100% 50% / 0.88; /* ✦ Theme/Colors/Charts/Blue Alpha/7/Harness Theme/Light */
+  --figma___colors-charts-blue-alpha-8: 208 100% 46% / 0.97; /* ✦ Theme/Colors/Charts/Blue Alpha/8/Harness Theme/Light */
+  --figma___colors-charts-blue-alpha-9: 211 100% 39% / 0.96; /* ✦ Theme/Colors/Charts/Blue Alpha/9/Harness Theme/Light */
+  --figma___colors-charts-blue-alpha-10: 216 100% 17% / 0.93; /* ✦ Theme/Colors/Charts/Blue Alpha/10/Harness Theme/Light */
+  --figma___colors-charts-indigo-1: 240 33% 99% / 1; /* ✦ Theme/Colors/Charts/Indigo/1/Harness Theme/Light */
+  --figma___colors-charts-indigo-2: 223 100% 99% / 1; /* ✦ Theme/Colors/Charts/Indigo/2/Harness Theme/Light */
+  --figma___colors-charts-indigo-3: 224 100% 97% / 1; /* ✦ Theme/Colors/Charts/Indigo/3/Harness Theme/Light */
+  --figma___colors-charts-indigo-4: 222 92% 95% / 1; /* ✦ Theme/Colors/Charts/Indigo/4/Harness Theme/Light */
+  --figma___colors-charts-indigo-5: 225 85% 92% / 1; /* ✦ Theme/Colors/Charts/Indigo/5/Harness Theme/Light */
+  --figma___colors-charts-indigo-6: 225 78% 82% / 1; /* ✦ Theme/Colors/Charts/Indigo/6/Harness Theme/Light */
+  --figma___colors-charts-indigo-7: 226 70% 55% / 1; /* ✦ Theme/Colors/Charts/Indigo/7/Harness Theme/Light */
+  --figma___colors-charts-indigo-8: 226 59% 51% / 1; /* ✦ Theme/Colors/Charts/Indigo/8/Harness Theme/Light */
+  --figma___colors-charts-indigo-9: 226 55% 45% / 1; /* ✦ Theme/Colors/Charts/Indigo/9/Harness Theme/Light */
+  --figma___colors-charts-indigo-10: 226 63% 17% / 1; /* ✦ Theme/Colors/Charts/Indigo/10/Harness Theme/Light */
+  --figma___colors-charts-indigo-alpha-1: 240 93% 26% / 0.01; /* ✦ Theme/Colors/Charts/Indigo Alpha/1/Harness Theme/Light */
+  --figma___colors-charts-indigo-alpha-2: 223 100% 51% / 0.03; /* ✦ Theme/Colors/Charts/Indigo Alpha/2/Harness Theme/Light */
+  --figma___colors-charts-indigo-alpha-3: 224 100% 50% / 0.06; /* ✦ Theme/Colors/Charts/Indigo Alpha/3/Harness Theme/Light */
+  --figma___colors-charts-indigo-alpha-4: 222 98% 48% / 0.1; /* ✦ Theme/Colors/Charts/Indigo Alpha/4/Harness Theme/Light */
+  --figma___colors-charts-indigo-alpha-5: 225 98% 46% / 0.15; /* ✦ Theme/Colors/Charts/Indigo Alpha/5/Harness Theme/Light */
+  --figma___colors-charts-indigo-alpha-6: 225 100% 44% / 0.32; /* ✦ Theme/Colors/Charts/Indigo Alpha/6/Harness Theme/Light */
+  --figma___colors-charts-indigo-alpha-7: 226 100% 41% / 0.76; /* ✦ Theme/Colors/Charts/Indigo Alpha/7/Harness Theme/Light */
+  --figma___colors-charts-indigo-alpha-8: 226 100% 37% / 0.77; /* ✦ Theme/Colors/Charts/Indigo Alpha/8/Harness Theme/Light */
+  --figma___colors-charts-indigo-alpha-9: 226 100% 31% / 0.8; /* ✦ Theme/Colors/Charts/Indigo Alpha/9/Harness Theme/Light */
+  --figma___colors-charts-indigo-alpha-10: 225 100% 14% / 0.88; /* ✦ Theme/Colors/Charts/Indigo Alpha/10/Harness Theme/Light */
+  --figma___colors-charts-mint-1: 168 71% 99% / 1; /* ✦ Theme/Colors/Charts/Mint/1/Harness Theme/Light */
+  --figma___colors-charts-mint-2: 164 88% 97% / 1; /* ✦ Theme/Colors/Charts/Mint/2/Harness Theme/Light */
+  --figma___colors-charts-mint-3: 164 79% 93% / 1; /* ✦ Theme/Colors/Charts/Mint/3/Harness Theme/Light */
+  --figma___colors-charts-mint-4: 165 73% 88% / 1; /* ✦ Theme/Colors/Charts/Mint/4/Harness Theme/Light */
+  --figma___colors-charts-mint-5: 166 60% 83% / 1; /* ✦ Theme/Colors/Charts/Mint/5/Harness Theme/Light */
+  --figma___colors-charts-mint-6: 166 44% 67% / 1; /* ✦ Theme/Colors/Charts/Mint/6/Harness Theme/Light */
+  --figma___colors-charts-mint-7: 167 70% 72% / 1; /* ✦ Theme/Colors/Charts/Mint/7/Harness Theme/Light */
+  --figma___colors-charts-mint-8: 167 62% 69% / 1; /* ✦ Theme/Colors/Charts/Mint/8/Harness Theme/Light */
+  --figma___colors-charts-mint-9: 172 50% 31% / 1; /* ✦ Theme/Colors/Charts/Mint/9/Harness Theme/Light */
+  --figma___colors-charts-mint-10: 171 51% 17% / 1; /* ✦ Theme/Colors/Charts/Mint/10/Harness Theme/Light */
+  --figma___colors-charts-mint-alpha-1: 168 95% 43% / 0.02; /* ✦ Theme/Colors/Charts/Mint Alpha/1/Harness Theme/Light */
+  --figma___colors-charts-mint-alpha-2: 164 99% 47% / 0.06; /* ✦ Theme/Colors/Charts/Mint Alpha/2/Harness Theme/Light */
+  --figma___colors-charts-mint-alpha-3: 164 99% 44% / 0.13; /* ✦ Theme/Colors/Charts/Mint Alpha/3/Harness Theme/Light */
+  --figma___colors-charts-mint-alpha-4: 165 100% 42% / 0.2; /* ✦ Theme/Colors/Charts/Mint Alpha/4/Harness Theme/Light */
+  --figma___colors-charts-mint-alpha-5: 166 100% 38% / 0.27; /* ✦ Theme/Colors/Charts/Mint Alpha/5/Harness Theme/Light */
+  --figma___colors-charts-mint-alpha-6: 166 100% 30% / 0.47; /* ✦ Theme/Colors/Charts/Mint Alpha/6/Harness Theme/Light */
+  --figma___colors-charts-mint-alpha-7: 167 100% 41% / 0.47; /* ✦ Theme/Colors/Charts/Mint Alpha/7/Harness Theme/Light */
+  --figma___colors-charts-mint-alpha-8: 167 100% 38% / 0.5; /* ✦ Theme/Colors/Charts/Mint Alpha/8/Harness Theme/Light */
+  --figma___colors-charts-mint-alpha-9: 172 100% 18% / 0.85; /* ✦ Theme/Colors/Charts/Mint Alpha/9/Harness Theme/Light */
+  --figma___colors-charts-mint-alpha-10: 171 100% 10% / 0.91; /* ✦ Theme/Colors/Charts/Mint Alpha/10/Harness Theme/Light */
+  --figma___colors-charts-orange-1: 20 60% 99% / 1; /* ✦ Theme/Colors/Charts/Orange/1/Harness Theme/Light */
+  --figma___colors-charts-orange-2: 22 100% 98% / 1; /* ✦ Theme/Colors/Charts/Orange/2/Harness Theme/Light */
+  --figma___colors-charts-orange-3: 34 100% 92% / 1; /* ✦ Theme/Colors/Charts/Orange/3/Harness Theme/Light */
+  --figma___colors-charts-orange-4: 33 100% 87% / 1; /* ✦ Theme/Colors/Charts/Orange/4/Harness Theme/Light */
+  --figma___colors-charts-orange-5: 31 100% 82% / 1; /* ✦ Theme/Colors/Charts/Orange/5/Harness Theme/Light */
+  --figma___colors-charts-orange-6: 21 100% 75% / 1; /* ✦ Theme/Colors/Charts/Orange/6/Harness Theme/Light */
+  --figma___colors-charts-orange-7: 24 94% 50% / 1; /* ✦ Theme/Colors/Charts/Orange/7/Harness Theme/Light */
+  --figma___colors-charts-orange-8: 24 100% 46% / 1; /* ✦ Theme/Colors/Charts/Orange/8/Harness Theme/Light */
+  --figma___colors-charts-orange-9: 16 45% 41% / 1; /* ✦ Theme/Colors/Charts/Orange/9/Harness Theme/Light */
+  --figma___colors-charts-orange-10: 16 50% 23% / 1; /* ✦ Theme/Colors/Charts/Orange/10/Harness Theme/Light */
+  --figma___colors-charts-orange-alpha-1: 20 95% 39% / 0.02; /* ✦ Theme/Colors/Charts/Orange Alpha/1/Harness Theme/Light */
+  --figma___colors-charts-orange-alpha-2: 22 100% 51% / 0.04; /* ✦ Theme/Colors/Charts/Orange Alpha/2/Harness Theme/Light */
+  --figma___colors-charts-orange-alpha-3: 34 100% 50% / 0.17; /* ✦ Theme/Colors/Charts/Orange Alpha/3/Harness Theme/Light */
+  --figma___colors-charts-orange-alpha-4: 33 100% 50% / 0.27; /* ✦ Theme/Colors/Charts/Orange Alpha/4/Harness Theme/Light */
+  --figma___colors-charts-orange-alpha-5: 31 100% 50% / 0.36; /* ✦ Theme/Colors/Charts/Orange Alpha/5/Harness Theme/Light */
+  --figma___colors-charts-orange-alpha-6: 21 100% 50% / 0.51; /* ✦ Theme/Colors/Charts/Orange Alpha/6/Harness Theme/Light */
+  --figma___colors-charts-orange-alpha-7: 24 100% 48% / 0.97; /* ✦ Theme/Colors/Charts/Orange Alpha/7/Harness Theme/Light */
+  --figma___colors-charts-orange-alpha-8: 24 100% 46% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/8/Harness Theme/Light */
+  --figma___colors-charts-orange-alpha-9: 16 100% 24% / 0.77; /* ✦ Theme/Colors/Charts/Orange Alpha/9/Harness Theme/Light */
+  --figma___colors-charts-orange-alpha-10: 16 100% 13% / 0.89; /* ✦ Theme/Colors/Charts/Orange Alpha/10/Harness Theme/Light */
+  --figma___colors-charts-yellow-1: 60 50% 98% / 1; /* ✦ Theme/Colors/Charts/Yellow/1/Harness Theme/Light */
+  --figma___colors-charts-yellow-2: 52 100% 94% / 1; /* ✦ Theme/Colors/Charts/Yellow/2/Harness Theme/Light */
+  --figma___colors-charts-yellow-3: 53 100% 89% / 1; /* ✦ Theme/Colors/Charts/Yellow/3/Harness Theme/Light */
+  --figma___colors-charts-yellow-4: 53 93% 84% / 1; /* ✦ Theme/Colors/Charts/Yellow/4/Harness Theme/Light */
+  --figma___colors-charts-yellow-5: 52 85% 79% / 1; /* ✦ Theme/Colors/Charts/Yellow/5/Harness Theme/Light */
+  --figma___colors-charts-yellow-6: 48 59% 64% / 1; /* ✦ Theme/Colors/Charts/Yellow/6/Harness Theme/Light */
+  --figma___colors-charts-yellow-7: 53 96% 58% / 1; /* ✦ Theme/Colors/Charts/Yellow/7/Harness Theme/Light */
+  --figma___colors-charts-yellow-8: 52 95% 52% / 1; /* ✦ Theme/Colors/Charts/Yellow/8/Harness Theme/Light */
+  --figma___colors-charts-yellow-9: 42 50% 31% / 1; /* ✦ Theme/Colors/Charts/Yellow/9/Harness Theme/Light */
+  --figma___colors-charts-yellow-10: 42 39% 20% / 1; /* ✦ Theme/Colors/Charts/Yellow/10/Harness Theme/Light */
+  --figma___colors-charts-yellow-alpha-1: 60 94% 35% / 0.02; /* ✦ Theme/Colors/Charts/Yellow Alpha/1/Harness Theme/Light */
+  --figma___colors-charts-yellow-alpha-2: 52 100% 50% / 0.12; /* ✦ Theme/Colors/Charts/Yellow Alpha/2/Harness Theme/Light */
+  --figma___colors-charts-yellow-alpha-3: 53 100% 50% / 0.22; /* ✦ Theme/Colors/Charts/Yellow Alpha/3/Harness Theme/Light */
+  --figma___colors-charts-yellow-alpha-4: 53 100% 48% / 0.31; /* ✦ Theme/Colors/Charts/Yellow Alpha/4/Harness Theme/Light */
+  --figma___colors-charts-yellow-alpha-5: 52 99% 46% / 0.39; /* ✦ Theme/Colors/Charts/Yellow Alpha/5/Harness Theme/Light */
+  --figma___colors-charts-yellow-alpha-6: 48 100% 37% / 0.57; /* ✦ Theme/Colors/Charts/Yellow Alpha/6/Harness Theme/Light */
+  --figma___colors-charts-yellow-alpha-7: 53 100% 49% / 0.82; /* ✦ Theme/Colors/Charts/Yellow Alpha/7/Harness Theme/Light */
+  --figma___colors-charts-yellow-alpha-8: 52 100% 49% / 0.94; /* ✦ Theme/Colors/Charts/Yellow Alpha/8/Harness Theme/Light */
+  --figma___colors-charts-yellow-alpha-9: 42 100% 18% / 0.84; /* ✦ Theme/Colors/Charts/Yellow Alpha/9/Harness Theme/Light */
+  --figma___colors-charts-yellow-alpha-10: 42 100% 9% / 0.88; /* ✦ Theme/Colors/Charts/Yellow Alpha/10/Harness Theme/Light */
+  --figma___colors-default-black-fixed: 0 0% 0% / 1; /* ✦ Theme/Colors/Default/Black (fixed)/Harness Theme/Light */
+  --figma___colors-default-brand-color: 194 100% 45% / 1; /* ✦ Theme/Colors/Default/Brand Color/Harness Theme/Light */
+  --figma___colors-default-dark-to-white: 0 0% 13% / 1; /* ✦ Theme/Colors/Default/Dark-to-white/Harness Theme/Light */
+  --figma___colors-default-white-fixed: 0 0% 100% / 1; /* ✦ Theme/Colors/Default/White (fixed)/Harness Theme/Light */
+  --figma___colors-module-ccm-100: 180 100% 96% / 1; /* ✦ Theme/Colors/Module/CCM/100/Harness Theme/Light */
+  --figma___colors-module-ccm-200: 181 99% 40% / 1; /* ✦ Theme/Colors/Module/CCM/200/Harness Theme/Light */
+  --figma___colors-module-ccm-300: 179 56% 32% / 1; /* ✦ Theme/Colors/Module/CCM/300/Harness Theme/Light */
+  --figma___colors-module-cd-100: 102 100% 97% / 1; /* ✦ Theme/Colors/Module/CD/100/Harness Theme/Light */
+  --figma___colors-module-cd-200: 110 40% 50% / 1; /* ✦ Theme/Colors/Module/CD/200/Harness Theme/Light */
+  --figma___colors-module-cd-300: 110 62% 32% / 1; /* ✦ Theme/Colors/Module/CD/300/Harness Theme/Light */
+  --figma___colors-module-ce-100: 334 100% 97% / 1; /* ✦ Theme/Colors/Module/CE/100/Harness Theme/Light */
+  --figma___colors-module-ce-200: 335 100% 50% / 1; /* ✦ Theme/Colors/Module/CE/200/Harness Theme/Light */
+  --figma___colors-module-ce-300: 335 100% 30% / 1; /* ✦ Theme/Colors/Module/CE/300/Harness Theme/Light */
+  --figma___colors-module-ci-100: 201 100% 94% / 1; /* ✦ Theme/Colors/Module/CI/100/Harness Theme/Light */
+  --figma___colors-module-ci-200: 200 88% 56% / 1; /* ✦ Theme/Colors/Module/CI/200/Harness Theme/Light */
+  --figma___colors-module-ci-300: 203 94% 37% / 1; /* ✦ Theme/Colors/Module/CI/300/Harness Theme/Light */
+  --figma___colors-module-ff-100: 41 81% 94% / 1; /* ✦ Theme/Colors/Module/FF/100/Harness Theme/Light */
+  --figma___colors-module-ff-200: 29 86% 54% / 1; /* ✦ Theme/Colors/Module/FF/200/Harness Theme/Light */
+  --figma___colors-module-ff-300: 26 91% 39% / 1; /* ✦ Theme/Colors/Module/FF/300/Harness Theme/Light */
+  --figma___colors-module-srm-100: 261 100% 97% / 1; /* ✦ Theme/Colors/Module/SRM/100/Harness Theme/Light */
+  --figma___colors-module-srm-200: 262 95% 75% / 1; /* ✦ Theme/Colors/Module/SRM/200/Harness Theme/Light */
+  --figma___colors-module-srm-300: 262 55% 49% / 1; /* ✦ Theme/Colors/Module/SRM/300/Harness Theme/Light */
+  --figma___colors-module-ssca-100: 0 100% 97% / 1; /* ✦ Theme/Colors/Module/SSCA/100/Harness Theme/Light */
+  --figma___colors-module-ssca-200: 0 58% 53% / 1; /* ✦ Theme/Colors/Module/SSCA/200/Harness Theme/Light */
+  --figma___colors-module-ssca-300: 0 98% 36% / 1; /* ✦ Theme/Colors/Module/SSCA/300/Harness Theme/Light */
+  --figma___colors-module-sto-100: 228 100% 96% / 1; /* ✦ Theme/Colors/Module/STO/100/Harness Theme/Light */
+  --figma___colors-module-sto-200: 216 100% 64% / 1; /* ✦ Theme/Colors/Module/STO/200/Harness Theme/Light */
+  --figma___colors-module-sto-300: 245 90% 53% / 1; /* ✦ Theme/Colors/Module/STO/300/Harness Theme/Light */
+  --figma___colors-neutral-gray-1: 0 0% 99% / 1; /* ✦ Theme/Colors/Neutral/Gray/1/Harness Theme/Light */
+  --figma___colors-neutral-gray-2: 0 0% 98% / 1; /* ✦ Theme/Colors/Neutral/Gray/2/Harness Theme/Light */
+  --figma___colors-neutral-gray-3: 0 0% 95% / 1; /* ✦ Theme/Colors/Neutral/Gray/3/Harness Theme/Light */
+  --figma___colors-neutral-gray-4: 0 0% 92% / 1; /* ✦ Theme/Colors/Neutral/Gray/4/Harness Theme/Light */
+  --figma___colors-neutral-gray-5: 0 0% 89% / 1; /* ✦ Theme/Colors/Neutral/Gray/5/Harness Theme/Light */
+  --figma___colors-neutral-gray-6: 0 0% 87% / 1; /* ✦ Theme/Colors/Neutral/Gray/6/Harness Theme/Light */
+  --figma___colors-neutral-gray-7: 0 0% 55% / 1; /* ✦ Theme/Colors/Neutral/Gray/7/Harness Theme/Light */
+  --figma___colors-neutral-gray-8: 0 0% 50% / 1; /* ✦ Theme/Colors/Neutral/Gray/8/Harness Theme/Light */
+  --figma___colors-neutral-gray-9: 0 0% 39% / 1; /* ✦ Theme/Colors/Neutral/Gray/9/Harness Theme/Light */
+  --figma___colors-neutral-gray-10: 0 0% 13% / 1; /* ✦ Theme/Colors/Neutral/Gray/10/Harness Theme/Light */
+  --figma___colors-neutral-gray-alpha-1: 0 0% 0% / 0.01; /* ✦ Theme/Colors/Neutral/Gray Alpha/1/Harness Theme/Light */
+  --figma___colors-neutral-gray-alpha-2: 240 89% 18% / 0.02; /* ✦ Theme/Colors/Neutral/Gray Alpha/2/Harness Theme/Light */
+  --figma___colors-neutral-gray-alpha-3: 0 0% 0% / 0.05; /* ✦ Theme/Colors/Neutral/Gray Alpha/3/Harness Theme/Light */
+  --figma___colors-neutral-gray-alpha-4: 0 0% 0% / 0.08; /* ✦ Theme/Colors/Neutral/Gray Alpha/4/Harness Theme/Light */
+  --figma___colors-neutral-gray-alpha-5: 0 0% 0% / 0.11; /* ✦ Theme/Colors/Neutral/Gray Alpha/5/Harness Theme/Light */
+  --figma___colors-neutral-gray-alpha-6: 0 0% 0% / 0.13; /* ✦ Theme/Colors/Neutral/Gray Alpha/6/Harness Theme/Light */
+  --figma___colors-neutral-gray-alpha-7: 0 0% 0% / 0.45; /* ✦ Theme/Colors/Neutral/Gray Alpha/7/Harness Theme/Light */
+  --figma___colors-neutral-gray-alpha-8: 0 0% 0% / 0.5; /* ✦ Theme/Colors/Neutral/Gray Alpha/8/Harness Theme/Light */
+  --figma___colors-neutral-gray-alpha-9: 0 0% 0% / 0.61; /* ✦ Theme/Colors/Neutral/Gray Alpha/9/Harness Theme/Light */
+  --figma___colors-neutral-gray-alpha-10: 0 0% 0% / 0.88; /* ✦ Theme/Colors/Neutral/Gray Alpha/10/Harness Theme/Light */
+  --figma___colors-primary-primary-accent-1: 210 100% 99% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/1/Harness Theme/Light */
+  --figma___colors-primary-primary-accent-2: 210 100% 98% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/2/Harness Theme/Light */
+  --figma___colors-primary-primary-accent-3: 210 100% 96% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/3/Harness Theme/Light */
+  --figma___colors-primary-primary-accent-4: 210 100% 94% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/4/Harness Theme/Light */
+  --figma___colors-primary-primary-accent-5: 209 96% 90% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/5/Harness Theme/Light */
+  --figma___colors-primary-primary-accent-6: 209 82% 85% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/6/Harness Theme/Light */
+  --figma___colors-primary-primary-accent-7: 214 73% 51% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/7/Harness Theme/Light */
+  --figma___colors-primary-primary-accent-8: 208 93% 47% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/8/Harness Theme/Light */
+  --figma___colors-primary-primary-accent-9: 211 90% 42% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/9/Harness Theme/Light */
+  --figma___colors-primary-primary-accent-10: 216 71% 23% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/10/Harness Theme/Light */
+  --figma___colors-primary-primary-alpha-1: 210 100% 51% / 0.02; /* ✦ Theme/Colors/Primary/Primary Alpha/1/Harness Theme/Light */
+  --figma___colors-primary-primary-alpha-2: 210 100% 51% / 0.04; /* ✦ Theme/Colors/Primary/Primary Alpha/2/Harness Theme/Light */
+  --figma___colors-primary-primary-alpha-3: 210 100% 50% / 0.07; /* ✦ Theme/Colors/Primary/Primary Alpha/3/Harness Theme/Light */
+  --figma___colors-primary-primary-alpha-4: 210 99% 49% / 0.19; /* ✦ Theme/Colors/Primary/Primary Alpha/4/Harness Theme/Light */
+  --figma___colors-primary-primary-alpha-5: 209 99% 49% / 0.19; /* ✦ Theme/Colors/Primary/Primary Alpha/5/Harness Theme/Light */
+  --figma___colors-primary-primary-alpha-6: 209 99% 45% / 0.28; /* ✦ Theme/Colors/Primary/Primary Alpha/6/Harness Theme/Light */
+  --figma___colors-primary-primary-alpha-7: 206 100% 50% / 0.88; /* ✦ Theme/Colors/Primary/Primary Alpha/7/Harness Theme/Light */
+  --figma___colors-primary-primary-alpha-8: 208 100% 46% / 0.97; /* ✦ Theme/Colors/Primary/Primary Alpha/8/Harness Theme/Light */
+  --figma___colors-primary-primary-alpha-9: 211 100% 39% / 0.96; /* ✦ Theme/Colors/Primary/Primary Alpha/9/Harness Theme/Light */
+  --figma___colors-primary-primary-alpha-10: 216 100% 17% / 0.93; /* ✦ Theme/Colors/Primary/Primary Alpha/10/Harness Theme/Light */
+  --figma___colors-secondary-crimson-crimson-1: 340 100% 99% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 1/Harness Theme/Light */
+  --figma___colors-secondary-crimson-crimson-10: 332 63% 24% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 10/Harness Theme/Light */
+  --figma___colors-secondary-crimson-crimson-2: 330 100% 98% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 2/Harness Theme/Light */
+  --figma___colors-secondary-crimson-crimson-3: 332 88% 97% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 3/Harness Theme/Light */
+  --figma___colors-secondary-crimson-crimson-4: 331 79% 94% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 4/Harness Theme/Light */
+  --figma___colors-secondary-crimson-crimson-5: 333 73% 91% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 5/Harness Theme/Light */
+  --figma___colors-secondary-crimson-crimson-6: 335 64% 80% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 6/Harness Theme/Light */
+  --figma___colors-secondary-crimson-crimson-7: 336 80% 58% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 7/Harness Theme/Light */
+  --figma___colors-secondary-crimson-crimson-8: 336 71% 53% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 8/Harness Theme/Light */
+  --figma___colors-secondary-crimson-crimson-9: 336 75% 45% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 9/Harness Theme/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-1: 340 100% 51% / 0.01; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Theme/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-10: 336 100% 38% / 0.89; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Theme/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-11: 332 100% 16% / 0.91; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Theme/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-2: 330 100% 51% / 0.03; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Theme/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-3: 332 100% 51% / 0.03; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Theme/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-4: 331 100% 44% / 0.1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Theme/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-5: 333 100% 42% / 0.15; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Theme/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-6: 335 100% 39% / 0.32; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Theme/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-8: 336 100% 44% / 0.76; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Theme/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-9: 336 100% 42% / 0.81; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Theme/Light */
+  --figma___colors-secondary-lime-1: 80 43% 99% / 1; /* ✦ Theme/Colors/Secondary/Lime/1/Harness Theme/Light */
+  --figma___colors-secondary-lime-2: 85 67% 96% / 1; /* ✦ Theme/Colors/Secondary/Lime/2/Harness Theme/Light */
+  --figma___colors-secondary-lime-3: 84 76% 92% / 1; /* ✦ Theme/Colors/Secondary/Lime/3/Harness Theme/Light */
+  --figma___colors-secondary-lime-4: 83 71% 86% / 1; /* ✦ Theme/Colors/Secondary/Lime/4/Harness Theme/Light */
+  --figma___colors-secondary-lime-5: 83 63% 81% / 1; /* ✦ Theme/Colors/Secondary/Lime/5/Harness Theme/Light */
+  --figma___colors-secondary-lime-6: 79 41% 65% / 1; /* ✦ Theme/Colors/Secondary/Lime/6/Harness Theme/Light */
+  --figma___colors-secondary-lime-7: 81 80% 66% / 1; /* ✦ Theme/Colors/Secondary/Lime/7/Harness Theme/Light */
+  --figma___colors-secondary-lime-8: 81 75% 60% / 1; /* ✦ Theme/Colors/Secondary/Lime/8/Harness Theme/Light */
+  --figma___colors-secondary-lime-9: 75 41% 29% / 1; /* ✦ Theme/Colors/Secondary/Lime/9/Harness Theme/Light */
+  --figma___colors-secondary-lime-10: 75 39% 18% / 1; /* ✦ Theme/Colors/Secondary/Lime/10/Harness Theme/Light */
+  --figma___colors-secondary-lime-alpha-1: 80 94% 31% / 0.02; /* ✦ Theme/Colors/Secondary/Lime Alpha/1/Harness Theme/Light */
+  --figma___colors-secondary-lime-alpha-2: 85 99% 40% / 0.06; /* ✦ Theme/Colors/Secondary/Lime Alpha/2/Harness Theme/Light */
+  --figma___colors-secondary-lime-alpha-3: 84 99% 44% / 0.15; /* ✦ Theme/Colors/Secondary/Lime Alpha/3/Harness Theme/Light */
+  --figma___colors-secondary-lime-alpha-4: 83 99% 42% / 0.23; /* ✦ Theme/Colors/Secondary/Lime Alpha/4/Harness Theme/Light */
+  --figma___colors-secondary-lime-alpha-5: 83 100% 39% / 0.31; /* ✦ Theme/Colors/Secondary/Lime Alpha/5/Harness Theme/Light */
+  --figma___colors-secondary-lime-alpha-6: 81 100% 34% / 0.4; /* ✦ Theme/Colors/Secondary/Lime Alpha/6/Harness Theme/Light */
+  --figma___colors-secondary-lime-alpha-7: 81 100% 45% / 0.61; /* ✦ Theme/Colors/Secondary/Lime Alpha/7/Harness Theme/Light */
+  --figma___colors-secondary-lime-alpha-8: 81 100% 43% / 0.7; /* ✦ Theme/Colors/Secondary/Lime Alpha/8/Harness Theme/Light */
+  --figma___colors-secondary-lime-alpha-9: 75 100% 14% / 0.83; /* ✦ Theme/Colors/Secondary/Lime Alpha/9/Harness Theme/Light */
+  --figma___colors-secondary-lime-alpha-10: 76 100% 8% / 0.89; /* ✦ Theme/Colors/Secondary/Lime Alpha/10/Harness Theme/Light */
+  --figma___colors-secondary-purple-1: 300 50% 99% / 1; /* ✦ Theme/Colors/Secondary/Purple/1/Harness Theme/Light */
+  --figma___colors-secondary-purple-2: 276 100% 99% / 1; /* ✦ Theme/Colors/Secondary/Purple/2/Harness Theme/Light */
+  --figma___colors-secondary-purple-3: 277 87% 97% / 1; /* ✦ Theme/Colors/Secondary/Purple/3/Harness Theme/Light */
+  --figma___colors-secondary-purple-4: 274 78% 95% / 1; /* ✦ Theme/Colors/Secondary/Purple/4/Harness Theme/Light */
+  --figma___colors-secondary-purple-5: 276 71% 92% / 1; /* ✦ Theme/Colors/Secondary/Purple/5/Harness Theme/Light */
+  --figma___colors-secondary-purple-6: 273 61% 82% / 1; /* ✦ Theme/Colors/Secondary/Purple/6/Harness Theme/Light */
+  --figma___colors-secondary-purple-7: 272 51% 54% / 1; /* ✦ Theme/Colors/Secondary/Purple/7/Harness Theme/Light */
+  --figma___colors-secondary-purple-8: 272 47% 50% / 1; /* ✦ Theme/Colors/Secondary/Purple/8/Harness Theme/Light */
+  --figma___colors-secondary-purple-9: 272 50% 46% / 1; /* ✦ Theme/Colors/Secondary/Purple/9/Harness Theme/Light */
+  --figma___colors-secondary-purple-10: 270 50% 25% / 1; /* ✦ Theme/Colors/Secondary/Purple/10/Harness Theme/Light */
+  --figma___colors-secondary-purple-alpha-1: 300 94% 35% / 0.01; /* ✦ Theme/Colors/Secondary/Purple Alpha/1/Harness Theme/Light */
+  --figma___colors-secondary-purple-alpha-2: 276 100% 51% / 0.02; /* ✦ Theme/Colors/Secondary/Purple Alpha/2/Harness Theme/Light */
+  --figma___colors-secondary-purple-alpha-3: 277 100% 46% / 0.05; /* ✦ Theme/Colors/Secondary/Purple Alpha/3/Harness Theme/Light */
+  --figma___colors-secondary-purple-alpha-4: 274 98% 44% / 0.09; /* ✦ Theme/Colors/Secondary/Purple Alpha/4/Harness Theme/Light */
+  --figma___colors-secondary-purple-alpha-5: 276 99% 42% / 0.14; /* ✦ Theme/Colors/Secondary/Purple Alpha/5/Harness Theme/Light */
+  --figma___colors-secondary-purple-alpha-6: 273 99% 38% / 0.29; /* ✦ Theme/Colors/Secondary/Purple Alpha/6/Harness Theme/Light */
+  --figma___colors-secondary-purple-alpha-7: 272 100% 34% / 0.69; /* ✦ Theme/Colors/Secondary/Purple Alpha/7/Harness Theme/Light */
+  --figma___colors-secondary-purple-alpha-8: 272 100% 32% / 0.73; /* ✦ Theme/Colors/Secondary/Purple Alpha/8/Harness Theme/Light */
+  --figma___colors-secondary-purple-alpha-9: 273 100% 30% / 0.77; /* ✦ Theme/Colors/Secondary/Purple Alpha/9/Harness Theme/Light */
+  --figma___colors-secondary-purple-alpha-10: 270 100% 14% / 0.88; /* ✦ Theme/Colors/Secondary/Purple Alpha/10/Harness Theme/Light */
+  --figma___colors-secondary-teal-1: 165 67% 99% / 1; /* ✦ Theme/Colors/Secondary/Teal/1/Harness Theme/Light */
+  --figma___colors-secondary-teal-2: 169 65% 97% / 1; /* ✦ Theme/Colors/Secondary/Teal/2/Harness Theme/Light */
+  --figma___colors-secondary-teal-3: 167 60% 94% / 1; /* ✦ Theme/Colors/Secondary/Teal/3/Harness Theme/Light */
+  --figma___colors-secondary-teal-4: 168 52% 90% / 1; /* ✦ Theme/Colors/Secondary/Teal/4/Harness Theme/Light */
+  --figma___colors-secondary-teal-5: 170 47% 85% / 1; /* ✦ Theme/Colors/Secondary/Teal/5/Harness Theme/Light */
+  --figma___colors-secondary-teal-6: 170 40% 68% / 1; /* ✦ Theme/Colors/Secondary/Teal/6/Harness Theme/Light */
+  --figma___colors-secondary-teal-7: 173 80% 36% / 1; /* ✦ Theme/Colors/Secondary/Teal/7/Harness Theme/Light */
+  --figma___colors-secondary-teal-8: 173 83% 33% / 1; /* ✦ Theme/Colors/Secondary/Teal/8/Harness Theme/Light */
+  --figma___colors-secondary-teal-9: 174 91% 25% / 1; /* ✦ Theme/Colors/Secondary/Teal/9/Harness Theme/Light */
+  --figma___colors-secondary-teal-10: 174 65% 15% / 1; /* ✦ Theme/Colors/Secondary/Teal/10/Harness Theme/Light */
+  --figma___colors-secondary-teal-alpha-1: 165 95% 41% / 0.02; /* ✦ Theme/Colors/Secondary/Teal Alpha/1/Harness Theme/Light */
+  --figma___colors-secondary-teal-alpha-2: 169 99% 39% / 0.05; /* ✦ Theme/Colors/Secondary/Teal Alpha/2/Harness Theme/Light */
+  --figma___colors-secondary-teal-alpha-3: 167 98% 38% / 0.09; /* ✦ Theme/Colors/Secondary/Teal Alpha/3/Harness Theme/Light */
+  --figma___colors-secondary-teal-alpha-4: 168 98% 35% / 0.15; /* ✦ Theme/Colors/Secondary/Teal Alpha/4/Harness Theme/Light */
+  --figma___colors-secondary-teal-alpha-5: 170 100% 32% / 0.22; /* ✦ Theme/Colors/Secondary/Teal Alpha/5/Harness Theme/Light */
+  --figma___colors-secondary-teal-alpha-6: 170 99% 29% / 0.45; /* ✦ Theme/Colors/Secondary/Teal Alpha/6/Harness Theme/Light */
+  --figma___colors-secondary-teal-alpha-7: 173 100% 31% / 0.93; /* ✦ Theme/Colors/Secondary/Teal Alpha/7/Harness Theme/Light */
+  --figma___colors-secondary-teal-alpha-8: 173 100% 29% / 0.95; /* ✦ Theme/Colors/Secondary/Teal Alpha/8/Harness Theme/Light */
+  --figma___colors-secondary-teal-alpha-9: 174 100% 23% / 0.98; /* ✦ Theme/Colors/Secondary/Teal Alpha/9/Harness Theme/Light */
+  --figma___colors-secondary-teal-alpha-10: 174 100% 10% / 0.95; /* ✦ Theme/Colors/Secondary/Teal Alpha/10/Harness Theme/Light */
+  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01; /* ✦ Theme/Overlays/Black Alpha/1/Harness Theme/Light */
+  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02; /* ✦ Theme/Overlays/Black Alpha/2/Harness Theme/Light */
+  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05; /* ✦ Theme/Overlays/Black Alpha/3/Harness Theme/Light */
+  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08; /* ✦ Theme/Overlays/Black Alpha/4/Harness Theme/Light */
+  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11; /* ✦ Theme/Overlays/Black Alpha/5/Harness Theme/Light */
+  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13; /* ✦ Theme/Overlays/Black Alpha/6/Harness Theme/Light */
+  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45; /* ✦ Theme/Overlays/Black Alpha/7/Harness Theme/Light */
+  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5; /* ✦ Theme/Overlays/Black Alpha/8/Harness Theme/Light */
+  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61; /* ✦ Theme/Overlays/Black Alpha/9/Harness Theme/Light */
+  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88; /* ✦ Theme/Overlays/Black Alpha/10/Harness Theme/Light */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 0; /* ✦ Theme/Overlays/White Alpha/1/Harness Theme/Light */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01; /* ✦ Theme/Overlays/White Alpha/2/Harness Theme/Light */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07; /* ✦ Theme/Overlays/White Alpha/3/Harness Theme/Light */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1; /* ✦ Theme/Overlays/White Alpha/4/Harness Theme/Light */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13; /* ✦ Theme/Overlays/White Alpha/5/Harness Theme/Light */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17; /* ✦ Theme/Overlays/White Alpha/6/Harness Theme/Light */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37; /* ✦ Theme/Overlays/White Alpha/7/Harness Theme/Light */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46; /* ✦ Theme/Overlays/White Alpha/8/Harness Theme/Light */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66; /* ✦ Theme/Overlays/White Alpha/9/Harness Theme/Light */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93; /* ✦ Theme/Overlays/White Alpha/10/Harness Theme/Light */
+  --figma___semantic-background-backdrop: 230 100% 9% / 0.28; /* ✦ Theme/Semantic/Background/Backdrop/Harness Theme/Light */
+  --figma___semantic-background-cards-and-rows-default: 0 0% 100% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Default/Harness Theme/Light */
+  --figma___semantic-background-cards-and-rows-hover: 0 0% 95% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Hover/Harness Theme/Light */
+  --figma___semantic-background-cards-and-rows-primary-blue-selected: 210 100% 50% / 0.07; /* ✦ Theme/Semantic/Background/Cards and Rows/Primary-blue-selected/Harness Theme/Light */
+  --figma___semantic-background-cards-and-rows-selected: 0 0% 95% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Selected/Harness Theme/Light */
+  --figma___semantic-background-header-page-header: 0 0% 100% / 1; /* ✦ Theme/Semantic/Background/Header/Page Header/Harness Theme/Light */
+  --figma___semantic-background-header-table-header: 0 0% 99% / 1; /* ✦ Theme/Semantic/Background/Header/Table Header/Harness Theme/Light */
+  --figma___semantic-background-paper: 0 0% 98% / 1; /* ✦ Theme/Semantic/Background/Paper/Harness Theme/Light */
+  --figma___semantic-background-primary: 0 0% 93% / 1; /* ✦ Theme/Semantic/Background/Primary/Harness Theme/Light */
+  --figma___semantic-background-solid: 0 0% 100% / 1; /* ✦ Theme/Semantic/Background/Solid/Harness Theme/Light */
+  --figma___semantic-border-disabled: 0 0% 0% / 0.05; /* ✦ Theme/Semantic/Border/Disabled/Harness Theme/Light */
+  --figma___semantic-border-hover: 0 0% 83% / 1; /* ✦ Theme/Semantic/Border/Hover/Harness Theme/Light */
+  --figma___semantic-border-primary: 0 0% 0% / 0.08; /* ✦ Theme/Semantic/Border/Primary/Harness Theme/Light */
+  --figma___semantic-border-secondary: 0 0% 95% / 1; /* ✦ Theme/Semantic/Border/Secondary/Harness Theme/Light */
+  --figma___semantic-border-selected: 208 93% 47% / 1; /* ✦ Theme/Semantic/Border/Selected/Harness Theme/Light */
+  --figma___semantic-text-disabled: 0 0% 0% / 0.45; /* ✦ Theme/Semantic/Text/Disabled/Harness Theme/Light */
+  --figma___semantic-text-links: 211 90% 42% / 1; /* ✦ Theme/Semantic/Text/Links/Harness Theme/Light */
+  --figma___semantic-text-secondary: 0 0% 39% / 1; /* ✦ Theme/Semantic/Text/Secondary/Harness Theme/Light */
+  --figma___semantic-text-tertiary: 0 0% 0% / 0.5; /* ✦ Theme/Semantic/Text/Tertiary/Harness Theme/Light */
+  --figma___semantic-text-primary: 0 0% 13% / 1; /* ✦ Theme/Semantic/Text/primary/Harness Theme/Light */
+  --figma___colors-default-white-to-dark: var(--figma___colors-default-white-fixed); /* ✦ Theme/Colors/Default/White-to-dark/Harness Theme/Light */
 }
 
 /* Color variables - dark mode */
 .harness-theme-dark {
-  --figma___background-backdrop: 0 0% 0% / 0.75;
-  /* ✦ Theme/Background/Backdrop/Harness Theme/Dark */
-  --figma___background-cards-and-rows-default: 240 6% 6% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Default/Harness Theme/Dark */
-  --figma___background-cards-and-rows-hover: 210 6% 20% / 0.24;
-  /* ✦ Theme/Background/Cards and Rows/Hover/Harness Theme/Dark */
-  --figma___background-cards-and-rows-primary-blue-selected: 216 100% 50% / 0.17;
-  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/Harness Theme/Dark */
-  --figma___background-cards-and-rows-selected: 210 6% 20% / 0.24;
-  /* ✦ Theme/Background/Cards and Rows/Selected/Harness Theme/Dark */
-  --figma___background-header-page-header: 240 6% 6% / 1;
-  /* ✦ Theme/Background/Header/Page Header/Harness Theme/Dark */
-  --figma___background-header-table-header: 0 0% 9% / 1;
-  /* ✦ Theme/Background/Header/Table Header/Harness Theme/Dark */
-  --figma___background-paper: 0 0% 6% / 1;
-  /* ✦ Theme/Background/Paper/Harness Theme/Dark */
-  --figma___background-primary: 0 4% 5% / 1;
-  /* ✦ Theme/Background/Primary/Harness Theme/Dark */
-  --figma___background-solid: 0 4% 5% / 1;
-  /* ✦ Theme/Background/Solid/Harness Theme/Dark */
-  --figma___badges-soft-amber-background: 24 100% 50% / 0.1;
-  /* ✦ Theme/Badges/Soft/Amber/background/Harness Theme/Dark */
-  --figma___badges-soft-amber-text: 43 100% 65% / 1;
-  /* ✦ Theme/Badges/Soft/Amber/text/Harness Theme/Dark */
-  --figma___badges-soft-blue-background: 216 100% 50% / 0.17;
-  /* ✦ Theme/Badges/Soft/Blue/background/Harness Theme/Dark */
-  --figma___badges-soft-blue-text: 205 100% 71% / 1;
-  /* ✦ Theme/Badges/Soft/Blue/text/Harness Theme/Dark */
-  --figma___badges-soft-bronze-background: 17 100% 79% / 0.06;
-  /* ✦ Theme/Badges/Soft/Bronze/background/Harness Theme/Dark */
-  --figma___badges-soft-bronze-text: 19 100% 89% / 0.81;
-  /* ✦ Theme/Badges/Soft/Bronze/text/Harness Theme/Dark */
-  --figma___badges-soft-brown-background: 25 99% 68% / 0.07;
-  /* ✦ Theme/Badges/Soft/Brown/background/Harness Theme/Dark */
-  --figma___badges-soft-brown-text: 28 100% 84% / 0.85;
-  /* ✦ Theme/Badges/Soft/Brown/text/Harness Theme/Dark */
-  --figma___badges-soft-crimson-background: 335 100% 55% / 0.14;
-  /* ✦ Theme/Badges/Soft/Crimson/background/Harness Theme/Dark */
-  --figma___badges-soft-crimson-text: 341 100% 76% / 1;
-  /* ✦ Theme/Badges/Soft/Crimson/text/Harness Theme/Dark */
-  --figma___badges-soft-cyan-background: 197 100% 50% / 0.1;
-  /* ✦ Theme/Badges/Soft/Cyan/background/Harness Theme/Dark */
-  --figma___badges-soft-cyan-text: 190 100% 56% / 0.95;
-  /* ✦ Theme/Badges/Soft/Cyan/text/Harness Theme/Dark */
-  --figma___badges-soft-gold-background: 50 100% 77% / 0.05;
-  /* ✦ Theme/Badges/Soft/Gold/background/Harness Theme/Dark */
-  --figma___badges-soft-gold-text: 35 100% 89% / 0.77;
-  /* ✦ Theme/Badges/Soft/Gold/text/Harness Theme/Dark */
-  --figma___badges-soft-grass-background: 139 98% 54% / 0.07;
-  /* ✦ Theme/Badges/Soft/Grass/background/Harness Theme/Dark */
-  --figma___badges-soft-grass-text: 131 100% 77% / 0.8;
-  /* ✦ Theme/Badges/Soft/Grass/text/Harness Theme/Dark */
-  --figma___badges-soft-green-background: 149 100% 49% / 0.07;
-  /* ✦ Theme/Badges/Soft/Green/background/Harness Theme/Dark */
-  --figma___badges-soft-green-text: 151 100% 64% / 0.82;
-  /* ✦ Theme/Badges/Soft/Green/text/Harness Theme/Dark */
-  --figma___badges-soft-indigo-background: 228 100% 57% / 0.18;
-  /* ✦ Theme/Badges/Soft/Indigo/background/Harness Theme/Dark */
-  --figma___badges-soft-indigo-text: 235 100% 80% / 1;
-  /* ✦ Theme/Badges/Soft/Indigo/text/Harness Theme/Dark */
-  --figma___badges-soft-iris-background: 244 99% 64% / 0.17;
-  /* ✦ Theme/Badges/Soft/Iris/background/Harness Theme/Dark */
-  --figma___badges-soft-iris-text: 242 100% 81% / 1;
-  /* ✦ Theme/Badges/Soft/Iris/text/Harness Theme/Dark */
-  --figma___badges-soft-jade-background: 145 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Soft/Jade/background/Harness Theme/Dark */
-  --figma___badges-soft-jade-text: 163 99% 56% / 0.83;
-  /* ✦ Theme/Badges/Soft/Jade/text/Harness Theme/Dark */
-  --figma___badges-soft-lime-background: 89 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Soft/Lime/background/Harness Theme/Dark */
-  --figma___badges-soft-lime-text: 70 100% 58% / 0.84;
-  /* ✦ Theme/Badges/Soft/Lime/text/Harness Theme/Dark */
-  --figma___badges-soft-mint-background: 174 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Soft/Mint/background/Harness Theme/Dark */
-  --figma___badges-soft-mint-text: 167 100% 66% / 0.86;
-  /* ✦ Theme/Badges/Soft/Mint/text/Harness Theme/Dark */
-  --figma___badges-soft-orange-background: 13 100% 50% / 0.12;
-  /* ✦ Theme/Badges/Soft/Orange/background/Harness Theme/Dark */
-  --figma___badges-soft-orange-text: 24 100% 70% / 1;
-  /* ✦ Theme/Badges/Soft/Orange/text/Harness Theme/Dark */
-  --figma___badges-soft-pink-background: 318 99% 56% / 0.14;
-  /* ✦ Theme/Badges/Soft/Pink/background/Harness Theme/Dark */
-  --figma___badges-soft-pink-text: 325 100% 77% / 0.98;
-  /* ✦ Theme/Badges/Soft/Pink/text/Harness Theme/Dark */
-  --figma___badges-soft-plum-background: 300 99% 59% / 0.12;
-  /* ✦ Theme/Badges/Soft/Plum/background/Harness Theme/Dark */
-  --figma___badges-soft-plum-text: 290 100% 80% / 0.91;
-  /* ✦ Theme/Badges/Soft/Plum/text/Harness Theme/Dark */
-  --figma___badges-soft-purple-background: 282 99% 60% / 0.15;
-  /* ✦ Theme/Badges/Soft/Purple/background/Harness Theme/Dark */
-  --figma___badges-soft-purple-text: 270 100% 80% / 0.98;
-  /* ✦ Theme/Badges/Soft/Purple/text/Harness Theme/Dark */
-  --figma___badges-soft-red-background: 353 99% 56% / 0.15;
-  /* ✦ Theme/Badges/Soft/Red/background/Harness Theme/Dark */
-  --figma___badges-soft-red-text: 358 100% 76% / 1;
-  /* ✦ Theme/Badges/Soft/Red/text/Harness Theme/Dark */
-  --figma___badges-soft-ruby-background: 348 99% 56% / 0.15;
-  /* ✦ Theme/Badges/Soft/Ruby/background/Harness Theme/Dark */
-  --figma___badges-soft-ruby-text: 348 100% 76% / 1;
-  /* ✦ Theme/Badges/Soft/Ruby/text/Harness Theme/Dark */
-  --figma___badges-soft-sky-background: 204 100% 50% / 0.12;
-  /* ✦ Theme/Badges/Soft/Sky/background/Harness Theme/Dark */
-  --figma___badges-soft-sky-text: 195 100% 66% / 1;
-  /* ✦ Theme/Badges/Soft/Sky/text/Harness Theme/Dark */
-  --figma___badges-soft-teal-background: 161 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Soft/Teal/background/Harness Theme/Dark */
-  --figma___badges-soft-teal-text: 170 100% 52% / 0.83;
-  /* ✦ Theme/Badges/Soft/Teal/text/Harness Theme/Dark */
-  --figma___badges-soft-violet-background: 255 99% 63% / 0.17;
-  /* ✦ Theme/Badges/Soft/Violet/background/Harness Theme/Dark */
-  --figma___badges-soft-violet-text: 255 100% 80% / 1;
-  /* ✦ Theme/Badges/Soft/Violet/text/Harness Theme/Dark */
-  --figma___badges-soft-yellow-background: 36 100% 50% / 0.09;
-  /* ✦ Theme/Badges/Soft/Yellow/background/Harness Theme/Dark */
-  --figma___badges-soft-yellow-text: 55 100% 60% / 1;
-  /* ✦ Theme/Badges/Soft/Yellow/text/Harness Theme/Dark */
-  --figma___badges-soft-accent-background: 216 100% 50% / 0.17;
-  /* ✦ Theme/Badges/Soft/accent/background/Harness Theme/Dark */
-  --figma___badges-soft-accent-text: 205 100% 71% / 1;
-  /* ✦ Theme/Badges/Soft/accent/text/Harness Theme/Dark */
-  --figma___badges-soft-error-background: 353 99% 56% / 0.15;
-  /* ✦ Theme/Badges/Soft/error/background/Harness Theme/Dark */
-  --figma___badges-soft-error-text: 358 100% 76% / 1;
-  /* ✦ Theme/Badges/Soft/error/text/Harness Theme/Dark */
-  --figma___badges-soft-info-background: 216 100% 50% / 0.17;
-  /* ✦ Theme/Badges/Soft/info/background/Harness Theme/Dark */
-  --figma___badges-soft-info-text: 205 100% 71% / 1;
-  /* ✦ Theme/Badges/Soft/info/text/Harness Theme/Dark */
-  --figma___badges-soft-success-background: 149 100% 49% / 0.07;
-  /* ✦ Theme/Badges/Soft/success/background/Harness Theme/Dark */
-  --figma___badges-soft-success-text: 151 65% 54% / 1;
-  /* ✦ Theme/Badges/Soft/success/text/Harness Theme/Dark */
-  --figma___badges-soft-warning-background: 34 63% 12% / 1;
-  /* ✦ Theme/Badges/Soft/warning/background/Harness Theme/Dark */
-  --figma___badges-soft-warning-text: 43 100% 65% / 1;
-  /* ✦ Theme/Badges/Soft/warning/text/Harness Theme/Dark */
-  --figma___badges-solid-amber-background: 42 100% 62% / 1;
-  /* ✦ Theme/Badges/Solid/Amber/background/Harness Theme/Dark */
-  --figma___badges-solid-blue-background: 214 73% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Blue/background/Harness Theme/Dark */
-  --figma___badges-solid-bronze-background: 18 20% 54% / 1;
-  /* ✦ Theme/Badges/Solid/Bronze/background/Harness Theme/Dark */
-  --figma___badges-solid-brown-background: 28 34% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Brown/background/Harness Theme/Dark */
-  --figma___badges-solid-crimson-background: 336 80% 58% / 1;
-  /* ✦ Theme/Badges/Solid/Crimson/background/Harness Theme/Dark */
-  --figma___badges-solid-cyan-background: 190 95% 39% / 1;
-  /* ✦ Theme/Badges/Solid/Cyan/background/Harness Theme/Dark */
-  --figma___badges-solid-gold-background: 36 20% 49% / 1;
-  /* ✦ Theme/Badges/Solid/Gold/background/Harness Theme/Dark */
-  --figma___badges-solid-grass-background: 132 59% 33% / 1;
-  /* ✦ Theme/Badges/Solid/Grass/background/Harness Theme/Dark */
-  --figma___badges-solid-green-background: 142 72% 29% / 1;
-  /* ✦ Theme/Badges/Solid/Green/background/Harness Theme/Dark */
-  --figma___badges-solid-indigo-background: 226 70% 55% / 1;
-  /* ✦ Theme/Badges/Solid/Indigo/background/Harness Theme/Dark */
-  --figma___badges-solid-iris-background: 240 60% 60% / 1;
-  /* ✦ Theme/Badges/Solid/Iris/background/Harness Theme/Dark */
-  --figma___badges-solid-jade-background: 164 60% 40% / 1;
-  /* ✦ Theme/Badges/Solid/Jade/background/Harness Theme/Dark */
-  --figma___badges-solid-lime-background: 81 80% 66% / 1;
-  /* ✦ Theme/Badges/Solid/Lime/background/Harness Theme/Dark */
-  --figma___badges-solid-mint-background: 167 70% 72% / 1;
-  /* ✦ Theme/Badges/Solid/Mint/background/Harness Theme/Dark */
-  --figma___badges-solid-orange-background: 24 100% 70% / 1;
-  /* ✦ Theme/Badges/Solid/Orange/background/Harness Theme/Dark */
-  --figma___badges-solid-pink-background: 322 65% 55% / 1;
-  /* ✦ Theme/Badges/Solid/Pink/background/Harness Theme/Dark */
-  --figma___badges-solid-plum-background: 292 45% 51% / 1;
-  /* ✦ Theme/Badges/Solid/Plum/background/Harness Theme/Dark */
-  --figma___badges-solid-purple-background: 272 51% 54% / 1;
-  /* ✦ Theme/Badges/Solid/Purple/background/Harness Theme/Dark */
-  --figma___badges-solid-red-background: 358 75% 59% / 1;
-  /* ✦ Theme/Badges/Solid/Red/background/Harness Theme/Dark */
-  --figma___badges-solid-ruby-background: 348 75% 59% / 1;
-  /* ✦ Theme/Badges/Solid/Ruby/background/Harness Theme/Dark */
-  --figma___badges-solid-sky-background: 193 98% 74% / 1;
-  /* ✦ Theme/Badges/Solid/Sky/background/Harness Theme/Dark */
-  --figma___badges-solid-success-background: 142 72% 29% / 1;
-  /* ✦ Theme/Badges/Solid/Success/background/Harness Theme/Dark */
-  --figma___badges-solid-teal-background: 173 80% 36% / 1;
-  /* ✦ Theme/Badges/Solid/Teal/background/Harness Theme/Dark */
-  --figma___badges-solid-violet-background: 252 56% 57% / 1;
-  /* ✦ Theme/Badges/Solid/Violet/background/Harness Theme/Dark */
-  --figma___badges-solid-yellow-background: 53 96% 58% / 1;
-  /* ✦ Theme/Badges/Solid/Yellow/background/Harness Theme/Dark */
-  --figma___badges-solid-accent-background: 214 73% 51% / 1;
-  /* ✦ Theme/Badges/Solid/accent/background/Harness Theme/Dark */
-  --figma___badges-solid-info-background: 214 73% 51% / 1;
-  /* ✦ Theme/Badges/Solid/info/background/Harness Theme/Dark */
-  --figma___badges-solid-warning-background: 42 100% 62% / 1;
-  /* ✦ Theme/Badges/Solid/warning/background/Harness Theme/Dark */
-  --figma___badges-surface-amber-background: 6 100% 49% / 0.06;
-  /* ✦ Theme/Badges/Surface/Amber/background/Harness Theme/Dark */
-  --figma___badges-surface-amber-border: 35 100% 57% / 0.38;
-  /* ✦ Theme/Badges/Surface/Amber/border/Harness Theme/Dark */
-  --figma___badges-surface-amber-text: 43 100% 65% / 1;
-  /* ✦ Theme/Badges/Surface/Amber/text/Harness Theme/Dark */
-  --figma___badges-surface-blue-background: 227 100% 50% / 0.09;
-  /* ✦ Theme/Badges/Surface/Blue/background/Harness Theme/Dark */
-  --figma___badges-surface-blue-border: 211 100% 51% / 0.55;
-  /* ✦ Theme/Badges/Surface/Blue/border/Harness Theme/Dark */
-  --figma___badges-surface-blue-text: 205 100% 71% / 1;
-  /* ✦ Theme/Badges/Surface/Blue/text/Harness Theme/Dark */
-  --figma___badges-surface-bronze-background: 15 93% 53% / 0.02;
-  /* ✦ Theme/Badges/Surface/Bronze/background/Harness Theme/Dark */
-  --figma___badges-surface-bronze-border: 17 100% 84% / 0.3;
-  /* ✦ Theme/Badges/Surface/Bronze/border/Harness Theme/Dark */
-  --figma___badges-surface-bronze-text: 19 100% 89% / 0.81;
-  /* ✦ Theme/Badges/Surface/Bronze/text/Harness Theme/Dark */
-  --figma___badges-surface-brown-background: 24 100% 50% / 0.03;
-  /* ✦ Theme/Badges/Surface/Brown/background/Harness Theme/Dark */
-  --figma___badges-surface-brown-border: 28 98% 75% / 0.32;
-  /* ✦ Theme/Badges/Surface/Brown/border/Harness Theme/Dark */
-  --figma___badges-surface-brown-text: 28 100% 84% / 0.85;
-  /* ✦ Theme/Badges/Surface/Brown/text/Harness Theme/Dark */
-  --figma___badges-surface-crimson-border: 336 100% 57% / 0.49;
-  /* ✦ Theme/Badges/Surface/Crimson/Border/Harness Theme/Dark */
-  --figma___badges-surface-crimson-background: 338 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/Crimson/background/Harness Theme/Dark */
-  --figma___badges-surface-crimson-text: 341 100% 76% / 1;
-  /* ✦ Theme/Badges/Surface/Crimson/text/Harness Theme/Dark */
-  --figma___badges-surface-cyan-border: 192 100% 57% / 0.35;
-  /* ✦ Theme/Badges/Surface/Cyan/Border/Harness Theme/Dark */
-  --figma___badges-surface-cyan-background: 207 100% 49% / 0.04;
-  /* ✦ Theme/Badges/Surface/Cyan/background/Harness Theme/Dark */
-  --figma___badges-surface-cyan-text: 190 100% 56% / 0.95;
-  /* ✦ Theme/Badges/Surface/Cyan/text/Harness Theme/Dark */
-  --figma___badges-surface-gold-border: 39 97% 85% / 0.27;
-  /* ✦ Theme/Badges/Surface/Gold/Border/Harness Theme/Dark */
-  --figma___badges-surface-gold-background: 42 100% 50% / 0.01;
-  /* ✦ Theme/Badges/Surface/Gold/background/Harness Theme/Dark */
-  --figma___badges-surface-gold-text: 35 100% 89% / 0.77;
-  /* ✦ Theme/Badges/Surface/Gold/text/Harness Theme/Dark */
-  --figma___badges-surface-grass-border: 135 100% 68% / 0.3;
-  /* ✦ Theme/Badges/Surface/Grass/Border/Harness Theme/Dark */
-  --figma___badges-surface-grass-background: 120 100% 49% / 0.02;
-  /* ✦ Theme/Badges/Surface/Grass/background/Harness Theme/Dark */
-  --figma___badges-surface-grass-text: 131 100% 77% / 0.8;
-  /* ✦ Theme/Badges/Surface/Grass/text/Harness Theme/Dark */
-  --figma___badges-surface-green-background: 120 100% 49% / 0.02;
-  /* ✦ Theme/Badges/Surface/Green/background/Harness Theme/Dark */
-  --figma___badges-surface-green-border: 152 99% 59% / 0.3;
-  /* ✦ Theme/Badges/Surface/Green/border/Harness Theme/Dark */
-  --figma___badges-surface-green-text: 151 100% 64% / 0.82;
-  /* ✦ Theme/Badges/Surface/Green/text/Harness Theme/Dark */
-  --figma___badges-surface-indigo-background: 232 100% 50% / 0.09;
-  /* ✦ Theme/Badges/Surface/Indigo/background/Harness Theme/Dark */
-  --figma___badges-surface-indigo-border: 226 100% 62% / 0.52;
-  /* ✦ Theme/Badges/Surface/Indigo/border/Harness Theme/Dark */
-  --figma___badges-surface-indigo-text: 235 100% 80% / 1;
-  /* ✦ Theme/Badges/Surface/Indigo/text/Harness Theme/Dark */
-  --figma___badges-surface-iris-border: 240 100% 71% / 0.49;
-  /* ✦ Theme/Badges/Surface/Iris/Border/Harness Theme/Dark */
-  --figma___badges-surface-iris-background: 243 100% 55% / 0.09;
-  /* ✦ Theme/Badges/Surface/Iris/background/Harness Theme/Dark */
-  --figma___badges-surface-iris-text: 242 100% 81% / 1;
-  /* ✦ Theme/Badges/Surface/Iris/text/Harness Theme/Dark */
-  --figma___badges-surface-jade-border: 159 99% 58% / 0.3;
-  /* ✦ Theme/Badges/Surface/Jade/Border/Harness Theme/Dark */
-  --figma___badges-surface-jade-background: 120 100% 49% / 0.03;
-  /* ✦ Theme/Badges/Surface/Jade/background/Harness Theme/Dark */
-  --figma___badges-surface-jade-text: 163 99% 56% / 0.83;
-  /* ✦ Theme/Badges/Surface/Jade/text/Harness Theme/Dark */
-  --figma___badges-surface-lime-border: 78 100% 61% / 0.28;
-  /* ✦ Theme/Badges/Surface/Lime/Border/Harness Theme/Dark */
-  --figma___badges-surface-lime-background: 114 100% 49% / 0.02;
-  /* ✦ Theme/Badges/Surface/Lime/background/Harness Theme/Dark */
-  --figma___badges-surface-lime-text: 70 100% 58% / 0.84;
-  /* ✦ Theme/Badges/Surface/Lime/text/Harness Theme/Dark */
-  --figma___badges-surface-mint-background: 165 100% 49% / 0.03;
-  /* ✦ Theme/Badges/Surface/Mint/background/Harness Theme/Dark */
-  --figma___badges-surface-mint-border: 173 100% 55% / 0.31;
-  /* ✦ Theme/Badges/Surface/Mint/border/Harness Theme/Dark */
-  --figma___badges-surface-mint-text: 167 100% 66% / 0.86;
-  /* ✦ Theme/Badges/Surface/Mint/text/Harness Theme/Dark */
-  --figma___badges-surface-orange-background: 0 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Surface/Orange/background/Harness Theme/Dark */
-  --figma___badges-surface-orange-border: 25 100% 51% / 0.44;
-  /* ✦ Theme/Badges/Surface/Orange/border/Harness Theme/Dark */
-  --figma___badges-surface-orange-text: 24 100% 70% / 1;
-  /* ✦ Theme/Badges/Surface/Orange/text/Harness Theme/Dark */
-  --figma___badges-surface-pink-background: 319 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/Pink/background/Harness Theme/Dark */
-  --figma___badges-surface-pink-border: 320 100% 62% / 0.43;
-  /* ✦ Theme/Badges/Surface/Pink/border/Harness Theme/Dark */
-  --figma___badges-surface-pink-text: 325 100% 77% / 0.98;
-  /* ✦ Theme/Badges/Surface/Pink/text/Harness Theme/Dark */
-  --figma___badges-surface-plum-background: 300 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Surface/Plum/background/Harness Theme/Dark */
-  --figma___badges-surface-plum-border: 294 100% 69% / 0.39;
-  /* ✦ Theme/Badges/Surface/Plum/border/Harness Theme/Dark */
-  --figma___badges-surface-plum-text: 290 100% 80% / 0.91;
-  /* ✦ Theme/Badges/Surface/Plum/text/Harness Theme/Dark */
-  --figma___badges-surface-purple-background: 283 100% 49% / 0.07;
-  /* ✦ Theme/Badges/Surface/Purple/background/Harness Theme/Dark */
-  --figma___badges-surface-purple-border: 276 100% 67% / 0.44;
-  /* ✦ Theme/Badges/Surface/Purple/border/Harness Theme/Dark */
-  --figma___badges-surface-purple-text: 270 100% 80% / 0.98;
-  /* ✦ Theme/Badges/Surface/Purple/text/Harness Theme/Dark */
-  --figma___badges-surface-red-background: 354 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/Red/background/Harness Theme/Dark */
-  --figma___badges-surface-red-border: 354 100% 57% / 0.5;
-  /* ✦ Theme/Badges/Surface/Red/border/Harness Theme/Dark */
-  --figma___badges-surface-red-text: 358 100% 76% / 1;
-  /* ✦ Theme/Badges/Surface/Red/text/Harness Theme/Dark */
-  --figma___badges-surface-ruby-background: 351 100% 50% / 0.08;
-  /* ✦ Theme/Badges/Surface/Ruby/background/Harness Theme/Dark */
-  --figma___badges-surface-ruby-border: 348 100% 57% / 0.49;
-  /* ✦ Theme/Badges/Surface/Ruby/border/Harness Theme/Dark */
-  --figma___badges-surface-ruby-text: 348 100% 76% / 1;
-  /* ✦ Theme/Badges/Surface/Ruby/text/Harness Theme/Dark */
-  --figma___badges-surface-sky-background: 215 100% 50% / 0.06;
-  /* ✦ Theme/Badges/Surface/Sky/background/Harness Theme/Dark */
-  --figma___badges-surface-sky-border: 200 100% 59% / 0.4;
-  /* ✦ Theme/Badges/Surface/Sky/border/Harness Theme/Dark */
-  --figma___badges-surface-sky-text: 195 100% 66% / 1;
-  /* ✦ Theme/Badges/Surface/Sky/text/Harness Theme/Dark */
-  --figma___badges-surface-teal-background: 141 100% 49% / 0.03;
-  /* ✦ Theme/Badges/Surface/Teal/background/Harness Theme/Dark */
-  --figma___badges-surface-teal-border: 171 99% 56% / 0.3;
-  /* ✦ Theme/Badges/Surface/Teal/border/Harness Theme/Dark */
-  --figma___badges-surface-teal-text: 170 100% 52% / 0.83;
-  /* ✦ Theme/Badges/Surface/Teal/text/Harness Theme/Dark */
-  --figma___badges-surface-violet-background: 255 98% 52% / 0.08;
-  /* ✦ Theme/Badges/Surface/Violet/background/Harness Theme/Dark */
-  --figma___badges-surface-violet-border: 251 100% 70% / 0.49;
-  /* ✦ Theme/Badges/Surface/Violet/border/Harness Theme/Dark */
-  --figma___badges-surface-violet-text: 255 100% 80% / 1;
-  /* ✦ Theme/Badges/Surface/Violet/text/Harness Theme/Dark */
-  --figma___badges-surface-yellow-background: 17 100% 49% / 0.04;
-  /* ✦ Theme/Badges/Surface/Yellow/background/Harness Theme/Dark */
-  --figma___badges-surface-yellow-border: 47 99% 55% / 0.32;
-  /* ✦ Theme/Badges/Surface/Yellow/border/Harness Theme/Dark */
-  --figma___badges-surface-yellow-text: 55 100% 60% / 1;
-  /* ✦ Theme/Badges/Surface/Yellow/text/Harness Theme/Dark */
-  --figma___badges-surface-accent-background: 227 100% 50% / 0.09;
-  /* ✦ Theme/Badges/Surface/accent/background/Harness Theme/Dark */
-  --figma___badges-surface-accent-border: 211 100% 51% / 0.55;
-  /* ✦ Theme/Badges/Surface/accent/border/Harness Theme/Dark */
-  --figma___badges-surface-accent-text: 211 100% 51% / 0.55;
-  /* ✦ Theme/Badges/Surface/accent/text/Harness Theme/Dark */
-  --figma___badges-surface-error-background: 354 100% 50% / 0.07;
-  /* ✦ Theme/Badges/Surface/error/background/Harness Theme/Dark */
-  --figma___badges-surface-error-border: 354 100% 57% / 0.5;
-  /* ✦ Theme/Badges/Surface/error/border/Harness Theme/Dark */
-  --figma___badges-surface-error-text: 358 100% 76% / 1;
-  /* ✦ Theme/Badges/Surface/error/text/Harness Theme/Dark */
-  --figma___badges-surface-info-background: 204 100% 50% / 0.12;
-  /* ✦ Theme/Badges/Surface/info/background/Harness Theme/Dark */
-  --figma___badges-surface-info-border: 200 100% 59% / 0.4;
-  /* ✦ Theme/Badges/Surface/info/border/Harness Theme/Dark */
-  --figma___badges-surface-info-text: 195 100% 66% / 1;
-  /* ✦ Theme/Badges/Surface/info/text/Harness Theme/Dark */
-  --figma___badges-surface-success-background: 120 100% 49% / 0.03;
-  /* ✦ Theme/Badges/Surface/success/background/Harness Theme/Dark */
-  --figma___badges-surface-success-border: 159 99% 58% / 0.3;
-  /* ✦ Theme/Badges/Surface/success/border/Harness Theme/Dark */
-  --figma___badges-surface-success-text: 163 99% 56% / 0.83;
-  /* ✦ Theme/Badges/Surface/success/text/Harness Theme/Dark */
-  --figma___badges-surface-warning-background: 6 100% 49% / 0.06;
-  /* ✦ Theme/Badges/Surface/warning/background/Harness Theme/Dark */
-  --figma___badges-surface-warning-border: 35 100% 57% / 0.38;
-  /* ✦ Theme/Badges/Surface/warning/border/Harness Theme/Dark */
-  --figma___badges-surface-warning-text: 43 100% 65% / 1;
-  /* ✦ Theme/Badges/Surface/warning/text/Harness Theme/Dark */
-  --figma___border-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Border/Disabled/Harness Theme/Dark */
-  --figma___border-hover: 0 0% 29% / 1;
-  /* ✦ Theme/Border/Hover/Harness Theme/Dark */
-  --figma___border-primary: 0 0% 100% / 0.1;
-  /* ✦ Theme/Border/Primary/Harness Theme/Dark */
-  --figma___border-secondary: 0 0% 16% / 1;
-  /* ✦ Theme/Border/Secondary/Harness Theme/Dark */
-  --figma___border-selected: 206 100% 62% / 1;
-  /* ✦ Theme/Border/Selected/Harness Theme/Dark */
-  --figma___breadcrumbs-current: 0 0% 93% / 1;
-  /* ✦ Theme/Breadcrumbs/current/Harness Theme/Dark */
-  --figma___breadcrumbs-visited: 0 0% 69% / 1;
-  /* ✦ Theme/Breadcrumbs/visited/Harness Theme/Dark */
-  --figma___button-ghost-accent-active: 214 100% 50% / 0.23;
-  /* ✦ Theme/Button/Ghost/Accent/Active/Harness Theme/Dark */
-  --figma___button-ghost-accent-active-text: 205 100% 71% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Active text/Harness Theme/Dark */
-  --figma___button-ghost-accent-hover: 216 100% 50% / 0.17;
-  /* ✦ Theme/Button/Ghost/Accent/Hover/Harness Theme/Dark */
-  --figma___button-ghost-accent-hover-text: 205 100% 71% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Hover text/Harness Theme/Dark */
-  --figma___button-ghost-accent-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/Harness Theme/Dark */
-  --figma___button-ghost-accent-text-primary: 205 100% 71% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Text-primary/Harness Theme/Dark */
-  --figma___button-ghost-error-active: 352 100% 56% / 0.21;
-  /* ✦ Theme/Button/Ghost/Error/Active/Harness Theme/Dark */
-  --figma___button-ghost-error-active-text: 358 100% 76% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Active Text/Harness Theme/Dark */
-  --figma___button-ghost-error-hover: 353 99% 56% / 0.15;
-  /* ✦ Theme/Button/Ghost/Error/Hover/Harness Theme/Dark */
-  --figma___button-ghost-error-hover-text: 358 100% 76% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Hover text/Harness Theme/Dark */
-  --figma___button-ghost-error-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Ghost/Error/Text-disabled/Harness Theme/Dark */
-  --figma___button-ghost-error-text-primary: 358 100% 76% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Text-primary/Harness Theme/Dark */
-  --figma___button-ghost-neutral-active: 0 0% 100% / 0.1;
-  /* ✦ Theme/Button/Ghost/Neutral/Active/Harness Theme/Dark */
-  --figma___button-ghost-neutral-active-text: 0 0% 69% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Active Text/Harness Theme/Dark */
-  --figma___button-ghost-neutral-hover: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover/Harness Theme/Dark */
-  --figma___button-ghost-neutral-hover-text: 0 0% 69% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover text/Harness Theme/Dark */
-  --figma___button-ghost-neutral-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/Harness Theme/Dark */
-  --figma___button-ghost-neutral-text-primary: 0 0% 69% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/Harness Theme/Dark */
-  --figma___button-ghost-success-active: 154 100% 50% / 0.11;
-  /* ✦ Theme/Button/Ghost/Success/Active/Harness Theme/Dark */
-  --figma___button-ghost-success-active-text: 151 65% 54% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Active Text/Harness Theme/Dark */
-  --figma___button-ghost-success-hover: 149 100% 49% / 0.07;
-  /* ✦ Theme/Button/Ghost/Success/Hover/Harness Theme/Dark */
-  --figma___button-ghost-success-hover-text: 151 65% 54% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Hover text/Harness Theme/Dark */
-  --figma___button-ghost-success-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Ghost/Success/Text-disabled/Harness Theme/Dark */
-  --figma___button-ghost-success-text-primary: 151 65% 54% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Text-primary/Harness Theme/Dark */
-  --figma___button-outline-accent-active: 216 100% 50% / 0.17;
-  /* ✦ Theme/Button/Outline/Accent/Active/Harness Theme/Dark */
-  --figma___button-outline-accent-default-border: 206 100% 50% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Default border/Harness Theme/Dark */
-  --figma___button-outline-accent-disabled-border: 0 0% 100% / 0.17;
-  /* ✦ Theme/Button/Outline/Accent/Disabled Border/Harness Theme/Dark */
-  --figma___button-outline-accent-hover: 227 100% 50% / 0.09;
-  /* ✦ Theme/Button/Outline/Accent/Hover/Harness Theme/Dark */
-  --figma___button-outline-accent-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Outline/Accent/Text-disabled/Harness Theme/Dark */
-  --figma___button-outline-accent-text-primary: 205 100% 71% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Text-primary/Harness Theme/Dark */
-  --figma___button-outline-error-active: 353 99% 56% / 0.15;
-  /* ✦ Theme/Button/Outline/Error/Active/Harness Theme/Dark */
-  --figma___button-outline-error-default-border: 358 100% 65% / 0.89;
-  /* ✦ Theme/Button/Outline/Error/Default - border/Harness Theme/Dark */
-  --figma___button-outline-error-disabled-border: 0 0% 100% / 0.17;
-  /* ✦ Theme/Button/Outline/Error/Disabled-border/Harness Theme/Dark */
-  --figma___button-outline-error-hover: 354 100% 50% / 0.07;
-  /* ✦ Theme/Button/Outline/Error/Hover/Harness Theme/Dark */
-  --figma___button-outline-error-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Outline/Error/Text-disabled/Harness Theme/Dark */
-  --figma___button-outline-error-text-primary: 358 100% 76% / 1;
-  /* ✦ Theme/Button/Outline/Error/Text-primary/Harness Theme/Dark */
-  --figma___button-outline-neutral-active: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Outline/Neutral/Active/Harness Theme/Dark */
-  --figma___button-outline-neutral-default-border: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Outline/Neutral/Default - border/Harness Theme/Dark */
-  --figma___button-outline-neutral-disabled-border: 0 0% 100% / 0.17;
-  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/Harness Theme/Dark */
-  --figma___button-outline-neutral-hover: 240 89% 18% / 0.02;
-  /* ✦ Theme/Button/Outline/Neutral/Hover/Harness Theme/Dark */
-  --figma___button-outline-neutral-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/Harness Theme/Dark */
-  --figma___button-outline-neutral-text-primary: 0 0% 69% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Text-primary/Harness Theme/Dark */
-  --figma___button-outline-success-active: 149 100% 49% / 0.07;
-  /* ✦ Theme/Button/Outline/Success/Active/Harness Theme/Dark */
-  --figma___button-outline-success-default-border: 151 100% 62% / 0.61;
-  /* ✦ Theme/Button/Outline/Success/Default-border/Harness Theme/Dark */
-  --figma___button-outline-success-disabled-border: 0 0% 100% / 0.17;
-  /* ✦ Theme/Button/Outline/Success/Disabled - border/Harness Theme/Dark */
-  --figma___button-outline-success-hover: 120 100% 49% / 0.02;
-  /* ✦ Theme/Button/Outline/Success/Hover/Harness Theme/Dark */
-  --figma___button-outline-success-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Outline/Success/Text-disabled/Harness Theme/Dark */
-  --figma___button-outline-success-text-primary: 151 65% 54% / 1;
-  /* ✦ Theme/Button/Outline/Success/Text-primary/Harness Theme/Dark */
-  --figma___button-soft-accent-active: 213 100% 51% / 0.29;
-  /* ✦ Theme/Button/Soft/Accent/Active/Harness Theme/Dark */
-  --figma___button-soft-accent-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Soft/Accent/Disabled/Harness Theme/Dark */
-  --figma___button-soft-accent-hover: 214 100% 50% / 0.23;
-  /* ✦ Theme/Button/Soft/Accent/Hover/Harness Theme/Dark */
-  --figma___button-soft-accent-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Soft/Accent/Text-disabled/Harness Theme/Dark */
-  --figma___button-soft-accent-text-primary: 205 100% 71% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Text-primary/Harness Theme/Dark */
-  --figma___button-soft-accent-default: 216 100% 50% / 0.17;
-  /* ✦ Theme/Button/Soft/Accent/default/Harness Theme/Dark */
-  --figma___button-soft-error-active: 354 99% 57% / 0.26;
-  /* ✦ Theme/Button/Soft/Error/Active/Harness Theme/Dark */
-  --figma___button-soft-error-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Soft/Error/Disabled/Harness Theme/Dark */
-  --figma___button-soft-error-hover: 352 100% 56% / 0.21;
-  /* ✦ Theme/Button/Soft/Error/Hover/Harness Theme/Dark */
-  --figma___button-soft-error-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Soft/Error/Text-disabled/Harness Theme/Dark */
-  --figma___button-soft-error-text-primary: 358 100% 76% / 1;
-  /* ✦ Theme/Button/Soft/Error/Text-primary/Harness Theme/Dark */
-  --figma___button-soft-error-default: 353 99% 56% / 0.15;
-  /* ✦ Theme/Button/Soft/Error/default/Harness Theme/Dark */
-  --figma___button-soft-neutral-active: 0 0% 100% / 0.13;
-  /* ✦ Theme/Button/Soft/Neutral/Active/Harness Theme/Dark */
-  --figma___button-soft-neutral-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Soft/Neutral/Disabled/Harness Theme/Dark */
-  --figma___button-soft-neutral-hover: 0 0% 100% / 0.1;
-  /* ✦ Theme/Button/Soft/Neutral/Hover/Harness Theme/Dark */
-  --figma___button-soft-neutral-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/Harness Theme/Dark */
-  --figma___button-soft-neutral-text-primary: 0 0% 69% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Text-primary/Harness Theme/Dark */
-  --figma___button-soft-neutral-default: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Soft/Neutral/default/Harness Theme/Dark */
-  --figma___button-soft-success-active: 153 99% 53% / 0.15;
-  /* ✦ Theme/Button/Soft/Success/Active/Harness Theme/Dark */
-  --figma___button-soft-success-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Soft/Success/Disabled/Harness Theme/Dark */
-  --figma___button-soft-success-hover: 154 100% 50% / 0.11;
-  /* ✦ Theme/Button/Soft/Success/Hover/Harness Theme/Dark */
-  --figma___button-soft-success-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Soft/Success/Text-disabled/Harness Theme/Dark */
-  --figma___button-soft-success-text-primary: 151 100% 64% / 0.82;
-  /* ✦ Theme/Button/Soft/Success/Text-primary/Harness Theme/Dark */
-  --figma___button-soft-success-default: 149 100% 49% / 0.07;
-  /* ✦ Theme/Button/Soft/Success/default/Harness Theme/Dark */
-  --figma___button-solid-accent-active: 214 73% 51% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Active/Harness Theme/Dark */
-  --figma___button-solid-accent-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Solid/Accent/Disabled/Harness Theme/Dark */
-  --figma___button-solid-accent-hover: 206 100% 62% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Hover/Harness Theme/Dark */
-  --figma___button-solid-accent-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Solid/Accent/Text-disabled/Harness Theme/Dark */
-  --figma___button-solid-accent-default: 214 73% 51% / 1;
-  /* ✦ Theme/Button/Solid/Accent/default/Harness Theme/Dark */
-  --figma___button-solid-error-active: 358 75% 59% / 1;
-  /* ✦ Theme/Button/Solid/Error/Active/Harness Theme/Dark */
-  --figma___button-solid-error-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Solid/Error/Disabled/Harness Theme/Dark */
-  --figma___button-solid-error-hover: 359 84% 67% / 1;
-  /* ✦ Theme/Button/Solid/Error/Hover/Harness Theme/Dark */
-  --figma___button-solid-error-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Solid/Error/Text-disabled/Harness Theme/Dark */
-  --figma___button-solid-error-default: 358 75% 59% / 1;
-  /* ✦ Theme/Button/Solid/Error/default/Harness Theme/Dark */
-  --figma___button-solid-neutral-active: 0 0% 43% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Active/Harness Theme/Dark */
-  --figma___button-solid-neutral-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Solid/Neutral/Disabled/Harness Theme/Dark */
-  --figma___button-solid-neutral-hover: 0 0% 51% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Hover/Harness Theme/Dark */
-  --figma___button-solid-neutral-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/Harness Theme/Dark */
-  --figma___button-solid-neutral-default: 0 0% 43% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/default/Harness Theme/Dark */
-  --figma___button-solid-success-active: 142 72% 29% / 1;
-  /* ✦ Theme/Button/Solid/Success/Active/Harness Theme/Dark */
-  --figma___button-solid-success-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Solid/Success/Disabled/Harness Theme/Dark */
-  --figma___button-solid-success-hover: 151 55% 47% / 1;
-  /* ✦ Theme/Button/Solid/Success/Hover/Harness Theme/Dark */
-  --figma___button-solid-success-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Solid/Success/Text-disabled/Harness Theme/Dark */
-  --figma___button-solid-success-default: 142 72% 29% / 1;
-  /* ✦ Theme/Button/Solid/Success/default/Harness Theme/Dark */
-  --figma___button-surface-accent-active: 213 100% 51% / 0.29;
-  /* ✦ Theme/Button/Surface/Accent/Active/Harness Theme/Dark */
-  --figma___button-surface-accent-active-border: 211 100% 53% / 0.88;
-  /* ✦ Theme/Button/Surface/Accent/Active border/Harness Theme/Dark */
-  --figma___button-surface-accent-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Surface/Accent/Disabled/Harness Theme/Dark */
-  --figma___button-surface-accent-hover: 214 100% 50% / 0.23;
-  /* ✦ Theme/Button/Surface/Accent/Hover/Harness Theme/Dark */
-  --figma___button-surface-accent-hover-border: 211 100% 53% / 0.88;
-  /* ✦ Theme/Button/Surface/Accent/Hover Border/Harness Theme/Dark */
-  --figma___button-surface-accent-text-disabled: 231 10% 75% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Text-disabled/Harness Theme/Dark */
-  --figma___button-surface-accent-text-primary: 205 100% 71% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Text-primary/Harness Theme/Dark */
-  --figma___button-surface-accent-default: 216 100% 50% / 0.17;
-  /* ✦ Theme/Button/Surface/Accent/default/Harness Theme/Dark */
-  --figma___button-surface-accent-default-border: 211 100% 51% / 0.55;
-  /* ✦ Theme/Button/Surface/Accent/default border/Harness Theme/Dark */
-  --figma___button-surface-error-active: 354 99% 57% / 0.26;
-  /* ✦ Theme/Button/Surface/Error/Active/Harness Theme/Dark */
-  --figma___button-surface-error-active-border: 359 100% 71% / 0.94;
-  /* ✦ Theme/Button/Surface/Error/Active border/Harness Theme/Dark */
-  --figma___button-surface-error-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Surface/Error/Disabled/Harness Theme/Dark */
-  --figma___button-surface-error-hover: 352 100% 56% / 0.21;
-  /* ✦ Theme/Button/Surface/Error/Hover/Harness Theme/Dark */
-  --figma___button-surface-error-hover-border: 359 100% 71% / 0.94;
-  /* ✦ Theme/Button/Surface/Error/Hover border/Harness Theme/Dark */
-  --figma___button-surface-error-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Surface/Error/Text-disabled/Harness Theme/Dark */
-  --figma___button-surface-error-text-primary: 358 100% 76% / 1;
-  /* ✦ Theme/Button/Surface/Error/Text-primary/Harness Theme/Dark */
-  --figma___button-surface-error-border: 354 100% 57% / 0.35;
-  /* ✦ Theme/Button/Surface/Error/border/Harness Theme/Dark */
-  --figma___button-surface-error-default: 353 99% 56% / 0.15;
-  /* ✦ Theme/Button/Surface/Error/default/Harness Theme/Dark */
-  --figma___button-surface-neutral-active: 223 100% 91% / 0.16;
-  /* ✦ Theme/Button/Surface/Neutral/Active/Harness Theme/Dark */
-  --figma___button-surface-neutral-disabled: 230 100% 87% / 0.09;
-  /* ✦ Theme/Button/Surface/Neutral/Disabled/Harness Theme/Dark */
-  --figma___button-surface-neutral-hover: 224 96% 89% / 0.13;
-  /* ✦ Theme/Button/Surface/Neutral/Hover/Harness Theme/Dark */
-  --figma___button-surface-neutral-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/Harness Theme/Dark */
-  --figma___button-surface-neutral-text-primary: 218 7% 70% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Text-primary/Harness Theme/Dark */
-  --figma___button-surface-neutral-border: 209 95% 92% / 0.24;
-  /* ✦ Theme/Button/Surface/Neutral/border/Harness Theme/Dark */
-  --figma___button-surface-neutral-default: 230 100% 87% / 0.09;
-  /* ✦ Theme/Button/Surface/Neutral/default/Harness Theme/Dark */
-  --figma___button-surface-success-active: 153 99% 53% / 0.15;
-  /* ✦ Theme/Button/Surface/Success/Active/Harness Theme/Dark */
-  --figma___button-surface-success-disabled: 0 0% 100% / 0.07;
-  /* ✦ Theme/Button/Surface/Success/Disabled/Harness Theme/Dark */
-  --figma___button-surface-success-hover: 154 100% 50% / 0.11;
-  /* ✦ Theme/Button/Surface/Success/Hover/Harness Theme/Dark */
-  --figma___button-surface-success-hover-border: 151 100% 63% / 0.7;
-  /* ✦ Theme/Button/Surface/Success/Hover border/Harness Theme/Dark */
-  --figma___button-surface-success-text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Button/Surface/Success/Text-disabled/Harness Theme/Dark */
-  --figma___button-surface-success-text-primary: 151 65% 54% / 1;
-  /* ✦ Theme/Button/Surface/Success/Text-primary/Harness Theme/Dark */
-  --figma___button-surface-success-active-border: 151 100% 63% / 0.7;
-  /* ✦ Theme/Button/Surface/Success/active border/Harness Theme/Dark */
-  --figma___button-surface-success-default: 149 100% 49% / 0.07;
-  /* ✦ Theme/Button/Surface/Success/default/Harness Theme/Dark */
-  --figma___button-surface-success-default-border: 155 99% 55% / 0.2;
-  /* ✦ Theme/Button/Surface/Success/default border/Harness Theme/Dark */
-  --figma___calendar-background: 240 7% 11% / 1;
-  /* ✦ Theme/Calendar/Background/Harness Theme/Dark */
-  --figma___calendar-selected-date-background: 214 73% 51% / 1;
-  /* ✦ Theme/Calendar/Selected Date/Background/Harness Theme/Dark */
-  --figma___calendar-selected-range-background: 216 100% 50% / 0.17;
-  /* ✦ Theme/Calendar/Selected Range/Background/Harness Theme/Dark */
-  --figma___calendar-selected-range-text: 205 100% 71% / 1;
-  /* ✦ Theme/Calendar/Selected Range/Text/Harness Theme/Dark */
-  --figma___checkbox-background: 236 19% 14% / 0.5;
-  /* ✦ Theme/Checkbox/Background/Harness Theme/Dark */
-  --figma___checkbox-paper: 0 0% 100% / 0.03;
-  /* ✦ Theme/Checkbox/Paper/Harness Theme/Dark */
-  --figma___checkbox-surface-checked-active-active: 206 100% 62% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/Harness Theme/Dark */
-  --figma___checkbox-surface-checked-active-hover: 206 100% 62% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/Harness Theme/Dark */
-  --figma___checkbox-surface-checked-active-default-background: 214 73% 51% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/Harness Theme/Dark */
-  --figma___checkbox-surface-checked-disabled-check: 217 95% 91% / 0.19;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/Harness Theme/Dark */
-  --figma___checkbox-surface-checked-disabled-disabled: 230 100% 87% / 0.09;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/Harness Theme/Dark */
-  --figma___checkbox-surface-checked-disabled-border: 217 95% 91% / 0.19;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/Harness Theme/Dark */
-  --figma___checkbox-surface-intermediate-active-active-border: 211 100% 53% / 0.88;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/Harness Theme/Dark */
-  --figma___checkbox-surface-intermediate-active-check: 205 100% 71% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/Harness Theme/Dark */
-  --figma___checkbox-surface-intermediate-active-hover-border: 211 100% 51% / 0.55;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/Harness Theme/Dark */
-  --figma___checkbox-surface-intermediate-active-default-background: 216 100% 50% / 0.17;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/Harness Theme/Dark */
-  --figma___checkbox-surface-intermediate-active-default-border: 212 100% 52% / 0.38;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/Harness Theme/Dark */
-  --figma___checkbox-surface-intermediate-disabled-check: 217 95% 91% / 0.19;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/Harness Theme/Dark */
-  --figma___checkbox-surface-intermediate-disabled-disabled: 230 100% 87% / 0.09;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/Harness Theme/Dark */
-  --figma___checkbox-surface-intermediate-disabled-border: 217 95% 91% / 0.19;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/Harness Theme/Dark */
-  --figma___checkbox-surface-unchecked-active-active-border: 202 88% 93% / 0.33;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/Harness Theme/Dark */
-  --figma___checkbox-surface-unchecked-active-hover-border: 209 95% 92% / 0.24;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/Harness Theme/Dark */
-  --figma___checkbox-surface-unchecked-active-default-background: 0 0% 6% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/Harness Theme/Dark */
-  --figma___checkbox-surface-unchecked-active-default-border: 217 95% 91% / 0.19;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/Harness Theme/Dark */
-  --figma___checkbox-surface-unchecked-disabled-disabled: 230 100% 87% / 0.09;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/Harness Theme/Dark */
-  --figma___checkbox-surface-unchecked-disabled-border: 217 95% 91% / 0.19;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/Harness Theme/Dark */
-  --figma___checkbox-border: 0 0% 100% / 0.07;
-  /* ✦ Theme/Checkbox/border/Harness Theme/Dark */
-  --figma___default-colors-black: 0 0% 0% / 1;
-  /* ✦ Theme/Default colors/black/Harness Theme/Dark */
-  --figma___default-colors-dark-to-white: 0 0% 93% / 1;
-  /* ✦ Theme/Default colors/dark-to-white/Harness Theme/Dark */
-  --figma___default-colors-white: 0 0% 100% / 1;
-  /* ✦ Theme/Default colors/white/Harness Theme/Dark */
-  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
-  /* ✦ Theme/Dropdown/Dropdown Item/Default/Harness Theme/Dark */
-  --figma___dropdown-dropdown-item-hover: 230 7% 16% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Hover/Harness Theme/Dark */
-  --figma___dropdown-dropdown-item-selected: 230 7% 16% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Selected/Harness Theme/Dark */
-  --figma___dropdown-text-shortcut-text-selected: 0 0% 100% / 0.46;
-  /* ✦ Theme/Dropdown/Text/Shortcut text selected/Harness Theme/Dark */
-  --figma___dropdown-text-text-selected: 0 0% 93% / 1;
-  /* ✦ Theme/Dropdown/Text/Text Selected/Harness Theme/Dark */
-  --figma___dropdown-text-hover: 0 0% 69% / 1;
-  /* ✦ Theme/Dropdown/Text/hover/Harness Theme/Dark */
-  --figma___dropdown-background: 240 7% 11% / 1;
-  /* ✦ Theme/Dropdown/background/Harness Theme/Dark */
-  --figma___dropdown-border: 230 100% 87% / 0.09;
-  /* ✦ Theme/Dropdown/border/Harness Theme/Dark */
-  --figma___dropdown-separator: 230 100% 87% / 0.09;
-  /* ✦ Theme/Dropdown/separator/Harness Theme/Dark */
-  --figma___filter-active: 230 100% 87% / 0.09;
-  /* ✦ Theme/Filter/Active/Harness Theme/Dark */
-  --figma___filter-hover: 230 100% 87% / 0.09;
-  /* ✦ Theme/Filter/Hover/Harness Theme/Dark */
-  --figma___inline-alert-banner-customisable: 240 7% 11% / 1;
-  /* ✦ Theme/Inline Alert Banner/Customisable/Harness Theme/Dark */
-  --figma___inline-alert-banner-error: 353 40% 16% / 1;
-  /* ✦ Theme/Inline Alert Banner/Error/Harness Theme/Dark */
-  --figma___inline-alert-banner-info: 216 100% 50% / 0.17;
-  /* ✦ Theme/Inline Alert Banner/Info/Harness Theme/Dark */
-  --figma___inline-alert-banner-reminder: 36 80% 8% / 1;
-  /* ✦ Theme/Inline Alert Banner/Reminder/Harness Theme/Dark */
-  --figma___inline-alert-banner-success: 155 46% 11% / 1;
-  /* ✦ Theme/Inline Alert Banner/Success/Harness Theme/Dark */
-  --figma___inline-alert-banner-warning: 26 68% 12% / 1;
-  /* ✦ Theme/Inline Alert Banner/Warning/Harness Theme/Dark */
-  --figma___modal-background: 236 19% 14% / 0.5;
-  /* ✦ Theme/Modal/Background/Harness Theme/Dark */
-  --figma___modal-paper: 0 0% 100% / 0.03;
-  /* ✦ Theme/Modal/Paper/Harness Theme/Dark */
-  --figma___modal-border: 0 0% 100% / 0.07;
-  /* ✦ Theme/Modal/border/Harness Theme/Dark */
-  --figma___neutral-color-gray-1: 0 0% 9% / 1;
-  /* ✦ Theme/Neutral color/Gray/1/Harness Theme/Dark */
-  --figma___neutral-color-gray-2: 0 0% 11% / 1;
-  /* ✦ Theme/Neutral color/Gray/2/Harness Theme/Dark */
-  --figma___neutral-color-gray-3: 0 0% 16% / 1;
-  /* ✦ Theme/Neutral color/Gray/3/Harness Theme/Dark */
-  --figma___neutral-color-gray-4: 0 0% 19% / 1;
-  /* ✦ Theme/Neutral color/Gray/4/Harness Theme/Dark */
-  --figma___neutral-color-gray-5: 0 0% 22% / 1;
-  /* ✦ Theme/Neutral color/Gray/5/Harness Theme/Dark */
-  --figma___neutral-color-gray-6: 0 0% 25% / 1;
-  /* ✦ Theme/Neutral color/Gray/6/Harness Theme/Dark */
-  --figma___neutral-color-gray-7: 0 0% 43% / 1;
-  /* ✦ Theme/Neutral color/Gray/7/Harness Theme/Dark */
-  --figma___neutral-color-gray-8: 0 0% 51% / 1;
-  /* ✦ Theme/Neutral color/Gray/8/Harness Theme/Dark */
-  --figma___neutral-color-gray-9: 0 0% 69% / 1;
-  /* ✦ Theme/Neutral color/Gray/9/Harness Theme/Dark */
-  --figma___neutral-color-gray-10: 0 0% 93% / 1;
-  /* ✦ Theme/Neutral color/Gray/10/Harness Theme/Dark */
-  --figma___neutral-color-gray-alpha-1: 0 0% 100% / 0;
-  /* ✦ Theme/Neutral color/Gray Alpha/1/Harness Theme/Dark */
-  --figma___neutral-color-gray-alpha-2: 240 89% 18% / 0.02;
-  /* ✦ Theme/Neutral color/Gray Alpha/2/Harness Theme/Dark */
-  --figma___neutral-color-gray-alpha-3: 0 0% 100% / 0.07;
-  /* ✦ Theme/Neutral color/Gray Alpha/3/Harness Theme/Dark */
-  --figma___neutral-color-gray-alpha-4: 0 0% 100% / 0.1;
-  /* ✦ Theme/Neutral color/Gray Alpha/4/Harness Theme/Dark */
-  --figma___neutral-color-gray-alpha-5: 0 0% 100% / 0.13;
-  /* ✦ Theme/Neutral color/Gray Alpha/5/Harness Theme/Dark */
-  --figma___neutral-color-gray-alpha-6: 0 0% 100% / 0.17;
-  /* ✦ Theme/Neutral color/Gray Alpha/6/Harness Theme/Dark */
-  --figma___neutral-color-gray-alpha-7: 0 0% 100% / 0.37;
-  /* ✦ Theme/Neutral color/Gray Alpha/7/Harness Theme/Dark */
-  --figma___neutral-color-gray-alpha-8: 0 0% 100% / 0.46;
-  /* ✦ Theme/Neutral color/Gray Alpha/8/Harness Theme/Dark */
-  --figma___neutral-color-gray-alpha-9: 0 0% 100% / 0.66;
-  /* ✦ Theme/Neutral color/Gray Alpha/9/Harness Theme/Dark */
-  --figma___neutral-color-gray-alpha-10: 0 0% 100% / 0.93;
-  /* ✦ Theme/Neutral color/Gray Alpha/10/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-1: 252 19% 10% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/1/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-2: 255 30% 13% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/2/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-3: 255 34% 18% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/3/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-4: 252 35% 22% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/4/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-5: 253 35% 25% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/5/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-6: 253 37% 30% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/6/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-7: 252 56% 57% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/7/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-8: 253 63% 64% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/8/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-9: 255 100% 80% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/9/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-10: 249 94% 93% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/10/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-alpha-1: 240 100% 49% / 0.03;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/1/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-alpha-2: 255 98% 52% / 0.08;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/2/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-alpha-3: 255 99% 63% / 0.17;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/3/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-alpha-4: 252 99% 66% / 0.23;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/4/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-alpha-5: 252 99% 67% / 0.28;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/5/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-alpha-6: 253 100% 68% / 0.35;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/6/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-alpha-7: 252 100% 70% / 0.79;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/7/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-alpha-8: 253 100% 74% / 0.85;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/8/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-alpha-9: 255 100% 80% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/9/Harness Theme/Dark */
-  --figma___other-colors-ai-violet-alpha-10: 249 100% 94% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/10/Harness Theme/Dark */
-  --figma___other-colors-blue-1: 212 36% 9% / 1;
-  /* ✦ Theme/Other Colors/Blue/1/Harness Theme/Dark */
-  --figma___other-colors-blue-2: 216 50% 12% / 1;
-  /* ✦ Theme/Other Colors/Blue/2/Harness Theme/Dark */
-  --figma___other-colors-blue-3: 214 58% 16% / 1;
-  /* ✦ Theme/Other Colors/Blue/3/Harness Theme/Dark */
-  --figma___other-colors-blue-4: 214 65% 18% / 1;
-  /* ✦ Theme/Other Colors/Blue/4/Harness Theme/Dark */
-  --figma___other-colors-blue-5: 213 67% 21% / 1;
-  /* ✦ Theme/Other Colors/Blue/5/Harness Theme/Dark */
-  --figma___other-colors-blue-6: 212 72% 25% / 1;
-  /* ✦ Theme/Other Colors/Blue/6/Harness Theme/Dark */
-  --figma___other-colors-blue-7: 214 73% 51% / 1;
-  /* ✦ Theme/Other Colors/Blue/7/Harness Theme/Dark */
-  --figma___other-colors-blue-8: 206 100% 62% / 1;
-  /* ✦ Theme/Other Colors/Blue/8/Harness Theme/Dark */
-  --figma___other-colors-blue-9: 205 100% 71% / 1;
-  /* ✦ Theme/Other Colors/Blue/9/Harness Theme/Dark */
-  --figma___other-colors-blue-10: 206 100% 88% / 1;
-  /* ✦ Theme/Other Colors/Blue/10/Harness Theme/Dark */
-  --figma___other-colors-blue-alpha-1: 240 100% 49% / 0.04;
-  /* ✦ Theme/Other Colors/Blue Alpha/1/Harness Theme/Dark */
-  --figma___other-colors-blue-alpha-2: 227 100% 50% / 0.09;
-  /* ✦ Theme/Other Colors/Blue Alpha/2/Harness Theme/Dark */
-  --figma___other-colors-blue-alpha-3: 216 100% 50% / 0.17;
-  /* ✦ Theme/Other Colors/Blue Alpha/3/Harness Theme/Dark */
-  --figma___other-colors-blue-alpha-4: 214 100% 50% / 0.23;
-  /* ✦ Theme/Other Colors/Blue Alpha/4/Harness Theme/Dark */
-  --figma___other-colors-blue-alpha-5: 213 100% 51% / 0.29;
-  /* ✦ Theme/Other Colors/Blue Alpha/5/Harness Theme/Dark */
-  --figma___other-colors-blue-alpha-6: 212 100% 52% / 0.38;
-  /* ✦ Theme/Other Colors/Blue Alpha/6/Harness Theme/Dark */
-  --figma___other-colors-blue-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/7/Harness Theme/Dark */
-  --figma___other-colors-blue-alpha-8: 206 100% 62% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/8/Harness Theme/Dark */
-  --figma___other-colors-blue-alpha-9: 205 100% 71% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/9/Harness Theme/Dark */
-  --figma___other-colors-blue-alpha-10: 206 100% 88% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/10/Harness Theme/Dark */
-  --figma___other-colors-indigo-1: 226 25% 10% / 1;
-  /* ✦ Theme/Other Colors/Indigo/1/Harness Theme/Dark */
-  --figma___other-colors-indigo-2: 230 36% 13% / 1;
-  /* ✦ Theme/Other Colors/Indigo/2/Harness Theme/Dark */
-  --figma___other-colors-indigo-3: 228 43% 18% / 1;
-  /* ✦ Theme/Other Colors/Indigo/3/Harness Theme/Dark */
-  --figma___other-colors-indigo-4: 228 45% 21% / 1;
-  /* ✦ Theme/Other Colors/Indigo/4/Harness Theme/Dark */
-  --figma___other-colors-indigo-5: 227 48% 24% / 1;
-  /* ✦ Theme/Other Colors/Indigo/5/Harness Theme/Dark */
-  --figma___other-colors-indigo-6: 225 51% 29% / 1;
-  /* ✦ Theme/Other Colors/Indigo/6/Harness Theme/Dark */
-  --figma___other-colors-indigo-7: 226 70% 55% / 1;
-  /* ✦ Theme/Other Colors/Indigo/7/Harness Theme/Dark */
-  --figma___other-colors-indigo-8: 230 74% 63% / 1;
-  /* ✦ Theme/Other Colors/Indigo/8/Harness Theme/Dark */
-  --figma___other-colors-indigo-9: 235 100% 80% / 1;
-  /* ✦ Theme/Other Colors/Indigo/9/Harness Theme/Dark */
-  --figma___other-colors-indigo-10: 236 94% 93% / 1;
-  /* ✦ Theme/Other Colors/Indigo/10/Harness Theme/Dark */
-  --figma___other-colors-indigo-alpha-1: 240 100% 49% / 0.04;
-  /* ✦ Theme/Other Colors/Indigo Alpha/1/Harness Theme/Dark */
-  --figma___other-colors-indigo-alpha-2: 232 100% 50% / 0.09;
-  /* ✦ Theme/Other Colors/Indigo Alpha/2/Harness Theme/Dark */
-  --figma___other-colors-indigo-alpha-3: 228 100% 57% / 0.18;
-  /* ✦ Theme/Other Colors/Indigo Alpha/3/Harness Theme/Dark */
-  --figma___other-colors-indigo-alpha-4: 228 99% 59% / 0.24;
-  /* ✦ Theme/Other Colors/Indigo Alpha/4/Harness Theme/Dark */
-  --figma___other-colors-indigo-alpha-5: 227 99% 60% / 0.29;
-  /* ✦ Theme/Other Colors/Indigo Alpha/5/Harness Theme/Dark */
-  --figma___other-colors-indigo-alpha-6: 225 100% 61% / 0.37;
-  /* ✦ Theme/Other Colors/Indigo Alpha/6/Harness Theme/Dark */
-  --figma___other-colors-indigo-alpha-7: 226 100% 63% / 0.85;
-  /* ✦ Theme/Other Colors/Indigo Alpha/7/Harness Theme/Dark */
-  --figma___other-colors-indigo-alpha-8: 230 100% 70% / 0.9;
-  /* ✦ Theme/Other Colors/Indigo Alpha/8/Harness Theme/Dark */
-  --figma___other-colors-indigo-alpha-9: 235 100% 80% / 1;
-  /* ✦ Theme/Other Colors/Indigo Alpha/9/Harness Theme/Dark */
-  --figma___other-colors-indigo-alpha-10: 236 100% 94% / 1;
-  /* ✦ Theme/Other Colors/Indigo Alpha/10/Harness Theme/Dark */
-  --figma___other-colors-mint-1: 173 52% 6% / 1;
-  /* ✦ Theme/Other Colors/Mint/1/Harness Theme/Dark */
-  --figma___other-colors-mint-2: 174 51% 8% / 1;
-  /* ✦ Theme/Other Colors/Mint/2/Harness Theme/Dark */
-  --figma___other-colors-mint-3: 176 52% 11% / 1;
-  /* ✦ Theme/Other Colors/Mint/3/Harness Theme/Dark */
-  --figma___other-colors-mint-4: 173 56% 13% / 1;
-  /* ✦ Theme/Other Colors/Mint/4/Harness Theme/Dark */
-  --figma___other-colors-mint-5: 173 57% 15% / 1;
-  /* ✦ Theme/Other Colors/Mint/5/Harness Theme/Dark */
-  --figma___other-colors-mint-6: 173 58% 18% / 1;
-  /* ✦ Theme/Other Colors/Mint/6/Harness Theme/Dark */
-  --figma___other-colors-mint-7: 167 70% 72% / 1;
-  /* ✦ Theme/Other Colors/Mint/7/Harness Theme/Dark */
-  --figma___other-colors-mint-8: 163 80% 77% / 1;
-  /* ✦ Theme/Other Colors/Mint/8/Harness Theme/Dark */
-  --figma___other-colors-mint-9: 167 70% 58% / 1;
-  /* ✦ Theme/Other Colors/Mint/9/Harness Theme/Dark */
-  --figma___other-colors-mint-10: 156 71% 86% / 1;
-  /* ✦ Theme/Other Colors/Mint/10/Harness Theme/Dark */
-  --figma___other-colors-mint-alpha-1: 120 100% 44% / 0;
-  /* ✦ Theme/Other Colors/Mint Alpha/1/Harness Theme/Dark */
-  --figma___other-colors-mint-alpha-2: 165 100% 49% / 0.03;
-  /* ✦ Theme/Other Colors/Mint Alpha/2/Harness Theme/Dark */
-  --figma___other-colors-mint-alpha-3: 174 100% 50% / 0.07;
-  /* ✦ Theme/Other Colors/Mint Alpha/3/Harness Theme/Dark */
-  --figma___other-colors-mint-alpha-4: 172 100% 50% / 0.11;
-  /* ✦ Theme/Other Colors/Mint Alpha/4/Harness Theme/Dark */
-  --figma___other-colors-mint-alpha-5: 172 100% 50% / 0.15;
-  /* ✦ Theme/Other Colors/Mint Alpha/5/Harness Theme/Dark */
-  --figma___other-colors-mint-alpha-6: 173 100% 50% / 0.21;
-  /* ✦ Theme/Other Colors/Mint Alpha/6/Harness Theme/Dark */
-  --figma___other-colors-mint-alpha-7: 167 100% 78% / 0.91;
-  /* ✦ Theme/Other Colors/Mint Alpha/7/Harness Theme/Dark */
-  --figma___other-colors-mint-alpha-8: 163 100% 81% / 0.95;
-  /* ✦ Theme/Other Colors/Mint Alpha/8/Harness Theme/Dark */
-  --figma___other-colors-mint-alpha-9: 167 100% 66% / 0.86;
-  /* ✦ Theme/Other Colors/Mint Alpha/9/Harness Theme/Dark */
-  --figma___other-colors-mint-alpha-10: 155 100% 90% / 0.96;
-  /* ✦ Theme/Other Colors/Mint Alpha/10/Harness Theme/Dark */
-  --figma___other-colors-orange-1: 29 68% 7% / 1;
-  /* ✦ Theme/Other Colors/Orange/1/Harness Theme/Dark */
-  --figma___other-colors-orange-2: 29 81% 8% / 1;
-  /* ✦ Theme/Other Colors/Orange/2/Harness Theme/Dark */
-  --figma___other-colors-orange-3: 26 68% 12% / 1;
-  /* ✦ Theme/Other Colors/Orange/3/Harness Theme/Dark */
-  --figma___other-colors-orange-4: 25 66% 15% / 1;
-  /* ✦ Theme/Other Colors/Orange/4/Harness Theme/Dark */
-  --figma___other-colors-orange-5: 25 65% 18% / 1;
-  /* ✦ Theme/Other Colors/Orange/5/Harness Theme/Dark */
-  --figma___other-colors-orange-6: 25 66% 22% / 1;
-  /* ✦ Theme/Other Colors/Orange/6/Harness Theme/Dark */
-  --figma___other-colors-orange-7: 24 94% 50% / 1;
-  /* ✦ Theme/Other Colors/Orange/7/Harness Theme/Dark */
-  --figma___other-colors-orange-8: 24 100% 58% / 1;
-  /* ✦ Theme/Other Colors/Orange/8/Harness Theme/Dark */
-  --figma___other-colors-orange-9: 24 100% 70% / 1;
-  /* ✦ Theme/Other Colors/Orange/9/Harness Theme/Dark */
-  --figma___other-colors-orange-10: 30 100% 88% / 1;
-  /* ✦ Theme/Other Colors/Orange/10/Harness Theme/Dark */
-  --figma___other-colors-orange-alpha-1: 0 100% 49% / 0.03;
-  /* ✦ Theme/Other Colors/Orange Alpha/1/Harness Theme/Dark */
-  --figma___other-colors-orange-alpha-2: 0 100% 50% / 0.06;
-  /* ✦ Theme/Other Colors/Orange Alpha/2/Harness Theme/Dark */
-  --figma___other-colors-orange-alpha-3: 13 100% 50% / 0.12;
-  /* ✦ Theme/Other Colors/Orange Alpha/3/Harness Theme/Dark */
-  --figma___other-colors-orange-alpha-4: 20 100% 50% / 0.17;
-  /* ✦ Theme/Other Colors/Orange Alpha/4/Harness Theme/Dark */
-  --figma___other-colors-orange-alpha-5: 24 100% 50% / 0.22;
-  /* ✦ Theme/Other Colors/Orange Alpha/5/Harness Theme/Dark */
-  --figma___other-colors-orange-alpha-6: 25 100% 51% / 0.3;
-  /* ✦ Theme/Other Colors/Orange Alpha/6/Harness Theme/Dark */
-  --figma___other-colors-orange-alpha-7: 24 100% 51% / 0.97;
-  /* ✦ Theme/Other Colors/Orange Alpha/7/Harness Theme/Dark */
-  --figma___other-colors-orange-alpha-8: 24 100% 58% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/8/Harness Theme/Dark */
-  --figma___other-colors-orange-alpha-9: 24 100% 70% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/9/Harness Theme/Dark */
-  --figma___other-colors-orange-alpha-10: 30 100% 88% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/10/Harness Theme/Dark */
-  --figma___other-colors-yellow-1: 45 100% 5% / 1;
-  /* ✦ Theme/Other Colors/Yellow/1/Harness Theme/Dark */
-  --figma___other-colors-yellow-2: 44 79% 7% / 1;
-  /* ✦ Theme/Other Colors/Yellow/2/Harness Theme/Dark */
-  --figma___other-colors-yellow-3: 44 63% 11% / 1;
-  /* ✦ Theme/Other Colors/Yellow/3/Harness Theme/Dark */
-  --figma___other-colors-yellow-4: 44 58% 13% / 1;
-  /* ✦ Theme/Other Colors/Yellow/4/Harness Theme/Dark */
-  --figma___other-colors-yellow-5: 45 56% 15% / 1;
-  /* ✦ Theme/Other Colors/Yellow/5/Harness Theme/Dark */
-  --figma___other-colors-yellow-6: 46 57% 18% / 1;
-  /* ✦ Theme/Other Colors/Yellow/6/Harness Theme/Dark */
-  --figma___other-colors-yellow-7: 53 96% 58% / 1;
-  /* ✦ Theme/Other Colors/Yellow/7/Harness Theme/Dark */
-  --figma___other-colors-yellow-8: 53 96% 67% / 1;
-  /* ✦ Theme/Other Colors/Yellow/8/Harness Theme/Dark */
-  --figma___other-colors-yellow-9: 55 100% 60% / 1;
-  /* ✦ Theme/Other Colors/Yellow/9/Harness Theme/Dark */
-  --figma___other-colors-yellow-10: 53 100% 84% / 1;
-  /* ✦ Theme/Other Colors/Yellow/10/Harness Theme/Dark */
-  --figma___other-colors-yellow-alpha-1: 0 100% 48% / 0.02;
-  /* ✦ Theme/Other Colors/Yellow Alpha/1/Harness Theme/Dark */
-  --figma___other-colors-yellow-alpha-2: 17 100% 49% / 0.04;
-  /* ✦ Theme/Other Colors/Yellow Alpha/2/Harness Theme/Dark */
-  --figma___other-colors-yellow-alpha-3: 36 100% 50% / 0.09;
-  /* ✦ Theme/Other Colors/Yellow Alpha/3/Harness Theme/Dark */
-  --figma___other-colors-yellow-alpha-4: 41 100% 50% / 0.12;
-  /* ✦ Theme/Other Colors/Yellow Alpha/4/Harness Theme/Dark */
-  --figma___other-colors-yellow-alpha-5: 44 100% 50% / 0.16;
-  /* ✦ Theme/Other Colors/Yellow Alpha/5/Harness Theme/Dark */
-  --figma___other-colors-yellow-alpha-6: 46 99% 51% / 0.21;
-  /* ✦ Theme/Other Colors/Yellow Alpha/6/Harness Theme/Dark */
-  --figma___other-colors-yellow-alpha-7: 53 100% 59% / 0.98;
-  /* ✦ Theme/Other Colors/Yellow Alpha/7/Harness Theme/Dark */
-  --figma___other-colors-yellow-alpha-8: 53 100% 68% / 0.99;
-  /* ✦ Theme/Other Colors/Yellow Alpha/8/Harness Theme/Dark */
-  --figma___other-colors-yellow-alpha-9: 55 100% 60% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/9/Harness Theme/Dark */
-  --figma___other-colors-yellow-alpha-10: 53 100% 84% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/10/Harness Theme/Dark */
-  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01;
-  /* ✦ Theme/Overlays/Black Alpha/1/Harness Theme/Dark */
-  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02;
-  /* ✦ Theme/Overlays/Black Alpha/2/Harness Theme/Dark */
-  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05;
-  /* ✦ Theme/Overlays/Black Alpha/3/Harness Theme/Dark */
-  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08;
-  /* ✦ Theme/Overlays/Black Alpha/4/Harness Theme/Dark */
-  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11;
-  /* ✦ Theme/Overlays/Black Alpha/5/Harness Theme/Dark */
-  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13;
-  /* ✦ Theme/Overlays/Black Alpha/6/Harness Theme/Dark */
-  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45;
-  /* ✦ Theme/Overlays/Black Alpha/7/Harness Theme/Dark */
-  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5;
-  /* ✦ Theme/Overlays/Black Alpha/8/Harness Theme/Dark */
-  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61;
-  /* ✦ Theme/Overlays/Black Alpha/9/Harness Theme/Dark */
-  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88;
-  /* ✦ Theme/Overlays/Black Alpha/10/Harness Theme/Dark */
-  --figma___overlays-white-alpha-1: 0 0% 100% / 0;
-  /* ✦ Theme/Overlays/White Alpha/1/Harness Theme/Dark */
-  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01;
-  /* ✦ Theme/Overlays/White Alpha/2/Harness Theme/Dark */
-  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07;
-  /* ✦ Theme/Overlays/White Alpha/3/Harness Theme/Dark */
-  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1;
-  /* ✦ Theme/Overlays/White Alpha/4/Harness Theme/Dark */
-  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13;
-  /* ✦ Theme/Overlays/White Alpha/5/Harness Theme/Dark */
-  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17;
-  /* ✦ Theme/Overlays/White Alpha/6/Harness Theme/Dark */
-  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37;
-  /* ✦ Theme/Overlays/White Alpha/7/Harness Theme/Dark */
-  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46;
-  /* ✦ Theme/Overlays/White Alpha/8/Harness Theme/Dark */
-  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66;
-  /* ✦ Theme/Overlays/White Alpha/9/Harness Theme/Dark */
-  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93;
-  /* ✦ Theme/Overlays/White Alpha/10/Harness Theme/Dark */
-  --figma___pagination-active-background: 214 73% 51% / 1;
-  /* ✦ Theme/Pagination/Active/Background/Harness Theme/Dark */
-  --figma___pagination-active-border: 214 73% 51% / 1;
-  /* ✦ Theme/Pagination/Active/Border/Harness Theme/Dark */
-  --figma___pagination-background: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Background/Harness Theme/Dark */
-  --figma___pagination-default-background: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Default/Background/Harness Theme/Dark */
-  --figma___pagination-default-border: 0 0% 100% / 0;
-  /* ✦ Theme/Pagination/Default/Border/Harness Theme/Dark */
-  --figma___pagination-default-text: 0 0% 100% / 0.46;
-  /* ✦ Theme/Pagination/Default/Text/Harness Theme/Dark */
-  --figma___pagination-hover-background: 230 100% 87% / 0.09;
-  /* ✦ Theme/Pagination/Hover/Background/Harness Theme/Dark */
-  --figma___pagination-hover-border: 0 0% 16% / 1;
-  /* ✦ Theme/Pagination/Hover/Border/Harness Theme/Dark */
-  --figma___pagination-hover-text: 205 100% 71% / 1;
-  /* ✦ Theme/Pagination/Hover/Text/Harness Theme/Dark */
-  --figma___pagination-pagination-shadow-1: 0 0% 0% / 0;
-  /* ✦ Theme/Pagination/Pagination shadow/1/Harness Theme/Dark */
-  --figma___pagination-pagination-shadow-2: 240 100% 12% / 0;
-  /* ✦ Theme/Pagination/Pagination shadow/2/Harness Theme/Dark */
-  --figma___primary-color-primary-accent-1: 212 36% 9% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/1/Harness Theme/Dark */
-  --figma___primary-color-primary-accent-2: 216 50% 12% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/2/Harness Theme/Dark */
-  --figma___primary-color-primary-accent-3: 214 58% 16% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/3/Harness Theme/Dark */
-  --figma___primary-color-primary-accent-4: 214 65% 18% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/4/Harness Theme/Dark */
-  --figma___primary-color-primary-accent-5: 213 67% 21% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/5/Harness Theme/Dark */
-  --figma___primary-color-primary-accent-6: 212 72% 25% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/6/Harness Theme/Dark */
-  --figma___primary-color-primary-accent-7: 214 73% 51% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/7/Harness Theme/Dark */
-  --figma___primary-color-primary-accent-8: 206 100% 62% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/8/Harness Theme/Dark */
-  --figma___primary-color-primary-accent-9: 205 100% 71% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/9/Harness Theme/Dark */
-  --figma___primary-color-primary-accent-10: 206 100% 88% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/10/Harness Theme/Dark */
-  --figma___primary-color-primary-alpha-1: 240 100% 49% / 0.04;
-  /* ✦ Theme/Primary Color/Primary Alpha/1/Harness Theme/Dark */
-  --figma___primary-color-primary-alpha-2: 227 100% 50% / 0.09;
-  /* ✦ Theme/Primary Color/Primary Alpha/2/Harness Theme/Dark */
-  --figma___primary-color-primary-alpha-3: 216 100% 50% / 0.17;
-  /* ✦ Theme/Primary Color/Primary Alpha/3/Harness Theme/Dark */
-  --figma___primary-color-primary-alpha-4: 214 100% 50% / 0.23;
-  /* ✦ Theme/Primary Color/Primary Alpha/4/Harness Theme/Dark */
-  --figma___primary-color-primary-alpha-5: 213 100% 51% / 0.29;
-  /* ✦ Theme/Primary Color/Primary Alpha/5/Harness Theme/Dark */
-  --figma___primary-color-primary-alpha-6: 212 100% 52% / 0.38;
-  /* ✦ Theme/Primary Color/Primary Alpha/6/Harness Theme/Dark */
-  --figma___primary-color-primary-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/7/Harness Theme/Dark */
-  --figma___primary-color-primary-alpha-8: 206 100% 62% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/8/Harness Theme/Dark */
-  --figma___primary-color-primary-alpha-9: 205 100% 71% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/9/Harness Theme/Dark */
-  --figma___primary-color-primary-alpha-10: 206 100% 88% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/10/Harness Theme/Dark */
-  --figma___radio-button-background: 236 19% 14% / 0.5;
-  /* ✦ Theme/Radio button/Background/Harness Theme/Dark */
-  --figma___radio-button-checked-active-active-border: 214 73% 51% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active Border/Harness Theme/Dark */
-  --figma___radio-button-checked-active-active-background: 214 73% 51% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active background/Harness Theme/Dark */
-  --figma___radio-button-checked-active-hover-background: 206 100% 62% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover background/Harness Theme/Dark */
-  --figma___radio-button-checked-active-hover-border: 206 100% 62% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover border/Harness Theme/Dark */
-  --figma___radio-button-checked-active-default-background: 214 73% 51% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default background/Harness Theme/Dark */
-  --figma___radio-button-checked-active-default-border: 214 73% 51% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default border/Harness Theme/Dark */
-  --figma___radio-button-checked-disabled-dot: 0 0% 100% / 0.31;
-  /* ✦ Theme/Radio button/Checked/Disabled/Dot/Harness Theme/Dark */
-  --figma___radio-button-checked-disabled-background: 0 0% 100% / 0.07;
-  /* ✦ Theme/Radio button/Checked/Disabled/background/Harness Theme/Dark */
-  --figma___radio-button-checked-disabled-border: 0 0% 100% / 0.17;
-  /* ✦ Theme/Radio button/Checked/Disabled/border/Harness Theme/Dark */
-  --figma___radio-button-paper: 0 0% 100% / 0.03;
-  /* ✦ Theme/Radio button/Paper/Harness Theme/Dark */
-  --figma___radio-button-unchecked-active-active-border: 0 0% 100% / 0.37;
-  /* ✦ Theme/Radio button/Unchecked/Active/Active border/Harness Theme/Dark */
-  --figma___radio-button-unchecked-active-hover-border: 0 0% 100% / 0.31;
-  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/Harness Theme/Dark */
-  --figma___radio-button-unchecked-active-default-background: 0 0% 100% / 0.07;
-  /* ✦ Theme/Radio button/Unchecked/Active/default background/Harness Theme/Dark */
-  --figma___radio-button-unchecked-active-default-border: 0 0% 100% / 0.22;
-  /* ✦ Theme/Radio button/Unchecked/Active/default border/Harness Theme/Dark */
-  --figma___radio-button-unchecked-disabled-background: 0 0% 100% / 0.07;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/background/Harness Theme/Dark */
-  --figma___radio-button-unchecked-disabled-border: 0 0% 100% / 0.17;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/border/Harness Theme/Dark */
-  --figma___radio-button-border: 0 0% 100% / 0.07;
-  /* ✦ Theme/Radio button/border/Harness Theme/Dark */
-  --figma___secondary-crimson-crimson-1: 333 18% 10% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 1/Harness Theme/Dark */
-  --figma___secondary-crimson-crimson-10: 330 91% 91% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 10/Harness Theme/Dark */
-  --figma___secondary-crimson-crimson-2: 336 32% 12% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 2/Harness Theme/Dark */
-  --figma___secondary-crimson-crimson-3: 335 41% 16% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 3/Harness Theme/Dark */
-  --figma___secondary-crimson-crimson-4: 336 45% 18% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 4/Harness Theme/Dark */
-  --figma___secondary-crimson-crimson-5: 336 49% 21% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 5/Harness Theme/Dark */
-  --figma___secondary-crimson-crimson-6: 336 54% 25% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 6/Harness Theme/Dark */
-  --figma___secondary-crimson-crimson-7: 336 80% 58% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 7/Harness Theme/Dark */
-  --figma___secondary-crimson-crimson-8: 339 87% 67% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 8/Harness Theme/Dark */
-  --figma___secondary-crimson-crimson-9: 341 100% 76% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 9/Harness Theme/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-1: 354 100% 49% / 0.02;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Theme/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-10: 341 100% 76% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Theme/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-11: 329 100% 92% / 0.99;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Theme/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-2: 338 100% 50% / 0.07;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Theme/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-3: 335 100% 55% / 0.14;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Theme/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-4: 336 99% 56% / 0.19;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Theme/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-5: 336 100% 58% / 0.25;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Theme/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-6: 336 99% 58% / 0.33;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Theme/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-8: 336 100% 63% / 0.9;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Theme/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-9: 339 100% 70% / 0.95;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Theme/Dark */
-  --figma___secondary-lime-1: 74 55% 6% / 1;
-  /* ✦ Theme/Secondary/Lime/1/Harness Theme/Dark */
-  --figma___secondary-lime-2: 78 41% 8% / 1;
-  /* ✦ Theme/Secondary/Lime/2/Harness Theme/Dark */
-  --figma___secondary-lime-3: 82 39% 11% / 1;
-  /* ✦ Theme/Secondary/Lime/3/Harness Theme/Dark */
-  --figma___secondary-lime-4: 82 40% 13% / 1;
-  /* ✦ Theme/Secondary/Lime/4/Harness Theme/Dark */
-  --figma___secondary-lime-5: 81 41% 15% / 1;
-  /* ✦ Theme/Secondary/Lime/5/Harness Theme/Dark */
-  --figma___secondary-lime-6: 80 43% 18% / 1;
-  /* ✦ Theme/Secondary/Lime/6/Harness Theme/Dark */
-  --figma___secondary-lime-7: 81 80% 66% / 1;
-  /* ✦ Theme/Secondary/Lime/7/Harness Theme/Dark */
-  --figma___secondary-lime-8: 75 85% 60% / 1;
-  /* ✦ Theme/Secondary/Lime/8/Harness Theme/Dark */
-  --figma___secondary-lime-9: 70 70% 50% / 1;
-  /* ✦ Theme/Secondary/Lime/9/Harness Theme/Dark */
-  --figma___secondary-lime-10: 80 79% 85% / 1;
-  /* ✦ Theme/Secondary/Lime/10/Harness Theme/Dark */
-  --figma___secondary-lime-alpha-1: 75 100% 5% / 0.71;
-  /* ✦ Theme/Secondary/Lime Alpha/1/Harness Theme/Dark */
-  --figma___secondary-lime-alpha-2: 114 100% 49% / 0.02;
-  /* ✦ Theme/Secondary/Lime Alpha/2/Harness Theme/Dark */
-  --figma___secondary-lime-alpha-3: 89 100% 50% / 0.06;
-  /* ✦ Theme/Secondary/Lime Alpha/3/Harness Theme/Dark */
-  --figma___secondary-lime-alpha-4: 84 100% 50% / 0.1;
-  /* ✦ Theme/Secondary/Lime Alpha/4/Harness Theme/Dark */
-  --figma___secondary-lime-alpha-5: 81 99% 53% / 0.14;
-  /* ✦ Theme/Secondary/Lime Alpha/5/Harness Theme/Dark */
-  --figma___secondary-lime-alpha-6: 80 99% 58% / 0.19;
-  /* ✦ Theme/Secondary/Lime Alpha/6/Harness Theme/Dark */
-  --figma___secondary-lime-alpha-7: 81 100% 71% / 0.93;
-  /* ✦ Theme/Secondary/Lime Alpha/7/Harness Theme/Dark */
-  --figma___secondary-lime-alpha-8: 75 100% 64% / 0.94;
-  /* ✦ Theme/Secondary/Lime Alpha/8/Harness Theme/Dark */
-  --figma___secondary-lime-alpha-9: 70 100% 58% / 0.84;
-  /* ✦ Theme/Secondary/Lime Alpha/9/Harness Theme/Dark */
-  --figma___secondary-lime-alpha-10: 80 100% 88% / 0.97;
-  /* ✦ Theme/Secondary/Lime Alpha/10/Harness Theme/Dark */
-  --figma___secondary-purple-1: 287 18% 10% / 1;
-  /* ✦ Theme/Secondary/Purple/1/Harness Theme/Dark */
-  --figma___secondary-purple-2: 284 31% 12% / 1;
-  /* ✦ Theme/Secondary/Purple/2/Harness Theme/Dark */
-  --figma___secondary-purple-3: 282 35% 17% / 1;
-  /* ✦ Theme/Secondary/Purple/3/Harness Theme/Dark */
-  --figma___secondary-purple-4: 281 37% 20% / 1;
-  /* ✦ Theme/Secondary/Purple/4/Harness Theme/Dark */
-  --figma___secondary-purple-5: 280 38% 23% / 1;
-  /* ✦ Theme/Secondary/Purple/5/Harness Theme/Dark */
-  --figma___secondary-purple-6: 278 40% 27% / 1;
-  /* ✦ Theme/Secondary/Purple/6/Harness Theme/Dark */
-  --figma___secondary-purple-7: 272 51% 54% / 1;
-  /* ✦ Theme/Secondary/Purple/7/Harness Theme/Dark */
-  --figma___secondary-purple-8: 271 58% 61% / 1;
-  /* ✦ Theme/Secondary/Purple/8/Harness Theme/Dark */
-  --figma___secondary-purple-9: 270 89% 78% / 1;
-  /* ✦ Theme/Secondary/Purple/9/Harness Theme/Dark */
-  --figma___secondary-purple-10: 275 77% 92% / 1;
-  /* ✦ Theme/Secondary/Purple/10/Harness Theme/Dark */
-  --figma___secondary-purple-alpha-1: 278 100% 49% / 0.02;
-  /* ✦ Theme/Secondary/Purple Alpha/1/Harness Theme/Dark */
-  --figma___secondary-purple-alpha-2: 283 100% 49% / 0.07;
-  /* ✦ Theme/Secondary/Purple Alpha/2/Harness Theme/Dark */
-  --figma___secondary-purple-alpha-3: 282 99% 60% / 0.15;
-  /* ✦ Theme/Secondary/Purple Alpha/3/Harness Theme/Dark */
-  --figma___secondary-purple-alpha-4: 281 99% 62% / 0.2;
-  /* ✦ Theme/Secondary/Purple Alpha/4/Harness Theme/Dark */
-  --figma___secondary-purple-alpha-5: 280 100% 64% / 0.25;
-  /* ✦ Theme/Secondary/Purple Alpha/5/Harness Theme/Dark */
-  --figma___secondary-purple-alpha-6: 278 99% 66% / 0.32;
-  /* ✦ Theme/Secondary/Purple Alpha/6/Harness Theme/Dark */
-  --figma___secondary-purple-alpha-7: 272 100% 69% / 0.75;
-  /* ✦ Theme/Secondary/Purple Alpha/7/Harness Theme/Dark */
-  --figma___secondary-purple-alpha-8: 271 100% 73% / 0.82;
-  /* ✦ Theme/Secondary/Purple Alpha/8/Harness Theme/Dark */
-  --figma___secondary-purple-alpha-9: 270 100% 80% / 0.98;
-  /* ✦ Theme/Secondary/Purple Alpha/9/Harness Theme/Dark */
-  --figma___secondary-purple-alpha-10: 275 100% 93% / 0.98;
-  /* ✦ Theme/Secondary/Purple Alpha/10/Harness Theme/Dark */
-  --figma___secondary-teal-1: 166 49% 7% / 1;
-  /* ✦ Theme/Secondary/Teal/1/Harness Theme/Dark */
-  --figma___secondary-teal-2: 166 55% 8% / 1;
-  /* ✦ Theme/Secondary/Teal/2/Harness Theme/Dark */
-  --figma___secondary-teal-3: 167 52% 11% / 1;
-  /* ✦ Theme/Secondary/Teal/3/Harness Theme/Dark */
-  --figma___secondary-teal-4: 169 53% 13% / 1;
-  /* ✦ Theme/Secondary/Teal/4/Harness Theme/Dark */
-  --figma___secondary-teal-5: 168 53% 15% / 1;
-  /* ✦ Theme/Secondary/Teal/5/Harness Theme/Dark */
-  --figma___secondary-teal-6: 169 52% 18% / 1;
-  /* ✦ Theme/Secondary/Teal/6/Harness Theme/Dark */
-  --figma___secondary-teal-7: 173 80% 36% / 1;
-  /* ✦ Theme/Secondary/Teal/7/Harness Theme/Dark */
-  --figma___secondary-teal-8: 172 90% 39% / 1;
-  /* ✦ Theme/Secondary/Teal/8/Harness Theme/Dark */
-  --figma___secondary-teal-9: 170 90% 45% / 1;
-  /* ✦ Theme/Secondary/Teal/9/Harness Theme/Dark */
-  --figma___secondary-teal-10: 163 69% 81% / 1;
-  /* ✦ Theme/Secondary/Teal/10/Harness Theme/Dark */
-  --figma___secondary-teal-alpha-1: 120 100% 48% / 0.01;
-  /* ✦ Theme/Secondary/Teal Alpha/1/Harness Theme/Dark */
-  --figma___secondary-teal-alpha-2: 141 100% 49% / 0.03;
-  /* ✦ Theme/Secondary/Teal Alpha/2/Harness Theme/Dark */
-  --figma___secondary-teal-alpha-3: 161 100% 50% / 0.07;
-  /* ✦ Theme/Secondary/Teal Alpha/3/Harness Theme/Dark */
-  --figma___secondary-teal-alpha-4: 167 100% 50% / 0.11;
-  /* ✦ Theme/Secondary/Teal Alpha/4/Harness Theme/Dark */
-  --figma___secondary-teal-alpha-5: 167 100% 50% / 0.15;
-  /* ✦ Theme/Secondary/Teal Alpha/5/Harness Theme/Dark */
-  --figma___secondary-teal-alpha-6: 169 99% 53% / 0.2;
-  /* ✦ Theme/Secondary/Teal Alpha/6/Harness Theme/Dark */
-  --figma___secondary-teal-alpha-7: 173 100% 53% / 0.61;
-  /* ✦ Theme/Secondary/Teal Alpha/7/Harness Theme/Dark */
-  --figma___secondary-teal-alpha-8: 172 100% 51% / 0.71;
-  /* ✦ Theme/Secondary/Teal Alpha/8/Harness Theme/Dark */
-  --figma___secondary-teal-alpha-9: 170 100% 52% / 0.83;
-  /* ✦ Theme/Secondary/Teal Alpha/9/Harness Theme/Dark */
-  --figma___secondary-teal-alpha-10: 163 100% 86% / 0.94;
-  /* ✦ Theme/Secondary/Teal Alpha/10/Harness Theme/Dark */
-  --figma___shadow-shadow-button-1: 0 0% 0% / 0.5;
-  /* ✦ Theme/Shadow/Shadow - button/1/Harness Theme/Dark */
-  --figma___shadow-shadow-button-2: 0 0% 100% / 0.31;
-  /* ✦ Theme/Shadow/Shadow - button/2/Harness Theme/Dark */
-  --figma___shadow-shadow-button-3: 0 0% 100% / 0.31;
-  /* ✦ Theme/Shadow/Shadow - button/3/Harness Theme/Dark */
-  --figma___shadow-shadow-button-4: 0 0% 0% / 0.11;
-  /* ✦ Theme/Shadow/Shadow - button/4/Harness Theme/Dark */
-  --figma___shadow-shadow-1-1: 0 0% 0% / 0.13;
-  /* ✦ Theme/Shadow/Shadow 1/1/Harness Theme/Dark */
-  --figma___shadow-shadow-2-1: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 2/1/Harness Theme/Dark */
-  --figma___shadow-shadow-2-2: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 2/2/Harness Theme/Dark */
-  --figma___shadow-shadow-2-3: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 2/3/Harness Theme/Dark */
-  --figma___shadow-shadow-3-1: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 3/1/Harness Theme/Dark */
-  --figma___shadow-shadow-3-2: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow 3/2/Harness Theme/Dark */
-  --figma___shadow-shadow-3-3: 0 0% 0% / 0.11;
-  /* ✦ Theme/Shadow/Shadow 3/3/Harness Theme/Dark */
-  --figma___shadow-shadow-4-1: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow 4/1/Harness Theme/Dark */
-  --figma___shadow-shadow-4-2: 0 0% 0% / 0.17;
-  /* ✦ Theme/Shadow/Shadow 4/2/Harness Theme/Dark */
-  --figma___shadow-shadow-5-1: 0 0% 0% / 0.5;
-  /* ✦ Theme/Shadow/Shadow 5/1/Harness Theme/Dark */
-  --figma___shadow-shadow-5-2: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow 5/2/Harness Theme/Dark */
-  --figma___shadow-shadow-6-1: 0 0% 0% / 0.88;
-  /* ✦ Theme/Shadow/Shadow 6/1/Harness Theme/Dark */
-  --figma___shadow-shadow-6-2: 0 0% 0% / 0.61;
-  /* ✦ Theme/Shadow/Shadow 6/2/Harness Theme/Dark */
-  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
-  /* ✦ Theme/Shadow/Shadow-button-active/1/Harness Theme/Dark */
-  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
-  /* ✦ Theme/Shadow/Shadow-button-active/2/Harness Theme/Dark */
-  --figma___shadow-shadow-button-active-3: 0 0% 100% / 0.27;
-  /* ✦ Theme/Shadow/Shadow-button-active/3/Harness Theme/Dark */
-  --figma___shadow-shadow-button-active-4: 0 0% 100% / 0.11;
-  /* ✦ Theme/Shadow/Shadow-button-active/4/Harness Theme/Dark */
-  --figma___side-nav-container-nav-background: 0 4% 5% / 1;
-  /* ✦ Theme/Side nav/Container/Nav-background/Harness Theme/Dark */
-  --figma___side-nav-container-nav-border: 0 0% 100% / 0;
-  /* ✦ Theme/Side nav/Container/Nav-border/Harness Theme/Dark */
-  --figma___side-nav-module-logo-text: 0 0% 93% / 1;
-  /* ✦ Theme/Side nav/Module Logo Text/Harness Theme/Dark */
-  --figma___side-nav-nav-item-default-icon: 0 0% 100% / 0.46;
-  /* ✦ Theme/Side nav/Nav-item/Default/Icon/Harness Theme/Dark */
-  --figma___side-nav-nav-item-default-text: 0 0% 69% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Default/Text/Harness Theme/Dark */
-  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
-  /* ✦ Theme/Side nav/Nav-item/Default/default/Harness Theme/Dark */
-  --figma___side-nav-nav-item-hover-background: 210 6% 20% / 0.24;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Background/Harness Theme/Dark */
-  --figma___side-nav-nav-item-hover-icon: 0 0% 69% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/Harness Theme/Dark */
-  --figma___side-nav-nav-item-hover-text: 0 0% 69% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Text/Harness Theme/Dark */
-  --figma___side-nav-nav-item-selected-background: 210 6% 20% / 0.24;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Background/Harness Theme/Dark */
-  --figma___side-nav-nav-item-selected-icon: 0 0% 93% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/Harness Theme/Dark */
-  --figma___side-nav-nav-item-selected-text: 0 0% 93% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Text/Harness Theme/Dark */
-  --figma___side-nav-profile-role: 0 0% 100% / 0.46;
-  /* ✦ Theme/Side nav/Profile/Role/Harness Theme/Dark */
-  --figma___side-nav-profile-text: 0 0% 93% / 1;
-  /* ✦ Theme/Side nav/Profile/Text/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-default-border: 0 0% 100% / 0.1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Border/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-default-main-text-icon: 0 0% 93% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-default-scope-name: 0 0% 100% / 0.46;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-default-default: 0 0% 0% / 0.5;
-  /* ✦ Theme/Side nav/Scope Selector/Default/default/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-hover-border: 205 100% 71% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-hover-main-text-icon: 0 0% 93% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-hover-scope-name: 0 0% 100% / 0.46;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-hover-default: 0 0% 0% / 0.5;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/default/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-selected-border: 205 100% 71% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-selected-main-text-icon: 0 0% 93% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-selected-scope-name: 0 0% 100% / 0.46;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/Harness Theme/Dark */
-  --figma___side-nav-scope-selector-selected-background: 0 0% 0% / 0.5;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/background/Harness Theme/Dark */
-  --figma___side-nav-separator: 0 0% 100% / 0.1;
-  /* ✦ Theme/Side nav/Separator/Harness Theme/Dark */
-  --figma___status-colors-error-1: 350 24% 10% / 1;
-  /* ✦ Theme/Status colors/Error/1/Harness Theme/Dark */
-  --figma___status-colors-error-2: 354 30% 12% / 1;
-  /* ✦ Theme/Status colors/Error/2/Harness Theme/Dark */
-  --figma___status-colors-error-3: 353 40% 16% / 1;
-  /* ✦ Theme/Status colors/Error/3/Harness Theme/Dark */
-  --figma___status-colors-error-4: 352 47% 19% / 1;
-  /* ✦ Theme/Status colors/Error/4/Harness Theme/Dark */
-  --figma___status-colors-error-5: 354 50% 22% / 1;
-  /* ✦ Theme/Status colors/Error/5/Harness Theme/Dark */
-  --figma___status-colors-error-6: 354 57% 26% / 1;
-  /* ✦ Theme/Status colors/Error/6/Harness Theme/Dark */
-  --figma___status-colors-error-7: 358 75% 59% / 1;
-  /* ✦ Theme/Status colors/Error/7/Harness Theme/Dark */
-  --figma___status-colors-error-8: 359 84% 67% / 1;
-  /* ✦ Theme/Status colors/Error/8/Harness Theme/Dark */
-  --figma___status-colors-error-9: 358 100% 76% / 1;
-  /* ✦ Theme/Status colors/Error/9/Harness Theme/Dark */
-  --figma___status-colors-error-10: 350 100% 91% / 1;
-  /* ✦ Theme/Status colors/Error/10/Harness Theme/Dark */
-  --figma___status-colors-error-alpha-1: 0 100% 49% / 0.03;
-  /* ✦ Theme/Status colors/Error Alpha/1/Harness Theme/Dark */
-  --figma___status-colors-error-alpha-2: 354 100% 50% / 0.07;
-  /* ✦ Theme/Status colors/Error Alpha/2/Harness Theme/Dark */
-  --figma___status-colors-error-alpha-3: 353 99% 56% / 0.15;
-  /* ✦ Theme/Status colors/Error Alpha/3/Harness Theme/Dark */
-  --figma___status-colors-error-alpha-4: 352 100% 56% / 0.21;
-  /* ✦ Theme/Status colors/Error Alpha/4/Harness Theme/Dark */
-  --figma___status-colors-error-alpha-5: 354 99% 57% / 0.26;
-  /* ✦ Theme/Status colors/Error Alpha/5/Harness Theme/Dark */
-  --figma___status-colors-error-alpha-6: 354 100% 57% / 0.35;
-  /* ✦ Theme/Status colors/Error Alpha/6/Harness Theme/Dark */
-  --figma___status-colors-error-alpha-7: 358 100% 65% / 0.89;
-  /* ✦ Theme/Status colors/Error Alpha/7/Harness Theme/Dark */
-  --figma___status-colors-error-alpha-8: 359 100% 71% / 0.94;
-  /* ✦ Theme/Status colors/Error Alpha/8/Harness Theme/Dark */
-  --figma___status-colors-error-alpha-9: 358 100% 76% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/9/Harness Theme/Dark */
-  --figma___status-colors-error-alpha-10: 350 100% 91% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/10/Harness Theme/Dark */
-  --figma___status-colors-info-1: 212 36% 9% / 1;
-  /* ✦ Theme/Status colors/Info/1/Harness Theme/Dark */
-  --figma___status-colors-info-2: 216 50% 12% / 1;
-  /* ✦ Theme/Status colors/Info/2/Harness Theme/Dark */
-  --figma___status-colors-info-3: 214 58% 16% / 1;
-  /* ✦ Theme/Status colors/Info/3/Harness Theme/Dark */
-  --figma___status-colors-info-4: 214 65% 18% / 1;
-  /* ✦ Theme/Status colors/Info/4/Harness Theme/Dark */
-  --figma___status-colors-info-5: 213 67% 21% / 1;
-  /* ✦ Theme/Status colors/Info/5/Harness Theme/Dark */
-  --figma___status-colors-info-6: 212 72% 25% / 1;
-  /* ✦ Theme/Status colors/Info/6/Harness Theme/Dark */
-  --figma___status-colors-info-7: 214 73% 51% / 1;
-  /* ✦ Theme/Status colors/Info/7/Harness Theme/Dark */
-  --figma___status-colors-info-8: 206 100% 62% / 1;
-  /* ✦ Theme/Status colors/Info/8/Harness Theme/Dark */
-  --figma___status-colors-info-9: 205 100% 71% / 1;
-  /* ✦ Theme/Status colors/Info/9/Harness Theme/Dark */
-  --figma___status-colors-info-10: 206 100% 88% / 1;
-  /* ✦ Theme/Status colors/Info/10/Harness Theme/Dark */
-  --figma___status-colors-info-alpha-1: 240 100% 49% / 0.04;
-  /* ✦ Theme/Status colors/Info Alpha/1/Harness Theme/Dark */
-  --figma___status-colors-info-alpha-2: 227 100% 50% / 0.09;
-  /* ✦ Theme/Status colors/Info Alpha/2/Harness Theme/Dark */
-  --figma___status-colors-info-alpha-3: 216 100% 50% / 0.17;
-  /* ✦ Theme/Status colors/Info Alpha/3/Harness Theme/Dark */
-  --figma___status-colors-info-alpha-4: 214 100% 50% / 0.23;
-  /* ✦ Theme/Status colors/Info Alpha/4/Harness Theme/Dark */
-  --figma___status-colors-info-alpha-5: 213 100% 51% / 0.29;
-  /* ✦ Theme/Status colors/Info Alpha/5/Harness Theme/Dark */
-  --figma___status-colors-info-alpha-6: 212 100% 52% / 0.38;
-  /* ✦ Theme/Status colors/Info Alpha/6/Harness Theme/Dark */
-  --figma___status-colors-info-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/7/Harness Theme/Dark */
-  --figma___status-colors-info-alpha-8: 206 100% 62% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/8/Harness Theme/Dark */
-  --figma___status-colors-info-alpha-9: 205 100% 71% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/9/Harness Theme/Dark */
-  --figma___status-colors-info-alpha-10: 206 100% 88% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/10/Harness Theme/Dark */
-  --figma___status-colors-success-1: 145 32% 7% / 1;
-  /* ✦ Theme/Status colors/Success/1/Harness Theme/Dark */
-  --figma___status-colors-success-2: 154 32% 9% / 1;
-  /* ✦ Theme/Status colors/Success/2/Harness Theme/Dark */
-  --figma___status-colors-success-3: 155 38% 11% / 1;
-  /* ✦ Theme/Status colors/Success/3/Harness Theme/Dark */
-  --figma___status-colors-success-4: 155 42% 14% / 1;
-  /* ✦ Theme/Status colors/Success/4/Harness Theme/Dark */
-  --figma___status-colors-success-5: 153 43% 16% / 1;
-  /* ✦ Theme/Status colors/Success/5/Harness Theme/Dark */
-  --figma___status-colors-success-6: 155 47% 19% / 1;
-  /* ✦ Theme/Status colors/Success/6/Harness Theme/Dark */
-  --figma___status-colors-success-7: 142 72% 29% / 1;
-  /* ✦ Theme/Status colors/Success/7/Harness Theme/Dark */
-  --figma___status-colors-success-8: 151 55% 47% / 1;
-  /* ✦ Theme/Status colors/Success/8/Harness Theme/Dark */
-  --figma___status-colors-success-9: 151 65% 54% / 1;
-  /* ✦ Theme/Status colors/Success/9/Harness Theme/Dark */
-  --figma___status-colors-success-10: 144 70% 82% / 1;
-  /* ✦ Theme/Status colors/Success/10/Harness Theme/Dark */
-  --figma___status-colors-success-alpha-1: 120 100% 44% / 0;
-  /* ✦ Theme/Status colors/Success Alpha/1/Harness Theme/Dark */
-  --figma___status-colors-success-alpha-2: 120 100% 49% / 0.02;
-  /* ✦ Theme/Status colors/Success Alpha/2/Harness Theme/Dark */
-  --figma___status-colors-success-alpha-3: 149 100% 49% / 0.07;
-  /* ✦ Theme/Status colors/Success Alpha/3/Harness Theme/Dark */
-  --figma___status-colors-success-alpha-4: 154 100% 50% / 0.11;
-  /* ✦ Theme/Status colors/Success Alpha/4/Harness Theme/Dark */
-  --figma___status-colors-success-alpha-5: 153 99% 53% / 0.15;
-  /* ✦ Theme/Status colors/Success Alpha/5/Harness Theme/Dark */
-  --figma___status-colors-success-alpha-6: 155 99% 55% / 0.2;
-  /* ✦ Theme/Status colors/Success Alpha/6/Harness Theme/Dark */
-  --figma___status-colors-success-alpha-7: 151 100% 62% / 0.61;
-  /* ✦ Theme/Status colors/Success Alpha/7/Harness Theme/Dark */
-  --figma___status-colors-success-alpha-8: 151 100% 63% / 0.7;
-  /* ✦ Theme/Status colors/Success Alpha/8/Harness Theme/Dark */
-  --figma___status-colors-success-alpha-9: 151 100% 64% / 0.82;
-  /* ✦ Theme/Status colors/Success Alpha/9/Harness Theme/Dark */
-  --figma___status-colors-success-alpha-10: 144 100% 87% / 0.94;
-  /* ✦ Theme/Status colors/Success Alpha/10/Harness Theme/Dark */
-  --figma___status-colors-warning-1: 37 100% 6% / 1;
-  /* ✦ Theme/Status colors/Warning/1/Harness Theme/Dark */
-  --figma___status-colors-warning-2: 36 80% 8% / 1;
-  /* ✦ Theme/Status colors/Warning/2/Harness Theme/Dark */
-  --figma___status-colors-warning-3: 34 63% 12% / 1;
-  /* ✦ Theme/Status colors/Warning/3/Harness Theme/Dark */
-  --figma___status-colors-warning-4: 34 58% 14% / 1;
-  /* ✦ Theme/Status colors/Warning/4/Harness Theme/Dark */
-  --figma___status-colors-warning-5: 34 58% 17% / 1;
-  /* ✦ Theme/Status colors/Warning/5/Harness Theme/Dark */
-  --figma___status-colors-warning-6: 34 58% 21% / 1;
-  /* ✦ Theme/Status colors/Warning/6/Harness Theme/Dark */
-  --figma___status-colors-warning-7: 42 100% 62% / 1;
-  /* ✦ Theme/Status colors/Warning/7/Harness Theme/Dark */
-  --figma___status-colors-warning-8: 43 100% 64% / 1;
-  /* ✦ Theme/Status colors/Warning/8/Harness Theme/Dark */
-  --figma___status-colors-warning-9: 43 100% 65% / 1;
-  /* ✦ Theme/Status colors/Warning/9/Harness Theme/Dark */
-  --figma___status-colors-warning-10: 41 100% 85% / 1;
-  /* ✦ Theme/Status colors/Warning/10/Harness Theme/Dark */
-  --figma___status-colors-warning-alpha-1: 0 100% 49% / 0.03;
-  /* ✦ Theme/Status colors/Warning Alpha/1/Harness Theme/Dark */
-  --figma___status-colors-warning-alpha-2: 6 100% 49% / 0.06;
-  /* ✦ Theme/Status colors/Warning Alpha/2/Harness Theme/Dark */
-  --figma___status-colors-warning-alpha-3: 24 100% 50% / 0.1;
-  /* ✦ Theme/Status colors/Warning Alpha/3/Harness Theme/Dark */
-  --figma___status-colors-warning-alpha-4: 30 100% 50% / 0.14;
-  /* ✦ Theme/Status colors/Warning Alpha/4/Harness Theme/Dark */
-  --figma___status-colors-warning-alpha-5: 33 100% 50% / 0.19;
-  /* ✦ Theme/Status colors/Warning Alpha/5/Harness Theme/Dark */
-  --figma___status-colors-warning-alpha-6: 34 100% 53% / 0.26;
-  /* ✦ Theme/Status colors/Warning Alpha/6/Harness Theme/Dark */
-  --figma___status-colors-warning-alpha-7: 42 100% 62% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/7/Harness Theme/Dark */
-  --figma___status-colors-warning-alpha-8: 43 100% 64% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/8/Harness Theme/Dark */
-  --figma___status-colors-warning-alpha-9: 43 100% 65% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/9/Harness Theme/Dark */
-  --figma___status-colors-warning-alpha-10: 41 100% 85% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/10/Harness Theme/Dark */
-  --figma___switch-background: 236 19% 14% / 0.5;
-  /* ✦ Theme/Switch/Background/Harness Theme/Dark */
-  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/Harness Theme/Dark */
-  --figma___switch-checked-active-background: 214 73% 51% / 1;
-  /* ✦ Theme/Switch/Checked/Active/background/Harness Theme/Dark */
-  --figma___switch-checked-active-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Checked/Active/border/Harness Theme/Dark */
-  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/Harness Theme/Dark */
-  --figma___switch-checked-default-default-background: 214 73% 51% / 1;
-  /* ✦ Theme/Switch/Checked/Default/default background/Harness Theme/Dark */
-  --figma___switch-checked-default-default-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Checked/Default/default border/Harness Theme/Dark */
-  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/Harness Theme/Dark */
-  --figma___switch-checked-disabled-background: 206 100% 50% / 1;
-  /* ✦ Theme/Switch/Checked/Disabled/background/Harness Theme/Dark */
-  --figma___switch-checked-disabled-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/border/Harness Theme/Dark */
-  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/Harness Theme/Dark */
-  --figma___switch-checked-hover-background: 206 100% 62% / 1;
-  /* ✦ Theme/Switch/Checked/Hover/background/Harness Theme/Dark */
-  --figma___switch-checked-hover-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/border/Harness Theme/Dark */
-  --figma___switch-paper: 0 0% 100% / 0.03;
-  /* ✦ Theme/Switch/Paper/Harness Theme/Dark */
-  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/Harness Theme/Dark */
-  --figma___switch-unchecked-active-background: 0 0% 100% / 0.13;
-  /* ✦ Theme/Switch/Unchecked/Active/background/Harness Theme/Dark */
-  --figma___switch-unchecked-active-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Unchecked/Active/border/Harness Theme/Dark */
-  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/Harness Theme/Dark */
-  --figma___switch-unchecked-default-default-background: 230 100% 87% / 0.09;
-  /* ✦ Theme/Switch/Unchecked/Default/default background/Harness Theme/Dark */
-  --figma___switch-unchecked-default-default-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Unchecked/Default/default border/Harness Theme/Dark */
-  --figma___switch-unchecked-disabled-thumb-thumb-background: 0 0% 100% / 0.07;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/Harness Theme/Dark */
-  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/Harness Theme/Dark */
-  --figma___switch-unchecked-disabled-background: 0 0% 16% / 1;
-  /* ✦ Theme/Switch/Unchecked/Disabled/background/Harness Theme/Dark */
-  --figma___switch-unchecked-disabled-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Unchecked/Disabled/border/Harness Theme/Dark */
-  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/Harness Theme/Dark */
-  --figma___switch-unchecked-hover-background: 224 96% 89% / 0.13;
-  /* ✦ Theme/Switch/Unchecked/Hover/background/Harness Theme/Dark */
-  --figma___switch-unchecked-hover-border: 233 96% 9% / 0;
-  /* ✦ Theme/Switch/Unchecked/Hover/border/Harness Theme/Dark */
-  --figma___switch-border: 0 0% 100% / 0.07;
-  /* ✦ Theme/Switch/border/Harness Theme/Dark */
-  --figma___tabs-number-active-background: 0 0% 93% / 1;
-  /* ✦ Theme/Tabs/Number/Active/Background/Harness Theme/Dark */
-  --figma___tabs-number-active-text: 0 0% 93% / 1;
-  /* ✦ Theme/Tabs/Number/Active/text/Harness Theme/Dark */
-  --figma___tabs-number-default-hover-background: 0 0% 22% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/Background/Harness Theme/Dark */
-  --figma___tabs-number-default-hover-text: 0 0% 93% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/text/Harness Theme/Dark */
-  --figma___tabs-pills-active-active: 223 7% 19% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Active/Harness Theme/Dark */
-  --figma___tabs-pills-active-text: 0 0% 93% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Text/Harness Theme/Dark */
-  --figma___tabs-pills-active-border-grad-1: 0 0% 100% / 0.1;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 1/Harness Theme/Dark */
-  --figma___tabs-pills-active-border-grad-2: 0 0% 100% / 0.1;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 2/Harness Theme/Dark */
-  --figma___tabs-pills-backgrounds: 240 100% 49% / 0.04;
-  /* ✦ Theme/Tabs/Pills/Backgrounds/Harness Theme/Dark */
-  --figma___tabs-pills-default-background: 230 100% 5% / 0;
-  /* ✦ Theme/Tabs/Pills/Default/Background/Harness Theme/Dark */
-  --figma___tabs-pills-default-text: 0 0% 100% / 0.46;
-  /* ✦ Theme/Tabs/Pills/Default/Text/Harness Theme/Dark */
-  --figma___tabs-pills-hover-background: 0 0% 19% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Background/Harness Theme/Dark */
-  --figma___tabs-pills-hover-text: 0 0% 69% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Text/Harness Theme/Dark */
-  --figma___tabs-pills-number-active-background: 0 0% 93% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/Background/Harness Theme/Dark */
-  --figma___tabs-pills-number-active-text: 0 0% 9% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/text/Harness Theme/Dark */
-  --figma___tabs-pills-border-grad-1: 0 0% 100% / 0.1;
-  /* ✦ Theme/Tabs/Pills/border grad 1/Harness Theme/Dark */
-  --figma___tabs-pills-border-grad-2: 0 0% 100% / 0.1;
-  /* ✦ Theme/Tabs/Pills/border grad 2/Harness Theme/Dark */
-  --figma___tabs-primary-active-text: 0 0% 93% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Text/Harness Theme/Dark */
-  --figma___tabs-primary-active-underline: 211 85% 48% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Underline/Harness Theme/Dark */
-  --figma___tabs-primary-border: 205 100% 71% / 1;
-  /* ✦ Theme/Tabs/Primary/Border/Harness Theme/Dark */
-  --figma___tabs-primary-default-background: 230 100% 5% / 0;
-  /* ✦ Theme/Tabs/Primary/Default/Background/Harness Theme/Dark */
-  --figma___tabs-primary-default-text: 0 0% 100% / 0.46;
-  /* ✦ Theme/Tabs/Primary/Default/Text/Harness Theme/Dark */
-  --figma___tabs-primary-hover-background: 0 0% 100% / 0.1;
-  /* ✦ Theme/Tabs/Primary/Hover/Background/Harness Theme/Dark */
-  --figma___tabs-primary-hover-text: 0 0% 93% / 1;
-  /* ✦ Theme/Tabs/Primary/Hover/Text/Harness Theme/Dark */
-  --figma___tabs-primary-pills-pills: 214 73% 51% / 1;
-  /* ✦ Theme/Tabs/Primary/Pills/Pills/Harness Theme/Dark */
-  --figma___text-disabled: 0 0% 100% / 0.37;
-  /* ✦ Theme/Text/Disabled/Harness Theme/Dark */
-  --figma___text-links: 205 100% 71% / 1;
-  /* ✦ Theme/Text/Links/Harness Theme/Dark */
-  --figma___text-secondary: 0 0% 69% / 1;
-  /* ✦ Theme/Text/Secondary/Harness Theme/Dark */
-  --figma___text-tertiary: 0 0% 100% / 0.46;
-  /* ✦ Theme/Text/Tertiary/Harness Theme/Dark */
-  --figma___text-primary: 0 0% 93% / 1;
-  /* ✦ Theme/Text/primary/Harness Theme/Dark */
-  --figma___textfield-assistive-text-primary: 0 0% 100% / 0.46;
-  /* ✦ Theme/Textfield/Assistive Text/Primary/Harness Theme/Dark */
-  --figma___textfield-background: 0 0% 0% / 0.5;
-  /* ✦ Theme/Textfield/Background/Harness Theme/Dark */
-  --figma___textfield-input-field-background: 0 0% 0% / 0.5;
-  /* ✦ Theme/Textfield/Input Field/Background/Harness Theme/Dark */
-  --figma___textfield-input-field-default: 0 0% 100% / 0.1;
-  /* ✦ Theme/Textfield/Input Field/Default/Harness Theme/Dark */
-  --figma___textfield-input-field-error: 358 75% 59% / 1;
-  /* ✦ Theme/Textfield/Input Field/Error/Harness Theme/Dark */
-  --figma___textfield-input-field-hover: 206 100% 62% / 1;
-  /* ✦ Theme/Textfield/Input Field/Hover/Harness Theme/Dark */
-  --figma___textfield-label-info-icon: 205 100% 71% / 1;
-  /* ✦ Theme/Textfield/Label/Info Icon/Harness Theme/Dark */
-  --figma___textfield-label-link: 205 100% 71% / 1;
-  /* ✦ Theme/Textfield/Label/Link/Harness Theme/Dark */
-  --figma___textfield-label-main: 0 0% 69% / 1;
-  /* ✦ Theme/Textfield/Label/Main/Harness Theme/Dark */
-  --figma___textfield-label-optional: 0 0% 100% / 0.46;
-  /* ✦ Theme/Textfield/Label/Optional/Harness Theme/Dark */
-  --figma___textfield-pin-soft-background: 216 50% 12% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/Background/Harness Theme/Dark */
-  --figma___textfield-pin-soft-border: 213 67% 21% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/border/Harness Theme/Dark */
-  --figma___textfield-pin-soft-pin: 205 100% 71% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/pin/Harness Theme/Dark */
-  --figma___textfield-pin-surface-background: 0 0% 11% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/Background/Harness Theme/Dark */
-  --figma___textfield-pin-surface-border: 0 0% 22% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/border/Harness Theme/Dark */
-  --figma___textfield-pin-surface-pin: 205 100% 71% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/pin/Harness Theme/Dark */
-  --figma___tooltip-background: 230 7% 16% / 1;
-  /* ✦ Theme/Tooltip/Background/Harness Theme/Dark */
-  --figma___tooltip-body-text: 0 0% 69% / 1;
-  /* ✦ Theme/Tooltip/Body Text/Harness Theme/Dark */
-  --figma___tooltip-dismissable-icon: 0 0% 69% / 1;
-  /* ✦ Theme/Tooltip/Dismissable icon/Harness Theme/Dark */
-  --figma___tooltip-tooltip-title: 0 0% 93% / 1;
-  /* ✦ Theme/Tooltip/Tooltip Title/Harness Theme/Dark */
-  --figma___badges-solid-amber-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Amber/text/Harness Theme/Dark */
-  --figma___badges-solid-blue-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Blue/text/Harness Theme/Dark */
-  --figma___badges-solid-bronze-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Bronze/text/Harness Theme/Dark */
-  --figma___badges-solid-brown-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Brown/text/Harness Theme/Dark */
-  --figma___badges-solid-crimson-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Crimson/text/Harness Theme/Dark */
-  --figma___badges-solid-cyan-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Cyan/text/Harness Theme/Dark */
-  --figma___badges-solid-gold-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Gold/text/Harness Theme/Dark */
-  --figma___badges-solid-grass-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Grass/text/Harness Theme/Dark */
-  --figma___badges-solid-green-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Green/text/Harness Theme/Dark */
-  --figma___badges-solid-indigo-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Indigo/text/Harness Theme/Dark */
-  --figma___badges-solid-iris-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Iris/text/Harness Theme/Dark */
-  --figma___badges-solid-jade-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Jade/text/Harness Theme/Dark */
-  --figma___badges-solid-lime-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Lime/text/Harness Theme/Dark */
-  --figma___badges-solid-mint-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Mint/text/Harness Theme/Dark */
-  --figma___badges-solid-orange-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Orange/text/Harness Theme/Dark */
-  --figma___badges-solid-pink-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Pink/text/Harness Theme/Dark */
-  --figma___badges-solid-plum-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Plum/text/Harness Theme/Dark */
-  --figma___badges-solid-purple-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Purple/text/Harness Theme/Dark */
-  --figma___badges-solid-red-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Red/text/Harness Theme/Dark */
-  --figma___badges-solid-ruby-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Ruby/text/Harness Theme/Dark */
-  --figma___badges-solid-sky-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Sky/text/Harness Theme/Dark */
-  --figma___badges-solid-success-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Success/text/Harness Theme/Dark */
-  --figma___badges-solid-teal-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Teal/text/Harness Theme/Dark */
-  --figma___badges-solid-violet-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/Violet/text/Harness Theme/Dark */
-  --figma___badges-solid-yellow-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/Yellow/text/Harness Theme/Dark */
-  --figma___badges-solid-accent-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Badges/Solid/accent/text/Harness Theme/Dark */
-  --figma___badges-solid-info-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/info/text/Harness Theme/Dark */
-  --figma___badges-solid-warning-text: var(--figma___default-colors-black);
-  /* ✦ Theme/Badges/Solid/warning/text/Harness Theme/Dark */
-  --figma___button-solid-accent-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Accent/Text-primary/Harness Theme/Dark */
-  --figma___button-solid-error-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Error/Text-primary/Harness Theme/Dark */
-  --figma___button-solid-neutral-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Neutral/Text-primary/Harness Theme/Dark */
-  --figma___button-solid-success-text-primary: var(--figma___default-colors-white);
-  /* ✦ Theme/Button/Solid/Success/Text-primary/Harness Theme/Dark */
-  --figma___calendar-selected-date-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Calendar/Selected Date/Text/Harness Theme/Dark */
-  --figma___checkbox-surface-checked-active-check: var(--figma___default-colors-white);
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/Harness Theme/Dark */
-  --figma___default-colors-white-to-dark: var(--figma___default-colors-white);
-  /* ✦ Theme/Default colors/white-to-dark/Harness Theme/Dark */
-  --figma___filter-default: var(--figma___default-colors-white);
-  /* ✦ Theme/Filter/Default/Harness Theme/Dark */
-  --figma___pagination-active-text: var(--figma___default-colors-white);
-  /* ✦ Theme/Pagination/Active/Text/Harness Theme/Dark */
-  --figma___radio-button-checked-active-dot: var(--figma___default-colors-white);
-  /* ✦ Theme/Radio button/Checked/Active/Dot/Harness Theme/Dark */
-  --figma___switch-checked-active-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/Harness Theme/Dark */
-  --figma___switch-checked-default-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/Harness Theme/Dark */
-  --figma___switch-checked-disabled-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/Harness Theme/Dark */
-  --figma___switch-checked-hover-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/Harness Theme/Dark */
-  --figma___switch-unchecked-active-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/Harness Theme/Dark */
-  --figma___switch-unchecked-default-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/Harness Theme/Dark */
-  --figma___switch-unchecked-hover-thumb-thumb-background: var(--figma___default-colors-white);
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-1: 350 24% 10% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/1/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-2: 354 30% 12% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/2/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-3: 353 40% 16% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/3/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-4: 352 47% 19% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/4/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-5: 354 50% 22% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/5/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-6: 354 66% 33% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/6/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-7: 358 75% 59% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/7/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-8: 359 84% 67% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/8/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-9: 358 100% 76% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/9/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-10: 350 100% 91% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/10/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-alpha-1: 0 100% 49% / 0.03; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/1/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-alpha-2: 354 100% 50% / 0.07; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/2/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-alpha-3: 353 99% 56% / 0.15; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/3/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-alpha-4: 352 100% 56% / 0.21; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/4/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-alpha-5: 354 99% 57% / 0.26; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/5/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-alpha-6: 354 100% 57% / 0.5; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/6/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-alpha-7: 358 100% 65% / 0.89; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/7/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-alpha-8: 359 100% 71% / 0.94; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/8/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-alpha-9: 358 100% 76% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/9/Harness Theme/Dark */
+  --figma___colors-alerts-status-error-alpha-10: 350 100% 91% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/10/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-1: 226 25% 10% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/1/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-2: 230 36% 13% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/2/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-3: 228 43% 18% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/3/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-4: 228 45% 21% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/4/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-5: 227 48% 24% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/5/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-6: 226 53% 37% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/6/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-7: 226 70% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/7/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-8: 230 74% 63% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/8/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-9: 235 100% 80% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/9/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-10: 236 94% 93% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/10/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-alpha-1: 240 100% 49% / 0.04; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/1/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-alpha-2: 232 100% 50% / 0.09; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/2/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-alpha-3: 228 100% 57% / 0.18; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/3/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-alpha-4: 228 99% 59% / 0.24; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/4/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-alpha-5: 227 99% 60% / 0.29; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/5/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-alpha-6: 226 100% 62% / 0.52; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/6/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-alpha-7: 226 100% 63% / 0.85; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/7/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-alpha-8: 230 100% 70% / 0.9; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/8/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-alpha-9: 235 100% 80% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/9/Harness Theme/Dark */
+  --figma___colors-alerts-status-info-alpha-10: 236 100% 94% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/10/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-1: 145 32% 7% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/1/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-2: 154 32% 9% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/2/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-3: 155 38% 11% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/3/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-4: 155 42% 14% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/4/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-5: 153 43% 16% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/5/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-6: 152 50% 25% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/6/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-7: 142 72% 29% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/7/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-8: 151 55% 47% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/8/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-9: 151 65% 54% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/9/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-10: 144 70% 82% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/10/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-alpha-1: 120 100% 44% / 0; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/1/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-alpha-2: 120 100% 49% / 0.02; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/2/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-alpha-3: 149 100% 49% / 0.07; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/3/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-alpha-4: 154 100% 50% / 0.11; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/4/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-alpha-5: 153 99% 53% / 0.15; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/5/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-alpha-6: 152 99% 59% / 0.3; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/6/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-alpha-7: 151 100% 62% / 0.61; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/7/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-alpha-8: 151 100% 63% / 0.7; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/8/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-alpha-9: 151 100% 64% / 0.82; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/9/Harness Theme/Dark */
+  --figma___colors-alerts-status-success-alpha-10: 144 100% 87% / 0.94; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/10/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-1: 37 100% 6% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/1/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-2: 36 80% 8% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/2/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-3: 34 63% 12% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/3/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-4: 34 58% 14% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/4/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-5: 34 58% 17% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/5/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-6: 35 59% 27% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/6/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-7: 42 100% 62% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/7/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-8: 43 100% 64% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/8/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-9: 43 100% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/9/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-10: 41 100% 85% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/10/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-alpha-1: 0 100% 49% / 0.03; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/1/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-alpha-2: 6 100% 49% / 0.06; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/2/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-alpha-3: 24 100% 50% / 0.1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/3/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-alpha-4: 30 100% 50% / 0.14; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/4/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-alpha-5: 33 100% 50% / 0.19; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/5/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-alpha-6: 35 100% 57% / 0.38; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/6/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-alpha-7: 42 100% 62% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/7/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-alpha-8: 43 100% 64% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/8/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-alpha-9: 43 100% 65% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/9/Harness Theme/Dark */
+  --figma___colors-alerts-status-warning-alpha-10: 41 100% 85% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/10/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-1: 252 19% 10% / 1; /* ✦ Theme/Colors/Charts/AI Violet/1/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-2: 255 30% 13% / 1; /* ✦ Theme/Colors/Charts/AI Violet/2/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-3: 255 34% 18% / 1; /* ✦ Theme/Colors/Charts/AI Violet/3/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-4: 252 35% 22% / 1; /* ✦ Theme/Colors/Charts/AI Violet/4/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-5: 253 35% 25% / 1; /* ✦ Theme/Colors/Charts/AI Violet/5/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-6: 251 38% 39% / 1; /* ✦ Theme/Colors/Charts/AI Violet/6/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-7: 252 56% 57% / 1; /* ✦ Theme/Colors/Charts/AI Violet/7/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-8: 253 63% 64% / 1; /* ✦ Theme/Colors/Charts/AI Violet/8/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-9: 255 100% 80% / 1; /* ✦ Theme/Colors/Charts/AI Violet/9/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-10: 249 94% 93% / 1; /* ✦ Theme/Colors/Charts/AI Violet/10/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-alpha-1: 240 100% 49% / 0.03; /* ✦ Theme/Colors/Charts/AI Violet Alpha/1/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-alpha-2: 255 98% 52% / 0.08; /* ✦ Theme/Colors/Charts/AI Violet Alpha/2/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-alpha-3: 255 99% 63% / 0.17; /* ✦ Theme/Colors/Charts/AI Violet Alpha/3/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-alpha-4: 252 99% 66% / 0.23; /* ✦ Theme/Colors/Charts/AI Violet Alpha/4/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-alpha-5: 252 99% 67% / 0.28; /* ✦ Theme/Colors/Charts/AI Violet Alpha/5/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-alpha-6: 251 100% 70% / 0.49; /* ✦ Theme/Colors/Charts/AI Violet Alpha/6/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-alpha-7: 252 100% 70% / 0.79; /* ✦ Theme/Colors/Charts/AI Violet Alpha/7/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-alpha-8: 253 100% 74% / 0.85; /* ✦ Theme/Colors/Charts/AI Violet Alpha/8/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-alpha-9: 255 100% 80% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/9/Harness Theme/Dark */
+  --figma___colors-charts-ai-violet-alpha-10: 249 100% 94% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/10/Harness Theme/Dark */
+  --figma___colors-charts-blue-1: 212 36% 9% / 1; /* ✦ Theme/Colors/Charts/Blue/1/Harness Theme/Dark */
+  --figma___colors-charts-blue-2: 216 50% 12% / 1; /* ✦ Theme/Colors/Charts/Blue/2/Harness Theme/Dark */
+  --figma___colors-charts-blue-3: 214 58% 16% / 1; /* ✦ Theme/Colors/Charts/Blue/3/Harness Theme/Dark */
+  --figma___colors-charts-blue-4: 214 65% 18% / 1; /* ✦ Theme/Colors/Charts/Blue/4/Harness Theme/Dark */
+  --figma___colors-charts-blue-5: 213 67% 21% / 1; /* ✦ Theme/Colors/Charts/Blue/5/Harness Theme/Dark */
+  --figma___colors-charts-blue-6: 211 82% 32% / 1; /* ✦ Theme/Colors/Charts/Blue/6/Harness Theme/Dark */
+  --figma___colors-charts-blue-7: 214 73% 51% / 1; /* ✦ Theme/Colors/Charts/Blue/7/Harness Theme/Dark */
+  --figma___colors-charts-blue-8: 206 100% 62% / 1; /* ✦ Theme/Colors/Charts/Blue/8/Harness Theme/Dark */
+  --figma___colors-charts-blue-9: 205 100% 71% / 1; /* ✦ Theme/Colors/Charts/Blue/9/Harness Theme/Dark */
+  --figma___colors-charts-blue-10: 206 100% 88% / 1; /* ✦ Theme/Colors/Charts/Blue/10/Harness Theme/Dark */
+  --figma___colors-charts-blue-alpha-1: 240 100% 49% / 0.04; /* ✦ Theme/Colors/Charts/Blue Alpha/1/Harness Theme/Dark */
+  --figma___colors-charts-blue-alpha-2: 227 100% 50% / 0.09; /* ✦ Theme/Colors/Charts/Blue Alpha/2/Harness Theme/Dark */
+  --figma___colors-charts-blue-alpha-3: 216 100% 50% / 0.17; /* ✦ Theme/Colors/Charts/Blue Alpha/3/Harness Theme/Dark */
+  --figma___colors-charts-blue-alpha-4: 214 100% 50% / 0.23; /* ✦ Theme/Colors/Charts/Blue Alpha/4/Harness Theme/Dark */
+  --figma___colors-charts-blue-alpha-5: 213 100% 51% / 0.29; /* ✦ Theme/Colors/Charts/Blue Alpha/5/Harness Theme/Dark */
+  --figma___colors-charts-blue-alpha-6: 211 100% 51% / 0.55; /* ✦ Theme/Colors/Charts/Blue Alpha/6/Harness Theme/Dark */
+  --figma___colors-charts-blue-alpha-7: 206 100% 50% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/7/Harness Theme/Dark */
+  --figma___colors-charts-blue-alpha-8: 206 100% 62% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/8/Harness Theme/Dark */
+  --figma___colors-charts-blue-alpha-9: 205 100% 71% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/9/Harness Theme/Dark */
+  --figma___colors-charts-blue-alpha-10: 206 100% 88% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/10/Harness Theme/Dark */
+  --figma___colors-charts-indigo-1: 226 25% 10% / 1; /* ✦ Theme/Colors/Charts/Indigo/1/Harness Theme/Dark */
+  --figma___colors-charts-indigo-2: 230 36% 13% / 1; /* ✦ Theme/Colors/Charts/Indigo/2/Harness Theme/Dark */
+  --figma___colors-charts-indigo-3: 228 43% 18% / 1; /* ✦ Theme/Colors/Charts/Indigo/3/Harness Theme/Dark */
+  --figma___colors-charts-indigo-4: 228 45% 21% / 1; /* ✦ Theme/Colors/Charts/Indigo/4/Harness Theme/Dark */
+  --figma___colors-charts-indigo-5: 227 48% 24% / 1; /* ✦ Theme/Colors/Charts/Indigo/5/Harness Theme/Dark */
+  --figma___colors-charts-indigo-6: 226 53% 37% / 1; /* ✦ Theme/Colors/Charts/Indigo/6/Harness Theme/Dark */
+  --figma___colors-charts-indigo-7: 226 70% 55% / 1; /* ✦ Theme/Colors/Charts/Indigo/7/Harness Theme/Dark */
+  --figma___colors-charts-indigo-8: 230 74% 63% / 1; /* ✦ Theme/Colors/Charts/Indigo/8/Harness Theme/Dark */
+  --figma___colors-charts-indigo-9: 235 100% 80% / 1; /* ✦ Theme/Colors/Charts/Indigo/9/Harness Theme/Dark */
+  --figma___colors-charts-indigo-10: 236 94% 93% / 1; /* ✦ Theme/Colors/Charts/Indigo/10/Harness Theme/Dark */
+  --figma___colors-charts-indigo-alpha-1: 240 100% 49% / 0.04; /* ✦ Theme/Colors/Charts/Indigo Alpha/1/Harness Theme/Dark */
+  --figma___colors-charts-indigo-alpha-2: 232 100% 50% / 0.09; /* ✦ Theme/Colors/Charts/Indigo Alpha/2/Harness Theme/Dark */
+  --figma___colors-charts-indigo-alpha-3: 228 100% 57% / 0.18; /* ✦ Theme/Colors/Charts/Indigo Alpha/3/Harness Theme/Dark */
+  --figma___colors-charts-indigo-alpha-4: 228 99% 59% / 0.24; /* ✦ Theme/Colors/Charts/Indigo Alpha/4/Harness Theme/Dark */
+  --figma___colors-charts-indigo-alpha-5: 227 99% 60% / 0.29; /* ✦ Theme/Colors/Charts/Indigo Alpha/5/Harness Theme/Dark */
+  --figma___colors-charts-indigo-alpha-6: 226 100% 62% / 0.52; /* ✦ Theme/Colors/Charts/Indigo Alpha/6/Harness Theme/Dark */
+  --figma___colors-charts-indigo-alpha-7: 226 100% 63% / 0.85; /* ✦ Theme/Colors/Charts/Indigo Alpha/7/Harness Theme/Dark */
+  --figma___colors-charts-indigo-alpha-8: 230 100% 70% / 0.9; /* ✦ Theme/Colors/Charts/Indigo Alpha/8/Harness Theme/Dark */
+  --figma___colors-charts-indigo-alpha-9: 235 100% 80% / 1; /* ✦ Theme/Colors/Charts/Indigo Alpha/9/Harness Theme/Dark */
+  --figma___colors-charts-indigo-alpha-10: 236 100% 94% / 1; /* ✦ Theme/Colors/Charts/Indigo Alpha/10/Harness Theme/Dark */
+  --figma___colors-charts-mint-1: 173 52% 6% / 1; /* ✦ Theme/Colors/Charts/Mint/1/Harness Theme/Dark */
+  --figma___colors-charts-mint-2: 174 51% 8% / 1; /* ✦ Theme/Colors/Charts/Mint/2/Harness Theme/Dark */
+  --figma___colors-charts-mint-3: 176 52% 11% / 1; /* ✦ Theme/Colors/Charts/Mint/3/Harness Theme/Dark */
+  --figma___colors-charts-mint-4: 173 56% 13% / 1; /* ✦ Theme/Colors/Charts/Mint/4/Harness Theme/Dark */
+  --figma___colors-charts-mint-5: 173 57% 15% / 1; /* ✦ Theme/Colors/Charts/Mint/5/Harness Theme/Dark */
+  --figma___colors-charts-mint-6: 173 60% 24% / 1; /* ✦ Theme/Colors/Charts/Mint/6/Harness Theme/Dark */
+  --figma___colors-charts-mint-7: 167 70% 72% / 1; /* ✦ Theme/Colors/Charts/Mint/7/Harness Theme/Dark */
+  --figma___colors-charts-mint-8: 163 80% 77% / 1; /* ✦ Theme/Colors/Charts/Mint/8/Harness Theme/Dark */
+  --figma___colors-charts-mint-9: 167 70% 58% / 1; /* ✦ Theme/Colors/Charts/Mint/9/Harness Theme/Dark */
+  --figma___colors-charts-mint-10: 156 71% 86% / 1; /* ✦ Theme/Colors/Charts/Mint/10/Harness Theme/Dark */
+  --figma___colors-charts-mint-alpha-1: 120 100% 44% / 0; /* ✦ Theme/Colors/Charts/Mint Alpha/1/Harness Theme/Dark */
+  --figma___colors-charts-mint-alpha-2: 165 100% 49% / 0.03; /* ✦ Theme/Colors/Charts/Mint Alpha/2/Harness Theme/Dark */
+  --figma___colors-charts-mint-alpha-3: 174 100% 50% / 0.07; /* ✦ Theme/Colors/Charts/Mint Alpha/3/Harness Theme/Dark */
+  --figma___colors-charts-mint-alpha-4: 172 100% 50% / 0.11; /* ✦ Theme/Colors/Charts/Mint Alpha/4/Harness Theme/Dark */
+  --figma___colors-charts-mint-alpha-5: 172 100% 50% / 0.15; /* ✦ Theme/Colors/Charts/Mint Alpha/5/Harness Theme/Dark */
+  --figma___colors-charts-mint-alpha-6: 173 100% 55% / 0.31; /* ✦ Theme/Colors/Charts/Mint Alpha/6/Harness Theme/Dark */
+  --figma___colors-charts-mint-alpha-7: 167 100% 78% / 0.91; /* ✦ Theme/Colors/Charts/Mint Alpha/7/Harness Theme/Dark */
+  --figma___colors-charts-mint-alpha-8: 163 100% 81% / 0.95; /* ✦ Theme/Colors/Charts/Mint Alpha/8/Harness Theme/Dark */
+  --figma___colors-charts-mint-alpha-9: 167 100% 66% / 0.86; /* ✦ Theme/Colors/Charts/Mint Alpha/9/Harness Theme/Dark */
+  --figma___colors-charts-mint-alpha-10: 155 100% 90% / 0.96; /* ✦ Theme/Colors/Charts/Mint Alpha/10/Harness Theme/Dark */
+  --figma___colors-charts-orange-1: 29 68% 7% / 1; /* ✦ Theme/Colors/Charts/Orange/1/Harness Theme/Dark */
+  --figma___colors-charts-orange-2: 29 81% 8% / 1; /* ✦ Theme/Colors/Charts/Orange/2/Harness Theme/Dark */
+  --figma___colors-charts-orange-3: 26 68% 12% / 1; /* ✦ Theme/Colors/Charts/Orange/3/Harness Theme/Dark */
+  --figma___colors-charts-orange-4: 25 66% 15% / 1; /* ✦ Theme/Colors/Charts/Orange/4/Harness Theme/Dark */
+  --figma___colors-charts-orange-5: 25 65% 18% / 1; /* ✦ Theme/Colors/Charts/Orange/5/Harness Theme/Dark */
+  --figma___colors-charts-orange-6: 25 68% 29% / 1; /* ✦ Theme/Colors/Charts/Orange/6/Harness Theme/Dark */
+  --figma___colors-charts-orange-7: 24 94% 50% / 1; /* ✦ Theme/Colors/Charts/Orange/7/Harness Theme/Dark */
+  --figma___colors-charts-orange-8: 24 100% 58% / 1; /* ✦ Theme/Colors/Charts/Orange/8/Harness Theme/Dark */
+  --figma___colors-charts-orange-9: 24 100% 70% / 1; /* ✦ Theme/Colors/Charts/Orange/9/Harness Theme/Dark */
+  --figma___colors-charts-orange-10: 30 100% 88% / 1; /* ✦ Theme/Colors/Charts/Orange/10/Harness Theme/Dark */
+  --figma___colors-charts-orange-alpha-1: 0 100% 49% / 0.03; /* ✦ Theme/Colors/Charts/Orange Alpha/1/Harness Theme/Dark */
+  --figma___colors-charts-orange-alpha-2: 0 100% 50% / 0.06; /* ✦ Theme/Colors/Charts/Orange Alpha/2/Harness Theme/Dark */
+  --figma___colors-charts-orange-alpha-3: 13 100% 50% / 0.12; /* ✦ Theme/Colors/Charts/Orange Alpha/3/Harness Theme/Dark */
+  --figma___colors-charts-orange-alpha-4: 20 100% 50% / 0.17; /* ✦ Theme/Colors/Charts/Orange Alpha/4/Harness Theme/Dark */
+  --figma___colors-charts-orange-alpha-5: 24 100% 50% / 0.22; /* ✦ Theme/Colors/Charts/Orange Alpha/5/Harness Theme/Dark */
+  --figma___colors-charts-orange-alpha-6: 25 100% 51% / 0.44; /* ✦ Theme/Colors/Charts/Orange Alpha/6/Harness Theme/Dark */
+  --figma___colors-charts-orange-alpha-7: 24 100% 51% / 0.97; /* ✦ Theme/Colors/Charts/Orange Alpha/7/Harness Theme/Dark */
+  --figma___colors-charts-orange-alpha-8: 24 100% 58% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/8/Harness Theme/Dark */
+  --figma___colors-charts-orange-alpha-9: 24 100% 70% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/9/Harness Theme/Dark */
+  --figma___colors-charts-orange-alpha-10: 30 100% 88% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/10/Harness Theme/Dark */
+  --figma___colors-charts-yellow-1: 45 100% 5% / 1; /* ✦ Theme/Colors/Charts/Yellow/1/Harness Theme/Dark */
+  --figma___colors-charts-yellow-2: 44 79% 7% / 1; /* ✦ Theme/Colors/Charts/Yellow/2/Harness Theme/Dark */
+  --figma___colors-charts-yellow-3: 44 63% 11% / 1; /* ✦ Theme/Colors/Charts/Yellow/3/Harness Theme/Dark */
+  --figma___colors-charts-yellow-4: 44 58% 13% / 1; /* ✦ Theme/Colors/Charts/Yellow/4/Harness Theme/Dark */
+  --figma___colors-charts-yellow-5: 45 56% 15% / 1; /* ✦ Theme/Colors/Charts/Yellow/5/Harness Theme/Dark */
+  --figma___colors-charts-yellow-6: 47 59% 24% / 1; /* ✦ Theme/Colors/Charts/Yellow/6/Harness Theme/Dark */
+  --figma___colors-charts-yellow-7: 53 96% 58% / 1; /* ✦ Theme/Colors/Charts/Yellow/7/Harness Theme/Dark */
+  --figma___colors-charts-yellow-8: 53 96% 67% / 1; /* ✦ Theme/Colors/Charts/Yellow/8/Harness Theme/Dark */
+  --figma___colors-charts-yellow-9: 55 100% 60% / 1; /* ✦ Theme/Colors/Charts/Yellow/9/Harness Theme/Dark */
+  --figma___colors-charts-yellow-10: 53 100% 84% / 1; /* ✦ Theme/Colors/Charts/Yellow/10/Harness Theme/Dark */
+  --figma___colors-charts-yellow-alpha-1: 0 100% 48% / 0.02; /* ✦ Theme/Colors/Charts/Yellow Alpha/1/Harness Theme/Dark */
+  --figma___colors-charts-yellow-alpha-2: 17 100% 49% / 0.04; /* ✦ Theme/Colors/Charts/Yellow Alpha/2/Harness Theme/Dark */
+  --figma___colors-charts-yellow-alpha-3: 36 100% 50% / 0.09; /* ✦ Theme/Colors/Charts/Yellow Alpha/3/Harness Theme/Dark */
+  --figma___colors-charts-yellow-alpha-4: 41 100% 50% / 0.12; /* ✦ Theme/Colors/Charts/Yellow Alpha/4/Harness Theme/Dark */
+  --figma___colors-charts-yellow-alpha-5: 44 100% 50% / 0.16; /* ✦ Theme/Colors/Charts/Yellow Alpha/5/Harness Theme/Dark */
+  --figma___colors-charts-yellow-alpha-6: 47 99% 55% / 0.32; /* ✦ Theme/Colors/Charts/Yellow Alpha/6/Harness Theme/Dark */
+  --figma___colors-charts-yellow-alpha-7: 53 100% 59% / 0.98; /* ✦ Theme/Colors/Charts/Yellow Alpha/7/Harness Theme/Dark */
+  --figma___colors-charts-yellow-alpha-8: 53 100% 68% / 0.99; /* ✦ Theme/Colors/Charts/Yellow Alpha/8/Harness Theme/Dark */
+  --figma___colors-charts-yellow-alpha-9: 55 100% 60% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/9/Harness Theme/Dark */
+  --figma___colors-charts-yellow-alpha-10: 53 100% 84% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/10/Harness Theme/Dark */
+  --figma___colors-default-black-fixed: 0 0% 0% / 1; /* ✦ Theme/Colors/Default/Black (fixed)/Harness Theme/Dark */
+  --figma___colors-default-brand-color: 194 100% 45% / 1; /* ✦ Theme/Colors/Default/Brand Color/Harness Theme/Dark */
+  --figma___colors-default-dark-to-white: 0 0% 93% / 1; /* ✦ Theme/Colors/Default/Dark-to-white/Harness Theme/Dark */
+  --figma___colors-default-white-fixed: 0 0% 100% / 1; /* ✦ Theme/Colors/Default/White (fixed)/Harness Theme/Dark */
+  --figma___colors-module-ccm-100: 179 56% 32% / 1; /* ✦ Theme/Colors/Module/CCM/100/Harness Theme/Dark */
+  --figma___colors-module-ccm-200: 181 99% 40% / 1; /* ✦ Theme/Colors/Module/CCM/200/Harness Theme/Dark */
+  --figma___colors-module-ccm-300: 180 100% 96% / 1; /* ✦ Theme/Colors/Module/CCM/300/Harness Theme/Dark */
+  --figma___colors-module-cd-100: 110 62% 32% / 1; /* ✦ Theme/Colors/Module/CD/100/Harness Theme/Dark */
+  --figma___colors-module-cd-200: 110 40% 50% / 1; /* ✦ Theme/Colors/Module/CD/200/Harness Theme/Dark */
+  --figma___colors-module-cd-300: 102 100% 97% / 1; /* ✦ Theme/Colors/Module/CD/300/Harness Theme/Dark */
+  --figma___colors-module-ce-100: 335 100% 30% / 1; /* ✦ Theme/Colors/Module/CE/100/Harness Theme/Dark */
+  --figma___colors-module-ce-200: 335 100% 50% / 1; /* ✦ Theme/Colors/Module/CE/200/Harness Theme/Dark */
+  --figma___colors-module-ce-300: 334 100% 97% / 1; /* ✦ Theme/Colors/Module/CE/300/Harness Theme/Dark */
+  --figma___colors-module-ci-100: 203 94% 37% / 1; /* ✦ Theme/Colors/Module/CI/100/Harness Theme/Dark */
+  --figma___colors-module-ci-200: 200 88% 56% / 1; /* ✦ Theme/Colors/Module/CI/200/Harness Theme/Dark */
+  --figma___colors-module-ci-300: 201 100% 94% / 1; /* ✦ Theme/Colors/Module/CI/300/Harness Theme/Dark */
+  --figma___colors-module-ff-100: 26 91% 39% / 1; /* ✦ Theme/Colors/Module/FF/100/Harness Theme/Dark */
+  --figma___colors-module-ff-200: 29 86% 54% / 1; /* ✦ Theme/Colors/Module/FF/200/Harness Theme/Dark */
+  --figma___colors-module-ff-300: 41 81% 94% / 1; /* ✦ Theme/Colors/Module/FF/300/Harness Theme/Dark */
+  --figma___colors-module-srm-100: 262 55% 49% / 1; /* ✦ Theme/Colors/Module/SRM/100/Harness Theme/Dark */
+  --figma___colors-module-srm-200: 262 95% 75% / 1; /* ✦ Theme/Colors/Module/SRM/200/Harness Theme/Dark */
+  --figma___colors-module-srm-300: 261 100% 97% / 1; /* ✦ Theme/Colors/Module/SRM/300/Harness Theme/Dark */
+  --figma___colors-module-ssca-100: 0 98% 36% / 1; /* ✦ Theme/Colors/Module/SSCA/100/Harness Theme/Dark */
+  --figma___colors-module-ssca-200: 0 58% 53% / 1; /* ✦ Theme/Colors/Module/SSCA/200/Harness Theme/Dark */
+  --figma___colors-module-ssca-300: 0 100% 97% / 1; /* ✦ Theme/Colors/Module/SSCA/300/Harness Theme/Dark */
+  --figma___colors-module-sto-100: 245 90% 53% / 1; /* ✦ Theme/Colors/Module/STO/100/Harness Theme/Dark */
+  --figma___colors-module-sto-200: 216 100% 64% / 1; /* ✦ Theme/Colors/Module/STO/200/Harness Theme/Dark */
+  --figma___colors-module-sto-300: 228 100% 96% / 1; /* ✦ Theme/Colors/Module/STO/300/Harness Theme/Dark */
+  --figma___colors-neutral-gray-1: 0 0% 9% / 1; /* ✦ Theme/Colors/Neutral/Gray/1/Harness Theme/Dark */
+  --figma___colors-neutral-gray-2: 0 0% 11% / 1; /* ✦ Theme/Colors/Neutral/Gray/2/Harness Theme/Dark */
+  --figma___colors-neutral-gray-3: 0 0% 16% / 1; /* ✦ Theme/Colors/Neutral/Gray/3/Harness Theme/Dark */
+  --figma___colors-neutral-gray-4: 0 0% 19% / 1; /* ✦ Theme/Colors/Neutral/Gray/4/Harness Theme/Dark */
+  --figma___colors-neutral-gray-5: 0 0% 22% / 1; /* ✦ Theme/Colors/Neutral/Gray/5/Harness Theme/Dark */
+  --figma___colors-neutral-gray-6: 0 0% 25% / 1; /* ✦ Theme/Colors/Neutral/Gray/6/Harness Theme/Dark */
+  --figma___colors-neutral-gray-7: 0 0% 43% / 1; /* ✦ Theme/Colors/Neutral/Gray/7/Harness Theme/Dark */
+  --figma___colors-neutral-gray-8: 0 0% 51% / 1; /* ✦ Theme/Colors/Neutral/Gray/8/Harness Theme/Dark */
+  --figma___colors-neutral-gray-9: 0 0% 69% / 1; /* ✦ Theme/Colors/Neutral/Gray/9/Harness Theme/Dark */
+  --figma___colors-neutral-gray-10: 0 0% 93% / 1; /* ✦ Theme/Colors/Neutral/Gray/10/Harness Theme/Dark */
+  --figma___colors-neutral-gray-alpha-1: 0 0% 100% / 0; /* ✦ Theme/Colors/Neutral/Gray Alpha/1/Harness Theme/Dark */
+  --figma___colors-neutral-gray-alpha-2: 240 89% 18% / 0.02; /* ✦ Theme/Colors/Neutral/Gray Alpha/2/Harness Theme/Dark */
+  --figma___colors-neutral-gray-alpha-3: 0 0% 100% / 0.07; /* ✦ Theme/Colors/Neutral/Gray Alpha/3/Harness Theme/Dark */
+  --figma___colors-neutral-gray-alpha-4: 0 0% 100% / 0.1; /* ✦ Theme/Colors/Neutral/Gray Alpha/4/Harness Theme/Dark */
+  --figma___colors-neutral-gray-alpha-5: 0 0% 100% / 0.13; /* ✦ Theme/Colors/Neutral/Gray Alpha/5/Harness Theme/Dark */
+  --figma___colors-neutral-gray-alpha-6: 0 0% 100% / 0.17; /* ✦ Theme/Colors/Neutral/Gray Alpha/6/Harness Theme/Dark */
+  --figma___colors-neutral-gray-alpha-7: 0 0% 100% / 0.37; /* ✦ Theme/Colors/Neutral/Gray Alpha/7/Harness Theme/Dark */
+  --figma___colors-neutral-gray-alpha-8: 0 0% 100% / 0.46; /* ✦ Theme/Colors/Neutral/Gray Alpha/8/Harness Theme/Dark */
+  --figma___colors-neutral-gray-alpha-9: 0 0% 100% / 0.66; /* ✦ Theme/Colors/Neutral/Gray Alpha/9/Harness Theme/Dark */
+  --figma___colors-neutral-gray-alpha-10: 0 0% 100% / 0.93; /* ✦ Theme/Colors/Neutral/Gray Alpha/10/Harness Theme/Dark */
+  --figma___colors-primary-primary-accent-1: 212 36% 9% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/1/Harness Theme/Dark */
+  --figma___colors-primary-primary-accent-2: 216 50% 12% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/2/Harness Theme/Dark */
+  --figma___colors-primary-primary-accent-3: 214 58% 16% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/3/Harness Theme/Dark */
+  --figma___colors-primary-primary-accent-4: 214 65% 18% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/4/Harness Theme/Dark */
+  --figma___colors-primary-primary-accent-5: 213 67% 21% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/5/Harness Theme/Dark */
+  --figma___colors-primary-primary-accent-6: 212 72% 25% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/6/Harness Theme/Dark */
+  --figma___colors-primary-primary-accent-7: 214 73% 51% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/7/Harness Theme/Dark */
+  --figma___colors-primary-primary-accent-8: 206 100% 62% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/8/Harness Theme/Dark */
+  --figma___colors-primary-primary-accent-9: 205 100% 71% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/9/Harness Theme/Dark */
+  --figma___colors-primary-primary-accent-10: 206 100% 88% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/10/Harness Theme/Dark */
+  --figma___colors-primary-primary-alpha-1: 240 100% 49% / 0.04; /* ✦ Theme/Colors/Primary/Primary Alpha/1/Harness Theme/Dark */
+  --figma___colors-primary-primary-alpha-2: 227 100% 50% / 0.09; /* ✦ Theme/Colors/Primary/Primary Alpha/2/Harness Theme/Dark */
+  --figma___colors-primary-primary-alpha-3: 216 100% 50% / 0.17; /* ✦ Theme/Colors/Primary/Primary Alpha/3/Harness Theme/Dark */
+  --figma___colors-primary-primary-alpha-4: 214 100% 50% / 0.23; /* ✦ Theme/Colors/Primary/Primary Alpha/4/Harness Theme/Dark */
+  --figma___colors-primary-primary-alpha-5: 213 100% 51% / 0.29; /* ✦ Theme/Colors/Primary/Primary Alpha/5/Harness Theme/Dark */
+  --figma___colors-primary-primary-alpha-6: 212 100% 52% / 0.38; /* ✦ Theme/Colors/Primary/Primary Alpha/6/Harness Theme/Dark */
+  --figma___colors-primary-primary-alpha-7: 206 100% 50% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/7/Harness Theme/Dark */
+  --figma___colors-primary-primary-alpha-8: 206 100% 62% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/8/Harness Theme/Dark */
+  --figma___colors-primary-primary-alpha-9: 205 100% 71% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/9/Harness Theme/Dark */
+  --figma___colors-primary-primary-alpha-10: 206 100% 88% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/10/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-crimson-1: 333 18% 10% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 1/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-crimson-10: 330 91% 91% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 10/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-crimson-2: 336 32% 12% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 2/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-crimson-3: 335 41% 16% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 3/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-crimson-4: 336 45% 18% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 4/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-crimson-5: 336 49% 21% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 5/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-crimson-6: 336 63% 33% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 6/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-crimson-7: 336 80% 58% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 7/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-crimson-8: 339 87% 67% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 8/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-crimson-9: 341 100% 76% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 9/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-1: 354 100% 49% / 0.02; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-10: 341 100% 76% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-11: 329 100% 92% / 0.99; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-2: 338 100% 50% / 0.07; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-3: 335 100% 55% / 0.14; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-4: 336 99% 56% / 0.19; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-5: 336 100% 58% / 0.25; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-6: 336 100% 57% / 0.49; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-8: 336 100% 63% / 0.9; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Theme/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-9: 339 100% 70% / 0.95; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Theme/Dark */
+  --figma___colors-secondary-lime-1: 74 55% 6% / 1; /* ✦ Theme/Colors/Secondary/Lime/1/Harness Theme/Dark */
+  --figma___colors-secondary-lime-2: 78 41% 8% / 1; /* ✦ Theme/Colors/Secondary/Lime/2/Harness Theme/Dark */
+  --figma___colors-secondary-lime-3: 82 39% 11% / 1; /* ✦ Theme/Colors/Secondary/Lime/3/Harness Theme/Dark */
+  --figma___colors-secondary-lime-4: 82 40% 13% / 1; /* ✦ Theme/Colors/Secondary/Lime/4/Harness Theme/Dark */
+  --figma___colors-secondary-lime-5: 81 41% 15% / 1; /* ✦ Theme/Colors/Secondary/Lime/5/Harness Theme/Dark */
+  --figma___colors-secondary-lime-6: 78 46% 24% / 1; /* ✦ Theme/Colors/Secondary/Lime/6/Harness Theme/Dark */
+  --figma___colors-secondary-lime-7: 81 80% 66% / 1; /* ✦ Theme/Colors/Secondary/Lime/7/Harness Theme/Dark */
+  --figma___colors-secondary-lime-8: 75 85% 60% / 1; /* ✦ Theme/Colors/Secondary/Lime/8/Harness Theme/Dark */
+  --figma___colors-secondary-lime-9: 70 70% 50% / 1; /* ✦ Theme/Colors/Secondary/Lime/9/Harness Theme/Dark */
+  --figma___colors-secondary-lime-10: 80 79% 85% / 1; /* ✦ Theme/Colors/Secondary/Lime/10/Harness Theme/Dark */
+  --figma___colors-secondary-lime-alpha-1: 75 100% 5% / 0.71; /* ✦ Theme/Colors/Secondary/Lime Alpha/1/Harness Theme/Dark */
+  --figma___colors-secondary-lime-alpha-2: 114 100% 49% / 0.02; /* ✦ Theme/Colors/Secondary/Lime Alpha/2/Harness Theme/Dark */
+  --figma___colors-secondary-lime-alpha-3: 89 100% 50% / 0.06; /* ✦ Theme/Colors/Secondary/Lime Alpha/3/Harness Theme/Dark */
+  --figma___colors-secondary-lime-alpha-4: 84 100% 50% / 0.1; /* ✦ Theme/Colors/Secondary/Lime Alpha/4/Harness Theme/Dark */
+  --figma___colors-secondary-lime-alpha-5: 81 99% 53% / 0.14; /* ✦ Theme/Colors/Secondary/Lime Alpha/5/Harness Theme/Dark */
+  --figma___colors-secondary-lime-alpha-6: 80 99% 58% / 0.19; /* ✦ Theme/Colors/Secondary/Lime Alpha/6/Harness Theme/Dark */
+  --figma___colors-secondary-lime-alpha-7: 81 100% 71% / 0.93; /* ✦ Theme/Colors/Secondary/Lime Alpha/7/Harness Theme/Dark */
+  --figma___colors-secondary-lime-alpha-8: 75 100% 64% / 0.94; /* ✦ Theme/Colors/Secondary/Lime Alpha/8/Harness Theme/Dark */
+  --figma___colors-secondary-lime-alpha-9: 70 100% 58% / 0.84; /* ✦ Theme/Colors/Secondary/Lime Alpha/9/Harness Theme/Dark */
+  --figma___colors-secondary-lime-alpha-10: 80 100% 88% / 0.97; /* ✦ Theme/Colors/Secondary/Lime Alpha/10/Harness Theme/Dark */
+  --figma___colors-secondary-purple-1: 287 18% 10% / 1; /* ✦ Theme/Colors/Secondary/Purple/1/Harness Theme/Dark */
+  --figma___colors-secondary-purple-2: 284 31% 12% / 1; /* ✦ Theme/Colors/Secondary/Purple/2/Harness Theme/Dark */
+  --figma___colors-secondary-purple-3: 282 35% 17% / 1; /* ✦ Theme/Colors/Secondary/Purple/3/Harness Theme/Dark */
+  --figma___colors-secondary-purple-4: 281 37% 20% / 1; /* ✦ Theme/Colors/Secondary/Purple/4/Harness Theme/Dark */
+  --figma___colors-secondary-purple-5: 280 38% 23% / 1; /* ✦ Theme/Colors/Secondary/Purple/5/Harness Theme/Dark */
+  --figma___colors-secondary-purple-6: 276 41% 35% / 1; /* ✦ Theme/Colors/Secondary/Purple/6/Harness Theme/Dark */
+  --figma___colors-secondary-purple-7: 272 51% 54% / 1; /* ✦ Theme/Colors/Secondary/Purple/7/Harness Theme/Dark */
+  --figma___colors-secondary-purple-8: 271 58% 61% / 1; /* ✦ Theme/Colors/Secondary/Purple/8/Harness Theme/Dark */
+  --figma___colors-secondary-purple-9: 270 89% 78% / 1; /* ✦ Theme/Colors/Secondary/Purple/9/Harness Theme/Dark */
+  --figma___colors-secondary-purple-10: 275 77% 92% / 1; /* ✦ Theme/Colors/Secondary/Purple/10/Harness Theme/Dark */
+  --figma___colors-secondary-purple-alpha-1: 278 100% 49% / 0.02; /* ✦ Theme/Colors/Secondary/Purple Alpha/1/Harness Theme/Dark */
+  --figma___colors-secondary-purple-alpha-2: 283 100% 49% / 0.07; /* ✦ Theme/Colors/Secondary/Purple Alpha/2/Harness Theme/Dark */
+  --figma___colors-secondary-purple-alpha-3: 282 99% 60% / 0.15; /* ✦ Theme/Colors/Secondary/Purple Alpha/3/Harness Theme/Dark */
+  --figma___colors-secondary-purple-alpha-4: 281 99% 62% / 0.2; /* ✦ Theme/Colors/Secondary/Purple Alpha/4/Harness Theme/Dark */
+  --figma___colors-secondary-purple-alpha-5: 280 100% 64% / 0.25; /* ✦ Theme/Colors/Secondary/Purple Alpha/5/Harness Theme/Dark */
+  --figma___colors-secondary-purple-alpha-6: 276 100% 67% / 0.44; /* ✦ Theme/Colors/Secondary/Purple Alpha/6/Harness Theme/Dark */
+  --figma___colors-secondary-purple-alpha-7: 272 100% 69% / 0.75; /* ✦ Theme/Colors/Secondary/Purple Alpha/7/Harness Theme/Dark */
+  --figma___colors-secondary-purple-alpha-8: 271 100% 73% / 0.82; /* ✦ Theme/Colors/Secondary/Purple Alpha/8/Harness Theme/Dark */
+  --figma___colors-secondary-purple-alpha-9: 270 100% 80% / 0.98; /* ✦ Theme/Colors/Secondary/Purple Alpha/9/Harness Theme/Dark */
+  --figma___colors-secondary-purple-alpha-10: 275 100% 93% / 0.98; /* ✦ Theme/Colors/Secondary/Purple Alpha/10/Harness Theme/Dark */
+  --figma___colors-secondary-teal-1: 166 49% 7% / 1; /* ✦ Theme/Colors/Secondary/Teal/1/Harness Theme/Dark */
+  --figma___colors-secondary-teal-2: 166 55% 8% / 1; /* ✦ Theme/Colors/Secondary/Teal/2/Harness Theme/Dark */
+  --figma___colors-secondary-teal-3: 167 52% 11% / 1; /* ✦ Theme/Colors/Secondary/Teal/3/Harness Theme/Dark */
+  --figma___colors-secondary-teal-4: 169 53% 13% / 1; /* ✦ Theme/Colors/Secondary/Teal/4/Harness Theme/Dark */
+  --figma___colors-secondary-teal-5: 168 53% 15% / 1; /* ✦ Theme/Colors/Secondary/Teal/5/Harness Theme/Dark */
+  --figma___colors-secondary-teal-6: 171 55% 24% / 1; /* ✦ Theme/Colors/Secondary/Teal/6/Harness Theme/Dark */
+  --figma___colors-secondary-teal-7: 173 80% 36% / 1; /* ✦ Theme/Colors/Secondary/Teal/7/Harness Theme/Dark */
+  --figma___colors-secondary-teal-8: 172 90% 39% / 1; /* ✦ Theme/Colors/Secondary/Teal/8/Harness Theme/Dark */
+  --figma___colors-secondary-teal-9: 170 90% 45% / 1; /* ✦ Theme/Colors/Secondary/Teal/9/Harness Theme/Dark */
+  --figma___colors-secondary-teal-10: 163 69% 81% / 1; /* ✦ Theme/Colors/Secondary/Teal/10/Harness Theme/Dark */
+  --figma___colors-secondary-teal-alpha-1: 120 100% 48% / 0.01; /* ✦ Theme/Colors/Secondary/Teal Alpha/1/Harness Theme/Dark */
+  --figma___colors-secondary-teal-alpha-2: 141 100% 49% / 0.03; /* ✦ Theme/Colors/Secondary/Teal Alpha/2/Harness Theme/Dark */
+  --figma___colors-secondary-teal-alpha-3: 161 100% 50% / 0.07; /* ✦ Theme/Colors/Secondary/Teal Alpha/3/Harness Theme/Dark */
+  --figma___colors-secondary-teal-alpha-4: 167 100% 50% / 0.11; /* ✦ Theme/Colors/Secondary/Teal Alpha/4/Harness Theme/Dark */
+  --figma___colors-secondary-teal-alpha-5: 167 100% 50% / 0.15; /* ✦ Theme/Colors/Secondary/Teal Alpha/5/Harness Theme/Dark */
+  --figma___colors-secondary-teal-alpha-6: 171 99% 56% / 0.3; /* ✦ Theme/Colors/Secondary/Teal Alpha/6/Harness Theme/Dark */
+  --figma___colors-secondary-teal-alpha-7: 173 100% 53% / 0.61; /* ✦ Theme/Colors/Secondary/Teal Alpha/7/Harness Theme/Dark */
+  --figma___colors-secondary-teal-alpha-8: 172 100% 51% / 0.71; /* ✦ Theme/Colors/Secondary/Teal Alpha/8/Harness Theme/Dark */
+  --figma___colors-secondary-teal-alpha-9: 170 100% 52% / 0.83; /* ✦ Theme/Colors/Secondary/Teal Alpha/9/Harness Theme/Dark */
+  --figma___colors-secondary-teal-alpha-10: 163 100% 86% / 0.94; /* ✦ Theme/Colors/Secondary/Teal Alpha/10/Harness Theme/Dark */
+  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01; /* ✦ Theme/Overlays/Black Alpha/1/Harness Theme/Dark */
+  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02; /* ✦ Theme/Overlays/Black Alpha/2/Harness Theme/Dark */
+  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05; /* ✦ Theme/Overlays/Black Alpha/3/Harness Theme/Dark */
+  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08; /* ✦ Theme/Overlays/Black Alpha/4/Harness Theme/Dark */
+  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11; /* ✦ Theme/Overlays/Black Alpha/5/Harness Theme/Dark */
+  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13; /* ✦ Theme/Overlays/Black Alpha/6/Harness Theme/Dark */
+  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45; /* ✦ Theme/Overlays/Black Alpha/7/Harness Theme/Dark */
+  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5; /* ✦ Theme/Overlays/Black Alpha/8/Harness Theme/Dark */
+  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61; /* ✦ Theme/Overlays/Black Alpha/9/Harness Theme/Dark */
+  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88; /* ✦ Theme/Overlays/Black Alpha/10/Harness Theme/Dark */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 0; /* ✦ Theme/Overlays/White Alpha/1/Harness Theme/Dark */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01; /* ✦ Theme/Overlays/White Alpha/2/Harness Theme/Dark */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07; /* ✦ Theme/Overlays/White Alpha/3/Harness Theme/Dark */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1; /* ✦ Theme/Overlays/White Alpha/4/Harness Theme/Dark */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13; /* ✦ Theme/Overlays/White Alpha/5/Harness Theme/Dark */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17; /* ✦ Theme/Overlays/White Alpha/6/Harness Theme/Dark */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37; /* ✦ Theme/Overlays/White Alpha/7/Harness Theme/Dark */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46; /* ✦ Theme/Overlays/White Alpha/8/Harness Theme/Dark */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66; /* ✦ Theme/Overlays/White Alpha/9/Harness Theme/Dark */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93; /* ✦ Theme/Overlays/White Alpha/10/Harness Theme/Dark */
+  --figma___semantic-background-backdrop: 0 0% 0% / 0.75; /* ✦ Theme/Semantic/Background/Backdrop/Harness Theme/Dark */
+  --figma___semantic-background-cards-and-rows-default: 240 6% 6% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Default/Harness Theme/Dark */
+  --figma___semantic-background-cards-and-rows-hover: 210 6% 20% / 0.24; /* ✦ Theme/Semantic/Background/Cards and Rows/Hover/Harness Theme/Dark */
+  --figma___semantic-background-cards-and-rows-primary-blue-selected: 216 100% 50% / 0.17; /* ✦ Theme/Semantic/Background/Cards and Rows/Primary-blue-selected/Harness Theme/Dark */
+  --figma___semantic-background-cards-and-rows-selected: 210 6% 20% / 0.24; /* ✦ Theme/Semantic/Background/Cards and Rows/Selected/Harness Theme/Dark */
+  --figma___semantic-background-header-page-header: 240 6% 6% / 1; /* ✦ Theme/Semantic/Background/Header/Page Header/Harness Theme/Dark */
+  --figma___semantic-background-header-table-header: 0 0% 9% / 1; /* ✦ Theme/Semantic/Background/Header/Table Header/Harness Theme/Dark */
+  --figma___semantic-background-paper: 0 0% 6% / 1; /* ✦ Theme/Semantic/Background/Paper/Harness Theme/Dark */
+  --figma___semantic-background-primary: 0 4% 5% / 1; /* ✦ Theme/Semantic/Background/Primary/Harness Theme/Dark */
+  --figma___semantic-background-solid: 0 4% 5% / 1; /* ✦ Theme/Semantic/Background/Solid/Harness Theme/Dark */
+  --figma___semantic-border-disabled: 0 0% 100% / 0.07; /* ✦ Theme/Semantic/Border/Disabled/Harness Theme/Dark */
+  --figma___semantic-border-hover: 0 0% 29% / 1; /* ✦ Theme/Semantic/Border/Hover/Harness Theme/Dark */
+  --figma___semantic-border-primary: 0 0% 100% / 0.1; /* ✦ Theme/Semantic/Border/Primary/Harness Theme/Dark */
+  --figma___semantic-border-secondary: 0 0% 16% / 1; /* ✦ Theme/Semantic/Border/Secondary/Harness Theme/Dark */
+  --figma___semantic-border-selected: 206 100% 62% / 1; /* ✦ Theme/Semantic/Border/Selected/Harness Theme/Dark */
+  --figma___semantic-text-disabled: 0 0% 100% / 0.37; /* ✦ Theme/Semantic/Text/Disabled/Harness Theme/Dark */
+  --figma___semantic-text-links: 205 100% 71% / 1; /* ✦ Theme/Semantic/Text/Links/Harness Theme/Dark */
+  --figma___semantic-text-secondary: 0 0% 69% / 1; /* ✦ Theme/Semantic/Text/Secondary/Harness Theme/Dark */
+  --figma___semantic-text-tertiary: 0 0% 100% / 0.46; /* ✦ Theme/Semantic/Text/Tertiary/Harness Theme/Dark */
+  --figma___semantic-text-primary: 0 0% 93% / 1; /* ✦ Theme/Semantic/Text/primary/Harness Theme/Dark */
+  --figma___colors-default-white-to-dark: var(--figma___colors-default-white-fixed); /* ✦ Theme/Colors/Default/White-to-dark/Harness Theme/Dark */
 }

--- a/packages/canary/src/style-tokens/themes/harness-theme.css
+++ b/packages/canary/src/style-tokens/themes/harness-theme.css
@@ -1,0 +1,3767 @@
+/* Non color variables */
+:root {
+  --figma___badges-badge-radius: 4px;
+  /* ✦ Theme/Badges/badge-radius/Harness Theme/Mode 1 */
+  --figma___grids-extra-large-1920-col: 12px;
+  /* ✦ Theme/Grids/Extra Large (> 1920)/Col/Harness Theme/Mode 1 */
+  --figma___grids-extra-large-1920-gutters: 20px;
+  /* ✦ Theme/Grids/Extra Large (> 1920)/Gutters/Harness Theme/Mode 1 */
+  --figma___grids-extra-large-1920-width: 138px;
+  /* ✦ Theme/Grids/Extra Large (> 1920)/Width/Harness Theme/Mode 1 */
+  --figma___grids-extra-small-0-to-480-col: 2px;
+  /* ✦ Theme/Grids/Extra Small (0 to 480)/Col/Harness Theme/Mode 1 */
+  --figma___grids-extra-small-0-to-480-gutters: 16px;
+  /* ✦ Theme/Grids/Extra Small (0 to 480)/Gutters/Harness Theme/Mode 1 */
+  --figma___grids-extra-small-0-to-480-margins: 16px;
+  /* ✦ Theme/Grids/Extra Small (0 to 480)/Margins/Harness Theme/Mode 1 */
+  --figma___grids-large-1280-to-1920-col: 12px;
+  /* ✦ Theme/Grids/Large (1280 to 1920)/Col/Harness Theme/Mode 1 */
+  --figma___grids-large-1280-to-1920-gutters: 20px;
+  /* ✦ Theme/Grids/Large (1280 to 1920)/Gutters/Harness Theme/Mode 1 */
+  --figma___grids-large-1280-to-1920-margins: 24px;
+  /* ✦ Theme/Grids/Large (1280 to 1920)/Margins/Harness Theme/Mode 1 */
+  --figma___grids-medium-576-to-1279-col: 8px;
+  /* ✦ Theme/Grids/Medium (576 to 1279)/Col/Harness Theme/Mode 1 */
+  --figma___grids-medium-576-to-1279-gutters: 16px;
+  /* ✦ Theme/Grids/Medium (576 to 1279)/Gutters/Harness Theme/Mode 1 */
+  --figma___grids-medium-576-to-1279-margins: 24px;
+  /* ✦ Theme/Grids/Medium (576 to 1279)/Margins/Harness Theme/Mode 1 */
+  --figma___grids-small-480-to-575-col: 4px;
+  /* ✦ Theme/Grids/Small (480 to 575)/Col/Harness Theme/Mode 1 */
+  --figma___grids-small-480-to-575-gutters: 16px;
+  /* ✦ Theme/Grids/Small (480 to 575)/Gutters/Harness Theme/Mode 1 */
+  --figma___grids-small-480-to-575-margins: 24px;
+  /* ✦ Theme/Grids/Small (480 to 575)/Margins/Harness Theme/Mode 1 */
+  --figma___height-button-height-1: 24px;
+  /* ✦ Theme/Height/button-height-1/Harness Theme/Mode 1 */
+  --figma___height-button-height-2: 32px;
+  /* ✦ Theme/Height/button-height-2/Harness Theme/Mode 1 */
+  --figma___height-button-height-3: 40px;
+  /* ✦ Theme/Height/button-height-3/Harness Theme/Mode 1 */
+  --figma___height-button-height-4: 48px;
+  /* ✦ Theme/Height/button-height-4/Harness Theme/Mode 1 */
+  --figma___height-menu-item-height-1: 24px;
+  /* ✦ Theme/Height/menu-item-height-1/Harness Theme/Mode 1 */
+  --figma___height-menu-item-height-2: 32px;
+  /* ✦ Theme/Height/menu-item-height-2/Harness Theme/Mode 1 */
+  --figma___height-table-cell-min-height-1: 36px;
+  /* ✦ Theme/Height/table-cell-min-height-1/Harness Theme/Mode 1 */
+  --figma___height-table-cell-min-height-2: 44px;
+  /* ✦ Theme/Height/table-cell-min-height-2/Harness Theme/Mode 1 */
+  --figma___height-table-cell-min-height-3: 48px;
+  /* ✦ Theme/Height/table-cell-min-height-3/Harness Theme/Mode 1 */
+  --figma___padding-main-content-padding: 12px;
+  /* ✦ Theme/Padding/Main content padding/Harness Theme/Mode 1 */
+  --figma___padding-table-cell-padding-1: 8px;
+  /* ✦ Theme/Padding/table-cell-padding-1/Harness Theme/Mode 1 */
+  --figma___padding-table-cell-padding-2: 12px;
+  /* ✦ Theme/Padding/table-cell-padding-2/Harness Theme/Mode 1 */
+  --figma___padding-table-cell-padding-3: 16px;
+  /* ✦ Theme/Padding/table-cell-padding-3/Harness Theme/Mode 1 */
+  --figma___pagination-active-border-radius: 6px;
+  /* ✦ Theme/Pagination/Active/Border-radius/Harness Theme/Mode 1 */
+  --figma___pagination-border-radius: 0px;
+  /* ✦ Theme/Pagination/Border-radius/Harness Theme/Mode 1 */
+  --figma___pagination-default-border-radius: 4px;
+  /* ✦ Theme/Pagination/Default/Border-radius/Harness Theme/Mode 1 */
+  --figma___pagination-gap: 0px;
+  /* ✦ Theme/Pagination/Gap/Harness Theme/Mode 1 */
+  --figma___pagination-hover-border-radius: 4px;
+  /* ✦ Theme/Pagination/Hover/Border-radius/Harness Theme/Mode 1 */
+  --figma___radius-1: 3px;
+  /* ✦ Theme/Radius/1/Harness Theme/Mode 1 */
+  --figma___radius-2: 4px;
+  /* ✦ Theme/Radius/2/Harness Theme/Mode 1 */
+  --figma___radius-3: 6px;
+  /* ✦ Theme/Radius/3/Harness Theme/Mode 1 */
+  --figma___radius-4: 8px;
+  /* ✦ Theme/Radius/4/Harness Theme/Mode 1 */
+  --figma___radius-5: 12px;
+  /* ✦ Theme/Radius/5/Harness Theme/Mode 1 */
+  --figma___radius-6: 16px;
+  /* ✦ Theme/Radius/6/Harness Theme/Mode 1 */
+  --figma___radius-1-max: 3px;
+  /* ✦ Theme/Radius/1-max/Harness Theme/Mode 1 */
+  --figma___radius-2-max: 4px;
+  /* ✦ Theme/Radius/2-max/Harness Theme/Mode 1 */
+  --figma___radius-3-max: 6px;
+  /* ✦ Theme/Radius/3-max/Harness Theme/Mode 1 */
+  --figma___radius-4-max: 8px;
+  /* ✦ Theme/Radius/4-max/Harness Theme/Mode 1 */
+  --figma___radius-5-max: 12px;
+  /* ✦ Theme/Radius/5-max/Harness Theme/Mode 1 */
+  --figma___radius-6-max: 16px;
+  /* ✦ Theme/Radius/6-max/Harness Theme/Mode 1 */
+  --figma___radius-main-content-radius: 8px;
+  /* ✦ Theme/Radius/Main content radius/Harness Theme/Mode 1 */
+  --figma___radius-full: 9999px;
+  /* ✦ Theme/Radius/full/Harness Theme/Mode 1 */
+  --figma___space-1: 4px;
+  /* ✦ Theme/Space/1/Harness Theme/Mode 1 */
+  --figma___space-2: 8px;
+  /* ✦ Theme/Space/2/Harness Theme/Mode 1 */
+  --figma___space-3: 12px;
+  /* ✦ Theme/Space/3/Harness Theme/Mode 1 */
+  --figma___space-4: 16px;
+  /* ✦ Theme/Space/4/Harness Theme/Mode 1 */
+  --figma___space-5: 24px;
+  /* ✦ Theme/Space/5/Harness Theme/Mode 1 */
+  --figma___space-6: 32px;
+  /* ✦ Theme/Space/6/Harness Theme/Mode 1 */
+  --figma___space-7: 40px;
+  /* ✦ Theme/Space/7/Harness Theme/Mode 1 */
+  --figma___space-8: 48px;
+  /* ✦ Theme/Space/8/Harness Theme/Mode 1 */
+  --figma___space-9: 64px;
+  /* ✦ Theme/Space/9/Harness Theme/Mode 1 */
+  --figma___switch-thumb-size-1: 12px;
+  /* ✦ Theme/Switch/Thumb Size/1/Harness Theme/Mode 1 */
+  --figma___switch-thumb-size-2: 16px;
+  /* ✦ Theme/Switch/Thumb Size/2/Harness Theme/Mode 1 */
+  --figma___switch-thumb-size-3: 20px;
+  /* ✦ Theme/Switch/Thumb Size/3/Harness Theme/Mode 1 */
+  --figma___tabs-pills-border-radius: 8px;
+  /* ✦ Theme/Tabs/Pills/border-radius/Harness Theme/Mode 1 */
+  --figma___tabs-pills-padding: 4px;
+  /* ✦ Theme/Tabs/Pills/padding/Harness Theme/Mode 1 */
+  --figma___tabs-pills-pill-border-radius: 4px;
+  /* ✦ Theme/Tabs/Pills/pill border radius/Harness Theme/Mode 1 */
+  --figma___textfield-assistive-text-assistive-text: 12px;
+  /* ✦ Theme/Textfield/Assistive Text/Assistive Text/Harness Theme/Mode 1 */
+  --figma___textfield-gap: 4px;
+  /* ✦ Theme/Textfield/Gap/Harness Theme/Mode 1 */
+  --figma___textfield-input-field-textfield-height: 32px;
+  /* ✦ Theme/Textfield/Input Field/Textfield Height/Harness Theme/Mode 1 */
+}
+
+/* Color variables - light mode */
+.harness-theme-light {
+  --figma___background-backdrop: 230 100% 9% / 0.28;
+  /* ✦ Theme/Background/Backdrop/Harness Theme/Light */
+  --figma___background-cards-and-rows-default: 0 0% 100% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Default/Harness Theme/Light */
+  --figma___background-cards-and-rows-hover: 0 0% 95% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Hover/Harness Theme/Light */
+  --figma___background-cards-and-rows-primary-blue-selected: 210 100% 50% / 0.07;
+  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/Harness Theme/Light */
+  --figma___background-cards-and-rows-selected: 0 0% 95% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Selected/Harness Theme/Light */
+  --figma___background-header-page-header: 0 0% 100% / 1;
+  /* ✦ Theme/Background/Header/Page Header/Harness Theme/Light */
+  --figma___background-header-table-header: 0 0% 99% / 1;
+  /* ✦ Theme/Background/Header/Table Header/Harness Theme/Light */
+  --figma___background-paper: 0 0% 98% / 1;
+  /* ✦ Theme/Background/Paper/Harness Theme/Light */
+  --figma___background-primary: 0 0% 93% / 1;
+  /* ✦ Theme/Background/Primary/Harness Theme/Light */
+  --figma___background-solid: 0 0% 100% / 1;
+  /* ✦ Theme/Background/Solid/Harness Theme/Light */
+  --figma___badges-soft-amber-background: 45 100% 50% / 0.19;
+  /* ✦ Theme/Badges/Soft/Amber/background/Harness Theme/Light */
+  --figma___badges-soft-amber-text: 25 100% 24% / 0.81;
+  /* ✦ Theme/Badges/Soft/Amber/text/Harness Theme/Light */
+  --figma___badges-soft-blue-background: 210 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Soft/Blue/background/Harness Theme/Light */
+  --figma___badges-soft-blue-text: 211 100% 39% / 0.96;
+  /* ✦ Theme/Badges/Soft/Blue/text/Harness Theme/Light */
+  --figma___badges-soft-bronze-background: 18 99% 30% / 0.07;
+  /* ✦ Theme/Badges/Soft/Bronze/background/Harness Theme/Light */
+  --figma___badges-soft-bronze-text: 15 100% 12% / 0.67;
+  /* ✦ Theme/Badges/Soft/Bronze/text/Harness Theme/Light */
+  --figma___badges-soft-brown-background: 30 98% 34% / 0.08;
+  /* ✦ Theme/Badges/Soft/Brown/background/Harness Theme/Light */
+  --figma___badges-soft-brown-text: 24 100% 16% / 0.73;
+  /* ✦ Theme/Badges/Soft/Brown/text/Harness Theme/Light */
+  --figma___badges-soft-crimson-background: 332 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Soft/Crimson/background/Harness Theme/Light */
+  --figma___badges-soft-crimson-text: 336 100% 38% / 0.89;
+  /* ✦ Theme/Badges/Soft/Crimson/text/Harness Theme/Light */
+  --figma___badges-soft-cyan-background: 186 98% 42% / 0.09;
+  /* ✦ Theme/Badges/Soft/Cyan/background/Harness Theme/Light */
+  --figma___badges-soft-cyan-text: 192 100% 28% / 0.95;
+  /* ✦ Theme/Badges/Soft/Cyan/text/Harness Theme/Light */
+  --figma___badges-soft-gold-background: 45 97% 28% / 0.09;
+  /* ✦ Theme/Badges/Soft/Gold/background/Harness Theme/Light */
+  --figma___badges-soft-gold-text: 36 100% 11% / 0.71;
+  /* ✦ Theme/Badges/Soft/Gold/text/Harness Theme/Light */
+  --figma___badges-soft-grass-background: 120 98% 35% / 0.08;
+  /* ✦ Theme/Badges/Soft/Grass/background/Harness Theme/Light */
+  --figma___badges-soft-grass-text: 133 100% 19% / 0.84;
+  /* ✦ Theme/Badges/Soft/Grass/text/Harness Theme/Light */
+  --figma___badges-soft-green-background: 139 98% 37% / 0.09;
+  /* ✦ Theme/Badges/Soft/Green/background/Harness Theme/Light */
+  --figma___badges-soft-green-text: 153 100% 21% / 0.91;
+  /* ✦ Theme/Badges/Soft/Green/text/Harness Theme/Light */
+  --figma___badges-soft-indigo-background: 224 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Soft/Indigo/background/Harness Theme/Light */
+  --figma___badges-soft-indigo-text: 226 100% 31% / 0.8;
+  /* ✦ Theme/Badges/Soft/Indigo/text/Harness Theme/Light */
+  --figma___badges-soft-iris-background: 240 100% 51% / 0.05;
+  /* ✦ Theme/Badges/Soft/Iris/background/Harness Theme/Light */
+  --figma___badges-soft-iris-text: 240 100% 34% / 0.72;
+  /* ✦ Theme/Badges/Soft/Iris/text/Harness Theme/Light */
+  --figma___badges-soft-jade-background: 150 100% 41% / 0.11;
+  /* ✦ Theme/Badges/Soft/Jade/background/Harness Theme/Light */
+  --figma___badges-soft-jade-text: 163 100% 21% / 0.9;
+  /* ✦ Theme/Badges/Soft/Jade/text/Harness Theme/Light */
+  --figma___badges-soft-lime-background: 84 99% 44% / 0.15;
+  /* ✦ Theme/Badges/Soft/Lime/background/Harness Theme/Light */
+  --figma___badges-soft-lime-text: 75 100% 14% / 0.83;
+  /* ✦ Theme/Badges/Soft/Lime/text/Harness Theme/Light */
+  --figma___badges-soft-mint-background: 164 99% 44% / 0.13;
+  /* ✦ Theme/Badges/Soft/Mint/background/Harness Theme/Light */
+  --figma___badges-soft-mint-text: 172 100% 18% / 0.85;
+  /* ✦ Theme/Badges/Soft/Mint/text/Harness Theme/Light */
+  --figma___badges-soft-orange-background: 34 100% 50% / 0.17;
+  /* ✦ Theme/Badges/Soft/Orange/background/Harness Theme/Light */
+  --figma___badges-soft-orange-text: 16 100% 24% / 0.77;
+  /* ✦ Theme/Badges/Soft/Orange/text/Harness Theme/Light */
+  --figma___badges-soft-pink-background: 323 99% 47% / 0.07;
+  /* ✦ Theme/Badges/Soft/Pink/background/Harness Theme/Light */
+  --figma___badges-soft-pink-text: 322 100% 37% / 0.89;
+  /* ✦ Theme/Badges/Soft/Pink/text/Harness Theme/Light */
+  --figma___badges-soft-plum-background: 300 99% 41% / 0.06;
+  /* ✦ Theme/Badges/Soft/Plum/background/Harness Theme/Light */
+  --figma___badges-soft-plum-text: 292 100% 31% / 0.83;
+  /* ✦ Theme/Badges/Soft/Plum/text/Harness Theme/Light */
+  --figma___badges-soft-purple-background: 277 100% 46% / 0.05;
+  /* ✦ Theme/Badges/Soft/Purple/background/Harness Theme/Light */
+  --figma___badges-soft-purple-text: 273 100% 30% / 0.77;
+  /* ✦ Theme/Badges/Soft/Purple/text/Harness Theme/Light */
+  --figma___badges-soft-red-background: 0 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Soft/Red/background/Harness Theme/Light */
+  --figma___badges-soft-red-text: 358 100% 37% / 0.84;
+  /* ✦ Theme/Badges/Soft/Red/text/Harness Theme/Light */
+  --figma___badges-soft-ruby-background: 344 100% 47% / 0.06;
+  /* ✦ Theme/Badges/Soft/Ruby/background/Harness Theme/Light */
+  --figma___badges-soft-ruby-text: 345 100% 38% / 0.86;
+  /* ✦ Theme/Badges/Soft/Ruby/text/Harness Theme/Light */
+  --figma___badges-soft-sky-background: 192 100% 50% / 0.11;
+  /* ✦ Theme/Badges/Soft/Sky/background/Harness Theme/Light */
+  --figma___badges-soft-sky-text: 200 100% 25% / 0.86;
+  /* ✦ Theme/Badges/Soft/Sky/text/Harness Theme/Light */
+  --figma___badges-soft-teal-background: 167 98% 38% / 0.09;
+  /* ✦ Theme/Badges/Soft/Teal/background/Harness Theme/Light */
+  --figma___badges-soft-teal-text: 174 100% 23% / 0.98;
+  /* ✦ Theme/Badges/Soft/Teal/text/Harness Theme/Light */
+  --figma___badges-soft-violet-background: 254 100% 50% / 0.05;
+  /* ✦ Theme/Badges/Soft/Violet/background/Harness Theme/Light */
+  --figma___badges-soft-violet-text: 250 100% 28% / 0.73;
+  /* ✦ Theme/Badges/Soft/Violet/text/Harness Theme/Light */
+  --figma___badges-soft-yellow-background: 53 100% 50% / 0.22;
+  /* ✦ Theme/Badges/Soft/Yellow/background/Harness Theme/Light */
+  --figma___badges-soft-yellow-text: 42 100% 18% / 0.84;
+  /* ✦ Theme/Badges/Soft/Yellow/text/Harness Theme/Light */
+  --figma___badges-soft-accent-background: 210 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Soft/accent/background/Harness Theme/Light */
+  --figma___badges-soft-accent-text: 211 100% 39% / 0.96;
+  /* ✦ Theme/Badges/Soft/accent/text/Harness Theme/Light */
+  --figma___badges-soft-error-background: 0 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Soft/error/background/Harness Theme/Light */
+  --figma___badges-soft-error-text: 358 65% 47% / 1;
+  /* ✦ Theme/Badges/Soft/error/text/Harness Theme/Light */
+  --figma___badges-soft-info-background: 210 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Soft/info/background/Harness Theme/Light */
+  --figma___badges-soft-info-text: 211 90% 42% / 1;
+  /* ✦ Theme/Badges/Soft/info/text/Harness Theme/Light */
+  --figma___badges-soft-success-background: 139 98% 37% / 0.09;
+  /* ✦ Theme/Badges/Soft/success/background/Harness Theme/Light */
+  --figma___badges-soft-success-text: 153 67% 28% / 1;
+  /* ✦ Theme/Badges/Soft/success/text/Harness Theme/Light */
+  --figma___badges-soft-warning-background: 45 100% 91% / 1;
+  /* ✦ Theme/Badges/Soft/warning/background/Harness Theme/Light */
+  --figma___badges-soft-warning-text: 25 50% 38% / 1;
+  /* ✦ Theme/Badges/Soft/warning/text/Harness Theme/Light */
+  --figma___badges-solid-amber-background: 42 100% 62% / 1;
+  /* ✦ Theme/Badges/Solid/Amber/background/Harness Theme/Light */
+  --figma___badges-solid-blue-background: 214 73% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Blue/background/Harness Theme/Light */
+  --figma___badges-solid-bronze-background: 18 20% 54% / 1;
+  /* ✦ Theme/Badges/Solid/Bronze/background/Harness Theme/Light */
+  --figma___badges-solid-brown-background: 28 34% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Brown/background/Harness Theme/Light */
+  --figma___badges-solid-crimson-background: 336 80% 58% / 1;
+  /* ✦ Theme/Badges/Solid/Crimson/background/Harness Theme/Light */
+  --figma___badges-solid-cyan-background: 190 95% 39% / 1;
+  /* ✦ Theme/Badges/Solid/Cyan/background/Harness Theme/Light */
+  --figma___badges-solid-gold-background: 36 20% 49% / 1;
+  /* ✦ Theme/Badges/Solid/Gold/background/Harness Theme/Light */
+  --figma___badges-solid-grass-background: 132 59% 33% / 1;
+  /* ✦ Theme/Badges/Solid/Grass/background/Harness Theme/Light */
+  --figma___badges-solid-green-background: 142 72% 29% / 1;
+  /* ✦ Theme/Badges/Solid/Green/background/Harness Theme/Light */
+  --figma___badges-solid-indigo-background: 226 70% 55% / 1;
+  /* ✦ Theme/Badges/Solid/Indigo/background/Harness Theme/Light */
+  --figma___badges-solid-iris-background: 240 60% 60% / 1;
+  /* ✦ Theme/Badges/Solid/Iris/background/Harness Theme/Light */
+  --figma___badges-solid-jade-background: 164 60% 40% / 1;
+  /* ✦ Theme/Badges/Solid/Jade/background/Harness Theme/Light */
+  --figma___badges-solid-lime-background: 81 80% 66% / 1;
+  /* ✦ Theme/Badges/Solid/Lime/background/Harness Theme/Light */
+  --figma___badges-solid-mint-background: 167 70% 72% / 1;
+  /* ✦ Theme/Badges/Solid/Mint/background/Harness Theme/Light */
+  --figma___badges-solid-orange-background: 16 45% 41% / 1;
+  /* ✦ Theme/Badges/Solid/Orange/background/Harness Theme/Light */
+  --figma___badges-solid-pink-background: 322 65% 55% / 1;
+  /* ✦ Theme/Badges/Solid/Pink/background/Harness Theme/Light */
+  --figma___badges-solid-plum-background: 292 45% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Plum/background/Harness Theme/Light */
+  --figma___badges-solid-purple-background: 272 51% 54% / 1;
+  /* ✦ Theme/Badges/Solid/Purple/background/Harness Theme/Light */
+  --figma___badges-solid-red-background: 358 75% 59% / 1;
+  /* ✦ Theme/Badges/Solid/Red/background/Harness Theme/Light */
+  --figma___badges-solid-ruby-background: 348 75% 59% / 1;
+  /* ✦ Theme/Badges/Solid/Ruby/background/Harness Theme/Light */
+  --figma___badges-solid-sky-background: 193 98% 74% / 1;
+  /* ✦ Theme/Badges/Solid/Sky/background/Harness Theme/Light */
+  --figma___badges-solid-success-background: 142 72% 29% / 1;
+  /* ✦ Theme/Badges/Solid/Success/background/Harness Theme/Light */
+  --figma___badges-solid-teal-background: 173 80% 36% / 1;
+  /* ✦ Theme/Badges/Solid/Teal/background/Harness Theme/Light */
+  --figma___badges-solid-violet-background: 252 56% 57% / 1;
+  /* ✦ Theme/Badges/Solid/Violet/background/Harness Theme/Light */
+  --figma___badges-solid-yellow-background: 53 96% 58% / 1;
+  /* ✦ Theme/Badges/Solid/Yellow/background/Harness Theme/Light */
+  --figma___badges-solid-accent-background: 214 73% 51% / 1;
+  /* ✦ Theme/Badges/Solid/accent/background/Harness Theme/Light */
+  --figma___badges-solid-info-background: 214 73% 51% / 1;
+  /* ✦ Theme/Badges/Solid/info/background/Harness Theme/Light */
+  --figma___badges-solid-warning-background: 42 100% 62% / 1;
+  /* ✦ Theme/Badges/Solid/warning/background/Harness Theme/Light */
+  --figma___badges-surface-amber-background: 40 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/Amber/background/Harness Theme/Light */
+  --figma___badges-surface-amber-border: 37 100% 40% / 0.53;
+  /* ✦ Theme/Badges/Surface/Amber/border/Harness Theme/Light */
+  --figma___badges-surface-amber-text: 25 100% 24% / 0.81;
+  /* ✦ Theme/Badges/Surface/Amber/text/Harness Theme/Light */
+  --figma___badges-surface-blue-background: 210 100% 51% / 0.04;
+  /* ✦ Theme/Badges/Surface/Blue/background/Harness Theme/Light */
+  --figma___badges-surface-blue-border: 208 100% 44% / 0.41;
+  /* ✦ Theme/Badges/Surface/Blue/border/Harness Theme/Light */
+  --figma___badges-surface-blue-text: 211 100% 39% / 0.96;
+  /* ✦ Theme/Badges/Surface/Blue/text/Harness Theme/Light */
+  --figma___badges-surface-bronze-background: 17 95% 40% / 0.04;
+  /* ✦ Theme/Badges/Surface/Bronze/background/Harness Theme/Light */
+  --figma___badges-surface-bronze-border: 18 100% 22% / 0.31;
+  /* ✦ Theme/Badges/Surface/Bronze/border/Harness Theme/Light */
+  --figma___badges-surface-bronze-text: 15 100% 12% / 0.67;
+  /* ✦ Theme/Badges/Surface/Bronze/text/Harness Theme/Light */
+  --figma___badges-surface-brown-background: 30 94% 35% / 0.04;
+  /* ✦ Theme/Badges/Surface/Brown/background/Harness Theme/Light */
+  --figma___badges-surface-brown-border: 29 100% 34% / 0.41;
+  /* ✦ Theme/Badges/Surface/Brown/border/Harness Theme/Light */
+  --figma___badges-surface-brown-text: 24 100% 16% / 0.73;
+  /* ✦ Theme/Badges/Surface/Brown/text/Harness Theme/Light */
+  --figma___badges-surface-crimson-border: 335 100% 39% / 0.32;
+  /* ✦ Theme/Badges/Surface/Crimson/Border/Harness Theme/Light */
+  --figma___badges-surface-crimson-background: 330 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Crimson/background/Harness Theme/Light */
+  --figma___badges-surface-crimson-text: 336 100% 38% / 0.89;
+  /* ✦ Theme/Badges/Surface/Crimson/text/Harness Theme/Light */
+  --figma___badges-surface-cyan-border: 189 100% 35% / 0.48;
+  /* ✦ Theme/Badges/Surface/Cyan/Border/Harness Theme/Light */
+  --figma___badges-surface-cyan-background: 186 100% 42% / 0.05;
+  /* ✦ Theme/Badges/Surface/Cyan/background/Harness Theme/Light */
+  --figma___badges-surface-cyan-text: 192 100% 28% / 0.95;
+  /* ✦ Theme/Badges/Surface/Cyan/text/Harness Theme/Light */
+  --figma___badges-surface-gold-border: 38 100% 22% / 0.36;
+  /* ✦ Theme/Badges/Surface/Gold/Border/Harness Theme/Light */
+  --figma___badges-surface-gold-background: 47 100% 35% / 0.05;
+  /* ✦ Theme/Badges/Surface/Gold/background/Harness Theme/Light */
+  --figma___badges-surface-gold-text: 36 100% 11% / 0.71;
+  /* ✦ Theme/Badges/Surface/Gold/text/Harness Theme/Light */
+  --figma___badges-surface-grass-border: 125 100% 27% / 0.41;
+  /* ✦ Theme/Badges/Surface/Grass/Border/Harness Theme/Light */
+  --figma___badges-surface-grass-background: 120 95% 39% / 0.05;
+  /* ✦ Theme/Badges/Surface/Grass/background/Harness Theme/Light */
+  --figma___badges-surface-grass-text: 133 100% 19% / 0.84;
+  /* ✦ Theme/Badges/Surface/Grass/text/Harness Theme/Light */
+  --figma___badges-surface-green-background: 139 98% 37% / 0.09;
+  /* ✦ Theme/Badges/Surface/Green/background/Harness Theme/Light */
+  --figma___badges-surface-green-border: 146 100% 27% / 0.43;
+  /* ✦ Theme/Badges/Surface/Green/border/Harness Theme/Light */
+  --figma___badges-surface-green-text: 153 100% 21% / 0.91;
+  /* ✦ Theme/Badges/Surface/Green/text/Harness Theme/Light */
+  --figma___badges-surface-indigo-background: 223 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Indigo/background/Harness Theme/Light */
+  --figma___badges-surface-indigo-border: 225 100% 44% / 0.32;
+  /* ✦ Theme/Badges/Surface/Indigo/border/Harness Theme/Light */
+  --figma___badges-surface-indigo-text: 226 100% 31% / 0.8;
+  /* ✦ Theme/Badges/Surface/Indigo/text/Harness Theme/Light */
+  --figma___badges-surface-iris-border: 239 100% 43% / 0.27;
+  /* ✦ Theme/Badges/Surface/Iris/Border/Harness Theme/Light */
+  --figma___badges-surface-iris-background: 240 100% 51% / 0.02;
+  /* ✦ Theme/Badges/Surface/Iris/background/Harness Theme/Light */
+  --figma___badges-surface-iris-text: 240 100% 34% / 0.72;
+  /* ✦ Theme/Badges/Surface/Iris/text/Harness Theme/Light */
+  --figma___badges-surface-jade-border: 159 100% 29% / 0.44;
+  /* ✦ Theme/Badges/Surface/Jade/Border/Harness Theme/Light */
+  --figma___badges-surface-jade-background: 150 99% 44% / 0.06;
+  /* ✦ Theme/Badges/Surface/Jade/background/Harness Theme/Light */
+  --figma___badges-surface-jade-text: 163 100% 21% / 0.9;
+  /* ✦ Theme/Badges/Surface/Jade/text/Harness Theme/Light */
+  --figma___badges-surface-lime-border: 79 100% 29% / 0.5;
+  /* ✦ Theme/Badges/Surface/Lime/Border/Harness Theme/Light */
+  --figma___badges-surface-lime-background: 85 99% 40% / 0.06;
+  /* ✦ Theme/Badges/Surface/Lime/background/Harness Theme/Light */
+  --figma___badges-surface-lime-text: 75 100% 14% / 0.83;
+  /* ✦ Theme/Badges/Surface/Lime/text/Harness Theme/Light */
+  --figma___badges-surface-mint-background: 164 99% 47% / 0.06;
+  /* ✦ Theme/Badges/Surface/Mint/background/Harness Theme/Light */
+  --figma___badges-surface-mint-border: 166 100% 30% / 0.47;
+  /* ✦ Theme/Badges/Surface/Mint/border/Harness Theme/Light */
+  --figma___badges-surface-mint-text: 172 100% 18% / 0.85;
+  /* ✦ Theme/Badges/Surface/Mint/text/Harness Theme/Light */
+  --figma___badges-surface-orange-background: 22 100% 51% / 0.04;
+  /* ✦ Theme/Badges/Surface/Orange/background/Harness Theme/Light */
+  --figma___badges-surface-orange-border: 21 100% 50% / 0.51;
+  /* ✦ Theme/Badges/Surface/Orange/border/Harness Theme/Light */
+  --figma___badges-surface-orange-text: 16 100% 24% / 0.77;
+  /* ✦ Theme/Badges/Surface/Orange/text/Harness Theme/Light */
+  --figma___badges-surface-pink-background: 323 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Pink/background/Harness Theme/Light */
+  --figma___badges-surface-pink-border: 323 100% 38% / 0.32;
+  /* ✦ Theme/Badges/Surface/Pink/border/Harness Theme/Light */
+  --figma___badges-surface-pink-text: 322 100% 37% / 0.89;
+  /* ✦ Theme/Badges/Surface/Pink/text/Harness Theme/Light */
+  --figma___badges-surface-plum-background: 300 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Plum/background/Harness Theme/Light */
+  --figma___badges-surface-plum-border: 295 100% 33% / 0.31;
+  /* ✦ Theme/Badges/Surface/Plum/border/Harness Theme/Light */
+  --figma___badges-surface-plum-text: 292 100% 31% / 0.83;
+  /* ✦ Theme/Badges/Surface/Plum/text/Harness Theme/Light */
+  --figma___badges-surface-purple-background: 276 100% 51% / 0.02;
+  /* ✦ Theme/Badges/Surface/Purple/background/Harness Theme/Light */
+  --figma___badges-surface-purple-border: 273 99% 38% / 0.29;
+  /* ✦ Theme/Badges/Surface/Purple/border/Harness Theme/Light */
+  --figma___badges-surface-purple-text: 273 100% 30% / 0.77;
+  /* ✦ Theme/Badges/Surface/Purple/text/Harness Theme/Light */
+  --figma___badges-surface-red-background: 0 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Red/background/Harness Theme/Light */
+  --figma___badges-surface-red-border: 359 100% 43% / 0.32;
+  /* ✦ Theme/Badges/Surface/Red/border/Harness Theme/Light */
+  --figma___badges-surface-red-text: 358 100% 37% / 0.84;
+  /* ✦ Theme/Badges/Surface/Red/text/Harness Theme/Light */
+  --figma___badges-surface-ruby-background: 345 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/Ruby/background/Harness Theme/Light */
+  --figma___badges-surface-ruby-border: 348 100% 39% / 0.31;
+  /* ✦ Theme/Badges/Surface/Ruby/border/Harness Theme/Light */
+  --figma___badges-surface-ruby-text: 345 100% 38% / 0.86;
+  /* ✦ Theme/Badges/Surface/Ruby/text/Harness Theme/Light */
+  --figma___badges-surface-sky-background: 193 100% 50% / 0.05;
+  /* ✦ Theme/Badges/Surface/Sky/background/Harness Theme/Light */
+  --figma___badges-surface-sky-border: 194 100% 38% / 0.49;
+  /* ✦ Theme/Badges/Surface/Sky/border/Harness Theme/Light */
+  --figma___badges-surface-sky-text: 200 100% 25% / 0.86;
+  /* ✦ Theme/Badges/Surface/Sky/text/Harness Theme/Light */
+  --figma___badges-surface-teal-background: 169 99% 39% / 0.05;
+  /* ✦ Theme/Badges/Surface/Teal/background/Harness Theme/Light */
+  --figma___badges-surface-teal-border: 170 99% 29% / 0.45;
+  /* ✦ Theme/Badges/Surface/Teal/border/Harness Theme/Light */
+  --figma___badges-surface-teal-text: 174 100% 23% / 0.98;
+  /* ✦ Theme/Badges/Surface/Teal/text/Harness Theme/Light */
+  --figma___badges-surface-violet-background: 252 100% 51% / 0.02;
+  /* ✦ Theme/Badges/Surface/Violet/background/Harness Theme/Light */
+  --figma___badges-surface-violet-border: 252 99% 42% / 0.28;
+  /* ✦ Theme/Badges/Surface/Violet/border/Harness Theme/Light */
+  --figma___badges-surface-violet-text: 250 100% 28% / 0.73;
+  /* ✦ Theme/Badges/Surface/Violet/text/Harness Theme/Light */
+  --figma___badges-surface-yellow-background: 52 100% 50% / 0.12;
+  /* ✦ Theme/Badges/Surface/Yellow/background/Harness Theme/Light */
+  --figma___badges-surface-yellow-border: 48 100% 37% / 0.57;
+  /* ✦ Theme/Badges/Surface/Yellow/border/Harness Theme/Light */
+  --figma___badges-surface-yellow-text: 42 100% 18% / 0.84;
+  /* ✦ Theme/Badges/Surface/Yellow/text/Harness Theme/Light */
+  --figma___badges-surface-accent-background: 210 100% 51% / 0.04;
+  /* ✦ Theme/Badges/Surface/accent/background/Harness Theme/Light */
+  --figma___badges-surface-accent-border: 208 100% 44% / 0.41;
+  /* ✦ Theme/Badges/Surface/accent/border/Harness Theme/Light */
+  --figma___badges-surface-accent-text: 208 100% 44% / 0.41;
+  /* ✦ Theme/Badges/Surface/accent/text/Harness Theme/Light */
+  --figma___badges-surface-error-background: 0 100% 51% / 0.03;
+  /* ✦ Theme/Badges/Surface/error/background/Harness Theme/Light */
+  --figma___badges-surface-error-border: 359 100% 43% / 0.32;
+  /* ✦ Theme/Badges/Surface/error/border/Harness Theme/Light */
+  --figma___badges-surface-error-text: 358 100% 37% / 0.84;
+  /* ✦ Theme/Badges/Surface/error/text/Harness Theme/Light */
+  --figma___badges-surface-info-background: 192 100% 50% / 0.11;
+  /* ✦ Theme/Badges/Surface/info/background/Harness Theme/Light */
+  --figma___badges-surface-info-border: 194 100% 38% / 0.49;
+  /* ✦ Theme/Badges/Surface/info/border/Harness Theme/Light */
+  --figma___badges-surface-info-text: 200 100% 25% / 0.86;
+  /* ✦ Theme/Badges/Surface/info/text/Harness Theme/Light */
+  --figma___badges-surface-success-background: 150 99% 44% / 0.06;
+  /* ✦ Theme/Badges/Surface/success/background/Harness Theme/Light */
+  --figma___badges-surface-success-border: 159 100% 29% / 0.44;
+  /* ✦ Theme/Badges/Surface/success/border/Harness Theme/Light */
+  --figma___badges-surface-success-text: 163 100% 21% / 0.9;
+  /* ✦ Theme/Badges/Surface/success/text/Harness Theme/Light */
+  --figma___badges-surface-warning-background: 40 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/warning/background/Harness Theme/Light */
+  --figma___badges-surface-warning-border: 37 100% 40% / 0.53;
+  /* ✦ Theme/Badges/Surface/warning/border/Harness Theme/Light */
+  --figma___badges-surface-warning-text: 25 100% 24% / 0.81;
+  /* ✦ Theme/Badges/Surface/warning/text/Harness Theme/Light */
+  --figma___border-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Border/Disabled/Harness Theme/Light */
+  --figma___border-hover: 0 0% 83% / 1;
+  /* ✦ Theme/Border/Hover/Harness Theme/Light */
+  --figma___border-primary: 0 0% 0% / 0.08;
+  /* ✦ Theme/Border/Primary/Harness Theme/Light */
+  --figma___border-secondary: 0 0% 95% / 1;
+  /* ✦ Theme/Border/Secondary/Harness Theme/Light */
+  --figma___border-selected: 208 93% 47% / 1;
+  /* ✦ Theme/Border/Selected/Harness Theme/Light */
+  --figma___breadcrumbs-current: 0 0% 13% / 1;
+  /* ✦ Theme/Breadcrumbs/current/Harness Theme/Light */
+  --figma___breadcrumbs-visited: 0 0% 39% / 1;
+  /* ✦ Theme/Breadcrumbs/visited/Harness Theme/Light */
+  --figma___button-ghost-accent-active: 210 99% 49% / 0.19;
+  /* ✦ Theme/Button/Ghost/Accent/Active/Harness Theme/Light */
+  --figma___button-ghost-accent-active-text: 211 90% 42% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Active text/Harness Theme/Light */
+  --figma___button-ghost-accent-hover: 210 100% 50% / 0.07;
+  /* ✦ Theme/Button/Ghost/Accent/Hover/Harness Theme/Light */
+  --figma___button-ghost-accent-hover-text: 211 90% 42% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Hover text/Harness Theme/Light */
+  --figma___button-ghost-accent-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/Harness Theme/Light */
+  --figma___button-ghost-accent-text-primary: 211 90% 42% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Text-primary/Harness Theme/Light */
+  --figma___button-ghost-error-active: 0 100% 50% / 0.1;
+  /* ✦ Theme/Button/Ghost/Error/Active/Harness Theme/Light */
+  --figma___button-ghost-error-active-text: 358 65% 47% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Active Text/Harness Theme/Light */
+  --figma___button-ghost-error-hover: 0 100% 50% / 0.06;
+  /* ✦ Theme/Button/Ghost/Error/Hover/Harness Theme/Light */
+  --figma___button-ghost-error-hover-text: 358 65% 47% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Hover text/Harness Theme/Light */
+  --figma___button-ghost-error-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Ghost/Error/Text-disabled/Harness Theme/Light */
+  --figma___button-ghost-error-text-primary: 358 65% 47% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Text-primary/Harness Theme/Light */
+  --figma___button-ghost-neutral-active: 0 0% 0% / 0.08;
+  /* ✦ Theme/Button/Ghost/Neutral/Active/Harness Theme/Light */
+  --figma___button-ghost-neutral-active-text: 0 0% 39% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Active Text/Harness Theme/Light */
+  --figma___button-ghost-neutral-hover: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover/Harness Theme/Light */
+  --figma___button-ghost-neutral-hover-text: 0 0% 39% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover text/Harness Theme/Light */
+  --figma___button-ghost-neutral-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/Harness Theme/Light */
+  --figma___button-ghost-neutral-text-primary: 0 0% 39% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/Harness Theme/Light */
+  --figma___button-ghost-success-active: 139 99% 33% / 0.13;
+  /* ✦ Theme/Button/Ghost/Success/Active/Harness Theme/Light */
+  --figma___button-ghost-success-active-text: 153 67% 28% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Active Text/Harness Theme/Light */
+  --figma___button-ghost-success-hover: 139 98% 37% / 0.09;
+  /* ✦ Theme/Button/Ghost/Success/Hover/Harness Theme/Light */
+  --figma___button-ghost-success-hover-text: 153 67% 28% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Hover text/Harness Theme/Light */
+  --figma___button-ghost-success-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Ghost/Success/Text-disabled/Harness Theme/Light */
+  --figma___button-ghost-success-text-primary: 153 67% 28% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Text-primary/Harness Theme/Light */
+  --figma___button-outline-accent-active: 210 100% 50% / 0.07;
+  /* ✦ Theme/Button/Outline/Accent/Active/Harness Theme/Light */
+  --figma___button-outline-accent-default-border: 206 100% 50% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Default border/Harness Theme/Light */
+  --figma___button-outline-accent-disabled-border: 0 0% 0% / 0.13;
+  /* ✦ Theme/Button/Outline/Accent/Disabled Border/Harness Theme/Light */
+  --figma___button-outline-accent-hover: 210 100% 51% / 0.04;
+  /* ✦ Theme/Button/Outline/Accent/Hover/Harness Theme/Light */
+  --figma___button-outline-accent-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Outline/Accent/Text-disabled/Harness Theme/Light */
+  --figma___button-outline-accent-text-primary: 211 90% 42% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Text-primary/Harness Theme/Light */
+  --figma___button-outline-error-active: 0 100% 50% / 0.06;
+  /* ✦ Theme/Button/Outline/Error/Active/Harness Theme/Light */
+  --figma___button-outline-error-default-border: 358 100% 43% / 0.72;
+  /* ✦ Theme/Button/Outline/Error/Default - border/Harness Theme/Light */
+  --figma___button-outline-error-disabled-border: 0 0% 0% / 0.13;
+  /* ✦ Theme/Button/Outline/Error/Disabled-border/Harness Theme/Light */
+  --figma___button-outline-error-hover: 0 100% 51% / 0.03;
+  /* ✦ Theme/Button/Outline/Error/Hover/Harness Theme/Light */
+  --figma___button-outline-error-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Outline/Error/Text-disabled/Harness Theme/Light */
+  --figma___button-outline-error-text-primary: 358 65% 47% / 1;
+  /* ✦ Theme/Button/Outline/Error/Text-primary/Harness Theme/Light */
+  --figma___button-outline-neutral-active: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Outline/Neutral/Active/Harness Theme/Light */
+  --figma___button-outline-neutral-default-border: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Outline/Neutral/Default - border/Harness Theme/Light */
+  --figma___button-outline-neutral-disabled-border: 0 0% 0% / 0.13;
+  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/Harness Theme/Light */
+  --figma___button-outline-neutral-hover: 240 89% 18% / 0.02;
+  /* ✦ Theme/Button/Outline/Neutral/Hover/Harness Theme/Light */
+  --figma___button-outline-neutral-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/Harness Theme/Light */
+  --figma___button-outline-neutral-text-primary: 0 0% 39% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Text-primary/Harness Theme/Light */
+  --figma___button-outline-success-active: 139 98% 37% / 0.09;
+  /* ✦ Theme/Button/Outline/Success/Active/Harness Theme/Light */
+  --figma___button-outline-success-default-border: 151 100% 28% / 0.81;
+  /* ✦ Theme/Button/Outline/Success/Default-border/Harness Theme/Light */
+  --figma___button-outline-success-disabled-border: 0 0% 0% / 0.13;
+  /* ✦ Theme/Button/Outline/Success/Disabled - border/Harness Theme/Light */
+  --figma___button-outline-success-hover: 139 98% 37% / 0.09;
+  /* ✦ Theme/Button/Outline/Success/Hover/Harness Theme/Light */
+  --figma___button-outline-success-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Outline/Success/Text-disabled/Harness Theme/Light */
+  --figma___button-outline-success-text-primary: 153 67% 28% / 1;
+  /* ✦ Theme/Button/Outline/Success/Text-primary/Harness Theme/Light */
+  --figma___button-soft-accent-active: 209 99% 49% / 0.19;
+  /* ✦ Theme/Button/Soft/Accent/Active/Harness Theme/Light */
+  --figma___button-soft-accent-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Soft/Accent/Disabled/Harness Theme/Light */
+  --figma___button-soft-accent-hover: 210 99% 49% / 0.19;
+  /* ✦ Theme/Button/Soft/Accent/Hover/Harness Theme/Light */
+  --figma___button-soft-accent-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Soft/Accent/Text-disabled/Harness Theme/Light */
+  --figma___button-soft-accent-text-primary: 211 90% 42% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Text-primary/Harness Theme/Light */
+  --figma___button-soft-accent-default: 210 100% 50% / 0.07;
+  /* ✦ Theme/Button/Soft/Accent/default/Harness Theme/Light */
+  --figma___button-soft-error-active: 0 100% 47% / 0.15;
+  /* ✦ Theme/Button/Soft/Error/Active/Harness Theme/Light */
+  --figma___button-soft-error-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Soft/Error/Disabled/Harness Theme/Light */
+  --figma___button-soft-error-hover: 0 100% 50% / 0.1;
+  /* ✦ Theme/Button/Soft/Error/Hover/Harness Theme/Light */
+  --figma___button-soft-error-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Soft/Error/Text-disabled/Harness Theme/Light */
+  --figma___button-soft-error-text-primary: 358 65% 47% / 1;
+  /* ✦ Theme/Button/Soft/Error/Text-primary/Harness Theme/Light */
+  --figma___button-soft-error-default: 0 100% 50% / 0.06;
+  /* ✦ Theme/Button/Soft/Error/default/Harness Theme/Light */
+  --figma___button-soft-neutral-active: 0 0% 0% / 0.11;
+  /* ✦ Theme/Button/Soft/Neutral/Active/Harness Theme/Light */
+  --figma___button-soft-neutral-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Soft/Neutral/Disabled/Harness Theme/Light */
+  --figma___button-soft-neutral-hover: 0 0% 0% / 0.08;
+  /* ✦ Theme/Button/Soft/Neutral/Hover/Harness Theme/Light */
+  --figma___button-soft-neutral-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/Harness Theme/Light */
+  --figma___button-soft-neutral-text-primary: 0 0% 39% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Text-primary/Harness Theme/Light */
+  --figma___button-soft-neutral-default: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Soft/Neutral/default/Harness Theme/Light */
+  --figma___button-soft-success-active: 141 100% 30% / 0.2;
+  /* ✦ Theme/Button/Soft/Success/Active/Harness Theme/Light */
+  --figma___button-soft-success-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Soft/Success/Disabled/Harness Theme/Light */
+  --figma___button-soft-success-hover: 139 99% 33% / 0.13;
+  /* ✦ Theme/Button/Soft/Success/Hover/Harness Theme/Light */
+  --figma___button-soft-success-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Soft/Success/Text-disabled/Harness Theme/Light */
+  --figma___button-soft-success-text-primary: 153 100% 21% / 0.91;
+  /* ✦ Theme/Button/Soft/Success/Text-primary/Harness Theme/Light */
+  --figma___button-soft-success-default: 139 98% 37% / 0.09;
+  /* ✦ Theme/Button/Soft/Success/default/Harness Theme/Light */
+  --figma___button-solid-accent-active: 214 73% 51% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Active/Harness Theme/Light */
+  --figma___button-solid-accent-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Solid/Accent/Disabled/Harness Theme/Light */
+  --figma___button-solid-accent-hover: 208 93% 47% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Hover/Harness Theme/Light */
+  --figma___button-solid-accent-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Solid/Accent/Text-disabled/Harness Theme/Light */
+  --figma___button-solid-accent-default: 214 73% 51% / 1;
+  /* ✦ Theme/Button/Solid/Accent/default/Harness Theme/Light */
+  --figma___button-solid-error-active: 358 75% 59% / 1;
+  /* ✦ Theme/Button/Solid/Error/Active/Harness Theme/Light */
+  --figma___button-solid-error-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Solid/Error/Disabled/Harness Theme/Light */
+  --figma___button-solid-error-hover: 358 67% 55% / 1;
+  /* ✦ Theme/Button/Solid/Error/Hover/Harness Theme/Light */
+  --figma___button-solid-error-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Solid/Error/Text-disabled/Harness Theme/Light */
+  --figma___button-solid-error-default: 358 75% 59% / 1;
+  /* ✦ Theme/Button/Solid/Error/default/Harness Theme/Light */
+  --figma___button-solid-neutral-active: 0 0% 55% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Active/Harness Theme/Light */
+  --figma___button-solid-neutral-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Solid/Neutral/Disabled/Harness Theme/Light */
+  --figma___button-solid-neutral-hover: 0 0% 50% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Hover/Harness Theme/Light */
+  --figma___button-solid-neutral-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/Harness Theme/Light */
+  --figma___button-solid-neutral-default: 0 0% 55% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/default/Harness Theme/Light */
+  --figma___button-solid-success-active: 142 72% 29% / 1;
+  /* ✦ Theme/Button/Solid/Success/Active/Harness Theme/Light */
+  --figma___button-solid-success-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Solid/Success/Disabled/Harness Theme/Light */
+  --figma___button-solid-success-hover: 152 57% 38% / 1;
+  /* ✦ Theme/Button/Solid/Success/Hover/Harness Theme/Light */
+  --figma___button-solid-success-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Solid/Success/Text-disabled/Harness Theme/Light */
+  --figma___button-solid-success-default: 142 72% 29% / 1;
+  /* ✦ Theme/Button/Solid/Success/default/Harness Theme/Light */
+  --figma___button-surface-accent-active: 209 99% 49% / 0.19;
+  /* ✦ Theme/Button/Surface/Accent/Active/Harness Theme/Light */
+  --figma___button-surface-accent-active-border: 206 100% 45% / 0.63;
+  /* ✦ Theme/Button/Surface/Accent/Active border/Harness Theme/Light */
+  --figma___button-surface-accent-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Surface/Accent/Disabled/Harness Theme/Light */
+  --figma___button-surface-accent-hover: 210 99% 49% / 0.19;
+  /* ✦ Theme/Button/Surface/Accent/Hover/Harness Theme/Light */
+  --figma___button-surface-accent-hover-border: 206 100% 45% / 0.63;
+  /* ✦ Theme/Button/Surface/Accent/Hover Border/Harness Theme/Light */
+  --figma___button-surface-accent-text-disabled: 231 10% 75% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Text-disabled/Harness Theme/Light */
+  --figma___button-surface-accent-text-primary: 211 90% 42% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Text-primary/Harness Theme/Light */
+  --figma___button-surface-accent-default: 210 100% 50% / 0.07;
+  /* ✦ Theme/Button/Surface/Accent/default/Harness Theme/Light */
+  --figma___button-surface-accent-default-border: 208 100% 44% / 0.41;
+  /* ✦ Theme/Button/Surface/Accent/default border/Harness Theme/Light */
+  --figma___button-surface-error-active: 0 100% 47% / 0.15;
+  /* ✦ Theme/Button/Surface/Error/Active/Harness Theme/Light */
+  --figma___button-surface-error-active-border: 358 100% 40% / 0.76;
+  /* ✦ Theme/Button/Surface/Error/Active border/Harness Theme/Light */
+  --figma___button-surface-error-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Surface/Error/Disabled/Harness Theme/Light */
+  --figma___button-surface-error-hover: 0 100% 50% / 0.1;
+  /* ✦ Theme/Button/Surface/Error/Hover/Harness Theme/Light */
+  --figma___button-surface-error-hover-border: 358 100% 40% / 0.76;
+  /* ✦ Theme/Button/Surface/Error/Hover border/Harness Theme/Light */
+  --figma___button-surface-error-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Surface/Error/Text-disabled/Harness Theme/Light */
+  --figma___button-surface-error-text-primary: 358 65% 47% / 1;
+  /* ✦ Theme/Button/Surface/Error/Text-primary/Harness Theme/Light */
+  --figma___button-surface-error-border: 0 99% 45% / 0.22;
+  /* ✦ Theme/Button/Surface/Error/border/Harness Theme/Light */
+  --figma___button-surface-error-default: 0 100% 50% / 0.06;
+  /* ✦ Theme/Button/Surface/Error/default/Harness Theme/Light */
+  --figma___button-surface-neutral-active: 240 100% 9% / 0.11;
+  /* ✦ Theme/Button/Surface/Neutral/Active/Harness Theme/Light */
+  --figma___button-surface-neutral-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Surface/Neutral/Disabled/Harness Theme/Light */
+  --figma___button-surface-neutral-hover: 240 93% 11% / 0.08;
+  /* ✦ Theme/Button/Surface/Neutral/Hover/Harness Theme/Light */
+  --figma___button-surface-neutral-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/Harness Theme/Light */
+  --figma___button-surface-neutral-text-primary: 220 6% 40% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Text-primary/Harness Theme/Light */
+  --figma___button-surface-neutral-border: 233 96% 9% / 0.17;
+  /* ✦ Theme/Button/Surface/Neutral/border/Harness Theme/Light */
+  --figma___button-surface-neutral-default: 240 100% 12% / 0.05;
+  /* ✦ Theme/Button/Surface/Neutral/default/Harness Theme/Light */
+  --figma___button-surface-success-active: 141 100% 30% / 0.2;
+  /* ✦ Theme/Button/Surface/Success/Active/Harness Theme/Light */
+  --figma___button-surface-success-disabled: 0 0% 0% / 0.05;
+  /* ✦ Theme/Button/Surface/Success/Disabled/Harness Theme/Light */
+  --figma___button-surface-success-hover: 139 99% 33% / 0.13;
+  /* ✦ Theme/Button/Surface/Success/Hover/Harness Theme/Light */
+  --figma___button-surface-success-hover-border: 153 100% 26% / 0.84;
+  /* ✦ Theme/Button/Surface/Success/Hover border/Harness Theme/Light */
+  --figma___button-surface-success-text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Button/Surface/Success/Text-disabled/Harness Theme/Light */
+  --figma___button-surface-success-text-primary: 153 67% 28% / 1;
+  /* ✦ Theme/Button/Surface/Success/Text-primary/Harness Theme/Light */
+  --figma___button-surface-success-active-border: 153 100% 26% / 0.84;
+  /* ✦ Theme/Button/Surface/Success/active border/Harness Theme/Light */
+  --figma___button-surface-success-default: 139 98% 37% / 0.09;
+  /* ✦ Theme/Button/Surface/Success/default/Harness Theme/Light */
+  --figma___button-surface-success-default-border: 142 99% 29% / 0.29;
+  /* ✦ Theme/Button/Surface/Success/default border/Harness Theme/Light */
+  --figma___calendar-background: 240 20% 98% / 1;
+  /* ✦ Theme/Calendar/Background/Harness Theme/Light */
+  --figma___calendar-selected-date-background: 214 73% 51% / 1;
+  /* ✦ Theme/Calendar/Selected Date/Background/Harness Theme/Light */
+  --figma___calendar-selected-range-background: 210 100% 50% / 0.07;
+  /* ✦ Theme/Calendar/Selected Range/Background/Harness Theme/Light */
+  --figma___calendar-selected-range-text: 211 100% 39% / 0.96;
+  /* ✦ Theme/Calendar/Selected Range/Text/Harness Theme/Light */
+  --figma___checkbox-background: 0 0% 100% / 0.8;
+  /* ✦ Theme/Checkbox/Background/Harness Theme/Light */
+  --figma___checkbox-paper: 0 0% 100% / 1;
+  /* ✦ Theme/Checkbox/Paper/Harness Theme/Light */
+  --figma___checkbox-surface-checked-active-active: 208 93% 47% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/Harness Theme/Light */
+  --figma___checkbox-surface-checked-active-hover: 208 93% 47% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/Harness Theme/Light */
+  --figma___checkbox-surface-checked-active-default-background: 214 73% 51% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/Harness Theme/Light */
+  --figma___checkbox-surface-checked-disabled-check: 240 96% 9% / 0.13;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/Harness Theme/Light */
+  --figma___checkbox-surface-checked-disabled-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/Harness Theme/Light */
+  --figma___checkbox-surface-checked-disabled-border: 240 96% 9% / 0.13;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/Harness Theme/Light */
+  --figma___checkbox-surface-intermediate-active-active-border: 206 100% 45% / 0.63;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/Harness Theme/Light */
+  --figma___checkbox-surface-intermediate-active-check: 211 100% 39% / 0.96;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/Harness Theme/Light */
+  --figma___checkbox-surface-intermediate-active-hover-border: 208 100% 44% / 0.41;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/Harness Theme/Light */
+  --figma___checkbox-surface-intermediate-active-default-background: 210 100% 50% / 0.07;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/Harness Theme/Light */
+  --figma___checkbox-surface-intermediate-active-default-border: 209 99% 45% / 0.28;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/Harness Theme/Light */
+  --figma___checkbox-surface-intermediate-disabled-check: 240 96% 9% / 0.13;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/Harness Theme/Light */
+  --figma___checkbox-surface-intermediate-disabled-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/Harness Theme/Light */
+  --figma___checkbox-surface-intermediate-disabled-border: 240 96% 9% / 0.13;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/Harness Theme/Light */
+  --figma___checkbox-surface-unchecked-active-active-border: 230 100% 9% / 0.28;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/Harness Theme/Light */
+  --figma___checkbox-surface-unchecked-active-hover-border: 233 96% 9% / 0.17;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/Harness Theme/Light */
+  --figma___checkbox-surface-unchecked-active-default-background: 0 0% 98% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/Harness Theme/Light */
+  --figma___checkbox-surface-unchecked-active-default-border: 240 96% 9% / 0.13;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/Harness Theme/Light */
+  --figma___checkbox-surface-unchecked-disabled-disabled: 240 100% 12% / 0.05;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/Harness Theme/Light */
+  --figma___checkbox-surface-unchecked-disabled-border: 240 96% 9% / 0.13;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/Harness Theme/Light */
+  --figma___checkbox-border: 0 0% 0% / 0.05;
+  /* ✦ Theme/Checkbox/border/Harness Theme/Light */
+  --figma___default-colors-black: 0 0% 0% / 1;
+  /* ✦ Theme/Default colors/black/Harness Theme/Light */
+  --figma___default-colors-dark-to-white: 0 0% 13% / 1;
+  /* ✦ Theme/Default colors/dark-to-white/Harness Theme/Light */
+  --figma___default-colors-white: 0 0% 100% / 1;
+  /* ✦ Theme/Default colors/white/Harness Theme/Light */
+  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
+  /* ✦ Theme/Dropdown/Dropdown Item/Default/Harness Theme/Light */
+  --figma___dropdown-dropdown-item-hover: 240 13% 95% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Hover/Harness Theme/Light */
+  --figma___dropdown-dropdown-item-selected: 240 13% 95% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Selected/Harness Theme/Light */
+  --figma___dropdown-text-shortcut-text-selected: 0 0% 0% / 0.5;
+  /* ✦ Theme/Dropdown/Text/Shortcut text selected/Harness Theme/Light */
+  --figma___dropdown-text-text-selected: 0 0% 13% / 1;
+  /* ✦ Theme/Dropdown/Text/Text Selected/Harness Theme/Light */
+  --figma___dropdown-text-hover: 0 0% 39% / 1;
+  /* ✦ Theme/Dropdown/Text/hover/Harness Theme/Light */
+  --figma___dropdown-background: 240 20% 98% / 1;
+  /* ✦ Theme/Dropdown/background/Harness Theme/Light */
+  --figma___dropdown-border: 240 100% 12% / 0.05;
+  /* ✦ Theme/Dropdown/border/Harness Theme/Light */
+  --figma___dropdown-separator: 240 100% 12% / 0.05;
+  /* ✦ Theme/Dropdown/separator/Harness Theme/Light */
+  --figma___filter-active: 240 100% 12% / 0.05;
+  /* ✦ Theme/Filter/Active/Harness Theme/Light */
+  --figma___filter-hover: 240 100% 12% / 0.05;
+  /* ✦ Theme/Filter/Hover/Harness Theme/Light */
+  --figma___inline-alert-banner-customisable: 240 20% 98% / 1;
+  /* ✦ Theme/Inline Alert Banner/Customisable/Harness Theme/Light */
+  --figma___inline-alert-banner-error: 0 100% 97% / 1;
+  /* ✦ Theme/Inline Alert Banner/Error/Harness Theme/Light */
+  --figma___inline-alert-banner-info: 210 100% 50% / 0.07;
+  /* ✦ Theme/Inline Alert Banner/Info/Harness Theme/Light */
+  --figma___inline-alert-banner-reminder: 40 100% 96% / 1;
+  /* ✦ Theme/Inline Alert Banner/Reminder/Harness Theme/Light */
+  --figma___inline-alert-banner-success: 150 69% 94% / 1;
+  /* ✦ Theme/Inline Alert Banner/Success/Harness Theme/Light */
+  --figma___inline-alert-banner-warning: 34 100% 92% / 1;
+  /* ✦ Theme/Inline Alert Banner/Warning/Harness Theme/Light */
+  --figma___modal-background: 0 0% 100% / 0.8;
+  /* ✦ Theme/Modal/Background/Harness Theme/Light */
+  --figma___modal-paper: 0 0% 100% / 1;
+  /* ✦ Theme/Modal/Paper/Harness Theme/Light */
+  --figma___modal-border: 0 0% 0% / 0.05;
+  /* ✦ Theme/Modal/border/Harness Theme/Light */
+  --figma___neutral-color-gray-1: 0 0% 99% / 1;
+  /* ✦ Theme/Neutral color/Gray/1/Harness Theme/Light */
+  --figma___neutral-color-gray-2: 0 0% 98% / 1;
+  /* ✦ Theme/Neutral color/Gray/2/Harness Theme/Light */
+  --figma___neutral-color-gray-3: 0 0% 95% / 1;
+  /* ✦ Theme/Neutral color/Gray/3/Harness Theme/Light */
+  --figma___neutral-color-gray-4: 0 0% 92% / 1;
+  /* ✦ Theme/Neutral color/Gray/4/Harness Theme/Light */
+  --figma___neutral-color-gray-5: 0 0% 89% / 1;
+  /* ✦ Theme/Neutral color/Gray/5/Harness Theme/Light */
+  --figma___neutral-color-gray-6: 0 0% 87% / 1;
+  /* ✦ Theme/Neutral color/Gray/6/Harness Theme/Light */
+  --figma___neutral-color-gray-7: 0 0% 55% / 1;
+  /* ✦ Theme/Neutral color/Gray/7/Harness Theme/Light */
+  --figma___neutral-color-gray-8: 0 0% 50% / 1;
+  /* ✦ Theme/Neutral color/Gray/8/Harness Theme/Light */
+  --figma___neutral-color-gray-9: 0 0% 39% / 1;
+  /* ✦ Theme/Neutral color/Gray/9/Harness Theme/Light */
+  --figma___neutral-color-gray-10: 0 0% 13% / 1;
+  /* ✦ Theme/Neutral color/Gray/10/Harness Theme/Light */
+  --figma___neutral-color-gray-alpha-1: 0 0% 0% / 0.01;
+  /* ✦ Theme/Neutral color/Gray Alpha/1/Harness Theme/Light */
+  --figma___neutral-color-gray-alpha-2: 240 89% 18% / 0.02;
+  /* ✦ Theme/Neutral color/Gray Alpha/2/Harness Theme/Light */
+  --figma___neutral-color-gray-alpha-3: 0 0% 0% / 0.05;
+  /* ✦ Theme/Neutral color/Gray Alpha/3/Harness Theme/Light */
+  --figma___neutral-color-gray-alpha-4: 0 0% 0% / 0.08;
+  /* ✦ Theme/Neutral color/Gray Alpha/4/Harness Theme/Light */
+  --figma___neutral-color-gray-alpha-5: 0 0% 0% / 0.11;
+  /* ✦ Theme/Neutral color/Gray Alpha/5/Harness Theme/Light */
+  --figma___neutral-color-gray-alpha-6: 0 0% 0% / 0.13;
+  /* ✦ Theme/Neutral color/Gray Alpha/6/Harness Theme/Light */
+  --figma___neutral-color-gray-alpha-7: 0 0% 0% / 0.45;
+  /* ✦ Theme/Neutral color/Gray Alpha/7/Harness Theme/Light */
+  --figma___neutral-color-gray-alpha-8: 0 0% 0% / 0.5;
+  /* ✦ Theme/Neutral color/Gray Alpha/8/Harness Theme/Light */
+  --figma___neutral-color-gray-alpha-9: 0 0% 0% / 0.61;
+  /* ✦ Theme/Neutral color/Gray Alpha/9/Harness Theme/Light */
+  --figma___neutral-color-gray-alpha-10: 0 0% 0% / 0.88;
+  /* ✦ Theme/Neutral color/Gray Alpha/10/Harness Theme/Light */
+  --figma___other-colors-ai-violet-1: 270 50% 99% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/1/Harness Theme/Light */
+  --figma___other-colors-ai-violet-2: 252 100% 99% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/2/Harness Theme/Light */
+  --figma___other-colors-ai-violet-3: 254 100% 97% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/3/Harness Theme/Light */
+  --figma___other-colors-ai-violet-4: 251 91% 95% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/4/Harness Theme/Light */
+  --figma___other-colors-ai-violet-5: 252 83% 93% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/5/Harness Theme/Light */
+  --figma___other-colors-ai-violet-6: 251 78% 89% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/6/Harness Theme/Light */
+  --figma___other-colors-ai-violet-7: 252 56% 57% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/7/Harness Theme/Light */
+  --figma___other-colors-ai-violet-8: 251 48% 53% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/8/Harness Theme/Light */
+  --figma___other-colors-ai-violet-9: 250 43% 48% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/9/Harness Theme/Light */
+  --figma___other-colors-ai-violet-10: 249 43% 26% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/10/Harness Theme/Light */
+  --figma___other-colors-ai-violet-alpha-1: 270 94% 35% / 0.01;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/1/Harness Theme/Light */
+  --figma___other-colors-ai-violet-alpha-2: 252 100% 51% / 0.02;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/2/Harness Theme/Light */
+  --figma___other-colors-ai-violet-alpha-3: 254 100% 50% / 0.05;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/3/Harness Theme/Light */
+  --figma___other-colors-ai-violet-alpha-4: 251 98% 48% / 0.09;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/4/Harness Theme/Light */
+  --figma___other-colors-ai-violet-alpha-5: 252 99% 46% / 0.13;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/5/Harness Theme/Light */
+  --figma___other-colors-ai-violet-alpha-6: 251 99% 44% / 0.19;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/6/Harness Theme/Light */
+  --figma___other-colors-ai-violet-alpha-7: 252 100% 36% / 0.66;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/7/Harness Theme/Light */
+  --figma___other-colors-ai-violet-alpha-8: 251 100% 32% / 0.69;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/8/Harness Theme/Light */
+  --figma___other-colors-ai-violet-alpha-9: 250 100% 28% / 0.73;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/9/Harness Theme/Light */
+  --figma___other-colors-ai-violet-alpha-10: 249 100% 13% / 0.85;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/10/Harness Theme/Light */
+  --figma___other-colors-blue-1: 210 100% 99% / 1;
+  /* ✦ Theme/Other Colors/Blue/1/Harness Theme/Light */
+  --figma___other-colors-blue-2: 210 100% 98% / 1;
+  /* ✦ Theme/Other Colors/Blue/2/Harness Theme/Light */
+  --figma___other-colors-blue-3: 210 100% 96% / 1;
+  /* ✦ Theme/Other Colors/Blue/3/Harness Theme/Light */
+  --figma___other-colors-blue-4: 210 100% 94% / 1;
+  /* ✦ Theme/Other Colors/Blue/4/Harness Theme/Light */
+  --figma___other-colors-blue-5: 209 96% 90% / 1;
+  /* ✦ Theme/Other Colors/Blue/5/Harness Theme/Light */
+  --figma___other-colors-blue-6: 209 82% 85% / 1;
+  /* ✦ Theme/Other Colors/Blue/6/Harness Theme/Light */
+  --figma___other-colors-blue-7: 214 73% 51% / 1;
+  /* ✦ Theme/Other Colors/Blue/7/Harness Theme/Light */
+  --figma___other-colors-blue-8: 208 93% 47% / 1;
+  /* ✦ Theme/Other Colors/Blue/8/Harness Theme/Light */
+  --figma___other-colors-blue-9: 211 90% 42% / 1;
+  /* ✦ Theme/Other Colors/Blue/9/Harness Theme/Light */
+  --figma___other-colors-blue-10: 216 71% 23% / 1;
+  /* ✦ Theme/Other Colors/Blue/10/Harness Theme/Light */
+  --figma___other-colors-blue-alpha-1: 210 100% 51% / 0.02;
+  /* ✦ Theme/Other Colors/Blue Alpha/1/Harness Theme/Light */
+  --figma___other-colors-blue-alpha-2: 210 100% 51% / 0.04;
+  /* ✦ Theme/Other Colors/Blue Alpha/2/Harness Theme/Light */
+  --figma___other-colors-blue-alpha-3: 210 100% 50% / 0.07;
+  /* ✦ Theme/Other Colors/Blue Alpha/3/Harness Theme/Light */
+  --figma___other-colors-blue-alpha-4: 210 99% 49% / 0.19;
+  /* ✦ Theme/Other Colors/Blue Alpha/4/Harness Theme/Light */
+  --figma___other-colors-blue-alpha-5: 209 99% 49% / 0.19;
+  /* ✦ Theme/Other Colors/Blue Alpha/5/Harness Theme/Light */
+  --figma___other-colors-blue-alpha-6: 209 99% 45% / 0.28;
+  /* ✦ Theme/Other Colors/Blue Alpha/6/Harness Theme/Light */
+  --figma___other-colors-blue-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/7/Harness Theme/Light */
+  --figma___other-colors-blue-alpha-8: 208 100% 46% / 0.97;
+  /* ✦ Theme/Other Colors/Blue Alpha/8/Harness Theme/Light */
+  --figma___other-colors-blue-alpha-9: 211 100% 39% / 0.96;
+  /* ✦ Theme/Other Colors/Blue Alpha/9/Harness Theme/Light */
+  --figma___other-colors-blue-alpha-10: 216 100% 17% / 0.93;
+  /* ✦ Theme/Other Colors/Blue Alpha/10/Harness Theme/Light */
+  --figma___other-colors-indigo-1: 240 33% 99% / 1;
+  /* ✦ Theme/Other Colors/Indigo/1/Harness Theme/Light */
+  --figma___other-colors-indigo-2: 223 100% 99% / 1;
+  /* ✦ Theme/Other Colors/Indigo/2/Harness Theme/Light */
+  --figma___other-colors-indigo-3: 224 100% 97% / 1;
+  /* ✦ Theme/Other Colors/Indigo/3/Harness Theme/Light */
+  --figma___other-colors-indigo-4: 222 92% 95% / 1;
+  /* ✦ Theme/Other Colors/Indigo/4/Harness Theme/Light */
+  --figma___other-colors-indigo-5: 225 85% 92% / 1;
+  /* ✦ Theme/Other Colors/Indigo/5/Harness Theme/Light */
+  --figma___other-colors-indigo-6: 224 81% 88% / 1;
+  /* ✦ Theme/Other Colors/Indigo/6/Harness Theme/Light */
+  --figma___other-colors-indigo-7: 226 70% 55% / 1;
+  /* ✦ Theme/Other Colors/Indigo/7/Harness Theme/Light */
+  --figma___other-colors-indigo-8: 226 59% 51% / 1;
+  /* ✦ Theme/Other Colors/Indigo/8/Harness Theme/Light */
+  --figma___other-colors-indigo-9: 226 55% 45% / 1;
+  /* ✦ Theme/Other Colors/Indigo/9/Harness Theme/Light */
+  --figma___other-colors-indigo-10: 226 63% 17% / 1;
+  /* ✦ Theme/Other Colors/Indigo/10/Harness Theme/Light */
+  --figma___other-colors-indigo-alpha-1: 240 93% 26% / 0.01;
+  /* ✦ Theme/Other Colors/Indigo Alpha/1/Harness Theme/Light */
+  --figma___other-colors-indigo-alpha-2: 223 100% 51% / 0.03;
+  /* ✦ Theme/Other Colors/Indigo Alpha/2/Harness Theme/Light */
+  --figma___other-colors-indigo-alpha-3: 224 100% 50% / 0.06;
+  /* ✦ Theme/Other Colors/Indigo Alpha/3/Harness Theme/Light */
+  --figma___other-colors-indigo-alpha-4: 222 98% 48% / 0.1;
+  /* ✦ Theme/Other Colors/Indigo Alpha/4/Harness Theme/Light */
+  --figma___other-colors-indigo-alpha-5: 225 98% 46% / 0.15;
+  /* ✦ Theme/Other Colors/Indigo Alpha/5/Harness Theme/Light */
+  --figma___other-colors-indigo-alpha-6: 224 99% 45% / 0.22;
+  /* ✦ Theme/Other Colors/Indigo Alpha/6/Harness Theme/Light */
+  --figma___other-colors-indigo-alpha-7: 226 100% 41% / 0.76;
+  /* ✦ Theme/Other Colors/Indigo Alpha/7/Harness Theme/Light */
+  --figma___other-colors-indigo-alpha-8: 226 100% 37% / 0.77;
+  /* ✦ Theme/Other Colors/Indigo Alpha/8/Harness Theme/Light */
+  --figma___other-colors-indigo-alpha-9: 226 100% 31% / 0.8;
+  /* ✦ Theme/Other Colors/Indigo Alpha/9/Harness Theme/Light */
+  --figma___other-colors-indigo-alpha-10: 225 100% 14% / 0.88;
+  /* ✦ Theme/Other Colors/Indigo Alpha/10/Harness Theme/Light */
+  --figma___other-colors-mint-1: 168 71% 99% / 1;
+  /* ✦ Theme/Other Colors/Mint/1/Harness Theme/Light */
+  --figma___other-colors-mint-2: 164 88% 97% / 1;
+  /* ✦ Theme/Other Colors/Mint/2/Harness Theme/Light */
+  --figma___other-colors-mint-3: 164 79% 93% / 1;
+  /* ✦ Theme/Other Colors/Mint/3/Harness Theme/Light */
+  --figma___other-colors-mint-4: 165 73% 88% / 1;
+  /* ✦ Theme/Other Colors/Mint/4/Harness Theme/Light */
+  --figma___other-colors-mint-5: 166 60% 83% / 1;
+  /* ✦ Theme/Other Colors/Mint/5/Harness Theme/Light */
+  --figma___other-colors-mint-6: 166 50% 77% / 1;
+  /* ✦ Theme/Other Colors/Mint/6/Harness Theme/Light */
+  --figma___other-colors-mint-7: 167 70% 72% / 1;
+  /* ✦ Theme/Other Colors/Mint/7/Harness Theme/Light */
+  --figma___other-colors-mint-8: 167 62% 69% / 1;
+  /* ✦ Theme/Other Colors/Mint/8/Harness Theme/Light */
+  --figma___other-colors-mint-9: 172 50% 31% / 1;
+  /* ✦ Theme/Other Colors/Mint/9/Harness Theme/Light */
+  --figma___other-colors-mint-10: 171 51% 17% / 1;
+  /* ✦ Theme/Other Colors/Mint/10/Harness Theme/Light */
+  --figma___other-colors-mint-alpha-1: 168 95% 43% / 0.02;
+  /* ✦ Theme/Other Colors/Mint Alpha/1/Harness Theme/Light */
+  --figma___other-colors-mint-alpha-2: 164 99% 47% / 0.06;
+  /* ✦ Theme/Other Colors/Mint Alpha/2/Harness Theme/Light */
+  --figma___other-colors-mint-alpha-3: 164 99% 44% / 0.13;
+  /* ✦ Theme/Other Colors/Mint Alpha/3/Harness Theme/Light */
+  --figma___other-colors-mint-alpha-4: 165 100% 42% / 0.2;
+  /* ✦ Theme/Other Colors/Mint Alpha/4/Harness Theme/Light */
+  --figma___other-colors-mint-alpha-5: 166 100% 38% / 0.27;
+  /* ✦ Theme/Other Colors/Mint Alpha/5/Harness Theme/Light */
+  --figma___other-colors-mint-alpha-6: 166 99% 33% / 0.35;
+  /* ✦ Theme/Other Colors/Mint Alpha/6/Harness Theme/Light */
+  --figma___other-colors-mint-alpha-7: 167 100% 41% / 0.47;
+  /* ✦ Theme/Other Colors/Mint Alpha/7/Harness Theme/Light */
+  --figma___other-colors-mint-alpha-8: 167 100% 38% / 0.5;
+  /* ✦ Theme/Other Colors/Mint Alpha/8/Harness Theme/Light */
+  --figma___other-colors-mint-alpha-9: 172 100% 18% / 0.85;
+  /* ✦ Theme/Other Colors/Mint Alpha/9/Harness Theme/Light */
+  --figma___other-colors-mint-alpha-10: 171 100% 10% / 0.91;
+  /* ✦ Theme/Other Colors/Mint Alpha/10/Harness Theme/Light */
+  --figma___other-colors-orange-1: 20 60% 99% / 1;
+  /* ✦ Theme/Other Colors/Orange/1/Harness Theme/Light */
+  --figma___other-colors-orange-2: 22 100% 98% / 1;
+  /* ✦ Theme/Other Colors/Orange/2/Harness Theme/Light */
+  --figma___other-colors-orange-3: 34 100% 92% / 1;
+  /* ✦ Theme/Other Colors/Orange/3/Harness Theme/Light */
+  --figma___other-colors-orange-4: 33 100% 87% / 1;
+  /* ✦ Theme/Other Colors/Orange/4/Harness Theme/Light */
+  --figma___other-colors-orange-5: 31 100% 82% / 1;
+  /* ✦ Theme/Other Colors/Orange/5/Harness Theme/Light */
+  --figma___other-colors-orange-6: 27 100% 78% / 1;
+  /* ✦ Theme/Other Colors/Orange/6/Harness Theme/Light */
+  --figma___other-colors-orange-7: 24 94% 50% / 1;
+  /* ✦ Theme/Other Colors/Orange/7/Harness Theme/Light */
+  --figma___other-colors-orange-8: 24 100% 46% / 1;
+  /* ✦ Theme/Other Colors/Orange/8/Harness Theme/Light */
+  --figma___other-colors-orange-9: 16 45% 41% / 1;
+  /* ✦ Theme/Other Colors/Orange/9/Harness Theme/Light */
+  --figma___other-colors-orange-10: 16 50% 23% / 1;
+  /* ✦ Theme/Other Colors/Orange/10/Harness Theme/Light */
+  --figma___other-colors-orange-alpha-1: 20 95% 39% / 0.02;
+  /* ✦ Theme/Other Colors/Orange Alpha/1/Harness Theme/Light */
+  --figma___other-colors-orange-alpha-2: 22 100% 51% / 0.04;
+  /* ✦ Theme/Other Colors/Orange Alpha/2/Harness Theme/Light */
+  --figma___other-colors-orange-alpha-3: 34 100% 50% / 0.17;
+  /* ✦ Theme/Other Colors/Orange Alpha/3/Harness Theme/Light */
+  --figma___other-colors-orange-alpha-4: 33 100% 50% / 0.27;
+  /* ✦ Theme/Other Colors/Orange Alpha/4/Harness Theme/Light */
+  --figma___other-colors-orange-alpha-5: 31 100% 50% / 0.36;
+  /* ✦ Theme/Other Colors/Orange Alpha/5/Harness Theme/Light */
+  --figma___other-colors-orange-alpha-6: 27 100% 50% / 0.43;
+  /* ✦ Theme/Other Colors/Orange Alpha/6/Harness Theme/Light */
+  --figma___other-colors-orange-alpha-7: 24 100% 48% / 0.97;
+  /* ✦ Theme/Other Colors/Orange Alpha/7/Harness Theme/Light */
+  --figma___other-colors-orange-alpha-8: 24 100% 46% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/8/Harness Theme/Light */
+  --figma___other-colors-orange-alpha-9: 16 100% 24% / 0.77;
+  /* ✦ Theme/Other Colors/Orange Alpha/9/Harness Theme/Light */
+  --figma___other-colors-orange-alpha-10: 16 100% 13% / 0.89;
+  /* ✦ Theme/Other Colors/Orange Alpha/10/Harness Theme/Light */
+  --figma___other-colors-yellow-1: 60 50% 98% / 1;
+  /* ✦ Theme/Other Colors/Yellow/1/Harness Theme/Light */
+  --figma___other-colors-yellow-2: 52 100% 94% / 1;
+  /* ✦ Theme/Other Colors/Yellow/2/Harness Theme/Light */
+  --figma___other-colors-yellow-3: 53 100% 89% / 1;
+  /* ✦ Theme/Other Colors/Yellow/3/Harness Theme/Light */
+  --figma___other-colors-yellow-4: 53 93% 84% / 1;
+  /* ✦ Theme/Other Colors/Yellow/4/Harness Theme/Light */
+  --figma___other-colors-yellow-5: 52 85% 79% / 1;
+  /* ✦ Theme/Other Colors/Yellow/5/Harness Theme/Light */
+  --figma___other-colors-yellow-6: 51 73% 72% / 1;
+  /* ✦ Theme/Other Colors/Yellow/6/Harness Theme/Light */
+  --figma___other-colors-yellow-7: 53 96% 58% / 1;
+  /* ✦ Theme/Other Colors/Yellow/7/Harness Theme/Light */
+  --figma___other-colors-yellow-8: 52 95% 52% / 1;
+  /* ✦ Theme/Other Colors/Yellow/8/Harness Theme/Light */
+  --figma___other-colors-yellow-9: 42 50% 31% / 1;
+  /* ✦ Theme/Other Colors/Yellow/9/Harness Theme/Light */
+  --figma___other-colors-yellow-10: 42 39% 20% / 1;
+  /* ✦ Theme/Other Colors/Yellow/10/Harness Theme/Light */
+  --figma___other-colors-yellow-alpha-1: 60 94% 35% / 0.02;
+  /* ✦ Theme/Other Colors/Yellow Alpha/1/Harness Theme/Light */
+  --figma___other-colors-yellow-alpha-2: 52 100% 50% / 0.12;
+  /* ✦ Theme/Other Colors/Yellow Alpha/2/Harness Theme/Light */
+  --figma___other-colors-yellow-alpha-3: 53 100% 50% / 0.22;
+  /* ✦ Theme/Other Colors/Yellow Alpha/3/Harness Theme/Light */
+  --figma___other-colors-yellow-alpha-4: 53 100% 48% / 0.31;
+  /* ✦ Theme/Other Colors/Yellow Alpha/4/Harness Theme/Light */
+  --figma___other-colors-yellow-alpha-5: 52 99% 46% / 0.39;
+  /* ✦ Theme/Other Colors/Yellow Alpha/5/Harness Theme/Light */
+  --figma___other-colors-yellow-alpha-6: 51 100% 42% / 0.48;
+  /* ✦ Theme/Other Colors/Yellow Alpha/6/Harness Theme/Light */
+  --figma___other-colors-yellow-alpha-7: 53 100% 49% / 0.82;
+  /* ✦ Theme/Other Colors/Yellow Alpha/7/Harness Theme/Light */
+  --figma___other-colors-yellow-alpha-8: 52 100% 49% / 0.94;
+  /* ✦ Theme/Other Colors/Yellow Alpha/8/Harness Theme/Light */
+  --figma___other-colors-yellow-alpha-9: 42 100% 18% / 0.84;
+  /* ✦ Theme/Other Colors/Yellow Alpha/9/Harness Theme/Light */
+  --figma___other-colors-yellow-alpha-10: 42 100% 9% / 0.88;
+  /* ✦ Theme/Other Colors/Yellow Alpha/10/Harness Theme/Light */
+  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01;
+  /* ✦ Theme/Overlays/Black Alpha/1/Harness Theme/Light */
+  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02;
+  /* ✦ Theme/Overlays/Black Alpha/2/Harness Theme/Light */
+  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05;
+  /* ✦ Theme/Overlays/Black Alpha/3/Harness Theme/Light */
+  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08;
+  /* ✦ Theme/Overlays/Black Alpha/4/Harness Theme/Light */
+  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11;
+  /* ✦ Theme/Overlays/Black Alpha/5/Harness Theme/Light */
+  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13;
+  /* ✦ Theme/Overlays/Black Alpha/6/Harness Theme/Light */
+  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45;
+  /* ✦ Theme/Overlays/Black Alpha/7/Harness Theme/Light */
+  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5;
+  /* ✦ Theme/Overlays/Black Alpha/8/Harness Theme/Light */
+  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61;
+  /* ✦ Theme/Overlays/Black Alpha/9/Harness Theme/Light */
+  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88;
+  /* ✦ Theme/Overlays/Black Alpha/10/Harness Theme/Light */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 0;
+  /* ✦ Theme/Overlays/White Alpha/1/Harness Theme/Light */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01;
+  /* ✦ Theme/Overlays/White Alpha/2/Harness Theme/Light */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07;
+  /* ✦ Theme/Overlays/White Alpha/3/Harness Theme/Light */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1;
+  /* ✦ Theme/Overlays/White Alpha/4/Harness Theme/Light */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13;
+  /* ✦ Theme/Overlays/White Alpha/5/Harness Theme/Light */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17;
+  /* ✦ Theme/Overlays/White Alpha/6/Harness Theme/Light */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37;
+  /* ✦ Theme/Overlays/White Alpha/7/Harness Theme/Light */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46;
+  /* ✦ Theme/Overlays/White Alpha/8/Harness Theme/Light */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66;
+  /* ✦ Theme/Overlays/White Alpha/9/Harness Theme/Light */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93;
+  /* ✦ Theme/Overlays/White Alpha/10/Harness Theme/Light */
+  --figma___pagination-active-background: 214 73% 51% / 1;
+  /* ✦ Theme/Pagination/Active/Background/Harness Theme/Light */
+  --figma___pagination-active-border: 214 73% 51% / 1;
+  /* ✦ Theme/Pagination/Active/Border/Harness Theme/Light */
+  --figma___pagination-background: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Background/Harness Theme/Light */
+  --figma___pagination-default-background: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Default/Background/Harness Theme/Light */
+  --figma___pagination-default-border: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Default/Border/Harness Theme/Light */
+  --figma___pagination-default-text: 0 0% 0% / 0.5;
+  /* ✦ Theme/Pagination/Default/Text/Harness Theme/Light */
+  --figma___pagination-hover-background: 240 100% 12% / 0.05;
+  /* ✦ Theme/Pagination/Hover/Background/Harness Theme/Light */
+  --figma___pagination-hover-border: 0 0% 95% / 1;
+  /* ✦ Theme/Pagination/Hover/Border/Harness Theme/Light */
+  --figma___pagination-hover-text: 211 90% 42% / 1;
+  /* ✦ Theme/Pagination/Hover/Text/Harness Theme/Light */
+  --figma___pagination-pagination-shadow-1: 0 0% 0% / 0;
+  /* ✦ Theme/Pagination/Pagination shadow/1/Harness Theme/Light */
+  --figma___pagination-pagination-shadow-2: 240 100% 12% / 0;
+  /* ✦ Theme/Pagination/Pagination shadow/2/Harness Theme/Light */
+  --figma___primary-color-primary-accent-1: 210 100% 99% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/1/Harness Theme/Light */
+  --figma___primary-color-primary-accent-2: 210 100% 98% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/2/Harness Theme/Light */
+  --figma___primary-color-primary-accent-3: 210 100% 96% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/3/Harness Theme/Light */
+  --figma___primary-color-primary-accent-4: 210 100% 94% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/4/Harness Theme/Light */
+  --figma___primary-color-primary-accent-5: 209 96% 90% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/5/Harness Theme/Light */
+  --figma___primary-color-primary-accent-6: 209 82% 85% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/6/Harness Theme/Light */
+  --figma___primary-color-primary-accent-7: 214 73% 51% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/7/Harness Theme/Light */
+  --figma___primary-color-primary-accent-8: 208 93% 47% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/8/Harness Theme/Light */
+  --figma___primary-color-primary-accent-9: 211 90% 42% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/9/Harness Theme/Light */
+  --figma___primary-color-primary-accent-10: 216 71% 23% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/10/Harness Theme/Light */
+  --figma___primary-color-primary-alpha-1: 210 100% 51% / 0.02;
+  /* ✦ Theme/Primary Color/Primary Alpha/1/Harness Theme/Light */
+  --figma___primary-color-primary-alpha-2: 210 100% 51% / 0.04;
+  /* ✦ Theme/Primary Color/Primary Alpha/2/Harness Theme/Light */
+  --figma___primary-color-primary-alpha-3: 210 100% 50% / 0.07;
+  /* ✦ Theme/Primary Color/Primary Alpha/3/Harness Theme/Light */
+  --figma___primary-color-primary-alpha-4: 210 99% 49% / 0.19;
+  /* ✦ Theme/Primary Color/Primary Alpha/4/Harness Theme/Light */
+  --figma___primary-color-primary-alpha-5: 209 99% 49% / 0.19;
+  /* ✦ Theme/Primary Color/Primary Alpha/5/Harness Theme/Light */
+  --figma___primary-color-primary-alpha-6: 209 99% 45% / 0.28;
+  /* ✦ Theme/Primary Color/Primary Alpha/6/Harness Theme/Light */
+  --figma___primary-color-primary-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/7/Harness Theme/Light */
+  --figma___primary-color-primary-alpha-8: 208 100% 46% / 0.97;
+  /* ✦ Theme/Primary Color/Primary Alpha/8/Harness Theme/Light */
+  --figma___primary-color-primary-alpha-9: 211 100% 39% / 0.96;
+  /* ✦ Theme/Primary Color/Primary Alpha/9/Harness Theme/Light */
+  --figma___primary-color-primary-alpha-10: 216 100% 17% / 0.93;
+  /* ✦ Theme/Primary Color/Primary Alpha/10/Harness Theme/Light */
+  --figma___radio-button-background: 0 0% 100% / 0.8;
+  /* ✦ Theme/Radio button/Background/Harness Theme/Light */
+  --figma___radio-button-checked-active-active-border: 214 73% 51% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active Border/Harness Theme/Light */
+  --figma___radio-button-checked-active-active-background: 214 73% 51% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active background/Harness Theme/Light */
+  --figma___radio-button-checked-active-hover-background: 208 93% 47% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover background/Harness Theme/Light */
+  --figma___radio-button-checked-active-hover-border: 208 93% 47% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover border/Harness Theme/Light */
+  --figma___radio-button-checked-active-default-background: 214 73% 51% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default background/Harness Theme/Light */
+  --figma___radio-button-checked-active-default-border: 214 73% 51% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default border/Harness Theme/Light */
+  --figma___radio-button-checked-disabled-dot: 0 0% 0% / 0.27;
+  /* ✦ Theme/Radio button/Checked/Disabled/Dot/Harness Theme/Light */
+  --figma___radio-button-checked-disabled-background: 0 0% 0% / 0.05;
+  /* ✦ Theme/Radio button/Checked/Disabled/background/Harness Theme/Light */
+  --figma___radio-button-checked-disabled-border: 0 0% 0% / 0.13;
+  /* ✦ Theme/Radio button/Checked/Disabled/border/Harness Theme/Light */
+  --figma___radio-button-paper: 0 0% 100% / 1;
+  /* ✦ Theme/Radio button/Paper/Harness Theme/Light */
+  --figma___radio-button-unchecked-active-active-border: 0 0% 0% / 0.45;
+  /* ✦ Theme/Radio button/Unchecked/Active/Active border/Harness Theme/Light */
+  --figma___radio-button-unchecked-active-hover-border: 0 0% 0% / 0.27;
+  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/Harness Theme/Light */
+  --figma___radio-button-unchecked-active-default-background: 0 0% 0% / 0.05;
+  /* ✦ Theme/Radio button/Unchecked/Active/default background/Harness Theme/Light */
+  --figma___radio-button-unchecked-active-default-border: 0 0% 0% / 0.17;
+  /* ✦ Theme/Radio button/Unchecked/Active/default border/Harness Theme/Light */
+  --figma___radio-button-unchecked-disabled-background: 0 0% 0% / 0.05;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/background/Harness Theme/Light */
+  --figma___radio-button-unchecked-disabled-border: 0 0% 0% / 0.13;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/border/Harness Theme/Light */
+  --figma___radio-button-border: 0 0% 0% / 0.05;
+  /* ✦ Theme/Radio button/border/Harness Theme/Light */
+  --figma___secondary-crimson-crimson-1: 340 100% 99% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 1/Harness Theme/Light */
+  --figma___secondary-crimson-crimson-10: 332 63% 24% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 10/Harness Theme/Light */
+  --figma___secondary-crimson-crimson-2: 330 100% 98% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 2/Harness Theme/Light */
+  --figma___secondary-crimson-crimson-3: 332 88% 97% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 3/Harness Theme/Light */
+  --figma___secondary-crimson-crimson-4: 331 79% 94% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 4/Harness Theme/Light */
+  --figma___secondary-crimson-crimson-5: 333 73% 91% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 5/Harness Theme/Light */
+  --figma___secondary-crimson-crimson-6: 333 68% 87% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 6/Harness Theme/Light */
+  --figma___secondary-crimson-crimson-7: 336 80% 58% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 7/Harness Theme/Light */
+  --figma___secondary-crimson-crimson-8: 336 71% 53% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 8/Harness Theme/Light */
+  --figma___secondary-crimson-crimson-9: 336 75% 45% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 9/Harness Theme/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-1: 340 100% 51% / 0.01;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Theme/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-10: 336 100% 38% / 0.89;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Theme/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-11: 332 100% 16% / 0.91;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Theme/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-2: 330 100% 51% / 0.03;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Theme/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-3: 332 100% 51% / 0.03;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Theme/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-4: 331 100% 44% / 0.1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Theme/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-5: 333 100% 42% / 0.15;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Theme/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-6: 333 99% 41% / 0.22;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Theme/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-8: 336 100% 44% / 0.76;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Theme/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-9: 336 100% 42% / 0.81;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Theme/Light */
+  --figma___secondary-lime-1: 80 43% 99% / 1;
+  /* ✦ Theme/Secondary/Lime/1/Harness Theme/Light */
+  --figma___secondary-lime-2: 85 67% 96% / 1;
+  /* ✦ Theme/Secondary/Lime/2/Harness Theme/Light */
+  --figma___secondary-lime-3: 84 76% 92% / 1;
+  /* ✦ Theme/Secondary/Lime/3/Harness Theme/Light */
+  --figma___secondary-lime-4: 83 71% 86% / 1;
+  /* ✦ Theme/Secondary/Lime/4/Harness Theme/Light */
+  --figma___secondary-lime-5: 83 63% 81% / 1;
+  /* ✦ Theme/Secondary/Lime/5/Harness Theme/Light */
+  --figma___secondary-lime-6: 81 51% 74% / 1;
+  /* ✦ Theme/Secondary/Lime/6/Harness Theme/Light */
+  --figma___secondary-lime-7: 81 80% 66% / 1;
+  /* ✦ Theme/Secondary/Lime/7/Harness Theme/Light */
+  --figma___secondary-lime-8: 81 75% 60% / 1;
+  /* ✦ Theme/Secondary/Lime/8/Harness Theme/Light */
+  --figma___secondary-lime-9: 75 41% 29% / 1;
+  /* ✦ Theme/Secondary/Lime/9/Harness Theme/Light */
+  --figma___secondary-lime-10: 75 39% 18% / 1;
+  /* ✦ Theme/Secondary/Lime/10/Harness Theme/Light */
+  --figma___secondary-lime-alpha-1: 80 94% 31% / 0.02;
+  /* ✦ Theme/Secondary/Lime Alpha/1/Harness Theme/Light */
+  --figma___secondary-lime-alpha-2: 85 99% 40% / 0.06;
+  /* ✦ Theme/Secondary/Lime Alpha/2/Harness Theme/Light */
+  --figma___secondary-lime-alpha-3: 84 99% 44% / 0.15;
+  /* ✦ Theme/Secondary/Lime Alpha/3/Harness Theme/Light */
+  --figma___secondary-lime-alpha-4: 83 99% 42% / 0.23;
+  /* ✦ Theme/Secondary/Lime Alpha/4/Harness Theme/Light */
+  --figma___secondary-lime-alpha-5: 83 100% 39% / 0.31;
+  /* ✦ Theme/Secondary/Lime Alpha/5/Harness Theme/Light */
+  --figma___secondary-lime-alpha-6: 81 100% 34% / 0.4;
+  /* ✦ Theme/Secondary/Lime Alpha/6/Harness Theme/Light */
+  --figma___secondary-lime-alpha-7: 81 100% 45% / 0.61;
+  /* ✦ Theme/Secondary/Lime Alpha/7/Harness Theme/Light */
+  --figma___secondary-lime-alpha-8: 81 100% 43% / 0.7;
+  /* ✦ Theme/Secondary/Lime Alpha/8/Harness Theme/Light */
+  --figma___secondary-lime-alpha-9: 75 100% 14% / 0.83;
+  /* ✦ Theme/Secondary/Lime Alpha/9/Harness Theme/Light */
+  --figma___secondary-lime-alpha-10: 76 100% 8% / 0.89;
+  /* ✦ Theme/Secondary/Lime Alpha/10/Harness Theme/Light */
+  --figma___secondary-purple-1: 300 50% 99% / 1;
+  /* ✦ Theme/Secondary/Purple/1/Harness Theme/Light */
+  --figma___secondary-purple-2: 276 100% 99% / 1;
+  /* ✦ Theme/Secondary/Purple/2/Harness Theme/Light */
+  --figma___secondary-purple-3: 277 87% 97% / 1;
+  /* ✦ Theme/Secondary/Purple/3/Harness Theme/Light */
+  --figma___secondary-purple-4: 274 78% 95% / 1;
+  /* ✦ Theme/Secondary/Purple/4/Harness Theme/Light */
+  --figma___secondary-purple-5: 276 71% 92% / 1;
+  /* ✦ Theme/Secondary/Purple/5/Harness Theme/Light */
+  --figma___secondary-purple-6: 274 65% 88% / 1;
+  /* ✦ Theme/Secondary/Purple/6/Harness Theme/Light */
+  --figma___secondary-purple-7: 272 51% 54% / 1;
+  /* ✦ Theme/Secondary/Purple/7/Harness Theme/Light */
+  --figma___secondary-purple-8: 272 47% 50% / 1;
+  /* ✦ Theme/Secondary/Purple/8/Harness Theme/Light */
+  --figma___secondary-purple-9: 272 50% 46% / 1;
+  /* ✦ Theme/Secondary/Purple/9/Harness Theme/Light */
+  --figma___secondary-purple-10: 270 50% 25% / 1;
+  /* ✦ Theme/Secondary/Purple/10/Harness Theme/Light */
+  --figma___secondary-purple-alpha-1: 300 94% 35% / 0.01;
+  /* ✦ Theme/Secondary/Purple Alpha/1/Harness Theme/Light */
+  --figma___secondary-purple-alpha-2: 276 100% 51% / 0.02;
+  /* ✦ Theme/Secondary/Purple Alpha/2/Harness Theme/Light */
+  --figma___secondary-purple-alpha-3: 277 100% 46% / 0.05;
+  /* ✦ Theme/Secondary/Purple Alpha/3/Harness Theme/Light */
+  --figma___secondary-purple-alpha-4: 274 98% 44% / 0.09;
+  /* ✦ Theme/Secondary/Purple Alpha/4/Harness Theme/Light */
+  --figma___secondary-purple-alpha-5: 276 99% 42% / 0.14;
+  /* ✦ Theme/Secondary/Purple Alpha/5/Harness Theme/Light */
+  --figma___secondary-purple-alpha-6: 275 100% 39% / 0.2;
+  /* ✦ Theme/Secondary/Purple Alpha/6/Harness Theme/Light */
+  --figma___secondary-purple-alpha-7: 272 100% 34% / 0.69;
+  /* ✦ Theme/Secondary/Purple Alpha/7/Harness Theme/Light */
+  --figma___secondary-purple-alpha-8: 272 100% 32% / 0.73;
+  /* ✦ Theme/Secondary/Purple Alpha/8/Harness Theme/Light */
+  --figma___secondary-purple-alpha-9: 273 100% 30% / 0.77;
+  /* ✦ Theme/Secondary/Purple Alpha/9/Harness Theme/Light */
+  --figma___secondary-purple-alpha-10: 270 100% 14% / 0.88;
+  /* ✦ Theme/Secondary/Purple Alpha/10/Harness Theme/Light */
+  --figma___secondary-teal-1: 165 67% 99% / 1;
+  /* ✦ Theme/Secondary/Teal/1/Harness Theme/Light */
+  --figma___secondary-teal-2: 169 65% 97% / 1;
+  /* ✦ Theme/Secondary/Teal/2/Harness Theme/Light */
+  --figma___secondary-teal-3: 167 60% 94% / 1;
+  /* ✦ Theme/Secondary/Teal/3/Harness Theme/Light */
+  --figma___secondary-teal-4: 168 52% 90% / 1;
+  /* ✦ Theme/Secondary/Teal/4/Harness Theme/Light */
+  --figma___secondary-teal-5: 170 47% 85% / 1;
+  /* ✦ Theme/Secondary/Teal/5/Harness Theme/Light */
+  --figma___secondary-teal-6: 170 43% 78% / 1;
+  /* ✦ Theme/Secondary/Teal/6/Harness Theme/Light */
+  --figma___secondary-teal-7: 173 80% 36% / 1;
+  /* ✦ Theme/Secondary/Teal/7/Harness Theme/Light */
+  --figma___secondary-teal-8: 173 83% 33% / 1;
+  /* ✦ Theme/Secondary/Teal/8/Harness Theme/Light */
+  --figma___secondary-teal-9: 174 91% 25% / 1;
+  /* ✦ Theme/Secondary/Teal/9/Harness Theme/Light */
+  --figma___secondary-teal-10: 174 65% 15% / 1;
+  /* ✦ Theme/Secondary/Teal/10/Harness Theme/Light */
+  --figma___secondary-teal-alpha-1: 165 95% 41% / 0.02;
+  /* ✦ Theme/Secondary/Teal Alpha/1/Harness Theme/Light */
+  --figma___secondary-teal-alpha-2: 169 99% 39% / 0.05;
+  /* ✦ Theme/Secondary/Teal Alpha/2/Harness Theme/Light */
+  --figma___secondary-teal-alpha-3: 167 98% 38% / 0.09;
+  /* ✦ Theme/Secondary/Teal Alpha/3/Harness Theme/Light */
+  --figma___secondary-teal-alpha-4: 168 98% 35% / 0.15;
+  /* ✦ Theme/Secondary/Teal Alpha/4/Harness Theme/Light */
+  --figma___secondary-teal-alpha-5: 170 100% 32% / 0.22;
+  /* ✦ Theme/Secondary/Teal Alpha/5/Harness Theme/Light */
+  --figma___secondary-teal-alpha-6: 170 100% 30% / 0.31;
+  /* ✦ Theme/Secondary/Teal Alpha/6/Harness Theme/Light */
+  --figma___secondary-teal-alpha-7: 173 100% 31% / 0.93;
+  /* ✦ Theme/Secondary/Teal Alpha/7/Harness Theme/Light */
+  --figma___secondary-teal-alpha-8: 173 100% 29% / 0.95;
+  /* ✦ Theme/Secondary/Teal Alpha/8/Harness Theme/Light */
+  --figma___secondary-teal-alpha-9: 174 100% 23% / 0.98;
+  /* ✦ Theme/Secondary/Teal Alpha/9/Harness Theme/Light */
+  --figma___secondary-teal-alpha-10: 174 100% 10% / 0.95;
+  /* ✦ Theme/Secondary/Teal Alpha/10/Harness Theme/Light */
+  --figma___shadow-shadow-button-1: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow - button/1/Harness Theme/Light */
+  --figma___shadow-shadow-button-2: 0 0% 100% / 0.31;
+  /* ✦ Theme/Shadow/Shadow - button/2/Harness Theme/Light */
+  --figma___shadow-shadow-button-3: 0 0% 100% / 0.46;
+  /* ✦ Theme/Shadow/Shadow - button/3/Harness Theme/Light */
+  --figma___shadow-shadow-button-4: 0 0% 100% / 0;
+  /* ✦ Theme/Shadow/Shadow - button/4/Harness Theme/Light */
+  --figma___shadow-shadow-1-1: 0 0% 0% / 0.13;
+  /* ✦ Theme/Shadow/Shadow 1/1/Harness Theme/Light */
+  --figma___shadow-shadow-2-1: 0 0% 0% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 2/1/Harness Theme/Light */
+  --figma___shadow-shadow-2-2: 240 100% 12% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 2/2/Harness Theme/Light */
+  --figma___shadow-shadow-2-3: 240 100% 12% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 2/3/Harness Theme/Light */
+  --figma___shadow-shadow-3-1: 0 0% 0% / 0.08;
+  /* ✦ Theme/Shadow/Shadow 3/1/Harness Theme/Light */
+  --figma___shadow-shadow-3-2: 0 0% 0% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 3/2/Harness Theme/Light */
+  --figma___shadow-shadow-3-3: 240 100% 12% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 3/3/Harness Theme/Light */
+  --figma___shadow-shadow-4-1: 0 0% 0% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 4/1/Harness Theme/Light */
+  --figma___shadow-shadow-4-2: 240 100% 12% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 4/2/Harness Theme/Light */
+  --figma___shadow-shadow-5-1: 0 0% 0% / 0.13;
+  /* ✦ Theme/Shadow/Shadow 5/1/Harness Theme/Light */
+  --figma___shadow-shadow-5-2: 240 96% 9% / 0.05;
+  /* ✦ Theme/Shadow/Shadow 5/2/Harness Theme/Light */
+  --figma___shadow-shadow-6-1: 233 96% 9% / 0.17;
+  /* ✦ Theme/Shadow/Shadow 6/1/Harness Theme/Light */
+  --figma___shadow-shadow-6-2: 233 96% 9% / 0.17;
+  /* ✦ Theme/Shadow/Shadow 6/2/Harness Theme/Light */
+  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
+  /* ✦ Theme/Shadow/Shadow-button-active/1/Harness Theme/Light */
+  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
+  /* ✦ Theme/Shadow/Shadow-button-active/2/Harness Theme/Light */
+  --figma___shadow-shadow-button-active-3: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow-button-active/3/Harness Theme/Light */
+  --figma___shadow-shadow-button-active-4: 0 0% 0% / 0.08;
+  /* ✦ Theme/Shadow/Shadow-button-active/4/Harness Theme/Light */
+  --figma___side-nav-container-nav-background: 0 0% 93% / 1;
+  /* ✦ Theme/Side nav/Container/Nav-background/Harness Theme/Light */
+  --figma___side-nav-container-nav-border: 0 0% 100% / 0;
+  /* ✦ Theme/Side nav/Container/Nav-border/Harness Theme/Light */
+  --figma___side-nav-module-logo-text: 0 0% 13% / 1;
+  /* ✦ Theme/Side nav/Module Logo Text/Harness Theme/Light */
+  --figma___side-nav-nav-item-default-icon: 0 0% 0% / 0.5;
+  /* ✦ Theme/Side nav/Nav-item/Default/Icon/Harness Theme/Light */
+  --figma___side-nav-nav-item-default-text: 0 0% 39% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Default/Text/Harness Theme/Light */
+  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
+  /* ✦ Theme/Side nav/Nav-item/Default/default/Harness Theme/Light */
+  --figma___side-nav-nav-item-hover-background: 0 0% 95% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Background/Harness Theme/Light */
+  --figma___side-nav-nav-item-hover-icon: 0 0% 39% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/Harness Theme/Light */
+  --figma___side-nav-nav-item-hover-text: 0 0% 39% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Text/Harness Theme/Light */
+  --figma___side-nav-nav-item-selected-background: 0 0% 95% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Background/Harness Theme/Light */
+  --figma___side-nav-nav-item-selected-icon: 0 0% 13% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/Harness Theme/Light */
+  --figma___side-nav-nav-item-selected-text: 0 0% 13% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Text/Harness Theme/Light */
+  --figma___side-nav-profile-role: 0 0% 0% / 0.5;
+  /* ✦ Theme/Side nav/Profile/Role/Harness Theme/Light */
+  --figma___side-nav-profile-text: 0 0% 13% / 1;
+  /* ✦ Theme/Side nav/Profile/Text/Harness Theme/Light */
+  --figma___side-nav-scope-selector-default-border: 0 0% 0% / 0.08;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Border/Harness Theme/Light */
+  --figma___side-nav-scope-selector-default-main-text-icon: 0 0% 13% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/Harness Theme/Light */
+  --figma___side-nav-scope-selector-default-scope-name: 0 0% 0% / 0.5;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/Harness Theme/Light */
+  --figma___side-nav-scope-selector-default-default: 0 0% 100% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/default/Harness Theme/Light */
+  --figma___side-nav-scope-selector-hover-border: 211 100% 39% / 0.96;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/Harness Theme/Light */
+  --figma___side-nav-scope-selector-hover-main-text-icon: 0 0% 13% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/Harness Theme/Light */
+  --figma___side-nav-scope-selector-hover-scope-name: 0 0% 0% / 0.5;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/Harness Theme/Light */
+  --figma___side-nav-scope-selector-hover-default: 0 0% 100% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/default/Harness Theme/Light */
+  --figma___side-nav-scope-selector-selected-border: 211 100% 39% / 0.96;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/Harness Theme/Light */
+  --figma___side-nav-scope-selector-selected-main-text-icon: 0 0% 13% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/Harness Theme/Light */
+  --figma___side-nav-scope-selector-selected-scope-name: 0 0% 0% / 0.5;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/Harness Theme/Light */
+  --figma___side-nav-scope-selector-selected-background: 0 0% 100% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/background/Harness Theme/Light */
+  --figma___side-nav-separator: 0 0% 0% / 0.08;
+  /* ✦ Theme/Side nav/Separator/Harness Theme/Light */
+  --figma___status-colors-error-1: 0 100% 99% / 1;
+  /* ✦ Theme/Status colors/Error/1/Harness Theme/Light */
+  --figma___status-colors-error-2: 0 100% 98% / 1;
+  /* ✦ Theme/Status colors/Error/2/Harness Theme/Light */
+  --figma___status-colors-error-3: 0 100% 97% / 1;
+  /* ✦ Theme/Status colors/Error/3/Harness Theme/Light */
+  --figma___status-colors-error-4: 0 100% 95% / 1;
+  /* ✦ Theme/Status colors/Error/4/Harness Theme/Light */
+  --figma___status-colors-error-5: 0 90% 92% / 1;
+  /* ✦ Theme/Status colors/Error/5/Harness Theme/Light */
+  --figma___status-colors-error-6: 0 81% 88% / 1;
+  /* ✦ Theme/Status colors/Error/6/Harness Theme/Light */
+  --figma___status-colors-error-7: 358 75% 59% / 1;
+  /* ✦ Theme/Status colors/Error/7/Harness Theme/Light */
+  --figma___status-colors-error-8: 358 67% 55% / 1;
+  /* ✦ Theme/Status colors/Error/8/Harness Theme/Light */
+  --figma___status-colors-error-9: 358 65% 47% / 1;
+  /* ✦ Theme/Status colors/Error/9/Harness Theme/Light */
+  --figma___status-colors-error-10: 351 63% 24% / 1;
+  /* ✦ Theme/Status colors/Error/10/Harness Theme/Light */
+  --figma___status-colors-error-alpha-1: 0 100% 51% / 0.01;
+  /* ✦ Theme/Status colors/Error Alpha/1/Harness Theme/Light */
+  --figma___status-colors-error-alpha-2: 0 100% 51% / 0.03;
+  /* ✦ Theme/Status colors/Error Alpha/2/Harness Theme/Light */
+  --figma___status-colors-error-alpha-3: 0 100% 50% / 0.06;
+  /* ✦ Theme/Status colors/Error Alpha/3/Harness Theme/Light */
+  --figma___status-colors-error-alpha-4: 0 100% 50% / 0.1;
+  /* ✦ Theme/Status colors/Error Alpha/4/Harness Theme/Light */
+  --figma___status-colors-error-alpha-5: 0 100% 47% / 0.15;
+  /* ✦ Theme/Status colors/Error Alpha/5/Harness Theme/Light */
+  --figma___status-colors-error-alpha-6: 0 99% 45% / 0.22;
+  /* ✦ Theme/Status colors/Error Alpha/6/Harness Theme/Light */
+  --figma___status-colors-error-alpha-7: 358 100% 43% / 0.72;
+  /* ✦ Theme/Status colors/Error Alpha/7/Harness Theme/Light */
+  --figma___status-colors-error-alpha-8: 358 100% 40% / 0.76;
+  /* ✦ Theme/Status colors/Error Alpha/8/Harness Theme/Light */
+  --figma___status-colors-error-alpha-9: 358 100% 37% / 0.84;
+  /* ✦ Theme/Status colors/Error Alpha/9/Harness Theme/Light */
+  --figma___status-colors-error-alpha-10: 351 100% 17% / 0.91;
+  /* ✦ Theme/Status colors/Error Alpha/10/Harness Theme/Light */
+  --figma___status-colors-info-1: 210 100% 99% / 1;
+  /* ✦ Theme/Status colors/Info/1/Harness Theme/Light */
+  --figma___status-colors-info-2: 210 100% 98% / 1;
+  /* ✦ Theme/Status colors/Info/2/Harness Theme/Light */
+  --figma___status-colors-info-3: 210 100% 96% / 1;
+  /* ✦ Theme/Status colors/Info/3/Harness Theme/Light */
+  --figma___status-colors-info-4: 210 100% 94% / 1;
+  /* ✦ Theme/Status colors/Info/4/Harness Theme/Light */
+  --figma___status-colors-info-5: 209 96% 90% / 1;
+  /* ✦ Theme/Status colors/Info/5/Harness Theme/Light */
+  --figma___status-colors-info-6: 209 82% 85% / 1;
+  /* ✦ Theme/Status colors/Info/6/Harness Theme/Light */
+  --figma___status-colors-info-7: 214 73% 51% / 1;
+  /* ✦ Theme/Status colors/Info/7/Harness Theme/Light */
+  --figma___status-colors-info-8: 208 93% 47% / 1;
+  /* ✦ Theme/Status colors/Info/8/Harness Theme/Light */
+  --figma___status-colors-info-9: 211 90% 42% / 1;
+  /* ✦ Theme/Status colors/Info/9/Harness Theme/Light */
+  --figma___status-colors-info-10: 216 71% 23% / 1;
+  /* ✦ Theme/Status colors/Info/10/Harness Theme/Light */
+  --figma___status-colors-info-alpha-1: 210 100% 51% / 0.02;
+  /* ✦ Theme/Status colors/Info Alpha/1/Harness Theme/Light */
+  --figma___status-colors-info-alpha-2: 210 100% 51% / 0.04;
+  /* ✦ Theme/Status colors/Info Alpha/2/Harness Theme/Light */
+  --figma___status-colors-info-alpha-3: 210 100% 50% / 0.07;
+  /* ✦ Theme/Status colors/Info Alpha/3/Harness Theme/Light */
+  --figma___status-colors-info-alpha-4: 210 99% 49% / 0.19;
+  /* ✦ Theme/Status colors/Info Alpha/4/Harness Theme/Light */
+  --figma___status-colors-info-alpha-5: 209 99% 49% / 0.19;
+  /* ✦ Theme/Status colors/Info Alpha/5/Harness Theme/Light */
+  --figma___status-colors-info-alpha-6: 209 99% 45% / 0.28;
+  /* ✦ Theme/Status colors/Info Alpha/6/Harness Theme/Light */
+  --figma___status-colors-info-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/7/Harness Theme/Light */
+  --figma___status-colors-info-alpha-8: 208 100% 46% / 0.97;
+  /* ✦ Theme/Status colors/Info Alpha/8/Harness Theme/Light */
+  --figma___status-colors-info-alpha-9: 211 100% 39% / 0.96;
+  /* ✦ Theme/Status colors/Info Alpha/9/Harness Theme/Light */
+  --figma___status-colors-info-alpha-10: 216 100% 17% / 0.93;
+  /* ✦ Theme/Status colors/Info Alpha/10/Harness Theme/Light */
+  --figma___status-colors-success-1: 140 60% 99% / 1;
+  /* ✦ Theme/Status colors/Success/1/Harness Theme/Light */
+  --figma___status-colors-success-2: 138 63% 97% / 1;
+  /* ✦ Theme/Status colors/Success/2/Harness Theme/Light */
+  --figma___status-colors-success-3: 139 57% 95% / 1;
+  /* ✦ Theme/Status colors/Success/3/Harness Theme/Light */
+  --figma___status-colors-success-4: 139 48% 91% / 1;
+  /* ✦ Theme/Status colors/Success/4/Harness Theme/Light */
+  --figma___status-colors-success-5: 141 44% 86% / 1;
+  /* ✦ Theme/Status colors/Success/5/Harness Theme/Light */
+  --figma___status-colors-success-6: 142 40% 79% / 1;
+  /* ✦ Theme/Status colors/Success/6/Harness Theme/Light */
+  --figma___status-colors-success-7: 142 72% 29% / 1;
+  /* ✦ Theme/Status colors/Success/7/Harness Theme/Light */
+  --figma___status-colors-success-8: 152 57% 38% / 1;
+  /* ✦ Theme/Status colors/Success/8/Harness Theme/Light */
+  --figma___status-colors-success-9: 153 67% 28% / 1;
+  /* ✦ Theme/Status colors/Success/9/Harness Theme/Light */
+  --figma___status-colors-success-10: 155 40% 16% / 1;
+  /* ✦ Theme/Status colors/Success/10/Harness Theme/Light */
+  --figma___status-colors-success-alpha-1: 140 95% 39% / 0.02;
+  /* ✦ Theme/Status colors/Success Alpha/1/Harness Theme/Light */
+  --figma___status-colors-success-alpha-2: 139 98% 37% / 0.09;
+  /* ✦ Theme/Status colors/Success Alpha/2/Harness Theme/Light */
+  --figma___status-colors-success-alpha-3: 139 98% 37% / 0.09;
+  /* ✦ Theme/Status colors/Success Alpha/3/Harness Theme/Light */
+  --figma___status-colors-success-alpha-4: 139 99% 33% / 0.13;
+  /* ✦ Theme/Status colors/Success Alpha/4/Harness Theme/Light */
+  --figma___status-colors-success-alpha-5: 141 100% 30% / 0.2;
+  /* ✦ Theme/Status colors/Success Alpha/5/Harness Theme/Light */
+  --figma___status-colors-success-alpha-6: 142 99% 29% / 0.29;
+  /* ✦ Theme/Status colors/Success Alpha/6/Harness Theme/Light */
+  --figma___status-colors-success-alpha-7: 151 100% 28% / 0.81;
+  /* ✦ Theme/Status colors/Success Alpha/7/Harness Theme/Light */
+  --figma___status-colors-success-alpha-8: 153 100% 26% / 0.84;
+  /* ✦ Theme/Status colors/Success Alpha/8/Harness Theme/Light */
+  --figma___status-colors-success-alpha-9: 153 100% 21% / 0.91;
+  /* ✦ Theme/Status colors/Success Alpha/9/Harness Theme/Light */
+  --figma___status-colors-success-alpha-10: 155 100% 7% / 0.9;
+  /* ✦ Theme/Status colors/Success Alpha/10/Harness Theme/Light */
+  --figma___status-colors-warning-1: 40 60% 99% / 1;
+  /* ✦ Theme/Status colors/Warning/1/Harness Theme/Light */
+  --figma___status-colors-warning-2: 40 100% 96% / 1;
+  /* ✦ Theme/Status colors/Warning/2/Harness Theme/Light */
+  --figma___status-colors-warning-3: 45 100% 91% / 1;
+  /* ✦ Theme/Status colors/Warning/3/Harness Theme/Light */
+  --figma___status-colors-warning-4: 44 100% 86% / 1;
+  /* ✦ Theme/Status colors/Warning/4/Harness Theme/Light */
+  --figma___status-colors-warning-5: 40 100% 82% / 1;
+  /* ✦ Theme/Status colors/Warning/5/Harness Theme/Light */
+  --figma___status-colors-warning-6: 39 84% 75% / 1;
+  /* ✦ Theme/Status colors/Warning/6/Harness Theme/Light */
+  --figma___status-colors-warning-7: 42 100% 62% / 1;
+  /* ✦ Theme/Status colors/Warning/7/Harness Theme/Light */
+  --figma___status-colors-warning-8: 42 100% 55% / 1;
+  /* ✦ Theme/Status colors/Warning/8/Harness Theme/Light */
+  --figma___status-colors-warning-9: 25 50% 38% / 1;
+  /* ✦ Theme/Status colors/Warning/9/Harness Theme/Light */
+  --figma___status-colors-warning-10: 24 40% 22% / 1;
+  /* ✦ Theme/Status colors/Warning/10/Harness Theme/Light */
+  --figma___status-colors-warning-alpha-1: 40 95% 39% / 0.02;
+  /* ✦ Theme/Status colors/Warning Alpha/1/Harness Theme/Light */
+  --figma___status-colors-warning-alpha-2: 40 100% 50% / 0.07;
+  /* ✦ Theme/Status colors/Warning Alpha/2/Harness Theme/Light */
+  --figma___status-colors-warning-alpha-3: 45 100% 50% / 0.19;
+  /* ✦ Theme/Status colors/Warning Alpha/3/Harness Theme/Light */
+  --figma___status-colors-warning-alpha-4: 44 100% 50% / 0.28;
+  /* ✦ Theme/Status colors/Warning Alpha/4/Harness Theme/Light */
+  --figma___status-colors-warning-alpha-5: 40 99% 50% / 0.37;
+  /* ✦ Theme/Status colors/Warning Alpha/5/Harness Theme/Light */
+  --figma___status-colors-warning-alpha-6: 39 100% 46% / 0.45;
+  /* ✦ Theme/Status colors/Warning Alpha/6/Harness Theme/Light */
+  --figma___status-colors-warning-alpha-7: 42 100% 50% / 0.76;
+  /* ✦ Theme/Status colors/Warning Alpha/7/Harness Theme/Light */
+  --figma___status-colors-warning-alpha-8: 42 100% 50% / 0.9;
+  /* ✦ Theme/Status colors/Warning Alpha/8/Harness Theme/Light */
+  --figma___status-colors-warning-alpha-9: 25 100% 24% / 0.81;
+  /* ✦ Theme/Status colors/Warning Alpha/9/Harness Theme/Light */
+  --figma___status-colors-warning-alpha-10: 24 100% 10% / 0.87;
+  /* ✦ Theme/Status colors/Warning Alpha/10/Harness Theme/Light */
+  --figma___switch-background: 0 0% 100% / 0.8;
+  /* ✦ Theme/Switch/Background/Harness Theme/Light */
+  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/Harness Theme/Light */
+  --figma___switch-checked-active-background: 214 73% 51% / 1;
+  /* ✦ Theme/Switch/Checked/Active/background/Harness Theme/Light */
+  --figma___switch-checked-active-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Checked/Active/border/Harness Theme/Light */
+  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/Harness Theme/Light */
+  --figma___switch-checked-default-default-background: 214 73% 51% / 1;
+  /* ✦ Theme/Switch/Checked/Default/default background/Harness Theme/Light */
+  --figma___switch-checked-default-default-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Checked/Default/default border/Harness Theme/Light */
+  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/Harness Theme/Light */
+  --figma___switch-checked-disabled-background: 206 100% 50% / 1;
+  /* ✦ Theme/Switch/Checked/Disabled/background/Harness Theme/Light */
+  --figma___switch-checked-disabled-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/border/Harness Theme/Light */
+  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/Harness Theme/Light */
+  --figma___switch-checked-hover-background: 208 93% 47% / 1;
+  /* ✦ Theme/Switch/Checked/Hover/background/Harness Theme/Light */
+  --figma___switch-checked-hover-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/border/Harness Theme/Light */
+  --figma___switch-paper: 0 0% 100% / 1;
+  /* ✦ Theme/Switch/Paper/Harness Theme/Light */
+  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/Harness Theme/Light */
+  --figma___switch-unchecked-active-background: 0 0% 0% / 0.11;
+  /* ✦ Theme/Switch/Unchecked/Active/background/Harness Theme/Light */
+  --figma___switch-unchecked-active-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Unchecked/Active/border/Harness Theme/Light */
+  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/Harness Theme/Light */
+  --figma___switch-unchecked-default-default-background: 240 100% 12% / 0.05;
+  /* ✦ Theme/Switch/Unchecked/Default/default background/Harness Theme/Light */
+  --figma___switch-unchecked-default-default-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Unchecked/Default/default border/Harness Theme/Light */
+  --figma___switch-unchecked-disabled-thumb-thumb-background: 0 0% 0% / 0.05;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/Harness Theme/Light */
+  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/Harness Theme/Light */
+  --figma___switch-unchecked-disabled-background: 0 0% 95% / 1;
+  /* ✦ Theme/Switch/Unchecked/Disabled/background/Harness Theme/Light */
+  --figma___switch-unchecked-disabled-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Unchecked/Disabled/border/Harness Theme/Light */
+  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/Harness Theme/Light */
+  --figma___switch-unchecked-hover-background: 240 93% 11% / 0.08;
+  /* ✦ Theme/Switch/Unchecked/Hover/background/Harness Theme/Light */
+  --figma___switch-unchecked-hover-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Unchecked/Hover/border/Harness Theme/Light */
+  --figma___switch-border: 0 0% 0% / 0.05;
+  /* ✦ Theme/Switch/border/Harness Theme/Light */
+  --figma___tabs-number-active-background: 0 0% 13% / 1;
+  /* ✦ Theme/Tabs/Number/Active/Background/Harness Theme/Light */
+  --figma___tabs-number-active-text: 0 0% 13% / 1;
+  /* ✦ Theme/Tabs/Number/Active/text/Harness Theme/Light */
+  --figma___tabs-number-default-hover-background: 0 0% 89% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/Background/Harness Theme/Light */
+  --figma___tabs-number-default-hover-text: 0 0% 13% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/text/Harness Theme/Light */
+  --figma___tabs-pills-active-active: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Active/Harness Theme/Light */
+  --figma___tabs-pills-active-text: 0 0% 13% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Text/Harness Theme/Light */
+  --figma___tabs-pills-active-border-grad-1: 0 0% 0% / 0.08;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 1/Harness Theme/Light */
+  --figma___tabs-pills-active-border-grad-2: 0 0% 0% / 0.08;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 2/Harness Theme/Light */
+  --figma___tabs-pills-backgrounds: 210 100% 51% / 0.02;
+  /* ✦ Theme/Tabs/Pills/Backgrounds/Harness Theme/Light */
+  --figma___tabs-pills-default-background: 230 100% 5% / 0;
+  /* ✦ Theme/Tabs/Pills/Default/Background/Harness Theme/Light */
+  --figma___tabs-pills-default-text: 0 0% 0% / 0.5;
+  /* ✦ Theme/Tabs/Pills/Default/Text/Harness Theme/Light */
+  --figma___tabs-pills-hover-background: 0 0% 92% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Background/Harness Theme/Light */
+  --figma___tabs-pills-hover-text: 0 0% 39% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Text/Harness Theme/Light */
+  --figma___tabs-pills-number-active-background: 0 0% 13% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/Background/Harness Theme/Light */
+  --figma___tabs-pills-number-active-text: 0 0% 99% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/text/Harness Theme/Light */
+  --figma___tabs-pills-border-grad-1: 0 0% 0% / 0.08;
+  /* ✦ Theme/Tabs/Pills/border grad 1/Harness Theme/Light */
+  --figma___tabs-pills-border-grad-2: 0 0% 0% / 0.08;
+  /* ✦ Theme/Tabs/Pills/border grad 2/Harness Theme/Light */
+  --figma___tabs-primary-active-text: 0 0% 13% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Text/Harness Theme/Light */
+  --figma___tabs-primary-active-underline: 206 82% 65% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Underline/Harness Theme/Light */
+  --figma___tabs-primary-border: 211 100% 39% / 0.96;
+  /* ✦ Theme/Tabs/Primary/Border/Harness Theme/Light */
+  --figma___tabs-primary-default-background: 230 100% 5% / 0;
+  /* ✦ Theme/Tabs/Primary/Default/Background/Harness Theme/Light */
+  --figma___tabs-primary-default-text: 0 0% 0% / 0.5;
+  /* ✦ Theme/Tabs/Primary/Default/Text/Harness Theme/Light */
+  --figma___tabs-primary-hover-background: 0 0% 0% / 0.08;
+  /* ✦ Theme/Tabs/Primary/Hover/Background/Harness Theme/Light */
+  --figma___tabs-primary-hover-text: 0 0% 13% / 1;
+  /* ✦ Theme/Tabs/Primary/Hover/Text/Harness Theme/Light */
+  --figma___tabs-primary-pills-pills: 214 73% 51% / 1;
+  /* ✦ Theme/Tabs/Primary/Pills/Pills/Harness Theme/Light */
+  --figma___text-disabled: 0 0% 0% / 0.45;
+  /* ✦ Theme/Text/Disabled/Harness Theme/Light */
+  --figma___text-links: 211 90% 42% / 1;
+  /* ✦ Theme/Text/Links/Harness Theme/Light */
+  --figma___text-secondary: 0 0% 39% / 1;
+  /* ✦ Theme/Text/Secondary/Harness Theme/Light */
+  --figma___text-tertiary: 0 0% 0% / 0.5;
+  /* ✦ Theme/Text/Tertiary/Harness Theme/Light */
+  --figma___text-primary: 0 0% 13% / 1;
+  /* ✦ Theme/Text/primary/Harness Theme/Light */
+  --figma___textfield-assistive-text-primary: 0 0% 0% / 0.5;
+  /* ✦ Theme/Textfield/Assistive Text/Primary/Harness Theme/Light */
+  --figma___textfield-background: 0 0% 100% / 1;
+  /* ✦ Theme/Textfield/Background/Harness Theme/Light */
+  --figma___textfield-input-field-background: 0 0% 100% / 1;
+  /* ✦ Theme/Textfield/Input Field/Background/Harness Theme/Light */
+  --figma___textfield-input-field-default: 0 0% 0% / 0.08;
+  /* ✦ Theme/Textfield/Input Field/Default/Harness Theme/Light */
+  --figma___textfield-input-field-error: 358 75% 59% / 1;
+  /* ✦ Theme/Textfield/Input Field/Error/Harness Theme/Light */
+  --figma___textfield-input-field-hover: 208 93% 47% / 1;
+  /* ✦ Theme/Textfield/Input Field/Hover/Harness Theme/Light */
+  --figma___textfield-label-info-icon: 211 100% 39% / 0.96;
+  /* ✦ Theme/Textfield/Label/Info Icon/Harness Theme/Light */
+  --figma___textfield-label-link: 211 100% 39% / 0.96;
+  /* ✦ Theme/Textfield/Label/Link/Harness Theme/Light */
+  --figma___textfield-label-main: 0 0% 39% / 1;
+  /* ✦ Theme/Textfield/Label/Main/Harness Theme/Light */
+  --figma___textfield-label-optional: 0 0% 0% / 0.5;
+  /* ✦ Theme/Textfield/Label/Optional/Harness Theme/Light */
+  --figma___textfield-pin-soft-background: 210 100% 98% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/Background/Harness Theme/Light */
+  --figma___textfield-pin-soft-border: 209 96% 90% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/border/Harness Theme/Light */
+  --figma___textfield-pin-soft-pin: 211 100% 39% / 0.96;
+  /* ✦ Theme/Textfield/Pin/Soft/pin/Harness Theme/Light */
+  --figma___textfield-pin-surface-background: 0 0% 98% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/Background/Harness Theme/Light */
+  --figma___textfield-pin-surface-border: 0 0% 89% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/border/Harness Theme/Light */
+  --figma___textfield-pin-surface-pin: 211 100% 39% / 0.96;
+  /* ✦ Theme/Textfield/Pin/Surface/pin/Harness Theme/Light */
+  --figma___tooltip-background: 240 13% 95% / 1;
+  /* ✦ Theme/Tooltip/Background/Harness Theme/Light */
+  --figma___tooltip-body-text: 0 0% 39% / 1;
+  /* ✦ Theme/Tooltip/Body Text/Harness Theme/Light */
+  --figma___tooltip-dismissable-icon: 0 0% 39% / 1;
+  /* ✦ Theme/Tooltip/Dismissable icon/Harness Theme/Light */
+  --figma___tooltip-tooltip-title: 0 0% 13% / 1;
+  /* ✦ Theme/Tooltip/Tooltip Title/Harness Theme/Light */
+  --figma___badges-solid-amber-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Amber/text/Harness Theme/Light */
+  --figma___badges-solid-blue-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Blue/text/Harness Theme/Light */
+  --figma___badges-solid-bronze-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Bronze/text/Harness Theme/Light */
+  --figma___badges-solid-brown-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Brown/text/Harness Theme/Light */
+  --figma___badges-solid-crimson-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Crimson/text/Harness Theme/Light */
+  --figma___badges-solid-cyan-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Cyan/text/Harness Theme/Light */
+  --figma___badges-solid-gold-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Gold/text/Harness Theme/Light */
+  --figma___badges-solid-grass-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Grass/text/Harness Theme/Light */
+  --figma___badges-solid-green-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Green/text/Harness Theme/Light */
+  --figma___badges-solid-indigo-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Indigo/text/Harness Theme/Light */
+  --figma___badges-solid-iris-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Iris/text/Harness Theme/Light */
+  --figma___badges-solid-jade-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Jade/text/Harness Theme/Light */
+  --figma___badges-solid-lime-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Lime/text/Harness Theme/Light */
+  --figma___badges-solid-mint-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Mint/text/Harness Theme/Light */
+  --figma___badges-solid-orange-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Orange/text/Harness Theme/Light */
+  --figma___badges-solid-pink-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Pink/text/Harness Theme/Light */
+  --figma___badges-solid-plum-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Plum/text/Harness Theme/Light */
+  --figma___badges-solid-purple-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Purple/text/Harness Theme/Light */
+  --figma___badges-solid-red-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Red/text/Harness Theme/Light */
+  --figma___badges-solid-ruby-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Ruby/text/Harness Theme/Light */
+  --figma___badges-solid-sky-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Sky/text/Harness Theme/Light */
+  --figma___badges-solid-success-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Success/text/Harness Theme/Light */
+  --figma___badges-solid-teal-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Teal/text/Harness Theme/Light */
+  --figma___badges-solid-violet-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Violet/text/Harness Theme/Light */
+  --figma___badges-solid-yellow-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Yellow/text/Harness Theme/Light */
+  --figma___badges-solid-accent-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/accent/text/Harness Theme/Light */
+  --figma___badges-solid-info-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/info/text/Harness Theme/Light */
+  --figma___badges-solid-warning-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/warning/text/Harness Theme/Light */
+  --figma___button-solid-accent-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Accent/Text-primary/Harness Theme/Light */
+  --figma___button-solid-error-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Error/Text-primary/Harness Theme/Light */
+  --figma___button-solid-neutral-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Neutral/Text-primary/Harness Theme/Light */
+  --figma___button-solid-success-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Success/Text-primary/Harness Theme/Light */
+  --figma___calendar-selected-date-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Calendar/Selected Date/Text/Harness Theme/Light */
+  --figma___checkbox-surface-checked-active-check: var(--figma___default-colors-white);
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/Harness Theme/Light */
+  --figma___default-colors-white-to-dark: var(--figma___default-colors-white);
+  /* ✦ Theme/Default colors/white-to-dark/Harness Theme/Light */
+  --figma___filter-default: var(--figma___default-colors-white);
+  /* ✦ Theme/Filter/Default/Harness Theme/Light */
+  --figma___pagination-active-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Pagination/Active/Text/Harness Theme/Light */
+  --figma___radio-button-checked-active-dot: var(--figma___default-colors-white);
+  /* ✦ Theme/Radio button/Checked/Active/Dot/Harness Theme/Light */
+  --figma___switch-checked-active-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/Harness Theme/Light */
+  --figma___switch-checked-default-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/Harness Theme/Light */
+  --figma___switch-checked-disabled-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/Harness Theme/Light */
+  --figma___switch-checked-hover-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/Harness Theme/Light */
+  --figma___switch-unchecked-active-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/Harness Theme/Light */
+  --figma___switch-unchecked-default-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/Harness Theme/Light */
+  --figma___switch-unchecked-hover-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/Harness Theme/Light */
+}
+
+/* Color variables - dark mode */
+.harness-theme-dark {
+  --figma___background-backdrop: 0 0% 0% / 0.75;
+  /* ✦ Theme/Background/Backdrop/Harness Theme/Dark */
+  --figma___background-cards-and-rows-default: 240 6% 6% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Default/Harness Theme/Dark */
+  --figma___background-cards-and-rows-hover: 210 6% 20% / 0.24;
+  /* ✦ Theme/Background/Cards and Rows/Hover/Harness Theme/Dark */
+  --figma___background-cards-and-rows-primary-blue-selected: 216 100% 50% / 0.17;
+  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/Harness Theme/Dark */
+  --figma___background-cards-and-rows-selected: 210 6% 20% / 0.24;
+  /* ✦ Theme/Background/Cards and Rows/Selected/Harness Theme/Dark */
+  --figma___background-header-page-header: 240 6% 6% / 1;
+  /* ✦ Theme/Background/Header/Page Header/Harness Theme/Dark */
+  --figma___background-header-table-header: 0 0% 9% / 1;
+  /* ✦ Theme/Background/Header/Table Header/Harness Theme/Dark */
+  --figma___background-paper: 0 0% 6% / 1;
+  /* ✦ Theme/Background/Paper/Harness Theme/Dark */
+  --figma___background-primary: 0 4% 5% / 1;
+  /* ✦ Theme/Background/Primary/Harness Theme/Dark */
+  --figma___background-solid: 0 4% 5% / 1;
+  /* ✦ Theme/Background/Solid/Harness Theme/Dark */
+  --figma___badges-soft-amber-background: 24 100% 50% / 0.1;
+  /* ✦ Theme/Badges/Soft/Amber/background/Harness Theme/Dark */
+  --figma___badges-soft-amber-text: 43 100% 65% / 1;
+  /* ✦ Theme/Badges/Soft/Amber/text/Harness Theme/Dark */
+  --figma___badges-soft-blue-background: 216 100% 50% / 0.17;
+  /* ✦ Theme/Badges/Soft/Blue/background/Harness Theme/Dark */
+  --figma___badges-soft-blue-text: 205 100% 71% / 1;
+  /* ✦ Theme/Badges/Soft/Blue/text/Harness Theme/Dark */
+  --figma___badges-soft-bronze-background: 17 100% 79% / 0.06;
+  /* ✦ Theme/Badges/Soft/Bronze/background/Harness Theme/Dark */
+  --figma___badges-soft-bronze-text: 19 100% 89% / 0.81;
+  /* ✦ Theme/Badges/Soft/Bronze/text/Harness Theme/Dark */
+  --figma___badges-soft-brown-background: 25 99% 68% / 0.07;
+  /* ✦ Theme/Badges/Soft/Brown/background/Harness Theme/Dark */
+  --figma___badges-soft-brown-text: 28 100% 84% / 0.85;
+  /* ✦ Theme/Badges/Soft/Brown/text/Harness Theme/Dark */
+  --figma___badges-soft-crimson-background: 335 100% 55% / 0.14;
+  /* ✦ Theme/Badges/Soft/Crimson/background/Harness Theme/Dark */
+  --figma___badges-soft-crimson-text: 341 100% 76% / 1;
+  /* ✦ Theme/Badges/Soft/Crimson/text/Harness Theme/Dark */
+  --figma___badges-soft-cyan-background: 197 100% 50% / 0.1;
+  /* ✦ Theme/Badges/Soft/Cyan/background/Harness Theme/Dark */
+  --figma___badges-soft-cyan-text: 190 100% 56% / 0.95;
+  /* ✦ Theme/Badges/Soft/Cyan/text/Harness Theme/Dark */
+  --figma___badges-soft-gold-background: 50 100% 77% / 0.05;
+  /* ✦ Theme/Badges/Soft/Gold/background/Harness Theme/Dark */
+  --figma___badges-soft-gold-text: 35 100% 89% / 0.77;
+  /* ✦ Theme/Badges/Soft/Gold/text/Harness Theme/Dark */
+  --figma___badges-soft-grass-background: 139 98% 54% / 0.07;
+  /* ✦ Theme/Badges/Soft/Grass/background/Harness Theme/Dark */
+  --figma___badges-soft-grass-text: 131 100% 77% / 0.8;
+  /* ✦ Theme/Badges/Soft/Grass/text/Harness Theme/Dark */
+  --figma___badges-soft-green-background: 149 100% 49% / 0.07;
+  /* ✦ Theme/Badges/Soft/Green/background/Harness Theme/Dark */
+  --figma___badges-soft-green-text: 151 100% 64% / 0.82;
+  /* ✦ Theme/Badges/Soft/Green/text/Harness Theme/Dark */
+  --figma___badges-soft-indigo-background: 228 100% 57% / 0.18;
+  /* ✦ Theme/Badges/Soft/Indigo/background/Harness Theme/Dark */
+  --figma___badges-soft-indigo-text: 235 100% 80% / 1;
+  /* ✦ Theme/Badges/Soft/Indigo/text/Harness Theme/Dark */
+  --figma___badges-soft-iris-background: 244 99% 64% / 0.17;
+  /* ✦ Theme/Badges/Soft/Iris/background/Harness Theme/Dark */
+  --figma___badges-soft-iris-text: 242 100% 81% / 1;
+  /* ✦ Theme/Badges/Soft/Iris/text/Harness Theme/Dark */
+  --figma___badges-soft-jade-background: 145 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Soft/Jade/background/Harness Theme/Dark */
+  --figma___badges-soft-jade-text: 163 99% 56% / 0.83;
+  /* ✦ Theme/Badges/Soft/Jade/text/Harness Theme/Dark */
+  --figma___badges-soft-lime-background: 89 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Soft/Lime/background/Harness Theme/Dark */
+  --figma___badges-soft-lime-text: 70 100% 58% / 0.84;
+  /* ✦ Theme/Badges/Soft/Lime/text/Harness Theme/Dark */
+  --figma___badges-soft-mint-background: 174 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Soft/Mint/background/Harness Theme/Dark */
+  --figma___badges-soft-mint-text: 167 100% 66% / 0.86;
+  /* ✦ Theme/Badges/Soft/Mint/text/Harness Theme/Dark */
+  --figma___badges-soft-orange-background: 13 100% 50% / 0.12;
+  /* ✦ Theme/Badges/Soft/Orange/background/Harness Theme/Dark */
+  --figma___badges-soft-orange-text: 24 100% 70% / 1;
+  /* ✦ Theme/Badges/Soft/Orange/text/Harness Theme/Dark */
+  --figma___badges-soft-pink-background: 318 99% 56% / 0.14;
+  /* ✦ Theme/Badges/Soft/Pink/background/Harness Theme/Dark */
+  --figma___badges-soft-pink-text: 325 100% 77% / 0.98;
+  /* ✦ Theme/Badges/Soft/Pink/text/Harness Theme/Dark */
+  --figma___badges-soft-plum-background: 300 99% 59% / 0.12;
+  /* ✦ Theme/Badges/Soft/Plum/background/Harness Theme/Dark */
+  --figma___badges-soft-plum-text: 290 100% 80% / 0.91;
+  /* ✦ Theme/Badges/Soft/Plum/text/Harness Theme/Dark */
+  --figma___badges-soft-purple-background: 282 99% 60% / 0.15;
+  /* ✦ Theme/Badges/Soft/Purple/background/Harness Theme/Dark */
+  --figma___badges-soft-purple-text: 270 100% 80% / 0.98;
+  /* ✦ Theme/Badges/Soft/Purple/text/Harness Theme/Dark */
+  --figma___badges-soft-red-background: 353 99% 56% / 0.15;
+  /* ✦ Theme/Badges/Soft/Red/background/Harness Theme/Dark */
+  --figma___badges-soft-red-text: 358 100% 76% / 1;
+  /* ✦ Theme/Badges/Soft/Red/text/Harness Theme/Dark */
+  --figma___badges-soft-ruby-background: 348 99% 56% / 0.15;
+  /* ✦ Theme/Badges/Soft/Ruby/background/Harness Theme/Dark */
+  --figma___badges-soft-ruby-text: 348 100% 76% / 1;
+  /* ✦ Theme/Badges/Soft/Ruby/text/Harness Theme/Dark */
+  --figma___badges-soft-sky-background: 204 100% 50% / 0.12;
+  /* ✦ Theme/Badges/Soft/Sky/background/Harness Theme/Dark */
+  --figma___badges-soft-sky-text: 195 100% 66% / 1;
+  /* ✦ Theme/Badges/Soft/Sky/text/Harness Theme/Dark */
+  --figma___badges-soft-teal-background: 161 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Soft/Teal/background/Harness Theme/Dark */
+  --figma___badges-soft-teal-text: 170 100% 52% / 0.83;
+  /* ✦ Theme/Badges/Soft/Teal/text/Harness Theme/Dark */
+  --figma___badges-soft-violet-background: 255 99% 63% / 0.17;
+  /* ✦ Theme/Badges/Soft/Violet/background/Harness Theme/Dark */
+  --figma___badges-soft-violet-text: 255 100% 80% / 1;
+  /* ✦ Theme/Badges/Soft/Violet/text/Harness Theme/Dark */
+  --figma___badges-soft-yellow-background: 36 100% 50% / 0.09;
+  /* ✦ Theme/Badges/Soft/Yellow/background/Harness Theme/Dark */
+  --figma___badges-soft-yellow-text: 55 100% 60% / 1;
+  /* ✦ Theme/Badges/Soft/Yellow/text/Harness Theme/Dark */
+  --figma___badges-soft-accent-background: 216 100% 50% / 0.17;
+  /* ✦ Theme/Badges/Soft/accent/background/Harness Theme/Dark */
+  --figma___badges-soft-accent-text: 205 100% 71% / 1;
+  /* ✦ Theme/Badges/Soft/accent/text/Harness Theme/Dark */
+  --figma___badges-soft-error-background: 353 99% 56% / 0.15;
+  /* ✦ Theme/Badges/Soft/error/background/Harness Theme/Dark */
+  --figma___badges-soft-error-text: 358 100% 76% / 1;
+  /* ✦ Theme/Badges/Soft/error/text/Harness Theme/Dark */
+  --figma___badges-soft-info-background: 216 100% 50% / 0.17;
+  /* ✦ Theme/Badges/Soft/info/background/Harness Theme/Dark */
+  --figma___badges-soft-info-text: 205 100% 71% / 1;
+  /* ✦ Theme/Badges/Soft/info/text/Harness Theme/Dark */
+  --figma___badges-soft-success-background: 149 100% 49% / 0.07;
+  /* ✦ Theme/Badges/Soft/success/background/Harness Theme/Dark */
+  --figma___badges-soft-success-text: 151 65% 54% / 1;
+  /* ✦ Theme/Badges/Soft/success/text/Harness Theme/Dark */
+  --figma___badges-soft-warning-background: 34 63% 12% / 1;
+  /* ✦ Theme/Badges/Soft/warning/background/Harness Theme/Dark */
+  --figma___badges-soft-warning-text: 43 100% 65% / 1;
+  /* ✦ Theme/Badges/Soft/warning/text/Harness Theme/Dark */
+  --figma___badges-solid-amber-background: 42 100% 62% / 1;
+  /* ✦ Theme/Badges/Solid/Amber/background/Harness Theme/Dark */
+  --figma___badges-solid-blue-background: 214 73% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Blue/background/Harness Theme/Dark */
+  --figma___badges-solid-bronze-background: 18 20% 54% / 1;
+  /* ✦ Theme/Badges/Solid/Bronze/background/Harness Theme/Dark */
+  --figma___badges-solid-brown-background: 28 34% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Brown/background/Harness Theme/Dark */
+  --figma___badges-solid-crimson-background: 336 80% 58% / 1;
+  /* ✦ Theme/Badges/Solid/Crimson/background/Harness Theme/Dark */
+  --figma___badges-solid-cyan-background: 190 95% 39% / 1;
+  /* ✦ Theme/Badges/Solid/Cyan/background/Harness Theme/Dark */
+  --figma___badges-solid-gold-background: 36 20% 49% / 1;
+  /* ✦ Theme/Badges/Solid/Gold/background/Harness Theme/Dark */
+  --figma___badges-solid-grass-background: 132 59% 33% / 1;
+  /* ✦ Theme/Badges/Solid/Grass/background/Harness Theme/Dark */
+  --figma___badges-solid-green-background: 142 72% 29% / 1;
+  /* ✦ Theme/Badges/Solid/Green/background/Harness Theme/Dark */
+  --figma___badges-solid-indigo-background: 226 70% 55% / 1;
+  /* ✦ Theme/Badges/Solid/Indigo/background/Harness Theme/Dark */
+  --figma___badges-solid-iris-background: 240 60% 60% / 1;
+  /* ✦ Theme/Badges/Solid/Iris/background/Harness Theme/Dark */
+  --figma___badges-solid-jade-background: 164 60% 40% / 1;
+  /* ✦ Theme/Badges/Solid/Jade/background/Harness Theme/Dark */
+  --figma___badges-solid-lime-background: 81 80% 66% / 1;
+  /* ✦ Theme/Badges/Solid/Lime/background/Harness Theme/Dark */
+  --figma___badges-solid-mint-background: 167 70% 72% / 1;
+  /* ✦ Theme/Badges/Solid/Mint/background/Harness Theme/Dark */
+  --figma___badges-solid-orange-background: 24 100% 70% / 1;
+  /* ✦ Theme/Badges/Solid/Orange/background/Harness Theme/Dark */
+  --figma___badges-solid-pink-background: 322 65% 55% / 1;
+  /* ✦ Theme/Badges/Solid/Pink/background/Harness Theme/Dark */
+  --figma___badges-solid-plum-background: 292 45% 51% / 1;
+  /* ✦ Theme/Badges/Solid/Plum/background/Harness Theme/Dark */
+  --figma___badges-solid-purple-background: 272 51% 54% / 1;
+  /* ✦ Theme/Badges/Solid/Purple/background/Harness Theme/Dark */
+  --figma___badges-solid-red-background: 358 75% 59% / 1;
+  /* ✦ Theme/Badges/Solid/Red/background/Harness Theme/Dark */
+  --figma___badges-solid-ruby-background: 348 75% 59% / 1;
+  /* ✦ Theme/Badges/Solid/Ruby/background/Harness Theme/Dark */
+  --figma___badges-solid-sky-background: 193 98% 74% / 1;
+  /* ✦ Theme/Badges/Solid/Sky/background/Harness Theme/Dark */
+  --figma___badges-solid-success-background: 142 72% 29% / 1;
+  /* ✦ Theme/Badges/Solid/Success/background/Harness Theme/Dark */
+  --figma___badges-solid-teal-background: 173 80% 36% / 1;
+  /* ✦ Theme/Badges/Solid/Teal/background/Harness Theme/Dark */
+  --figma___badges-solid-violet-background: 252 56% 57% / 1;
+  /* ✦ Theme/Badges/Solid/Violet/background/Harness Theme/Dark */
+  --figma___badges-solid-yellow-background: 53 96% 58% / 1;
+  /* ✦ Theme/Badges/Solid/Yellow/background/Harness Theme/Dark */
+  --figma___badges-solid-accent-background: 214 73% 51% / 1;
+  /* ✦ Theme/Badges/Solid/accent/background/Harness Theme/Dark */
+  --figma___badges-solid-info-background: 214 73% 51% / 1;
+  /* ✦ Theme/Badges/Solid/info/background/Harness Theme/Dark */
+  --figma___badges-solid-warning-background: 42 100% 62% / 1;
+  /* ✦ Theme/Badges/Solid/warning/background/Harness Theme/Dark */
+  --figma___badges-surface-amber-background: 6 100% 49% / 0.06;
+  /* ✦ Theme/Badges/Surface/Amber/background/Harness Theme/Dark */
+  --figma___badges-surface-amber-border: 35 100% 57% / 0.38;
+  /* ✦ Theme/Badges/Surface/Amber/border/Harness Theme/Dark */
+  --figma___badges-surface-amber-text: 43 100% 65% / 1;
+  /* ✦ Theme/Badges/Surface/Amber/text/Harness Theme/Dark */
+  --figma___badges-surface-blue-background: 227 100% 50% / 0.09;
+  /* ✦ Theme/Badges/Surface/Blue/background/Harness Theme/Dark */
+  --figma___badges-surface-blue-border: 211 100% 51% / 0.55;
+  /* ✦ Theme/Badges/Surface/Blue/border/Harness Theme/Dark */
+  --figma___badges-surface-blue-text: 205 100% 71% / 1;
+  /* ✦ Theme/Badges/Surface/Blue/text/Harness Theme/Dark */
+  --figma___badges-surface-bronze-background: 15 93% 53% / 0.02;
+  /* ✦ Theme/Badges/Surface/Bronze/background/Harness Theme/Dark */
+  --figma___badges-surface-bronze-border: 17 100% 84% / 0.3;
+  /* ✦ Theme/Badges/Surface/Bronze/border/Harness Theme/Dark */
+  --figma___badges-surface-bronze-text: 19 100% 89% / 0.81;
+  /* ✦ Theme/Badges/Surface/Bronze/text/Harness Theme/Dark */
+  --figma___badges-surface-brown-background: 24 100% 50% / 0.03;
+  /* ✦ Theme/Badges/Surface/Brown/background/Harness Theme/Dark */
+  --figma___badges-surface-brown-border: 28 98% 75% / 0.32;
+  /* ✦ Theme/Badges/Surface/Brown/border/Harness Theme/Dark */
+  --figma___badges-surface-brown-text: 28 100% 84% / 0.85;
+  /* ✦ Theme/Badges/Surface/Brown/text/Harness Theme/Dark */
+  --figma___badges-surface-crimson-border: 336 100% 57% / 0.49;
+  /* ✦ Theme/Badges/Surface/Crimson/Border/Harness Theme/Dark */
+  --figma___badges-surface-crimson-background: 338 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/Crimson/background/Harness Theme/Dark */
+  --figma___badges-surface-crimson-text: 341 100% 76% / 1;
+  /* ✦ Theme/Badges/Surface/Crimson/text/Harness Theme/Dark */
+  --figma___badges-surface-cyan-border: 192 100% 57% / 0.35;
+  /* ✦ Theme/Badges/Surface/Cyan/Border/Harness Theme/Dark */
+  --figma___badges-surface-cyan-background: 207 100% 49% / 0.04;
+  /* ✦ Theme/Badges/Surface/Cyan/background/Harness Theme/Dark */
+  --figma___badges-surface-cyan-text: 190 100% 56% / 0.95;
+  /* ✦ Theme/Badges/Surface/Cyan/text/Harness Theme/Dark */
+  --figma___badges-surface-gold-border: 39 97% 85% / 0.27;
+  /* ✦ Theme/Badges/Surface/Gold/Border/Harness Theme/Dark */
+  --figma___badges-surface-gold-background: 42 100% 50% / 0.01;
+  /* ✦ Theme/Badges/Surface/Gold/background/Harness Theme/Dark */
+  --figma___badges-surface-gold-text: 35 100% 89% / 0.77;
+  /* ✦ Theme/Badges/Surface/Gold/text/Harness Theme/Dark */
+  --figma___badges-surface-grass-border: 135 100% 68% / 0.3;
+  /* ✦ Theme/Badges/Surface/Grass/Border/Harness Theme/Dark */
+  --figma___badges-surface-grass-background: 120 100% 49% / 0.02;
+  /* ✦ Theme/Badges/Surface/Grass/background/Harness Theme/Dark */
+  --figma___badges-surface-grass-text: 131 100% 77% / 0.8;
+  /* ✦ Theme/Badges/Surface/Grass/text/Harness Theme/Dark */
+  --figma___badges-surface-green-background: 120 100% 49% / 0.02;
+  /* ✦ Theme/Badges/Surface/Green/background/Harness Theme/Dark */
+  --figma___badges-surface-green-border: 152 99% 59% / 0.3;
+  /* ✦ Theme/Badges/Surface/Green/border/Harness Theme/Dark */
+  --figma___badges-surface-green-text: 151 100% 64% / 0.82;
+  /* ✦ Theme/Badges/Surface/Green/text/Harness Theme/Dark */
+  --figma___badges-surface-indigo-background: 232 100% 50% / 0.09;
+  /* ✦ Theme/Badges/Surface/Indigo/background/Harness Theme/Dark */
+  --figma___badges-surface-indigo-border: 226 100% 62% / 0.52;
+  /* ✦ Theme/Badges/Surface/Indigo/border/Harness Theme/Dark */
+  --figma___badges-surface-indigo-text: 235 100% 80% / 1;
+  /* ✦ Theme/Badges/Surface/Indigo/text/Harness Theme/Dark */
+  --figma___badges-surface-iris-border: 240 100% 71% / 0.49;
+  /* ✦ Theme/Badges/Surface/Iris/Border/Harness Theme/Dark */
+  --figma___badges-surface-iris-background: 243 100% 55% / 0.09;
+  /* ✦ Theme/Badges/Surface/Iris/background/Harness Theme/Dark */
+  --figma___badges-surface-iris-text: 242 100% 81% / 1;
+  /* ✦ Theme/Badges/Surface/Iris/text/Harness Theme/Dark */
+  --figma___badges-surface-jade-border: 159 99% 58% / 0.3;
+  /* ✦ Theme/Badges/Surface/Jade/Border/Harness Theme/Dark */
+  --figma___badges-surface-jade-background: 120 100% 49% / 0.03;
+  /* ✦ Theme/Badges/Surface/Jade/background/Harness Theme/Dark */
+  --figma___badges-surface-jade-text: 163 99% 56% / 0.83;
+  /* ✦ Theme/Badges/Surface/Jade/text/Harness Theme/Dark */
+  --figma___badges-surface-lime-border: 78 100% 61% / 0.28;
+  /* ✦ Theme/Badges/Surface/Lime/Border/Harness Theme/Dark */
+  --figma___badges-surface-lime-background: 114 100% 49% / 0.02;
+  /* ✦ Theme/Badges/Surface/Lime/background/Harness Theme/Dark */
+  --figma___badges-surface-lime-text: 70 100% 58% / 0.84;
+  /* ✦ Theme/Badges/Surface/Lime/text/Harness Theme/Dark */
+  --figma___badges-surface-mint-background: 165 100% 49% / 0.03;
+  /* ✦ Theme/Badges/Surface/Mint/background/Harness Theme/Dark */
+  --figma___badges-surface-mint-border: 173 100% 55% / 0.31;
+  /* ✦ Theme/Badges/Surface/Mint/border/Harness Theme/Dark */
+  --figma___badges-surface-mint-text: 167 100% 66% / 0.86;
+  /* ✦ Theme/Badges/Surface/Mint/text/Harness Theme/Dark */
+  --figma___badges-surface-orange-background: 0 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Surface/Orange/background/Harness Theme/Dark */
+  --figma___badges-surface-orange-border: 25 100% 51% / 0.44;
+  /* ✦ Theme/Badges/Surface/Orange/border/Harness Theme/Dark */
+  --figma___badges-surface-orange-text: 24 100% 70% / 1;
+  /* ✦ Theme/Badges/Surface/Orange/text/Harness Theme/Dark */
+  --figma___badges-surface-pink-background: 319 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/Pink/background/Harness Theme/Dark */
+  --figma___badges-surface-pink-border: 320 100% 62% / 0.43;
+  /* ✦ Theme/Badges/Surface/Pink/border/Harness Theme/Dark */
+  --figma___badges-surface-pink-text: 325 100% 77% / 0.98;
+  /* ✦ Theme/Badges/Surface/Pink/text/Harness Theme/Dark */
+  --figma___badges-surface-plum-background: 300 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Surface/Plum/background/Harness Theme/Dark */
+  --figma___badges-surface-plum-border: 294 100% 69% / 0.39;
+  /* ✦ Theme/Badges/Surface/Plum/border/Harness Theme/Dark */
+  --figma___badges-surface-plum-text: 290 100% 80% / 0.91;
+  /* ✦ Theme/Badges/Surface/Plum/text/Harness Theme/Dark */
+  --figma___badges-surface-purple-background: 283 100% 49% / 0.07;
+  /* ✦ Theme/Badges/Surface/Purple/background/Harness Theme/Dark */
+  --figma___badges-surface-purple-border: 276 100% 67% / 0.44;
+  /* ✦ Theme/Badges/Surface/Purple/border/Harness Theme/Dark */
+  --figma___badges-surface-purple-text: 270 100% 80% / 0.98;
+  /* ✦ Theme/Badges/Surface/Purple/text/Harness Theme/Dark */
+  --figma___badges-surface-red-background: 354 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/Red/background/Harness Theme/Dark */
+  --figma___badges-surface-red-border: 354 100% 57% / 0.5;
+  /* ✦ Theme/Badges/Surface/Red/border/Harness Theme/Dark */
+  --figma___badges-surface-red-text: 358 100% 76% / 1;
+  /* ✦ Theme/Badges/Surface/Red/text/Harness Theme/Dark */
+  --figma___badges-surface-ruby-background: 351 100% 50% / 0.08;
+  /* ✦ Theme/Badges/Surface/Ruby/background/Harness Theme/Dark */
+  --figma___badges-surface-ruby-border: 348 100% 57% / 0.49;
+  /* ✦ Theme/Badges/Surface/Ruby/border/Harness Theme/Dark */
+  --figma___badges-surface-ruby-text: 348 100% 76% / 1;
+  /* ✦ Theme/Badges/Surface/Ruby/text/Harness Theme/Dark */
+  --figma___badges-surface-sky-background: 215 100% 50% / 0.06;
+  /* ✦ Theme/Badges/Surface/Sky/background/Harness Theme/Dark */
+  --figma___badges-surface-sky-border: 200 100% 59% / 0.4;
+  /* ✦ Theme/Badges/Surface/Sky/border/Harness Theme/Dark */
+  --figma___badges-surface-sky-text: 195 100% 66% / 1;
+  /* ✦ Theme/Badges/Surface/Sky/text/Harness Theme/Dark */
+  --figma___badges-surface-teal-background: 141 100% 49% / 0.03;
+  /* ✦ Theme/Badges/Surface/Teal/background/Harness Theme/Dark */
+  --figma___badges-surface-teal-border: 171 99% 56% / 0.3;
+  /* ✦ Theme/Badges/Surface/Teal/border/Harness Theme/Dark */
+  --figma___badges-surface-teal-text: 170 100% 52% / 0.83;
+  /* ✦ Theme/Badges/Surface/Teal/text/Harness Theme/Dark */
+  --figma___badges-surface-violet-background: 255 98% 52% / 0.08;
+  /* ✦ Theme/Badges/Surface/Violet/background/Harness Theme/Dark */
+  --figma___badges-surface-violet-border: 251 100% 70% / 0.49;
+  /* ✦ Theme/Badges/Surface/Violet/border/Harness Theme/Dark */
+  --figma___badges-surface-violet-text: 255 100% 80% / 1;
+  /* ✦ Theme/Badges/Surface/Violet/text/Harness Theme/Dark */
+  --figma___badges-surface-yellow-background: 17 100% 49% / 0.04;
+  /* ✦ Theme/Badges/Surface/Yellow/background/Harness Theme/Dark */
+  --figma___badges-surface-yellow-border: 47 99% 55% / 0.32;
+  /* ✦ Theme/Badges/Surface/Yellow/border/Harness Theme/Dark */
+  --figma___badges-surface-yellow-text: 55 100% 60% / 1;
+  /* ✦ Theme/Badges/Surface/Yellow/text/Harness Theme/Dark */
+  --figma___badges-surface-accent-background: 227 100% 50% / 0.09;
+  /* ✦ Theme/Badges/Surface/accent/background/Harness Theme/Dark */
+  --figma___badges-surface-accent-border: 211 100% 51% / 0.55;
+  /* ✦ Theme/Badges/Surface/accent/border/Harness Theme/Dark */
+  --figma___badges-surface-accent-text: 211 100% 51% / 0.55;
+  /* ✦ Theme/Badges/Surface/accent/text/Harness Theme/Dark */
+  --figma___badges-surface-error-background: 354 100% 50% / 0.07;
+  /* ✦ Theme/Badges/Surface/error/background/Harness Theme/Dark */
+  --figma___badges-surface-error-border: 354 100% 57% / 0.5;
+  /* ✦ Theme/Badges/Surface/error/border/Harness Theme/Dark */
+  --figma___badges-surface-error-text: 358 100% 76% / 1;
+  /* ✦ Theme/Badges/Surface/error/text/Harness Theme/Dark */
+  --figma___badges-surface-info-background: 204 100% 50% / 0.12;
+  /* ✦ Theme/Badges/Surface/info/background/Harness Theme/Dark */
+  --figma___badges-surface-info-border: 200 100% 59% / 0.4;
+  /* ✦ Theme/Badges/Surface/info/border/Harness Theme/Dark */
+  --figma___badges-surface-info-text: 195 100% 66% / 1;
+  /* ✦ Theme/Badges/Surface/info/text/Harness Theme/Dark */
+  --figma___badges-surface-success-background: 120 100% 49% / 0.03;
+  /* ✦ Theme/Badges/Surface/success/background/Harness Theme/Dark */
+  --figma___badges-surface-success-border: 159 99% 58% / 0.3;
+  /* ✦ Theme/Badges/Surface/success/border/Harness Theme/Dark */
+  --figma___badges-surface-success-text: 163 99% 56% / 0.83;
+  /* ✦ Theme/Badges/Surface/success/text/Harness Theme/Dark */
+  --figma___badges-surface-warning-background: 6 100% 49% / 0.06;
+  /* ✦ Theme/Badges/Surface/warning/background/Harness Theme/Dark */
+  --figma___badges-surface-warning-border: 35 100% 57% / 0.38;
+  /* ✦ Theme/Badges/Surface/warning/border/Harness Theme/Dark */
+  --figma___badges-surface-warning-text: 43 100% 65% / 1;
+  /* ✦ Theme/Badges/Surface/warning/text/Harness Theme/Dark */
+  --figma___border-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Border/Disabled/Harness Theme/Dark */
+  --figma___border-hover: 0 0% 29% / 1;
+  /* ✦ Theme/Border/Hover/Harness Theme/Dark */
+  --figma___border-primary: 0 0% 100% / 0.1;
+  /* ✦ Theme/Border/Primary/Harness Theme/Dark */
+  --figma___border-secondary: 0 0% 16% / 1;
+  /* ✦ Theme/Border/Secondary/Harness Theme/Dark */
+  --figma___border-selected: 206 100% 62% / 1;
+  /* ✦ Theme/Border/Selected/Harness Theme/Dark */
+  --figma___breadcrumbs-current: 0 0% 93% / 1;
+  /* ✦ Theme/Breadcrumbs/current/Harness Theme/Dark */
+  --figma___breadcrumbs-visited: 0 0% 69% / 1;
+  /* ✦ Theme/Breadcrumbs/visited/Harness Theme/Dark */
+  --figma___button-ghost-accent-active: 214 100% 50% / 0.23;
+  /* ✦ Theme/Button/Ghost/Accent/Active/Harness Theme/Dark */
+  --figma___button-ghost-accent-active-text: 205 100% 71% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Active text/Harness Theme/Dark */
+  --figma___button-ghost-accent-hover: 216 100% 50% / 0.17;
+  /* ✦ Theme/Button/Ghost/Accent/Hover/Harness Theme/Dark */
+  --figma___button-ghost-accent-hover-text: 205 100% 71% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Hover text/Harness Theme/Dark */
+  --figma___button-ghost-accent-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/Harness Theme/Dark */
+  --figma___button-ghost-accent-text-primary: 205 100% 71% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Text-primary/Harness Theme/Dark */
+  --figma___button-ghost-error-active: 352 100% 56% / 0.21;
+  /* ✦ Theme/Button/Ghost/Error/Active/Harness Theme/Dark */
+  --figma___button-ghost-error-active-text: 358 100% 76% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Active Text/Harness Theme/Dark */
+  --figma___button-ghost-error-hover: 353 99% 56% / 0.15;
+  /* ✦ Theme/Button/Ghost/Error/Hover/Harness Theme/Dark */
+  --figma___button-ghost-error-hover-text: 358 100% 76% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Hover text/Harness Theme/Dark */
+  --figma___button-ghost-error-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Ghost/Error/Text-disabled/Harness Theme/Dark */
+  --figma___button-ghost-error-text-primary: 358 100% 76% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Text-primary/Harness Theme/Dark */
+  --figma___button-ghost-neutral-active: 0 0% 100% / 0.1;
+  /* ✦ Theme/Button/Ghost/Neutral/Active/Harness Theme/Dark */
+  --figma___button-ghost-neutral-active-text: 0 0% 69% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Active Text/Harness Theme/Dark */
+  --figma___button-ghost-neutral-hover: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover/Harness Theme/Dark */
+  --figma___button-ghost-neutral-hover-text: 0 0% 69% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover text/Harness Theme/Dark */
+  --figma___button-ghost-neutral-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/Harness Theme/Dark */
+  --figma___button-ghost-neutral-text-primary: 0 0% 69% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/Harness Theme/Dark */
+  --figma___button-ghost-success-active: 154 100% 50% / 0.11;
+  /* ✦ Theme/Button/Ghost/Success/Active/Harness Theme/Dark */
+  --figma___button-ghost-success-active-text: 151 65% 54% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Active Text/Harness Theme/Dark */
+  --figma___button-ghost-success-hover: 149 100% 49% / 0.07;
+  /* ✦ Theme/Button/Ghost/Success/Hover/Harness Theme/Dark */
+  --figma___button-ghost-success-hover-text: 151 65% 54% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Hover text/Harness Theme/Dark */
+  --figma___button-ghost-success-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Ghost/Success/Text-disabled/Harness Theme/Dark */
+  --figma___button-ghost-success-text-primary: 151 65% 54% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Text-primary/Harness Theme/Dark */
+  --figma___button-outline-accent-active: 216 100% 50% / 0.17;
+  /* ✦ Theme/Button/Outline/Accent/Active/Harness Theme/Dark */
+  --figma___button-outline-accent-default-border: 206 100% 50% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Default border/Harness Theme/Dark */
+  --figma___button-outline-accent-disabled-border: 0 0% 100% / 0.17;
+  /* ✦ Theme/Button/Outline/Accent/Disabled Border/Harness Theme/Dark */
+  --figma___button-outline-accent-hover: 227 100% 50% / 0.09;
+  /* ✦ Theme/Button/Outline/Accent/Hover/Harness Theme/Dark */
+  --figma___button-outline-accent-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Outline/Accent/Text-disabled/Harness Theme/Dark */
+  --figma___button-outline-accent-text-primary: 205 100% 71% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Text-primary/Harness Theme/Dark */
+  --figma___button-outline-error-active: 353 99% 56% / 0.15;
+  /* ✦ Theme/Button/Outline/Error/Active/Harness Theme/Dark */
+  --figma___button-outline-error-default-border: 358 100% 65% / 0.89;
+  /* ✦ Theme/Button/Outline/Error/Default - border/Harness Theme/Dark */
+  --figma___button-outline-error-disabled-border: 0 0% 100% / 0.17;
+  /* ✦ Theme/Button/Outline/Error/Disabled-border/Harness Theme/Dark */
+  --figma___button-outline-error-hover: 354 100% 50% / 0.07;
+  /* ✦ Theme/Button/Outline/Error/Hover/Harness Theme/Dark */
+  --figma___button-outline-error-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Outline/Error/Text-disabled/Harness Theme/Dark */
+  --figma___button-outline-error-text-primary: 358 100% 76% / 1;
+  /* ✦ Theme/Button/Outline/Error/Text-primary/Harness Theme/Dark */
+  --figma___button-outline-neutral-active: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Outline/Neutral/Active/Harness Theme/Dark */
+  --figma___button-outline-neutral-default-border: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Outline/Neutral/Default - border/Harness Theme/Dark */
+  --figma___button-outline-neutral-disabled-border: 0 0% 100% / 0.17;
+  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/Harness Theme/Dark */
+  --figma___button-outline-neutral-hover: 240 89% 18% / 0.02;
+  /* ✦ Theme/Button/Outline/Neutral/Hover/Harness Theme/Dark */
+  --figma___button-outline-neutral-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/Harness Theme/Dark */
+  --figma___button-outline-neutral-text-primary: 0 0% 69% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Text-primary/Harness Theme/Dark */
+  --figma___button-outline-success-active: 149 100% 49% / 0.07;
+  /* ✦ Theme/Button/Outline/Success/Active/Harness Theme/Dark */
+  --figma___button-outline-success-default-border: 151 100% 62% / 0.61;
+  /* ✦ Theme/Button/Outline/Success/Default-border/Harness Theme/Dark */
+  --figma___button-outline-success-disabled-border: 0 0% 100% / 0.17;
+  /* ✦ Theme/Button/Outline/Success/Disabled - border/Harness Theme/Dark */
+  --figma___button-outline-success-hover: 120 100% 49% / 0.02;
+  /* ✦ Theme/Button/Outline/Success/Hover/Harness Theme/Dark */
+  --figma___button-outline-success-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Outline/Success/Text-disabled/Harness Theme/Dark */
+  --figma___button-outline-success-text-primary: 151 65% 54% / 1;
+  /* ✦ Theme/Button/Outline/Success/Text-primary/Harness Theme/Dark */
+  --figma___button-soft-accent-active: 213 100% 51% / 0.29;
+  /* ✦ Theme/Button/Soft/Accent/Active/Harness Theme/Dark */
+  --figma___button-soft-accent-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Soft/Accent/Disabled/Harness Theme/Dark */
+  --figma___button-soft-accent-hover: 214 100% 50% / 0.23;
+  /* ✦ Theme/Button/Soft/Accent/Hover/Harness Theme/Dark */
+  --figma___button-soft-accent-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Soft/Accent/Text-disabled/Harness Theme/Dark */
+  --figma___button-soft-accent-text-primary: 205 100% 71% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Text-primary/Harness Theme/Dark */
+  --figma___button-soft-accent-default: 216 100% 50% / 0.17;
+  /* ✦ Theme/Button/Soft/Accent/default/Harness Theme/Dark */
+  --figma___button-soft-error-active: 354 99% 57% / 0.26;
+  /* ✦ Theme/Button/Soft/Error/Active/Harness Theme/Dark */
+  --figma___button-soft-error-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Soft/Error/Disabled/Harness Theme/Dark */
+  --figma___button-soft-error-hover: 352 100% 56% / 0.21;
+  /* ✦ Theme/Button/Soft/Error/Hover/Harness Theme/Dark */
+  --figma___button-soft-error-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Soft/Error/Text-disabled/Harness Theme/Dark */
+  --figma___button-soft-error-text-primary: 358 100% 76% / 1;
+  /* ✦ Theme/Button/Soft/Error/Text-primary/Harness Theme/Dark */
+  --figma___button-soft-error-default: 353 99% 56% / 0.15;
+  /* ✦ Theme/Button/Soft/Error/default/Harness Theme/Dark */
+  --figma___button-soft-neutral-active: 0 0% 100% / 0.13;
+  /* ✦ Theme/Button/Soft/Neutral/Active/Harness Theme/Dark */
+  --figma___button-soft-neutral-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Soft/Neutral/Disabled/Harness Theme/Dark */
+  --figma___button-soft-neutral-hover: 0 0% 100% / 0.1;
+  /* ✦ Theme/Button/Soft/Neutral/Hover/Harness Theme/Dark */
+  --figma___button-soft-neutral-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/Harness Theme/Dark */
+  --figma___button-soft-neutral-text-primary: 0 0% 69% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Text-primary/Harness Theme/Dark */
+  --figma___button-soft-neutral-default: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Soft/Neutral/default/Harness Theme/Dark */
+  --figma___button-soft-success-active: 153 99% 53% / 0.15;
+  /* ✦ Theme/Button/Soft/Success/Active/Harness Theme/Dark */
+  --figma___button-soft-success-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Soft/Success/Disabled/Harness Theme/Dark */
+  --figma___button-soft-success-hover: 154 100% 50% / 0.11;
+  /* ✦ Theme/Button/Soft/Success/Hover/Harness Theme/Dark */
+  --figma___button-soft-success-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Soft/Success/Text-disabled/Harness Theme/Dark */
+  --figma___button-soft-success-text-primary: 151 100% 64% / 0.82;
+  /* ✦ Theme/Button/Soft/Success/Text-primary/Harness Theme/Dark */
+  --figma___button-soft-success-default: 149 100% 49% / 0.07;
+  /* ✦ Theme/Button/Soft/Success/default/Harness Theme/Dark */
+  --figma___button-solid-accent-active: 214 73% 51% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Active/Harness Theme/Dark */
+  --figma___button-solid-accent-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Solid/Accent/Disabled/Harness Theme/Dark */
+  --figma___button-solid-accent-hover: 206 100% 62% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Hover/Harness Theme/Dark */
+  --figma___button-solid-accent-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Solid/Accent/Text-disabled/Harness Theme/Dark */
+  --figma___button-solid-accent-default: 214 73% 51% / 1;
+  /* ✦ Theme/Button/Solid/Accent/default/Harness Theme/Dark */
+  --figma___button-solid-error-active: 358 75% 59% / 1;
+  /* ✦ Theme/Button/Solid/Error/Active/Harness Theme/Dark */
+  --figma___button-solid-error-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Solid/Error/Disabled/Harness Theme/Dark */
+  --figma___button-solid-error-hover: 359 84% 67% / 1;
+  /* ✦ Theme/Button/Solid/Error/Hover/Harness Theme/Dark */
+  --figma___button-solid-error-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Solid/Error/Text-disabled/Harness Theme/Dark */
+  --figma___button-solid-error-default: 358 75% 59% / 1;
+  /* ✦ Theme/Button/Solid/Error/default/Harness Theme/Dark */
+  --figma___button-solid-neutral-active: 0 0% 43% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Active/Harness Theme/Dark */
+  --figma___button-solid-neutral-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Solid/Neutral/Disabled/Harness Theme/Dark */
+  --figma___button-solid-neutral-hover: 0 0% 51% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Hover/Harness Theme/Dark */
+  --figma___button-solid-neutral-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/Harness Theme/Dark */
+  --figma___button-solid-neutral-default: 0 0% 43% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/default/Harness Theme/Dark */
+  --figma___button-solid-success-active: 142 72% 29% / 1;
+  /* ✦ Theme/Button/Solid/Success/Active/Harness Theme/Dark */
+  --figma___button-solid-success-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Solid/Success/Disabled/Harness Theme/Dark */
+  --figma___button-solid-success-hover: 151 55% 47% / 1;
+  /* ✦ Theme/Button/Solid/Success/Hover/Harness Theme/Dark */
+  --figma___button-solid-success-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Solid/Success/Text-disabled/Harness Theme/Dark */
+  --figma___button-solid-success-default: 142 72% 29% / 1;
+  /* ✦ Theme/Button/Solid/Success/default/Harness Theme/Dark */
+  --figma___button-surface-accent-active: 213 100% 51% / 0.29;
+  /* ✦ Theme/Button/Surface/Accent/Active/Harness Theme/Dark */
+  --figma___button-surface-accent-active-border: 211 100% 53% / 0.88;
+  /* ✦ Theme/Button/Surface/Accent/Active border/Harness Theme/Dark */
+  --figma___button-surface-accent-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Surface/Accent/Disabled/Harness Theme/Dark */
+  --figma___button-surface-accent-hover: 214 100% 50% / 0.23;
+  /* ✦ Theme/Button/Surface/Accent/Hover/Harness Theme/Dark */
+  --figma___button-surface-accent-hover-border: 211 100% 53% / 0.88;
+  /* ✦ Theme/Button/Surface/Accent/Hover Border/Harness Theme/Dark */
+  --figma___button-surface-accent-text-disabled: 231 10% 75% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Text-disabled/Harness Theme/Dark */
+  --figma___button-surface-accent-text-primary: 205 100% 71% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Text-primary/Harness Theme/Dark */
+  --figma___button-surface-accent-default: 216 100% 50% / 0.17;
+  /* ✦ Theme/Button/Surface/Accent/default/Harness Theme/Dark */
+  --figma___button-surface-accent-default-border: 211 100% 51% / 0.55;
+  /* ✦ Theme/Button/Surface/Accent/default border/Harness Theme/Dark */
+  --figma___button-surface-error-active: 354 99% 57% / 0.26;
+  /* ✦ Theme/Button/Surface/Error/Active/Harness Theme/Dark */
+  --figma___button-surface-error-active-border: 359 100% 71% / 0.94;
+  /* ✦ Theme/Button/Surface/Error/Active border/Harness Theme/Dark */
+  --figma___button-surface-error-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Surface/Error/Disabled/Harness Theme/Dark */
+  --figma___button-surface-error-hover: 352 100% 56% / 0.21;
+  /* ✦ Theme/Button/Surface/Error/Hover/Harness Theme/Dark */
+  --figma___button-surface-error-hover-border: 359 100% 71% / 0.94;
+  /* ✦ Theme/Button/Surface/Error/Hover border/Harness Theme/Dark */
+  --figma___button-surface-error-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Surface/Error/Text-disabled/Harness Theme/Dark */
+  --figma___button-surface-error-text-primary: 358 100% 76% / 1;
+  /* ✦ Theme/Button/Surface/Error/Text-primary/Harness Theme/Dark */
+  --figma___button-surface-error-border: 354 100% 57% / 0.35;
+  /* ✦ Theme/Button/Surface/Error/border/Harness Theme/Dark */
+  --figma___button-surface-error-default: 353 99% 56% / 0.15;
+  /* ✦ Theme/Button/Surface/Error/default/Harness Theme/Dark */
+  --figma___button-surface-neutral-active: 223 100% 91% / 0.16;
+  /* ✦ Theme/Button/Surface/Neutral/Active/Harness Theme/Dark */
+  --figma___button-surface-neutral-disabled: 230 100% 87% / 0.09;
+  /* ✦ Theme/Button/Surface/Neutral/Disabled/Harness Theme/Dark */
+  --figma___button-surface-neutral-hover: 224 96% 89% / 0.13;
+  /* ✦ Theme/Button/Surface/Neutral/Hover/Harness Theme/Dark */
+  --figma___button-surface-neutral-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/Harness Theme/Dark */
+  --figma___button-surface-neutral-text-primary: 218 7% 70% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Text-primary/Harness Theme/Dark */
+  --figma___button-surface-neutral-border: 209 95% 92% / 0.24;
+  /* ✦ Theme/Button/Surface/Neutral/border/Harness Theme/Dark */
+  --figma___button-surface-neutral-default: 230 100% 87% / 0.09;
+  /* ✦ Theme/Button/Surface/Neutral/default/Harness Theme/Dark */
+  --figma___button-surface-success-active: 153 99% 53% / 0.15;
+  /* ✦ Theme/Button/Surface/Success/Active/Harness Theme/Dark */
+  --figma___button-surface-success-disabled: 0 0% 100% / 0.07;
+  /* ✦ Theme/Button/Surface/Success/Disabled/Harness Theme/Dark */
+  --figma___button-surface-success-hover: 154 100% 50% / 0.11;
+  /* ✦ Theme/Button/Surface/Success/Hover/Harness Theme/Dark */
+  --figma___button-surface-success-hover-border: 151 100% 63% / 0.7;
+  /* ✦ Theme/Button/Surface/Success/Hover border/Harness Theme/Dark */
+  --figma___button-surface-success-text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Button/Surface/Success/Text-disabled/Harness Theme/Dark */
+  --figma___button-surface-success-text-primary: 151 65% 54% / 1;
+  /* ✦ Theme/Button/Surface/Success/Text-primary/Harness Theme/Dark */
+  --figma___button-surface-success-active-border: 151 100% 63% / 0.7;
+  /* ✦ Theme/Button/Surface/Success/active border/Harness Theme/Dark */
+  --figma___button-surface-success-default: 149 100% 49% / 0.07;
+  /* ✦ Theme/Button/Surface/Success/default/Harness Theme/Dark */
+  --figma___button-surface-success-default-border: 155 99% 55% / 0.2;
+  /* ✦ Theme/Button/Surface/Success/default border/Harness Theme/Dark */
+  --figma___calendar-background: 240 7% 11% / 1;
+  /* ✦ Theme/Calendar/Background/Harness Theme/Dark */
+  --figma___calendar-selected-date-background: 214 73% 51% / 1;
+  /* ✦ Theme/Calendar/Selected Date/Background/Harness Theme/Dark */
+  --figma___calendar-selected-range-background: 216 100% 50% / 0.17;
+  /* ✦ Theme/Calendar/Selected Range/Background/Harness Theme/Dark */
+  --figma___calendar-selected-range-text: 205 100% 71% / 1;
+  /* ✦ Theme/Calendar/Selected Range/Text/Harness Theme/Dark */
+  --figma___checkbox-background: 236 19% 14% / 0.5;
+  /* ✦ Theme/Checkbox/Background/Harness Theme/Dark */
+  --figma___checkbox-paper: 0 0% 100% / 0.03;
+  /* ✦ Theme/Checkbox/Paper/Harness Theme/Dark */
+  --figma___checkbox-surface-checked-active-active: 206 100% 62% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/Harness Theme/Dark */
+  --figma___checkbox-surface-checked-active-hover: 206 100% 62% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/Harness Theme/Dark */
+  --figma___checkbox-surface-checked-active-default-background: 214 73% 51% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/Harness Theme/Dark */
+  --figma___checkbox-surface-checked-disabled-check: 217 95% 91% / 0.19;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/Harness Theme/Dark */
+  --figma___checkbox-surface-checked-disabled-disabled: 230 100% 87% / 0.09;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/Harness Theme/Dark */
+  --figma___checkbox-surface-checked-disabled-border: 217 95% 91% / 0.19;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/Harness Theme/Dark */
+  --figma___checkbox-surface-intermediate-active-active-border: 211 100% 53% / 0.88;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/Harness Theme/Dark */
+  --figma___checkbox-surface-intermediate-active-check: 205 100% 71% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/Harness Theme/Dark */
+  --figma___checkbox-surface-intermediate-active-hover-border: 211 100% 51% / 0.55;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/Harness Theme/Dark */
+  --figma___checkbox-surface-intermediate-active-default-background: 216 100% 50% / 0.17;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/Harness Theme/Dark */
+  --figma___checkbox-surface-intermediate-active-default-border: 212 100% 52% / 0.38;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/Harness Theme/Dark */
+  --figma___checkbox-surface-intermediate-disabled-check: 217 95% 91% / 0.19;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/Harness Theme/Dark */
+  --figma___checkbox-surface-intermediate-disabled-disabled: 230 100% 87% / 0.09;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/Harness Theme/Dark */
+  --figma___checkbox-surface-intermediate-disabled-border: 217 95% 91% / 0.19;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/Harness Theme/Dark */
+  --figma___checkbox-surface-unchecked-active-active-border: 202 88% 93% / 0.33;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/Harness Theme/Dark */
+  --figma___checkbox-surface-unchecked-active-hover-border: 209 95% 92% / 0.24;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/Harness Theme/Dark */
+  --figma___checkbox-surface-unchecked-active-default-background: 0 0% 6% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/Harness Theme/Dark */
+  --figma___checkbox-surface-unchecked-active-default-border: 217 95% 91% / 0.19;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/Harness Theme/Dark */
+  --figma___checkbox-surface-unchecked-disabled-disabled: 230 100% 87% / 0.09;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/Harness Theme/Dark */
+  --figma___checkbox-surface-unchecked-disabled-border: 217 95% 91% / 0.19;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/Harness Theme/Dark */
+  --figma___checkbox-border: 0 0% 100% / 0.07;
+  /* ✦ Theme/Checkbox/border/Harness Theme/Dark */
+  --figma___default-colors-black: 0 0% 0% / 1;
+  /* ✦ Theme/Default colors/black/Harness Theme/Dark */
+  --figma___default-colors-dark-to-white: 0 0% 93% / 1;
+  /* ✦ Theme/Default colors/dark-to-white/Harness Theme/Dark */
+  --figma___default-colors-white: 0 0% 100% / 1;
+  /* ✦ Theme/Default colors/white/Harness Theme/Dark */
+  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
+  /* ✦ Theme/Dropdown/Dropdown Item/Default/Harness Theme/Dark */
+  --figma___dropdown-dropdown-item-hover: 230 7% 16% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Hover/Harness Theme/Dark */
+  --figma___dropdown-dropdown-item-selected: 230 7% 16% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Selected/Harness Theme/Dark */
+  --figma___dropdown-text-shortcut-text-selected: 0 0% 100% / 0.46;
+  /* ✦ Theme/Dropdown/Text/Shortcut text selected/Harness Theme/Dark */
+  --figma___dropdown-text-text-selected: 0 0% 93% / 1;
+  /* ✦ Theme/Dropdown/Text/Text Selected/Harness Theme/Dark */
+  --figma___dropdown-text-hover: 0 0% 69% / 1;
+  /* ✦ Theme/Dropdown/Text/hover/Harness Theme/Dark */
+  --figma___dropdown-background: 240 7% 11% / 1;
+  /* ✦ Theme/Dropdown/background/Harness Theme/Dark */
+  --figma___dropdown-border: 230 100% 87% / 0.09;
+  /* ✦ Theme/Dropdown/border/Harness Theme/Dark */
+  --figma___dropdown-separator: 230 100% 87% / 0.09;
+  /* ✦ Theme/Dropdown/separator/Harness Theme/Dark */
+  --figma___filter-active: 230 100% 87% / 0.09;
+  /* ✦ Theme/Filter/Active/Harness Theme/Dark */
+  --figma___filter-hover: 230 100% 87% / 0.09;
+  /* ✦ Theme/Filter/Hover/Harness Theme/Dark */
+  --figma___inline-alert-banner-customisable: 240 7% 11% / 1;
+  /* ✦ Theme/Inline Alert Banner/Customisable/Harness Theme/Dark */
+  --figma___inline-alert-banner-error: 353 40% 16% / 1;
+  /* ✦ Theme/Inline Alert Banner/Error/Harness Theme/Dark */
+  --figma___inline-alert-banner-info: 216 100% 50% / 0.17;
+  /* ✦ Theme/Inline Alert Banner/Info/Harness Theme/Dark */
+  --figma___inline-alert-banner-reminder: 36 80% 8% / 1;
+  /* ✦ Theme/Inline Alert Banner/Reminder/Harness Theme/Dark */
+  --figma___inline-alert-banner-success: 155 46% 11% / 1;
+  /* ✦ Theme/Inline Alert Banner/Success/Harness Theme/Dark */
+  --figma___inline-alert-banner-warning: 26 68% 12% / 1;
+  /* ✦ Theme/Inline Alert Banner/Warning/Harness Theme/Dark */
+  --figma___modal-background: 236 19% 14% / 0.5;
+  /* ✦ Theme/Modal/Background/Harness Theme/Dark */
+  --figma___modal-paper: 0 0% 100% / 0.03;
+  /* ✦ Theme/Modal/Paper/Harness Theme/Dark */
+  --figma___modal-border: 0 0% 100% / 0.07;
+  /* ✦ Theme/Modal/border/Harness Theme/Dark */
+  --figma___neutral-color-gray-1: 0 0% 9% / 1;
+  /* ✦ Theme/Neutral color/Gray/1/Harness Theme/Dark */
+  --figma___neutral-color-gray-2: 0 0% 11% / 1;
+  /* ✦ Theme/Neutral color/Gray/2/Harness Theme/Dark */
+  --figma___neutral-color-gray-3: 0 0% 16% / 1;
+  /* ✦ Theme/Neutral color/Gray/3/Harness Theme/Dark */
+  --figma___neutral-color-gray-4: 0 0% 19% / 1;
+  /* ✦ Theme/Neutral color/Gray/4/Harness Theme/Dark */
+  --figma___neutral-color-gray-5: 0 0% 22% / 1;
+  /* ✦ Theme/Neutral color/Gray/5/Harness Theme/Dark */
+  --figma___neutral-color-gray-6: 0 0% 25% / 1;
+  /* ✦ Theme/Neutral color/Gray/6/Harness Theme/Dark */
+  --figma___neutral-color-gray-7: 0 0% 43% / 1;
+  /* ✦ Theme/Neutral color/Gray/7/Harness Theme/Dark */
+  --figma___neutral-color-gray-8: 0 0% 51% / 1;
+  /* ✦ Theme/Neutral color/Gray/8/Harness Theme/Dark */
+  --figma___neutral-color-gray-9: 0 0% 69% / 1;
+  /* ✦ Theme/Neutral color/Gray/9/Harness Theme/Dark */
+  --figma___neutral-color-gray-10: 0 0% 93% / 1;
+  /* ✦ Theme/Neutral color/Gray/10/Harness Theme/Dark */
+  --figma___neutral-color-gray-alpha-1: 0 0% 100% / 0;
+  /* ✦ Theme/Neutral color/Gray Alpha/1/Harness Theme/Dark */
+  --figma___neutral-color-gray-alpha-2: 240 89% 18% / 0.02;
+  /* ✦ Theme/Neutral color/Gray Alpha/2/Harness Theme/Dark */
+  --figma___neutral-color-gray-alpha-3: 0 0% 100% / 0.07;
+  /* ✦ Theme/Neutral color/Gray Alpha/3/Harness Theme/Dark */
+  --figma___neutral-color-gray-alpha-4: 0 0% 100% / 0.1;
+  /* ✦ Theme/Neutral color/Gray Alpha/4/Harness Theme/Dark */
+  --figma___neutral-color-gray-alpha-5: 0 0% 100% / 0.13;
+  /* ✦ Theme/Neutral color/Gray Alpha/5/Harness Theme/Dark */
+  --figma___neutral-color-gray-alpha-6: 0 0% 100% / 0.17;
+  /* ✦ Theme/Neutral color/Gray Alpha/6/Harness Theme/Dark */
+  --figma___neutral-color-gray-alpha-7: 0 0% 100% / 0.37;
+  /* ✦ Theme/Neutral color/Gray Alpha/7/Harness Theme/Dark */
+  --figma___neutral-color-gray-alpha-8: 0 0% 100% / 0.46;
+  /* ✦ Theme/Neutral color/Gray Alpha/8/Harness Theme/Dark */
+  --figma___neutral-color-gray-alpha-9: 0 0% 100% / 0.66;
+  /* ✦ Theme/Neutral color/Gray Alpha/9/Harness Theme/Dark */
+  --figma___neutral-color-gray-alpha-10: 0 0% 100% / 0.93;
+  /* ✦ Theme/Neutral color/Gray Alpha/10/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-1: 252 19% 10% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/1/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-2: 255 30% 13% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/2/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-3: 255 34% 18% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/3/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-4: 252 35% 22% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/4/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-5: 253 35% 25% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/5/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-6: 253 37% 30% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/6/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-7: 252 56% 57% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/7/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-8: 253 63% 64% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/8/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-9: 255 100% 80% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/9/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-10: 249 94% 93% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/10/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-alpha-1: 240 100% 49% / 0.03;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/1/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-alpha-2: 255 98% 52% / 0.08;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/2/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-alpha-3: 255 99% 63% / 0.17;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/3/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-alpha-4: 252 99% 66% / 0.23;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/4/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-alpha-5: 252 99% 67% / 0.28;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/5/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-alpha-6: 253 100% 68% / 0.35;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/6/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-alpha-7: 252 100% 70% / 0.79;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/7/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-alpha-8: 253 100% 74% / 0.85;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/8/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-alpha-9: 255 100% 80% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/9/Harness Theme/Dark */
+  --figma___other-colors-ai-violet-alpha-10: 249 100% 94% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/10/Harness Theme/Dark */
+  --figma___other-colors-blue-1: 212 36% 9% / 1;
+  /* ✦ Theme/Other Colors/Blue/1/Harness Theme/Dark */
+  --figma___other-colors-blue-2: 216 50% 12% / 1;
+  /* ✦ Theme/Other Colors/Blue/2/Harness Theme/Dark */
+  --figma___other-colors-blue-3: 214 58% 16% / 1;
+  /* ✦ Theme/Other Colors/Blue/3/Harness Theme/Dark */
+  --figma___other-colors-blue-4: 214 65% 18% / 1;
+  /* ✦ Theme/Other Colors/Blue/4/Harness Theme/Dark */
+  --figma___other-colors-blue-5: 213 67% 21% / 1;
+  /* ✦ Theme/Other Colors/Blue/5/Harness Theme/Dark */
+  --figma___other-colors-blue-6: 212 72% 25% / 1;
+  /* ✦ Theme/Other Colors/Blue/6/Harness Theme/Dark */
+  --figma___other-colors-blue-7: 214 73% 51% / 1;
+  /* ✦ Theme/Other Colors/Blue/7/Harness Theme/Dark */
+  --figma___other-colors-blue-8: 206 100% 62% / 1;
+  /* ✦ Theme/Other Colors/Blue/8/Harness Theme/Dark */
+  --figma___other-colors-blue-9: 205 100% 71% / 1;
+  /* ✦ Theme/Other Colors/Blue/9/Harness Theme/Dark */
+  --figma___other-colors-blue-10: 206 100% 88% / 1;
+  /* ✦ Theme/Other Colors/Blue/10/Harness Theme/Dark */
+  --figma___other-colors-blue-alpha-1: 240 100% 49% / 0.04;
+  /* ✦ Theme/Other Colors/Blue Alpha/1/Harness Theme/Dark */
+  --figma___other-colors-blue-alpha-2: 227 100% 50% / 0.09;
+  /* ✦ Theme/Other Colors/Blue Alpha/2/Harness Theme/Dark */
+  --figma___other-colors-blue-alpha-3: 216 100% 50% / 0.17;
+  /* ✦ Theme/Other Colors/Blue Alpha/3/Harness Theme/Dark */
+  --figma___other-colors-blue-alpha-4: 214 100% 50% / 0.23;
+  /* ✦ Theme/Other Colors/Blue Alpha/4/Harness Theme/Dark */
+  --figma___other-colors-blue-alpha-5: 213 100% 51% / 0.29;
+  /* ✦ Theme/Other Colors/Blue Alpha/5/Harness Theme/Dark */
+  --figma___other-colors-blue-alpha-6: 212 100% 52% / 0.38;
+  /* ✦ Theme/Other Colors/Blue Alpha/6/Harness Theme/Dark */
+  --figma___other-colors-blue-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/7/Harness Theme/Dark */
+  --figma___other-colors-blue-alpha-8: 206 100% 62% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/8/Harness Theme/Dark */
+  --figma___other-colors-blue-alpha-9: 205 100% 71% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/9/Harness Theme/Dark */
+  --figma___other-colors-blue-alpha-10: 206 100% 88% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/10/Harness Theme/Dark */
+  --figma___other-colors-indigo-1: 226 25% 10% / 1;
+  /* ✦ Theme/Other Colors/Indigo/1/Harness Theme/Dark */
+  --figma___other-colors-indigo-2: 230 36% 13% / 1;
+  /* ✦ Theme/Other Colors/Indigo/2/Harness Theme/Dark */
+  --figma___other-colors-indigo-3: 228 43% 18% / 1;
+  /* ✦ Theme/Other Colors/Indigo/3/Harness Theme/Dark */
+  --figma___other-colors-indigo-4: 228 45% 21% / 1;
+  /* ✦ Theme/Other Colors/Indigo/4/Harness Theme/Dark */
+  --figma___other-colors-indigo-5: 227 48% 24% / 1;
+  /* ✦ Theme/Other Colors/Indigo/5/Harness Theme/Dark */
+  --figma___other-colors-indigo-6: 225 51% 29% / 1;
+  /* ✦ Theme/Other Colors/Indigo/6/Harness Theme/Dark */
+  --figma___other-colors-indigo-7: 226 70% 55% / 1;
+  /* ✦ Theme/Other Colors/Indigo/7/Harness Theme/Dark */
+  --figma___other-colors-indigo-8: 230 74% 63% / 1;
+  /* ✦ Theme/Other Colors/Indigo/8/Harness Theme/Dark */
+  --figma___other-colors-indigo-9: 235 100% 80% / 1;
+  /* ✦ Theme/Other Colors/Indigo/9/Harness Theme/Dark */
+  --figma___other-colors-indigo-10: 236 94% 93% / 1;
+  /* ✦ Theme/Other Colors/Indigo/10/Harness Theme/Dark */
+  --figma___other-colors-indigo-alpha-1: 240 100% 49% / 0.04;
+  /* ✦ Theme/Other Colors/Indigo Alpha/1/Harness Theme/Dark */
+  --figma___other-colors-indigo-alpha-2: 232 100% 50% / 0.09;
+  /* ✦ Theme/Other Colors/Indigo Alpha/2/Harness Theme/Dark */
+  --figma___other-colors-indigo-alpha-3: 228 100% 57% / 0.18;
+  /* ✦ Theme/Other Colors/Indigo Alpha/3/Harness Theme/Dark */
+  --figma___other-colors-indigo-alpha-4: 228 99% 59% / 0.24;
+  /* ✦ Theme/Other Colors/Indigo Alpha/4/Harness Theme/Dark */
+  --figma___other-colors-indigo-alpha-5: 227 99% 60% / 0.29;
+  /* ✦ Theme/Other Colors/Indigo Alpha/5/Harness Theme/Dark */
+  --figma___other-colors-indigo-alpha-6: 225 100% 61% / 0.37;
+  /* ✦ Theme/Other Colors/Indigo Alpha/6/Harness Theme/Dark */
+  --figma___other-colors-indigo-alpha-7: 226 100% 63% / 0.85;
+  /* ✦ Theme/Other Colors/Indigo Alpha/7/Harness Theme/Dark */
+  --figma___other-colors-indigo-alpha-8: 230 100% 70% / 0.9;
+  /* ✦ Theme/Other Colors/Indigo Alpha/8/Harness Theme/Dark */
+  --figma___other-colors-indigo-alpha-9: 235 100% 80% / 1;
+  /* ✦ Theme/Other Colors/Indigo Alpha/9/Harness Theme/Dark */
+  --figma___other-colors-indigo-alpha-10: 236 100% 94% / 1;
+  /* ✦ Theme/Other Colors/Indigo Alpha/10/Harness Theme/Dark */
+  --figma___other-colors-mint-1: 173 52% 6% / 1;
+  /* ✦ Theme/Other Colors/Mint/1/Harness Theme/Dark */
+  --figma___other-colors-mint-2: 174 51% 8% / 1;
+  /* ✦ Theme/Other Colors/Mint/2/Harness Theme/Dark */
+  --figma___other-colors-mint-3: 176 52% 11% / 1;
+  /* ✦ Theme/Other Colors/Mint/3/Harness Theme/Dark */
+  --figma___other-colors-mint-4: 173 56% 13% / 1;
+  /* ✦ Theme/Other Colors/Mint/4/Harness Theme/Dark */
+  --figma___other-colors-mint-5: 173 57% 15% / 1;
+  /* ✦ Theme/Other Colors/Mint/5/Harness Theme/Dark */
+  --figma___other-colors-mint-6: 173 58% 18% / 1;
+  /* ✦ Theme/Other Colors/Mint/6/Harness Theme/Dark */
+  --figma___other-colors-mint-7: 167 70% 72% / 1;
+  /* ✦ Theme/Other Colors/Mint/7/Harness Theme/Dark */
+  --figma___other-colors-mint-8: 163 80% 77% / 1;
+  /* ✦ Theme/Other Colors/Mint/8/Harness Theme/Dark */
+  --figma___other-colors-mint-9: 167 70% 58% / 1;
+  /* ✦ Theme/Other Colors/Mint/9/Harness Theme/Dark */
+  --figma___other-colors-mint-10: 156 71% 86% / 1;
+  /* ✦ Theme/Other Colors/Mint/10/Harness Theme/Dark */
+  --figma___other-colors-mint-alpha-1: 120 100% 44% / 0;
+  /* ✦ Theme/Other Colors/Mint Alpha/1/Harness Theme/Dark */
+  --figma___other-colors-mint-alpha-2: 165 100% 49% / 0.03;
+  /* ✦ Theme/Other Colors/Mint Alpha/2/Harness Theme/Dark */
+  --figma___other-colors-mint-alpha-3: 174 100% 50% / 0.07;
+  /* ✦ Theme/Other Colors/Mint Alpha/3/Harness Theme/Dark */
+  --figma___other-colors-mint-alpha-4: 172 100% 50% / 0.11;
+  /* ✦ Theme/Other Colors/Mint Alpha/4/Harness Theme/Dark */
+  --figma___other-colors-mint-alpha-5: 172 100% 50% / 0.15;
+  /* ✦ Theme/Other Colors/Mint Alpha/5/Harness Theme/Dark */
+  --figma___other-colors-mint-alpha-6: 173 100% 50% / 0.21;
+  /* ✦ Theme/Other Colors/Mint Alpha/6/Harness Theme/Dark */
+  --figma___other-colors-mint-alpha-7: 167 100% 78% / 0.91;
+  /* ✦ Theme/Other Colors/Mint Alpha/7/Harness Theme/Dark */
+  --figma___other-colors-mint-alpha-8: 163 100% 81% / 0.95;
+  /* ✦ Theme/Other Colors/Mint Alpha/8/Harness Theme/Dark */
+  --figma___other-colors-mint-alpha-9: 167 100% 66% / 0.86;
+  /* ✦ Theme/Other Colors/Mint Alpha/9/Harness Theme/Dark */
+  --figma___other-colors-mint-alpha-10: 155 100% 90% / 0.96;
+  /* ✦ Theme/Other Colors/Mint Alpha/10/Harness Theme/Dark */
+  --figma___other-colors-orange-1: 29 68% 7% / 1;
+  /* ✦ Theme/Other Colors/Orange/1/Harness Theme/Dark */
+  --figma___other-colors-orange-2: 29 81% 8% / 1;
+  /* ✦ Theme/Other Colors/Orange/2/Harness Theme/Dark */
+  --figma___other-colors-orange-3: 26 68% 12% / 1;
+  /* ✦ Theme/Other Colors/Orange/3/Harness Theme/Dark */
+  --figma___other-colors-orange-4: 25 66% 15% / 1;
+  /* ✦ Theme/Other Colors/Orange/4/Harness Theme/Dark */
+  --figma___other-colors-orange-5: 25 65% 18% / 1;
+  /* ✦ Theme/Other Colors/Orange/5/Harness Theme/Dark */
+  --figma___other-colors-orange-6: 25 66% 22% / 1;
+  /* ✦ Theme/Other Colors/Orange/6/Harness Theme/Dark */
+  --figma___other-colors-orange-7: 24 94% 50% / 1;
+  /* ✦ Theme/Other Colors/Orange/7/Harness Theme/Dark */
+  --figma___other-colors-orange-8: 24 100% 58% / 1;
+  /* ✦ Theme/Other Colors/Orange/8/Harness Theme/Dark */
+  --figma___other-colors-orange-9: 24 100% 70% / 1;
+  /* ✦ Theme/Other Colors/Orange/9/Harness Theme/Dark */
+  --figma___other-colors-orange-10: 30 100% 88% / 1;
+  /* ✦ Theme/Other Colors/Orange/10/Harness Theme/Dark */
+  --figma___other-colors-orange-alpha-1: 0 100% 49% / 0.03;
+  /* ✦ Theme/Other Colors/Orange Alpha/1/Harness Theme/Dark */
+  --figma___other-colors-orange-alpha-2: 0 100% 50% / 0.06;
+  /* ✦ Theme/Other Colors/Orange Alpha/2/Harness Theme/Dark */
+  --figma___other-colors-orange-alpha-3: 13 100% 50% / 0.12;
+  /* ✦ Theme/Other Colors/Orange Alpha/3/Harness Theme/Dark */
+  --figma___other-colors-orange-alpha-4: 20 100% 50% / 0.17;
+  /* ✦ Theme/Other Colors/Orange Alpha/4/Harness Theme/Dark */
+  --figma___other-colors-orange-alpha-5: 24 100% 50% / 0.22;
+  /* ✦ Theme/Other Colors/Orange Alpha/5/Harness Theme/Dark */
+  --figma___other-colors-orange-alpha-6: 25 100% 51% / 0.3;
+  /* ✦ Theme/Other Colors/Orange Alpha/6/Harness Theme/Dark */
+  --figma___other-colors-orange-alpha-7: 24 100% 51% / 0.97;
+  /* ✦ Theme/Other Colors/Orange Alpha/7/Harness Theme/Dark */
+  --figma___other-colors-orange-alpha-8: 24 100% 58% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/8/Harness Theme/Dark */
+  --figma___other-colors-orange-alpha-9: 24 100% 70% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/9/Harness Theme/Dark */
+  --figma___other-colors-orange-alpha-10: 30 100% 88% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/10/Harness Theme/Dark */
+  --figma___other-colors-yellow-1: 45 100% 5% / 1;
+  /* ✦ Theme/Other Colors/Yellow/1/Harness Theme/Dark */
+  --figma___other-colors-yellow-2: 44 79% 7% / 1;
+  /* ✦ Theme/Other Colors/Yellow/2/Harness Theme/Dark */
+  --figma___other-colors-yellow-3: 44 63% 11% / 1;
+  /* ✦ Theme/Other Colors/Yellow/3/Harness Theme/Dark */
+  --figma___other-colors-yellow-4: 44 58% 13% / 1;
+  /* ✦ Theme/Other Colors/Yellow/4/Harness Theme/Dark */
+  --figma___other-colors-yellow-5: 45 56% 15% / 1;
+  /* ✦ Theme/Other Colors/Yellow/5/Harness Theme/Dark */
+  --figma___other-colors-yellow-6: 46 57% 18% / 1;
+  /* ✦ Theme/Other Colors/Yellow/6/Harness Theme/Dark */
+  --figma___other-colors-yellow-7: 53 96% 58% / 1;
+  /* ✦ Theme/Other Colors/Yellow/7/Harness Theme/Dark */
+  --figma___other-colors-yellow-8: 53 96% 67% / 1;
+  /* ✦ Theme/Other Colors/Yellow/8/Harness Theme/Dark */
+  --figma___other-colors-yellow-9: 55 100% 60% / 1;
+  /* ✦ Theme/Other Colors/Yellow/9/Harness Theme/Dark */
+  --figma___other-colors-yellow-10: 53 100% 84% / 1;
+  /* ✦ Theme/Other Colors/Yellow/10/Harness Theme/Dark */
+  --figma___other-colors-yellow-alpha-1: 0 100% 48% / 0.02;
+  /* ✦ Theme/Other Colors/Yellow Alpha/1/Harness Theme/Dark */
+  --figma___other-colors-yellow-alpha-2: 17 100% 49% / 0.04;
+  /* ✦ Theme/Other Colors/Yellow Alpha/2/Harness Theme/Dark */
+  --figma___other-colors-yellow-alpha-3: 36 100% 50% / 0.09;
+  /* ✦ Theme/Other Colors/Yellow Alpha/3/Harness Theme/Dark */
+  --figma___other-colors-yellow-alpha-4: 41 100% 50% / 0.12;
+  /* ✦ Theme/Other Colors/Yellow Alpha/4/Harness Theme/Dark */
+  --figma___other-colors-yellow-alpha-5: 44 100% 50% / 0.16;
+  /* ✦ Theme/Other Colors/Yellow Alpha/5/Harness Theme/Dark */
+  --figma___other-colors-yellow-alpha-6: 46 99% 51% / 0.21;
+  /* ✦ Theme/Other Colors/Yellow Alpha/6/Harness Theme/Dark */
+  --figma___other-colors-yellow-alpha-7: 53 100% 59% / 0.98;
+  /* ✦ Theme/Other Colors/Yellow Alpha/7/Harness Theme/Dark */
+  --figma___other-colors-yellow-alpha-8: 53 100% 68% / 0.99;
+  /* ✦ Theme/Other Colors/Yellow Alpha/8/Harness Theme/Dark */
+  --figma___other-colors-yellow-alpha-9: 55 100% 60% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/9/Harness Theme/Dark */
+  --figma___other-colors-yellow-alpha-10: 53 100% 84% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/10/Harness Theme/Dark */
+  --figma___overlays-black-alpha-1: 0 0% 0% / 0.01;
+  /* ✦ Theme/Overlays/Black Alpha/1/Harness Theme/Dark */
+  --figma___overlays-black-alpha-2: 0 0% 0% / 0.02;
+  /* ✦ Theme/Overlays/Black Alpha/2/Harness Theme/Dark */
+  --figma___overlays-black-alpha-3: 0 0% 0% / 0.05;
+  /* ✦ Theme/Overlays/Black Alpha/3/Harness Theme/Dark */
+  --figma___overlays-black-alpha-4: 0 0% 0% / 0.08;
+  /* ✦ Theme/Overlays/Black Alpha/4/Harness Theme/Dark */
+  --figma___overlays-black-alpha-5: 0 0% 0% / 0.11;
+  /* ✦ Theme/Overlays/Black Alpha/5/Harness Theme/Dark */
+  --figma___overlays-black-alpha-6: 0 0% 0% / 0.13;
+  /* ✦ Theme/Overlays/Black Alpha/6/Harness Theme/Dark */
+  --figma___overlays-black-alpha-7: 0 0% 0% / 0.45;
+  /* ✦ Theme/Overlays/Black Alpha/7/Harness Theme/Dark */
+  --figma___overlays-black-alpha-8: 0 0% 0% / 0.5;
+  /* ✦ Theme/Overlays/Black Alpha/8/Harness Theme/Dark */
+  --figma___overlays-black-alpha-9: 0 0% 0% / 0.61;
+  /* ✦ Theme/Overlays/Black Alpha/9/Harness Theme/Dark */
+  --figma___overlays-black-alpha-10: 0 0% 0% / 0.88;
+  /* ✦ Theme/Overlays/Black Alpha/10/Harness Theme/Dark */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 0;
+  /* ✦ Theme/Overlays/White Alpha/1/Harness Theme/Dark */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 0.01;
+  /* ✦ Theme/Overlays/White Alpha/2/Harness Theme/Dark */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 0.07;
+  /* ✦ Theme/Overlays/White Alpha/3/Harness Theme/Dark */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 0.1;
+  /* ✦ Theme/Overlays/White Alpha/4/Harness Theme/Dark */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 0.13;
+  /* ✦ Theme/Overlays/White Alpha/5/Harness Theme/Dark */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 0.17;
+  /* ✦ Theme/Overlays/White Alpha/6/Harness Theme/Dark */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 0.37;
+  /* ✦ Theme/Overlays/White Alpha/7/Harness Theme/Dark */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 0.46;
+  /* ✦ Theme/Overlays/White Alpha/8/Harness Theme/Dark */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 0.66;
+  /* ✦ Theme/Overlays/White Alpha/9/Harness Theme/Dark */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 0.93;
+  /* ✦ Theme/Overlays/White Alpha/10/Harness Theme/Dark */
+  --figma___pagination-active-background: 214 73% 51% / 1;
+  /* ✦ Theme/Pagination/Active/Background/Harness Theme/Dark */
+  --figma___pagination-active-border: 214 73% 51% / 1;
+  /* ✦ Theme/Pagination/Active/Border/Harness Theme/Dark */
+  --figma___pagination-background: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Background/Harness Theme/Dark */
+  --figma___pagination-default-background: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Default/Background/Harness Theme/Dark */
+  --figma___pagination-default-border: 0 0% 100% / 0;
+  /* ✦ Theme/Pagination/Default/Border/Harness Theme/Dark */
+  --figma___pagination-default-text: 0 0% 100% / 0.46;
+  /* ✦ Theme/Pagination/Default/Text/Harness Theme/Dark */
+  --figma___pagination-hover-background: 230 100% 87% / 0.09;
+  /* ✦ Theme/Pagination/Hover/Background/Harness Theme/Dark */
+  --figma___pagination-hover-border: 0 0% 16% / 1;
+  /* ✦ Theme/Pagination/Hover/Border/Harness Theme/Dark */
+  --figma___pagination-hover-text: 205 100% 71% / 1;
+  /* ✦ Theme/Pagination/Hover/Text/Harness Theme/Dark */
+  --figma___pagination-pagination-shadow-1: 0 0% 0% / 0;
+  /* ✦ Theme/Pagination/Pagination shadow/1/Harness Theme/Dark */
+  --figma___pagination-pagination-shadow-2: 240 100% 12% / 0;
+  /* ✦ Theme/Pagination/Pagination shadow/2/Harness Theme/Dark */
+  --figma___primary-color-primary-accent-1: 212 36% 9% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/1/Harness Theme/Dark */
+  --figma___primary-color-primary-accent-2: 216 50% 12% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/2/Harness Theme/Dark */
+  --figma___primary-color-primary-accent-3: 214 58% 16% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/3/Harness Theme/Dark */
+  --figma___primary-color-primary-accent-4: 214 65% 18% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/4/Harness Theme/Dark */
+  --figma___primary-color-primary-accent-5: 213 67% 21% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/5/Harness Theme/Dark */
+  --figma___primary-color-primary-accent-6: 212 72% 25% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/6/Harness Theme/Dark */
+  --figma___primary-color-primary-accent-7: 214 73% 51% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/7/Harness Theme/Dark */
+  --figma___primary-color-primary-accent-8: 206 100% 62% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/8/Harness Theme/Dark */
+  --figma___primary-color-primary-accent-9: 205 100% 71% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/9/Harness Theme/Dark */
+  --figma___primary-color-primary-accent-10: 206 100% 88% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/10/Harness Theme/Dark */
+  --figma___primary-color-primary-alpha-1: 240 100% 49% / 0.04;
+  /* ✦ Theme/Primary Color/Primary Alpha/1/Harness Theme/Dark */
+  --figma___primary-color-primary-alpha-2: 227 100% 50% / 0.09;
+  /* ✦ Theme/Primary Color/Primary Alpha/2/Harness Theme/Dark */
+  --figma___primary-color-primary-alpha-3: 216 100% 50% / 0.17;
+  /* ✦ Theme/Primary Color/Primary Alpha/3/Harness Theme/Dark */
+  --figma___primary-color-primary-alpha-4: 214 100% 50% / 0.23;
+  /* ✦ Theme/Primary Color/Primary Alpha/4/Harness Theme/Dark */
+  --figma___primary-color-primary-alpha-5: 213 100% 51% / 0.29;
+  /* ✦ Theme/Primary Color/Primary Alpha/5/Harness Theme/Dark */
+  --figma___primary-color-primary-alpha-6: 212 100% 52% / 0.38;
+  /* ✦ Theme/Primary Color/Primary Alpha/6/Harness Theme/Dark */
+  --figma___primary-color-primary-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/7/Harness Theme/Dark */
+  --figma___primary-color-primary-alpha-8: 206 100% 62% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/8/Harness Theme/Dark */
+  --figma___primary-color-primary-alpha-9: 205 100% 71% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/9/Harness Theme/Dark */
+  --figma___primary-color-primary-alpha-10: 206 100% 88% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/10/Harness Theme/Dark */
+  --figma___radio-button-background: 236 19% 14% / 0.5;
+  /* ✦ Theme/Radio button/Background/Harness Theme/Dark */
+  --figma___radio-button-checked-active-active-border: 214 73% 51% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active Border/Harness Theme/Dark */
+  --figma___radio-button-checked-active-active-background: 214 73% 51% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active background/Harness Theme/Dark */
+  --figma___radio-button-checked-active-hover-background: 206 100% 62% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover background/Harness Theme/Dark */
+  --figma___radio-button-checked-active-hover-border: 206 100% 62% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover border/Harness Theme/Dark */
+  --figma___radio-button-checked-active-default-background: 214 73% 51% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default background/Harness Theme/Dark */
+  --figma___radio-button-checked-active-default-border: 214 73% 51% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default border/Harness Theme/Dark */
+  --figma___radio-button-checked-disabled-dot: 0 0% 100% / 0.31;
+  /* ✦ Theme/Radio button/Checked/Disabled/Dot/Harness Theme/Dark */
+  --figma___radio-button-checked-disabled-background: 0 0% 100% / 0.07;
+  /* ✦ Theme/Radio button/Checked/Disabled/background/Harness Theme/Dark */
+  --figma___radio-button-checked-disabled-border: 0 0% 100% / 0.17;
+  /* ✦ Theme/Radio button/Checked/Disabled/border/Harness Theme/Dark */
+  --figma___radio-button-paper: 0 0% 100% / 0.03;
+  /* ✦ Theme/Radio button/Paper/Harness Theme/Dark */
+  --figma___radio-button-unchecked-active-active-border: 0 0% 100% / 0.37;
+  /* ✦ Theme/Radio button/Unchecked/Active/Active border/Harness Theme/Dark */
+  --figma___radio-button-unchecked-active-hover-border: 0 0% 100% / 0.31;
+  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/Harness Theme/Dark */
+  --figma___radio-button-unchecked-active-default-background: 0 0% 100% / 0.07;
+  /* ✦ Theme/Radio button/Unchecked/Active/default background/Harness Theme/Dark */
+  --figma___radio-button-unchecked-active-default-border: 0 0% 100% / 0.22;
+  /* ✦ Theme/Radio button/Unchecked/Active/default border/Harness Theme/Dark */
+  --figma___radio-button-unchecked-disabled-background: 0 0% 100% / 0.07;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/background/Harness Theme/Dark */
+  --figma___radio-button-unchecked-disabled-border: 0 0% 100% / 0.17;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/border/Harness Theme/Dark */
+  --figma___radio-button-border: 0 0% 100% / 0.07;
+  /* ✦ Theme/Radio button/border/Harness Theme/Dark */
+  --figma___secondary-crimson-crimson-1: 333 18% 10% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 1/Harness Theme/Dark */
+  --figma___secondary-crimson-crimson-10: 330 91% 91% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 10/Harness Theme/Dark */
+  --figma___secondary-crimson-crimson-2: 336 32% 12% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 2/Harness Theme/Dark */
+  --figma___secondary-crimson-crimson-3: 335 41% 16% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 3/Harness Theme/Dark */
+  --figma___secondary-crimson-crimson-4: 336 45% 18% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 4/Harness Theme/Dark */
+  --figma___secondary-crimson-crimson-5: 336 49% 21% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 5/Harness Theme/Dark */
+  --figma___secondary-crimson-crimson-6: 336 54% 25% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 6/Harness Theme/Dark */
+  --figma___secondary-crimson-crimson-7: 336 80% 58% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 7/Harness Theme/Dark */
+  --figma___secondary-crimson-crimson-8: 339 87% 67% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 8/Harness Theme/Dark */
+  --figma___secondary-crimson-crimson-9: 341 100% 76% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 9/Harness Theme/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-1: 354 100% 49% / 0.02;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/Harness Theme/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-10: 341 100% 76% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/Harness Theme/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-11: 329 100% 92% / 0.99;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/Harness Theme/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-2: 338 100% 50% / 0.07;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/Harness Theme/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-3: 335 100% 55% / 0.14;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/Harness Theme/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-4: 336 99% 56% / 0.19;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/Harness Theme/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-5: 336 100% 58% / 0.25;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/Harness Theme/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-6: 336 99% 58% / 0.33;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/Harness Theme/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-8: 336 100% 63% / 0.9;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/Harness Theme/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-9: 339 100% 70% / 0.95;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/Harness Theme/Dark */
+  --figma___secondary-lime-1: 74 55% 6% / 1;
+  /* ✦ Theme/Secondary/Lime/1/Harness Theme/Dark */
+  --figma___secondary-lime-2: 78 41% 8% / 1;
+  /* ✦ Theme/Secondary/Lime/2/Harness Theme/Dark */
+  --figma___secondary-lime-3: 82 39% 11% / 1;
+  /* ✦ Theme/Secondary/Lime/3/Harness Theme/Dark */
+  --figma___secondary-lime-4: 82 40% 13% / 1;
+  /* ✦ Theme/Secondary/Lime/4/Harness Theme/Dark */
+  --figma___secondary-lime-5: 81 41% 15% / 1;
+  /* ✦ Theme/Secondary/Lime/5/Harness Theme/Dark */
+  --figma___secondary-lime-6: 80 43% 18% / 1;
+  /* ✦ Theme/Secondary/Lime/6/Harness Theme/Dark */
+  --figma___secondary-lime-7: 81 80% 66% / 1;
+  /* ✦ Theme/Secondary/Lime/7/Harness Theme/Dark */
+  --figma___secondary-lime-8: 75 85% 60% / 1;
+  /* ✦ Theme/Secondary/Lime/8/Harness Theme/Dark */
+  --figma___secondary-lime-9: 70 70% 50% / 1;
+  /* ✦ Theme/Secondary/Lime/9/Harness Theme/Dark */
+  --figma___secondary-lime-10: 80 79% 85% / 1;
+  /* ✦ Theme/Secondary/Lime/10/Harness Theme/Dark */
+  --figma___secondary-lime-alpha-1: 75 100% 5% / 0.71;
+  /* ✦ Theme/Secondary/Lime Alpha/1/Harness Theme/Dark */
+  --figma___secondary-lime-alpha-2: 114 100% 49% / 0.02;
+  /* ✦ Theme/Secondary/Lime Alpha/2/Harness Theme/Dark */
+  --figma___secondary-lime-alpha-3: 89 100% 50% / 0.06;
+  /* ✦ Theme/Secondary/Lime Alpha/3/Harness Theme/Dark */
+  --figma___secondary-lime-alpha-4: 84 100% 50% / 0.1;
+  /* ✦ Theme/Secondary/Lime Alpha/4/Harness Theme/Dark */
+  --figma___secondary-lime-alpha-5: 81 99% 53% / 0.14;
+  /* ✦ Theme/Secondary/Lime Alpha/5/Harness Theme/Dark */
+  --figma___secondary-lime-alpha-6: 80 99% 58% / 0.19;
+  /* ✦ Theme/Secondary/Lime Alpha/6/Harness Theme/Dark */
+  --figma___secondary-lime-alpha-7: 81 100% 71% / 0.93;
+  /* ✦ Theme/Secondary/Lime Alpha/7/Harness Theme/Dark */
+  --figma___secondary-lime-alpha-8: 75 100% 64% / 0.94;
+  /* ✦ Theme/Secondary/Lime Alpha/8/Harness Theme/Dark */
+  --figma___secondary-lime-alpha-9: 70 100% 58% / 0.84;
+  /* ✦ Theme/Secondary/Lime Alpha/9/Harness Theme/Dark */
+  --figma___secondary-lime-alpha-10: 80 100% 88% / 0.97;
+  /* ✦ Theme/Secondary/Lime Alpha/10/Harness Theme/Dark */
+  --figma___secondary-purple-1: 287 18% 10% / 1;
+  /* ✦ Theme/Secondary/Purple/1/Harness Theme/Dark */
+  --figma___secondary-purple-2: 284 31% 12% / 1;
+  /* ✦ Theme/Secondary/Purple/2/Harness Theme/Dark */
+  --figma___secondary-purple-3: 282 35% 17% / 1;
+  /* ✦ Theme/Secondary/Purple/3/Harness Theme/Dark */
+  --figma___secondary-purple-4: 281 37% 20% / 1;
+  /* ✦ Theme/Secondary/Purple/4/Harness Theme/Dark */
+  --figma___secondary-purple-5: 280 38% 23% / 1;
+  /* ✦ Theme/Secondary/Purple/5/Harness Theme/Dark */
+  --figma___secondary-purple-6: 278 40% 27% / 1;
+  /* ✦ Theme/Secondary/Purple/6/Harness Theme/Dark */
+  --figma___secondary-purple-7: 272 51% 54% / 1;
+  /* ✦ Theme/Secondary/Purple/7/Harness Theme/Dark */
+  --figma___secondary-purple-8: 271 58% 61% / 1;
+  /* ✦ Theme/Secondary/Purple/8/Harness Theme/Dark */
+  --figma___secondary-purple-9: 270 89% 78% / 1;
+  /* ✦ Theme/Secondary/Purple/9/Harness Theme/Dark */
+  --figma___secondary-purple-10: 275 77% 92% / 1;
+  /* ✦ Theme/Secondary/Purple/10/Harness Theme/Dark */
+  --figma___secondary-purple-alpha-1: 278 100% 49% / 0.02;
+  /* ✦ Theme/Secondary/Purple Alpha/1/Harness Theme/Dark */
+  --figma___secondary-purple-alpha-2: 283 100% 49% / 0.07;
+  /* ✦ Theme/Secondary/Purple Alpha/2/Harness Theme/Dark */
+  --figma___secondary-purple-alpha-3: 282 99% 60% / 0.15;
+  /* ✦ Theme/Secondary/Purple Alpha/3/Harness Theme/Dark */
+  --figma___secondary-purple-alpha-4: 281 99% 62% / 0.2;
+  /* ✦ Theme/Secondary/Purple Alpha/4/Harness Theme/Dark */
+  --figma___secondary-purple-alpha-5: 280 100% 64% / 0.25;
+  /* ✦ Theme/Secondary/Purple Alpha/5/Harness Theme/Dark */
+  --figma___secondary-purple-alpha-6: 278 99% 66% / 0.32;
+  /* ✦ Theme/Secondary/Purple Alpha/6/Harness Theme/Dark */
+  --figma___secondary-purple-alpha-7: 272 100% 69% / 0.75;
+  /* ✦ Theme/Secondary/Purple Alpha/7/Harness Theme/Dark */
+  --figma___secondary-purple-alpha-8: 271 100% 73% / 0.82;
+  /* ✦ Theme/Secondary/Purple Alpha/8/Harness Theme/Dark */
+  --figma___secondary-purple-alpha-9: 270 100% 80% / 0.98;
+  /* ✦ Theme/Secondary/Purple Alpha/9/Harness Theme/Dark */
+  --figma___secondary-purple-alpha-10: 275 100% 93% / 0.98;
+  /* ✦ Theme/Secondary/Purple Alpha/10/Harness Theme/Dark */
+  --figma___secondary-teal-1: 166 49% 7% / 1;
+  /* ✦ Theme/Secondary/Teal/1/Harness Theme/Dark */
+  --figma___secondary-teal-2: 166 55% 8% / 1;
+  /* ✦ Theme/Secondary/Teal/2/Harness Theme/Dark */
+  --figma___secondary-teal-3: 167 52% 11% / 1;
+  /* ✦ Theme/Secondary/Teal/3/Harness Theme/Dark */
+  --figma___secondary-teal-4: 169 53% 13% / 1;
+  /* ✦ Theme/Secondary/Teal/4/Harness Theme/Dark */
+  --figma___secondary-teal-5: 168 53% 15% / 1;
+  /* ✦ Theme/Secondary/Teal/5/Harness Theme/Dark */
+  --figma___secondary-teal-6: 169 52% 18% / 1;
+  /* ✦ Theme/Secondary/Teal/6/Harness Theme/Dark */
+  --figma___secondary-teal-7: 173 80% 36% / 1;
+  /* ✦ Theme/Secondary/Teal/7/Harness Theme/Dark */
+  --figma___secondary-teal-8: 172 90% 39% / 1;
+  /* ✦ Theme/Secondary/Teal/8/Harness Theme/Dark */
+  --figma___secondary-teal-9: 170 90% 45% / 1;
+  /* ✦ Theme/Secondary/Teal/9/Harness Theme/Dark */
+  --figma___secondary-teal-10: 163 69% 81% / 1;
+  /* ✦ Theme/Secondary/Teal/10/Harness Theme/Dark */
+  --figma___secondary-teal-alpha-1: 120 100% 48% / 0.01;
+  /* ✦ Theme/Secondary/Teal Alpha/1/Harness Theme/Dark */
+  --figma___secondary-teal-alpha-2: 141 100% 49% / 0.03;
+  /* ✦ Theme/Secondary/Teal Alpha/2/Harness Theme/Dark */
+  --figma___secondary-teal-alpha-3: 161 100% 50% / 0.07;
+  /* ✦ Theme/Secondary/Teal Alpha/3/Harness Theme/Dark */
+  --figma___secondary-teal-alpha-4: 167 100% 50% / 0.11;
+  /* ✦ Theme/Secondary/Teal Alpha/4/Harness Theme/Dark */
+  --figma___secondary-teal-alpha-5: 167 100% 50% / 0.15;
+  /* ✦ Theme/Secondary/Teal Alpha/5/Harness Theme/Dark */
+  --figma___secondary-teal-alpha-6: 169 99% 53% / 0.2;
+  /* ✦ Theme/Secondary/Teal Alpha/6/Harness Theme/Dark */
+  --figma___secondary-teal-alpha-7: 173 100% 53% / 0.61;
+  /* ✦ Theme/Secondary/Teal Alpha/7/Harness Theme/Dark */
+  --figma___secondary-teal-alpha-8: 172 100% 51% / 0.71;
+  /* ✦ Theme/Secondary/Teal Alpha/8/Harness Theme/Dark */
+  --figma___secondary-teal-alpha-9: 170 100% 52% / 0.83;
+  /* ✦ Theme/Secondary/Teal Alpha/9/Harness Theme/Dark */
+  --figma___secondary-teal-alpha-10: 163 100% 86% / 0.94;
+  /* ✦ Theme/Secondary/Teal Alpha/10/Harness Theme/Dark */
+  --figma___shadow-shadow-button-1: 0 0% 0% / 0.5;
+  /* ✦ Theme/Shadow/Shadow - button/1/Harness Theme/Dark */
+  --figma___shadow-shadow-button-2: 0 0% 100% / 0.31;
+  /* ✦ Theme/Shadow/Shadow - button/2/Harness Theme/Dark */
+  --figma___shadow-shadow-button-3: 0 0% 100% / 0.31;
+  /* ✦ Theme/Shadow/Shadow - button/3/Harness Theme/Dark */
+  --figma___shadow-shadow-button-4: 0 0% 0% / 0.11;
+  /* ✦ Theme/Shadow/Shadow - button/4/Harness Theme/Dark */
+  --figma___shadow-shadow-1-1: 0 0% 0% / 0.13;
+  /* ✦ Theme/Shadow/Shadow 1/1/Harness Theme/Dark */
+  --figma___shadow-shadow-2-1: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 2/1/Harness Theme/Dark */
+  --figma___shadow-shadow-2-2: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 2/2/Harness Theme/Dark */
+  --figma___shadow-shadow-2-3: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 2/3/Harness Theme/Dark */
+  --figma___shadow-shadow-3-1: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 3/1/Harness Theme/Dark */
+  --figma___shadow-shadow-3-2: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow 3/2/Harness Theme/Dark */
+  --figma___shadow-shadow-3-3: 0 0% 0% / 0.11;
+  /* ✦ Theme/Shadow/Shadow 3/3/Harness Theme/Dark */
+  --figma___shadow-shadow-4-1: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow 4/1/Harness Theme/Dark */
+  --figma___shadow-shadow-4-2: 0 0% 0% / 0.17;
+  /* ✦ Theme/Shadow/Shadow 4/2/Harness Theme/Dark */
+  --figma___shadow-shadow-5-1: 0 0% 0% / 0.5;
+  /* ✦ Theme/Shadow/Shadow 5/1/Harness Theme/Dark */
+  --figma___shadow-shadow-5-2: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow 5/2/Harness Theme/Dark */
+  --figma___shadow-shadow-6-1: 0 0% 0% / 0.88;
+  /* ✦ Theme/Shadow/Shadow 6/1/Harness Theme/Dark */
+  --figma___shadow-shadow-6-2: 0 0% 0% / 0.61;
+  /* ✦ Theme/Shadow/Shadow 6/2/Harness Theme/Dark */
+  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
+  /* ✦ Theme/Shadow/Shadow-button-active/1/Harness Theme/Dark */
+  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
+  /* ✦ Theme/Shadow/Shadow-button-active/2/Harness Theme/Dark */
+  --figma___shadow-shadow-button-active-3: 0 0% 100% / 0.27;
+  /* ✦ Theme/Shadow/Shadow-button-active/3/Harness Theme/Dark */
+  --figma___shadow-shadow-button-active-4: 0 0% 100% / 0.11;
+  /* ✦ Theme/Shadow/Shadow-button-active/4/Harness Theme/Dark */
+  --figma___side-nav-container-nav-background: 0 4% 5% / 1;
+  /* ✦ Theme/Side nav/Container/Nav-background/Harness Theme/Dark */
+  --figma___side-nav-container-nav-border: 0 0% 100% / 0;
+  /* ✦ Theme/Side nav/Container/Nav-border/Harness Theme/Dark */
+  --figma___side-nav-module-logo-text: 0 0% 93% / 1;
+  /* ✦ Theme/Side nav/Module Logo Text/Harness Theme/Dark */
+  --figma___side-nav-nav-item-default-icon: 0 0% 100% / 0.46;
+  /* ✦ Theme/Side nav/Nav-item/Default/Icon/Harness Theme/Dark */
+  --figma___side-nav-nav-item-default-text: 0 0% 69% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Default/Text/Harness Theme/Dark */
+  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
+  /* ✦ Theme/Side nav/Nav-item/Default/default/Harness Theme/Dark */
+  --figma___side-nav-nav-item-hover-background: 210 6% 20% / 0.24;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Background/Harness Theme/Dark */
+  --figma___side-nav-nav-item-hover-icon: 0 0% 69% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/Harness Theme/Dark */
+  --figma___side-nav-nav-item-hover-text: 0 0% 69% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Text/Harness Theme/Dark */
+  --figma___side-nav-nav-item-selected-background: 210 6% 20% / 0.24;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Background/Harness Theme/Dark */
+  --figma___side-nav-nav-item-selected-icon: 0 0% 93% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/Harness Theme/Dark */
+  --figma___side-nav-nav-item-selected-text: 0 0% 93% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Text/Harness Theme/Dark */
+  --figma___side-nav-profile-role: 0 0% 100% / 0.46;
+  /* ✦ Theme/Side nav/Profile/Role/Harness Theme/Dark */
+  --figma___side-nav-profile-text: 0 0% 93% / 1;
+  /* ✦ Theme/Side nav/Profile/Text/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-default-border: 0 0% 100% / 0.1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Border/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-default-main-text-icon: 0 0% 93% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-default-scope-name: 0 0% 100% / 0.46;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-default-default: 0 0% 0% / 0.5;
+  /* ✦ Theme/Side nav/Scope Selector/Default/default/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-hover-border: 205 100% 71% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-hover-main-text-icon: 0 0% 93% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-hover-scope-name: 0 0% 100% / 0.46;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-hover-default: 0 0% 0% / 0.5;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/default/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-selected-border: 205 100% 71% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-selected-main-text-icon: 0 0% 93% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-selected-scope-name: 0 0% 100% / 0.46;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/Harness Theme/Dark */
+  --figma___side-nav-scope-selector-selected-background: 0 0% 0% / 0.5;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/background/Harness Theme/Dark */
+  --figma___side-nav-separator: 0 0% 100% / 0.1;
+  /* ✦ Theme/Side nav/Separator/Harness Theme/Dark */
+  --figma___status-colors-error-1: 350 24% 10% / 1;
+  /* ✦ Theme/Status colors/Error/1/Harness Theme/Dark */
+  --figma___status-colors-error-2: 354 30% 12% / 1;
+  /* ✦ Theme/Status colors/Error/2/Harness Theme/Dark */
+  --figma___status-colors-error-3: 353 40% 16% / 1;
+  /* ✦ Theme/Status colors/Error/3/Harness Theme/Dark */
+  --figma___status-colors-error-4: 352 47% 19% / 1;
+  /* ✦ Theme/Status colors/Error/4/Harness Theme/Dark */
+  --figma___status-colors-error-5: 354 50% 22% / 1;
+  /* ✦ Theme/Status colors/Error/5/Harness Theme/Dark */
+  --figma___status-colors-error-6: 354 57% 26% / 1;
+  /* ✦ Theme/Status colors/Error/6/Harness Theme/Dark */
+  --figma___status-colors-error-7: 358 75% 59% / 1;
+  /* ✦ Theme/Status colors/Error/7/Harness Theme/Dark */
+  --figma___status-colors-error-8: 359 84% 67% / 1;
+  /* ✦ Theme/Status colors/Error/8/Harness Theme/Dark */
+  --figma___status-colors-error-9: 358 100% 76% / 1;
+  /* ✦ Theme/Status colors/Error/9/Harness Theme/Dark */
+  --figma___status-colors-error-10: 350 100% 91% / 1;
+  /* ✦ Theme/Status colors/Error/10/Harness Theme/Dark */
+  --figma___status-colors-error-alpha-1: 0 100% 49% / 0.03;
+  /* ✦ Theme/Status colors/Error Alpha/1/Harness Theme/Dark */
+  --figma___status-colors-error-alpha-2: 354 100% 50% / 0.07;
+  /* ✦ Theme/Status colors/Error Alpha/2/Harness Theme/Dark */
+  --figma___status-colors-error-alpha-3: 353 99% 56% / 0.15;
+  /* ✦ Theme/Status colors/Error Alpha/3/Harness Theme/Dark */
+  --figma___status-colors-error-alpha-4: 352 100% 56% / 0.21;
+  /* ✦ Theme/Status colors/Error Alpha/4/Harness Theme/Dark */
+  --figma___status-colors-error-alpha-5: 354 99% 57% / 0.26;
+  /* ✦ Theme/Status colors/Error Alpha/5/Harness Theme/Dark */
+  --figma___status-colors-error-alpha-6: 354 100% 57% / 0.35;
+  /* ✦ Theme/Status colors/Error Alpha/6/Harness Theme/Dark */
+  --figma___status-colors-error-alpha-7: 358 100% 65% / 0.89;
+  /* ✦ Theme/Status colors/Error Alpha/7/Harness Theme/Dark */
+  --figma___status-colors-error-alpha-8: 359 100% 71% / 0.94;
+  /* ✦ Theme/Status colors/Error Alpha/8/Harness Theme/Dark */
+  --figma___status-colors-error-alpha-9: 358 100% 76% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/9/Harness Theme/Dark */
+  --figma___status-colors-error-alpha-10: 350 100% 91% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/10/Harness Theme/Dark */
+  --figma___status-colors-info-1: 212 36% 9% / 1;
+  /* ✦ Theme/Status colors/Info/1/Harness Theme/Dark */
+  --figma___status-colors-info-2: 216 50% 12% / 1;
+  /* ✦ Theme/Status colors/Info/2/Harness Theme/Dark */
+  --figma___status-colors-info-3: 214 58% 16% / 1;
+  /* ✦ Theme/Status colors/Info/3/Harness Theme/Dark */
+  --figma___status-colors-info-4: 214 65% 18% / 1;
+  /* ✦ Theme/Status colors/Info/4/Harness Theme/Dark */
+  --figma___status-colors-info-5: 213 67% 21% / 1;
+  /* ✦ Theme/Status colors/Info/5/Harness Theme/Dark */
+  --figma___status-colors-info-6: 212 72% 25% / 1;
+  /* ✦ Theme/Status colors/Info/6/Harness Theme/Dark */
+  --figma___status-colors-info-7: 214 73% 51% / 1;
+  /* ✦ Theme/Status colors/Info/7/Harness Theme/Dark */
+  --figma___status-colors-info-8: 206 100% 62% / 1;
+  /* ✦ Theme/Status colors/Info/8/Harness Theme/Dark */
+  --figma___status-colors-info-9: 205 100% 71% / 1;
+  /* ✦ Theme/Status colors/Info/9/Harness Theme/Dark */
+  --figma___status-colors-info-10: 206 100% 88% / 1;
+  /* ✦ Theme/Status colors/Info/10/Harness Theme/Dark */
+  --figma___status-colors-info-alpha-1: 240 100% 49% / 0.04;
+  /* ✦ Theme/Status colors/Info Alpha/1/Harness Theme/Dark */
+  --figma___status-colors-info-alpha-2: 227 100% 50% / 0.09;
+  /* ✦ Theme/Status colors/Info Alpha/2/Harness Theme/Dark */
+  --figma___status-colors-info-alpha-3: 216 100% 50% / 0.17;
+  /* ✦ Theme/Status colors/Info Alpha/3/Harness Theme/Dark */
+  --figma___status-colors-info-alpha-4: 214 100% 50% / 0.23;
+  /* ✦ Theme/Status colors/Info Alpha/4/Harness Theme/Dark */
+  --figma___status-colors-info-alpha-5: 213 100% 51% / 0.29;
+  /* ✦ Theme/Status colors/Info Alpha/5/Harness Theme/Dark */
+  --figma___status-colors-info-alpha-6: 212 100% 52% / 0.38;
+  /* ✦ Theme/Status colors/Info Alpha/6/Harness Theme/Dark */
+  --figma___status-colors-info-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/7/Harness Theme/Dark */
+  --figma___status-colors-info-alpha-8: 206 100% 62% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/8/Harness Theme/Dark */
+  --figma___status-colors-info-alpha-9: 205 100% 71% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/9/Harness Theme/Dark */
+  --figma___status-colors-info-alpha-10: 206 100% 88% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/10/Harness Theme/Dark */
+  --figma___status-colors-success-1: 145 32% 7% / 1;
+  /* ✦ Theme/Status colors/Success/1/Harness Theme/Dark */
+  --figma___status-colors-success-2: 154 32% 9% / 1;
+  /* ✦ Theme/Status colors/Success/2/Harness Theme/Dark */
+  --figma___status-colors-success-3: 155 38% 11% / 1;
+  /* ✦ Theme/Status colors/Success/3/Harness Theme/Dark */
+  --figma___status-colors-success-4: 155 42% 14% / 1;
+  /* ✦ Theme/Status colors/Success/4/Harness Theme/Dark */
+  --figma___status-colors-success-5: 153 43% 16% / 1;
+  /* ✦ Theme/Status colors/Success/5/Harness Theme/Dark */
+  --figma___status-colors-success-6: 155 47% 19% / 1;
+  /* ✦ Theme/Status colors/Success/6/Harness Theme/Dark */
+  --figma___status-colors-success-7: 142 72% 29% / 1;
+  /* ✦ Theme/Status colors/Success/7/Harness Theme/Dark */
+  --figma___status-colors-success-8: 151 55% 47% / 1;
+  /* ✦ Theme/Status colors/Success/8/Harness Theme/Dark */
+  --figma___status-colors-success-9: 151 65% 54% / 1;
+  /* ✦ Theme/Status colors/Success/9/Harness Theme/Dark */
+  --figma___status-colors-success-10: 144 70% 82% / 1;
+  /* ✦ Theme/Status colors/Success/10/Harness Theme/Dark */
+  --figma___status-colors-success-alpha-1: 120 100% 44% / 0;
+  /* ✦ Theme/Status colors/Success Alpha/1/Harness Theme/Dark */
+  --figma___status-colors-success-alpha-2: 120 100% 49% / 0.02;
+  /* ✦ Theme/Status colors/Success Alpha/2/Harness Theme/Dark */
+  --figma___status-colors-success-alpha-3: 149 100% 49% / 0.07;
+  /* ✦ Theme/Status colors/Success Alpha/3/Harness Theme/Dark */
+  --figma___status-colors-success-alpha-4: 154 100% 50% / 0.11;
+  /* ✦ Theme/Status colors/Success Alpha/4/Harness Theme/Dark */
+  --figma___status-colors-success-alpha-5: 153 99% 53% / 0.15;
+  /* ✦ Theme/Status colors/Success Alpha/5/Harness Theme/Dark */
+  --figma___status-colors-success-alpha-6: 155 99% 55% / 0.2;
+  /* ✦ Theme/Status colors/Success Alpha/6/Harness Theme/Dark */
+  --figma___status-colors-success-alpha-7: 151 100% 62% / 0.61;
+  /* ✦ Theme/Status colors/Success Alpha/7/Harness Theme/Dark */
+  --figma___status-colors-success-alpha-8: 151 100% 63% / 0.7;
+  /* ✦ Theme/Status colors/Success Alpha/8/Harness Theme/Dark */
+  --figma___status-colors-success-alpha-9: 151 100% 64% / 0.82;
+  /* ✦ Theme/Status colors/Success Alpha/9/Harness Theme/Dark */
+  --figma___status-colors-success-alpha-10: 144 100% 87% / 0.94;
+  /* ✦ Theme/Status colors/Success Alpha/10/Harness Theme/Dark */
+  --figma___status-colors-warning-1: 37 100% 6% / 1;
+  /* ✦ Theme/Status colors/Warning/1/Harness Theme/Dark */
+  --figma___status-colors-warning-2: 36 80% 8% / 1;
+  /* ✦ Theme/Status colors/Warning/2/Harness Theme/Dark */
+  --figma___status-colors-warning-3: 34 63% 12% / 1;
+  /* ✦ Theme/Status colors/Warning/3/Harness Theme/Dark */
+  --figma___status-colors-warning-4: 34 58% 14% / 1;
+  /* ✦ Theme/Status colors/Warning/4/Harness Theme/Dark */
+  --figma___status-colors-warning-5: 34 58% 17% / 1;
+  /* ✦ Theme/Status colors/Warning/5/Harness Theme/Dark */
+  --figma___status-colors-warning-6: 34 58% 21% / 1;
+  /* ✦ Theme/Status colors/Warning/6/Harness Theme/Dark */
+  --figma___status-colors-warning-7: 42 100% 62% / 1;
+  /* ✦ Theme/Status colors/Warning/7/Harness Theme/Dark */
+  --figma___status-colors-warning-8: 43 100% 64% / 1;
+  /* ✦ Theme/Status colors/Warning/8/Harness Theme/Dark */
+  --figma___status-colors-warning-9: 43 100% 65% / 1;
+  /* ✦ Theme/Status colors/Warning/9/Harness Theme/Dark */
+  --figma___status-colors-warning-10: 41 100% 85% / 1;
+  /* ✦ Theme/Status colors/Warning/10/Harness Theme/Dark */
+  --figma___status-colors-warning-alpha-1: 0 100% 49% / 0.03;
+  /* ✦ Theme/Status colors/Warning Alpha/1/Harness Theme/Dark */
+  --figma___status-colors-warning-alpha-2: 6 100% 49% / 0.06;
+  /* ✦ Theme/Status colors/Warning Alpha/2/Harness Theme/Dark */
+  --figma___status-colors-warning-alpha-3: 24 100% 50% / 0.1;
+  /* ✦ Theme/Status colors/Warning Alpha/3/Harness Theme/Dark */
+  --figma___status-colors-warning-alpha-4: 30 100% 50% / 0.14;
+  /* ✦ Theme/Status colors/Warning Alpha/4/Harness Theme/Dark */
+  --figma___status-colors-warning-alpha-5: 33 100% 50% / 0.19;
+  /* ✦ Theme/Status colors/Warning Alpha/5/Harness Theme/Dark */
+  --figma___status-colors-warning-alpha-6: 34 100% 53% / 0.26;
+  /* ✦ Theme/Status colors/Warning Alpha/6/Harness Theme/Dark */
+  --figma___status-colors-warning-alpha-7: 42 100% 62% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/7/Harness Theme/Dark */
+  --figma___status-colors-warning-alpha-8: 43 100% 64% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/8/Harness Theme/Dark */
+  --figma___status-colors-warning-alpha-9: 43 100% 65% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/9/Harness Theme/Dark */
+  --figma___status-colors-warning-alpha-10: 41 100% 85% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/10/Harness Theme/Dark */
+  --figma___switch-background: 236 19% 14% / 0.5;
+  /* ✦ Theme/Switch/Background/Harness Theme/Dark */
+  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/Harness Theme/Dark */
+  --figma___switch-checked-active-background: 214 73% 51% / 1;
+  /* ✦ Theme/Switch/Checked/Active/background/Harness Theme/Dark */
+  --figma___switch-checked-active-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Checked/Active/border/Harness Theme/Dark */
+  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/Harness Theme/Dark */
+  --figma___switch-checked-default-default-background: 214 73% 51% / 1;
+  /* ✦ Theme/Switch/Checked/Default/default background/Harness Theme/Dark */
+  --figma___switch-checked-default-default-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Checked/Default/default border/Harness Theme/Dark */
+  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/Harness Theme/Dark */
+  --figma___switch-checked-disabled-background: 206 100% 50% / 1;
+  /* ✦ Theme/Switch/Checked/Disabled/background/Harness Theme/Dark */
+  --figma___switch-checked-disabled-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/border/Harness Theme/Dark */
+  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/Harness Theme/Dark */
+  --figma___switch-checked-hover-background: 206 100% 62% / 1;
+  /* ✦ Theme/Switch/Checked/Hover/background/Harness Theme/Dark */
+  --figma___switch-checked-hover-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/border/Harness Theme/Dark */
+  --figma___switch-paper: 0 0% 100% / 0.03;
+  /* ✦ Theme/Switch/Paper/Harness Theme/Dark */
+  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/Harness Theme/Dark */
+  --figma___switch-unchecked-active-background: 0 0% 100% / 0.13;
+  /* ✦ Theme/Switch/Unchecked/Active/background/Harness Theme/Dark */
+  --figma___switch-unchecked-active-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Unchecked/Active/border/Harness Theme/Dark */
+  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/Harness Theme/Dark */
+  --figma___switch-unchecked-default-default-background: 230 100% 87% / 0.09;
+  /* ✦ Theme/Switch/Unchecked/Default/default background/Harness Theme/Dark */
+  --figma___switch-unchecked-default-default-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Unchecked/Default/default border/Harness Theme/Dark */
+  --figma___switch-unchecked-disabled-thumb-thumb-background: 0 0% 100% / 0.07;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/Harness Theme/Dark */
+  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/Harness Theme/Dark */
+  --figma___switch-unchecked-disabled-background: 0 0% 16% / 1;
+  /* ✦ Theme/Switch/Unchecked/Disabled/background/Harness Theme/Dark */
+  --figma___switch-unchecked-disabled-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Unchecked/Disabled/border/Harness Theme/Dark */
+  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/Harness Theme/Dark */
+  --figma___switch-unchecked-hover-background: 224 96% 89% / 0.13;
+  /* ✦ Theme/Switch/Unchecked/Hover/background/Harness Theme/Dark */
+  --figma___switch-unchecked-hover-border: 233 96% 9% / 0;
+  /* ✦ Theme/Switch/Unchecked/Hover/border/Harness Theme/Dark */
+  --figma___switch-border: 0 0% 100% / 0.07;
+  /* ✦ Theme/Switch/border/Harness Theme/Dark */
+  --figma___tabs-number-active-background: 0 0% 93% / 1;
+  /* ✦ Theme/Tabs/Number/Active/Background/Harness Theme/Dark */
+  --figma___tabs-number-active-text: 0 0% 93% / 1;
+  /* ✦ Theme/Tabs/Number/Active/text/Harness Theme/Dark */
+  --figma___tabs-number-default-hover-background: 0 0% 22% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/Background/Harness Theme/Dark */
+  --figma___tabs-number-default-hover-text: 0 0% 93% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/text/Harness Theme/Dark */
+  --figma___tabs-pills-active-active: 223 7% 19% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Active/Harness Theme/Dark */
+  --figma___tabs-pills-active-text: 0 0% 93% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Text/Harness Theme/Dark */
+  --figma___tabs-pills-active-border-grad-1: 0 0% 100% / 0.1;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 1/Harness Theme/Dark */
+  --figma___tabs-pills-active-border-grad-2: 0 0% 100% / 0.1;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 2/Harness Theme/Dark */
+  --figma___tabs-pills-backgrounds: 240 100% 49% / 0.04;
+  /* ✦ Theme/Tabs/Pills/Backgrounds/Harness Theme/Dark */
+  --figma___tabs-pills-default-background: 230 100% 5% / 0;
+  /* ✦ Theme/Tabs/Pills/Default/Background/Harness Theme/Dark */
+  --figma___tabs-pills-default-text: 0 0% 100% / 0.46;
+  /* ✦ Theme/Tabs/Pills/Default/Text/Harness Theme/Dark */
+  --figma___tabs-pills-hover-background: 0 0% 19% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Background/Harness Theme/Dark */
+  --figma___tabs-pills-hover-text: 0 0% 69% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Text/Harness Theme/Dark */
+  --figma___tabs-pills-number-active-background: 0 0% 93% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/Background/Harness Theme/Dark */
+  --figma___tabs-pills-number-active-text: 0 0% 9% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/text/Harness Theme/Dark */
+  --figma___tabs-pills-border-grad-1: 0 0% 100% / 0.1;
+  /* ✦ Theme/Tabs/Pills/border grad 1/Harness Theme/Dark */
+  --figma___tabs-pills-border-grad-2: 0 0% 100% / 0.1;
+  /* ✦ Theme/Tabs/Pills/border grad 2/Harness Theme/Dark */
+  --figma___tabs-primary-active-text: 0 0% 93% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Text/Harness Theme/Dark */
+  --figma___tabs-primary-active-underline: 211 85% 48% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Underline/Harness Theme/Dark */
+  --figma___tabs-primary-border: 205 100% 71% / 1;
+  /* ✦ Theme/Tabs/Primary/Border/Harness Theme/Dark */
+  --figma___tabs-primary-default-background: 230 100% 5% / 0;
+  /* ✦ Theme/Tabs/Primary/Default/Background/Harness Theme/Dark */
+  --figma___tabs-primary-default-text: 0 0% 100% / 0.46;
+  /* ✦ Theme/Tabs/Primary/Default/Text/Harness Theme/Dark */
+  --figma___tabs-primary-hover-background: 0 0% 100% / 0.1;
+  /* ✦ Theme/Tabs/Primary/Hover/Background/Harness Theme/Dark */
+  --figma___tabs-primary-hover-text: 0 0% 93% / 1;
+  /* ✦ Theme/Tabs/Primary/Hover/Text/Harness Theme/Dark */
+  --figma___tabs-primary-pills-pills: 214 73% 51% / 1;
+  /* ✦ Theme/Tabs/Primary/Pills/Pills/Harness Theme/Dark */
+  --figma___text-disabled: 0 0% 100% / 0.37;
+  /* ✦ Theme/Text/Disabled/Harness Theme/Dark */
+  --figma___text-links: 205 100% 71% / 1;
+  /* ✦ Theme/Text/Links/Harness Theme/Dark */
+  --figma___text-secondary: 0 0% 69% / 1;
+  /* ✦ Theme/Text/Secondary/Harness Theme/Dark */
+  --figma___text-tertiary: 0 0% 100% / 0.46;
+  /* ✦ Theme/Text/Tertiary/Harness Theme/Dark */
+  --figma___text-primary: 0 0% 93% / 1;
+  /* ✦ Theme/Text/primary/Harness Theme/Dark */
+  --figma___textfield-assistive-text-primary: 0 0% 100% / 0.46;
+  /* ✦ Theme/Textfield/Assistive Text/Primary/Harness Theme/Dark */
+  --figma___textfield-background: 0 0% 0% / 0.5;
+  /* ✦ Theme/Textfield/Background/Harness Theme/Dark */
+  --figma___textfield-input-field-background: 0 0% 0% / 0.5;
+  /* ✦ Theme/Textfield/Input Field/Background/Harness Theme/Dark */
+  --figma___textfield-input-field-default: 0 0% 100% / 0.1;
+  /* ✦ Theme/Textfield/Input Field/Default/Harness Theme/Dark */
+  --figma___textfield-input-field-error: 358 75% 59% / 1;
+  /* ✦ Theme/Textfield/Input Field/Error/Harness Theme/Dark */
+  --figma___textfield-input-field-hover: 206 100% 62% / 1;
+  /* ✦ Theme/Textfield/Input Field/Hover/Harness Theme/Dark */
+  --figma___textfield-label-info-icon: 205 100% 71% / 1;
+  /* ✦ Theme/Textfield/Label/Info Icon/Harness Theme/Dark */
+  --figma___textfield-label-link: 205 100% 71% / 1;
+  /* ✦ Theme/Textfield/Label/Link/Harness Theme/Dark */
+  --figma___textfield-label-main: 0 0% 69% / 1;
+  /* ✦ Theme/Textfield/Label/Main/Harness Theme/Dark */
+  --figma___textfield-label-optional: 0 0% 100% / 0.46;
+  /* ✦ Theme/Textfield/Label/Optional/Harness Theme/Dark */
+  --figma___textfield-pin-soft-background: 216 50% 12% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/Background/Harness Theme/Dark */
+  --figma___textfield-pin-soft-border: 213 67% 21% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/border/Harness Theme/Dark */
+  --figma___textfield-pin-soft-pin: 205 100% 71% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/pin/Harness Theme/Dark */
+  --figma___textfield-pin-surface-background: 0 0% 11% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/Background/Harness Theme/Dark */
+  --figma___textfield-pin-surface-border: 0 0% 22% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/border/Harness Theme/Dark */
+  --figma___textfield-pin-surface-pin: 205 100% 71% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/pin/Harness Theme/Dark */
+  --figma___tooltip-background: 230 7% 16% / 1;
+  /* ✦ Theme/Tooltip/Background/Harness Theme/Dark */
+  --figma___tooltip-body-text: 0 0% 69% / 1;
+  /* ✦ Theme/Tooltip/Body Text/Harness Theme/Dark */
+  --figma___tooltip-dismissable-icon: 0 0% 69% / 1;
+  /* ✦ Theme/Tooltip/Dismissable icon/Harness Theme/Dark */
+  --figma___tooltip-tooltip-title: 0 0% 93% / 1;
+  /* ✦ Theme/Tooltip/Tooltip Title/Harness Theme/Dark */
+  --figma___badges-solid-amber-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Amber/text/Harness Theme/Dark */
+  --figma___badges-solid-blue-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Blue/text/Harness Theme/Dark */
+  --figma___badges-solid-bronze-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Bronze/text/Harness Theme/Dark */
+  --figma___badges-solid-brown-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Brown/text/Harness Theme/Dark */
+  --figma___badges-solid-crimson-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Crimson/text/Harness Theme/Dark */
+  --figma___badges-solid-cyan-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Cyan/text/Harness Theme/Dark */
+  --figma___badges-solid-gold-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Gold/text/Harness Theme/Dark */
+  --figma___badges-solid-grass-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Grass/text/Harness Theme/Dark */
+  --figma___badges-solid-green-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Green/text/Harness Theme/Dark */
+  --figma___badges-solid-indigo-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Indigo/text/Harness Theme/Dark */
+  --figma___badges-solid-iris-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Iris/text/Harness Theme/Dark */
+  --figma___badges-solid-jade-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Jade/text/Harness Theme/Dark */
+  --figma___badges-solid-lime-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Lime/text/Harness Theme/Dark */
+  --figma___badges-solid-mint-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Mint/text/Harness Theme/Dark */
+  --figma___badges-solid-orange-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Orange/text/Harness Theme/Dark */
+  --figma___badges-solid-pink-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Pink/text/Harness Theme/Dark */
+  --figma___badges-solid-plum-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Plum/text/Harness Theme/Dark */
+  --figma___badges-solid-purple-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Purple/text/Harness Theme/Dark */
+  --figma___badges-solid-red-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Red/text/Harness Theme/Dark */
+  --figma___badges-solid-ruby-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Ruby/text/Harness Theme/Dark */
+  --figma___badges-solid-sky-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Sky/text/Harness Theme/Dark */
+  --figma___badges-solid-success-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Success/text/Harness Theme/Dark */
+  --figma___badges-solid-teal-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Teal/text/Harness Theme/Dark */
+  --figma___badges-solid-violet-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/Violet/text/Harness Theme/Dark */
+  --figma___badges-solid-yellow-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/Yellow/text/Harness Theme/Dark */
+  --figma___badges-solid-accent-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Badges/Solid/accent/text/Harness Theme/Dark */
+  --figma___badges-solid-info-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/info/text/Harness Theme/Dark */
+  --figma___badges-solid-warning-text: var(--figma___default-colors-black);
+  /* ✦ Theme/Badges/Solid/warning/text/Harness Theme/Dark */
+  --figma___button-solid-accent-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Accent/Text-primary/Harness Theme/Dark */
+  --figma___button-solid-error-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Error/Text-primary/Harness Theme/Dark */
+  --figma___button-solid-neutral-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Neutral/Text-primary/Harness Theme/Dark */
+  --figma___button-solid-success-text-primary: var(--figma___default-colors-white);
+  /* ✦ Theme/Button/Solid/Success/Text-primary/Harness Theme/Dark */
+  --figma___calendar-selected-date-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Calendar/Selected Date/Text/Harness Theme/Dark */
+  --figma___checkbox-surface-checked-active-check: var(--figma___default-colors-white);
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/Harness Theme/Dark */
+  --figma___default-colors-white-to-dark: var(--figma___default-colors-white);
+  /* ✦ Theme/Default colors/white-to-dark/Harness Theme/Dark */
+  --figma___filter-default: var(--figma___default-colors-white);
+  /* ✦ Theme/Filter/Default/Harness Theme/Dark */
+  --figma___pagination-active-text: var(--figma___default-colors-white);
+  /* ✦ Theme/Pagination/Active/Text/Harness Theme/Dark */
+  --figma___radio-button-checked-active-dot: var(--figma___default-colors-white);
+  /* ✦ Theme/Radio button/Checked/Active/Dot/Harness Theme/Dark */
+  --figma___switch-checked-active-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/Harness Theme/Dark */
+  --figma___switch-checked-default-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/Harness Theme/Dark */
+  --figma___switch-checked-disabled-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/Harness Theme/Dark */
+  --figma___switch-checked-hover-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/Harness Theme/Dark */
+  --figma___switch-unchecked-active-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/Harness Theme/Dark */
+  --figma___switch-unchecked-default-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/Harness Theme/Dark */
+  --figma___switch-unchecked-hover-thumb-thumb-background: var(--figma___default-colors-white);
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/Harness Theme/Dark */
+}

--- a/packages/canary/src/style-tokens/themes/ui-core.css
+++ b/packages/canary/src/style-tokens/themes/ui-core.css
@@ -1,3767 +1,804 @@
 /* Non color variables */
 :root {
-  --figma___badges-badge-radius: 4px;
-  /* ✦ Theme/Badges/badge-radius/UI Core/Mode 1 */
-  --figma___grids-extra-large-1920-col: 12px;
-  /* ✦ Theme/Grids/Extra Large (> 1920)/Col/UI Core/Mode 1 */
-  --figma___grids-extra-large-1920-gutters: 20px;
-  /* ✦ Theme/Grids/Extra Large (> 1920)/Gutters/UI Core/Mode 1 */
-  --figma___grids-extra-large-1920-width: 138px;
-  /* ✦ Theme/Grids/Extra Large (> 1920)/Width/UI Core/Mode 1 */
-  --figma___grids-extra-small-0-to-480-col: 2px;
-  /* ✦ Theme/Grids/Extra Small (0 to 480)/Col/UI Core/Mode 1 */
-  --figma___grids-extra-small-0-to-480-gutters: 16px;
-  /* ✦ Theme/Grids/Extra Small (0 to 480)/Gutters/UI Core/Mode 1 */
-  --figma___grids-extra-small-0-to-480-margins: 16px;
-  /* ✦ Theme/Grids/Extra Small (0 to 480)/Margins/UI Core/Mode 1 */
-  --figma___grids-large-1280-to-1920-col: 12px;
-  /* ✦ Theme/Grids/Large (1280 to 1920)/Col/UI Core/Mode 1 */
-  --figma___grids-large-1280-to-1920-gutters: 20px;
-  /* ✦ Theme/Grids/Large (1280 to 1920)/Gutters/UI Core/Mode 1 */
-  --figma___grids-large-1280-to-1920-margins: 24px;
-  /* ✦ Theme/Grids/Large (1280 to 1920)/Margins/UI Core/Mode 1 */
-  --figma___grids-medium-576-to-1279-col: 8px;
-  /* ✦ Theme/Grids/Medium (576 to 1279)/Col/UI Core/Mode 1 */
-  --figma___grids-medium-576-to-1279-gutters: 16px;
-  /* ✦ Theme/Grids/Medium (576 to 1279)/Gutters/UI Core/Mode 1 */
-  --figma___grids-medium-576-to-1279-margins: 24px;
-  /* ✦ Theme/Grids/Medium (576 to 1279)/Margins/UI Core/Mode 1 */
-  --figma___grids-small-480-to-575-col: 8px;
-  /* ✦ Theme/Grids/Small (480 to 575)/Col/UI Core/Mode 1 */
-  --figma___grids-small-480-to-575-gutters: 16px;
-  /* ✦ Theme/Grids/Small (480 to 575)/Gutters/UI Core/Mode 1 */
-  --figma___grids-small-480-to-575-margins: 24px;
-  /* ✦ Theme/Grids/Small (480 to 575)/Margins/UI Core/Mode 1 */
-  --figma___height-button-height-1: 24px;
-  /* ✦ Theme/Height/button-height-1/UI Core/Mode 1 */
-  --figma___height-button-height-2: 32px;
-  /* ✦ Theme/Height/button-height-2/UI Core/Mode 1 */
-  --figma___height-button-height-3: 40px;
-  /* ✦ Theme/Height/button-height-3/UI Core/Mode 1 */
-  --figma___height-button-height-4: 48px;
-  /* ✦ Theme/Height/button-height-4/UI Core/Mode 1 */
-  --figma___height-menu-item-height-1: 24px;
-  /* ✦ Theme/Height/menu-item-height-1/UI Core/Mode 1 */
-  --figma___height-menu-item-height-2: 32px;
-  /* ✦ Theme/Height/menu-item-height-2/UI Core/Mode 1 */
-  --figma___height-table-cell-min-height-1: 36px;
-  /* ✦ Theme/Height/table-cell-min-height-1/UI Core/Mode 1 */
-  --figma___height-table-cell-min-height-2: 44px;
-  /* ✦ Theme/Height/table-cell-min-height-2/UI Core/Mode 1 */
-  --figma___height-table-cell-min-height-3: 48px;
-  /* ✦ Theme/Height/table-cell-min-height-3/UI Core/Mode 1 */
-  --figma___padding-main-content-padding: 0px;
-  /* ✦ Theme/Padding/Main content padding/UI Core/Mode 1 */
-  --figma___padding-table-cell-padding-1: 8px;
-  /* ✦ Theme/Padding/table-cell-padding-1/UI Core/Mode 1 */
-  --figma___padding-table-cell-padding-2: 12px;
-  /* ✦ Theme/Padding/table-cell-padding-2/UI Core/Mode 1 */
-  --figma___padding-table-cell-padding-3: 16px;
-  /* ✦ Theme/Padding/table-cell-padding-3/UI Core/Mode 1 */
-  --figma___pagination-active-border-radius: 0px;
-  /* ✦ Theme/Pagination/Active/Border-radius/UI Core/Mode 1 */
-  --figma___pagination-border-radius: 8px;
-  /* ✦ Theme/Pagination/Border-radius/UI Core/Mode 1 */
-  --figma___pagination-default-border-radius: 0px;
-  /* ✦ Theme/Pagination/Default/Border-radius/UI Core/Mode 1 */
-  --figma___pagination-gap: 1px;
-  /* ✦ Theme/Pagination/Gap/UI Core/Mode 1 */
-  --figma___pagination-hover-border-radius: 0px;
-  /* ✦ Theme/Pagination/Hover/Border-radius/UI Core/Mode 1 */
-  --figma___radius-1: 3px;
-  /* ✦ Theme/Radius/1/UI Core/Mode 1 */
-  --figma___radius-2: 4px;
-  /* ✦ Theme/Radius/2/UI Core/Mode 1 */
-  --figma___radius-3: 6px;
-  /* ✦ Theme/Radius/3/UI Core/Mode 1 */
-  --figma___radius-4: 8px;
-  /* ✦ Theme/Radius/4/UI Core/Mode 1 */
-  --figma___radius-5: 12px;
-  /* ✦ Theme/Radius/5/UI Core/Mode 1 */
-  --figma___radius-6: 16px;
-  /* ✦ Theme/Radius/6/UI Core/Mode 1 */
-  --figma___radius-1-max: 3px;
-  /* ✦ Theme/Radius/1-max/UI Core/Mode 1 */
-  --figma___radius-2-max: 4px;
-  /* ✦ Theme/Radius/2-max/UI Core/Mode 1 */
-  --figma___radius-3-max: 6px;
-  /* ✦ Theme/Radius/3-max/UI Core/Mode 1 */
-  --figma___radius-4-max: 8px;
-  /* ✦ Theme/Radius/4-max/UI Core/Mode 1 */
-  --figma___radius-5-max: 12px;
-  /* ✦ Theme/Radius/5-max/UI Core/Mode 1 */
-  --figma___radius-6-max: 16px;
-  /* ✦ Theme/Radius/6-max/UI Core/Mode 1 */
-  --figma___radius-main-content-radius: 0px;
-  /* ✦ Theme/Radius/Main content radius/UI Core/Mode 1 */
-  --figma___radius-full: 9999px;
-  /* ✦ Theme/Radius/full/UI Core/Mode 1 */
-  --figma___space-1: 4px;
-  /* ✦ Theme/Space/1/UI Core/Mode 1 */
-  --figma___space-2: 8px;
-  /* ✦ Theme/Space/2/UI Core/Mode 1 */
-  --figma___space-3: 12px;
-  /* ✦ Theme/Space/3/UI Core/Mode 1 */
-  --figma___space-4: 16px;
-  /* ✦ Theme/Space/4/UI Core/Mode 1 */
-  --figma___space-5: 24px;
-  /* ✦ Theme/Space/5/UI Core/Mode 1 */
-  --figma___space-6: 32px;
-  /* ✦ Theme/Space/6/UI Core/Mode 1 */
-  --figma___space-7: 40px;
-  /* ✦ Theme/Space/7/UI Core/Mode 1 */
-  --figma___space-8: 48px;
-  /* ✦ Theme/Space/8/UI Core/Mode 1 */
-  --figma___space-9: 64px;
-  /* ✦ Theme/Space/9/UI Core/Mode 1 */
-  --figma___switch-thumb-size-1: 12px;
-  /* ✦ Theme/Switch/Thumb Size/1/UI Core/Mode 1 */
-  --figma___switch-thumb-size-2: 16px;
-  /* ✦ Theme/Switch/Thumb Size/2/UI Core/Mode 1 */
-  --figma___switch-thumb-size-3: 20px;
-  /* ✦ Theme/Switch/Thumb Size/3/UI Core/Mode 1 */
-  --figma___tabs-pills-border-radius: 4px;
-  /* ✦ Theme/Tabs/Pills/border-radius/UI Core/Mode 1 */
-  --figma___tabs-pills-padding: 1px;
-  /* ✦ Theme/Tabs/Pills/padding/UI Core/Mode 1 */
-  --figma___tabs-pills-pill-border-radius: 0px;
-  /* ✦ Theme/Tabs/Pills/pill border radius/UI Core/Mode 1 */
-  --figma___textfield-assistive-text-assistive-text: 12px;
-  /* ✦ Theme/Textfield/Assistive Text/Assistive Text/UI Core/Mode 1 */
-  --figma___textfield-gap: 4px;
-  /* ✦ Theme/Textfield/Gap/UI Core/Mode 1 */
-  --figma___textfield-input-field-textfield-height: 32px;
-  /* ✦ Theme/Textfield/Input Field/Textfield Height/UI Core/Mode 1 */
+  --figma___component-pagination-border-radius: 8px; /* ✦ Theme/Component/Pagination/Border-radius/UI Core/Mode 1 */
+  --figma___component-pagination-gap: 1px; /* ✦ Theme/Component/Pagination/Gap/UI Core/Mode 1 */
+  --figma___component-switch-thumb-size-1: 12px; /* ✦ Theme/Component/Switch/Thumb Size/1/UI Core/Mode 1 */
+  --figma___component-switch-thumb-size-2: 16px; /* ✦ Theme/Component/Switch/Thumb Size/2/UI Core/Mode 1 */
+  --figma___component-switch-thumb-size-3: 20px; /* ✦ Theme/Component/Switch/Thumb Size/3/UI Core/Mode 1 */
+  --figma___component-textfield-gap: 4px; /* ✦ Theme/Component/Textfield/Gap/UI Core/Mode 1 */
+  --figma___padding-main-content-padding: 0px; /* ✦ Theme/Padding/Main content padding/UI Core/Mode 1 */
+  --figma___radius-1: 3px; /* ✦ Theme/Radius/1/UI Core/Mode 1 */
+  --figma___radius-2: 4px; /* ✦ Theme/Radius/2/UI Core/Mode 1 */
+  --figma___radius-3: 6px; /* ✦ Theme/Radius/3/UI Core/Mode 1 */
+  --figma___radius-4: 8px; /* ✦ Theme/Radius/4/UI Core/Mode 1 */
+  --figma___radius-5: 12px; /* ✦ Theme/Radius/5/UI Core/Mode 1 */
+  --figma___radius-6: 16px; /* ✦ Theme/Radius/6/UI Core/Mode 1 */
+  --figma___radius-main-content-radius: 0px; /* ✦ Theme/Radius/Main content radius/UI Core/Mode 1 */
+  --figma___radius-full: 9999px; /* ✦ Theme/Radius/full/UI Core/Mode 1 */
 }
 
 /* Color variables - light mode */
 .ui-core-light {
-  --figma___background-backdrop: 212 72% 10% / 0.75;
-  /* ✦ Theme/Background/Backdrop/UI Core/Light */
-  --figma___background-cards-and-rows-default: 0 0% 100% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Default/UI Core/Light */
-  --figma___background-cards-and-rows-hover: 216 100% 99% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Hover/UI Core/Light */
-  --figma___background-cards-and-rows-primary-blue-selected: 206 98% 42% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/UI Core/Light */
-  --figma___background-cards-and-rows-selected: 216 100% 99% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Selected/UI Core/Light */
-  --figma___background-header-page-header: 0 0% 100% / 1;
-  /* ✦ Theme/Background/Header/Page Header/UI Core/Light */
-  --figma___background-header-table-header: 0 0% 100% / 1;
-  /* ✦ Theme/Background/Header/Table Header/UI Core/Light */
-  --figma___background-paper: 216 100% 99% / 1;
-  /* ✦ Theme/Background/Paper/UI Core/Light */
-  --figma___background-primary: 216 100% 99% / 1;
-  /* ✦ Theme/Background/Primary/UI Core/Light */
-  --figma___background-solid: 0 0% 100% / 1;
-  /* ✦ Theme/Background/Solid/UI Core/Light */
-  --figma___badges-soft-amber-background: 45 100% 95% / 1;
-  /* ✦ Theme/Badges/Soft/Amber/background/UI Core/Light */
-  --figma___badges-soft-amber-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Soft/Amber/text/UI Core/Light */
-  --figma___badges-soft-blue-background: 195 100% 97% / 1;
-  /* ✦ Theme/Badges/Soft/Blue/background/UI Core/Light */
-  --figma___badges-soft-blue-text: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Soft/Blue/text/UI Core/Light */
-  --figma___badges-soft-bronze-background: 24 100% 95% / 1;
-  /* ✦ Theme/Badges/Soft/Bronze/background/UI Core/Light */
-  --figma___badges-soft-bronze-text: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Soft/Bronze/text/UI Core/Light */
-  --figma___badges-soft-brown-background: 27 100% 96% / 1;
-  /* ✦ Theme/Badges/Soft/Brown/background/UI Core/Light */
-  --figma___badges-soft-brown-text: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Soft/Brown/text/UI Core/Light */
-  --figma___badges-soft-crimson-background: 328 100% 97% / 1;
-  /* ✦ Theme/Badges/Soft/Crimson/background/UI Core/Light */
-  --figma___badges-soft-crimson-text: 331 85% 55% / 1;
-  /* ✦ Theme/Badges/Soft/Crimson/text/UI Core/Light */
-  --figma___badges-soft-cyan-background: 183 97% 87% / 1;
-  /* ✦ Theme/Badges/Soft/Cyan/background/UI Core/Light */
-  --figma___badges-soft-cyan-text: 184 94% 39% / 1;
-  /* ✦ Theme/Badges/Soft/Cyan/text/UI Core/Light */
-  --figma___badges-soft-gold-background: 24 100% 95% / 1;
-  /* ✦ Theme/Badges/Soft/Gold/background/UI Core/Light */
-  --figma___badges-soft-gold-text: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Soft/Gold/text/UI Core/Light */
-  --figma___badges-soft-grass-background: 112 58% 93% / 1;
-  /* ✦ Theme/Badges/Soft/Grass/background/UI Core/Light */
-  --figma___badges-soft-grass-text: 122 58% 38% / 1;
-  /* ✦ Theme/Badges/Soft/Grass/text/UI Core/Light */
-  --figma___badges-soft-green-background: 112 56% 89% / 1;
-  /* ✦ Theme/Badges/Soft/Green/background/UI Core/Light */
-  --figma___badges-soft-green-text: 122 53% 55% / 1;
-  /* ✦ Theme/Badges/Soft/Green/text/UI Core/Light */
-  --figma___badges-soft-indigo-background: 241 100% 90% / 1;
-  /* ✦ Theme/Badges/Soft/Indigo/background/UI Core/Light */
-  --figma___badges-soft-indigo-text: 241 82% 66% / 1;
-  /* ✦ Theme/Badges/Soft/Indigo/text/UI Core/Light */
-  --figma___badges-soft-iris-background: 256 70% 95% / 1;
-  /* ✦ Theme/Badges/Soft/Iris/background/UI Core/Light */
-  --figma___badges-soft-iris-text: 256 68% 56% / 1;
-  /* ✦ Theme/Badges/Soft/Iris/text/UI Core/Light */
-  --figma___badges-soft-jade-background: 112 56% 89% / 1;
-  /* ✦ Theme/Badges/Soft/Jade/background/UI Core/Light */
-  --figma___badges-soft-jade-text: 122 58% 38% / 1;
-  /* ✦ Theme/Badges/Soft/Jade/text/UI Core/Light */
-  --figma___badges-soft-lime-background: 89 67% 92% / 1;
-  /* ✦ Theme/Badges/Soft/Lime/background/UI Core/Light */
-  --figma___badges-soft-lime-text: 92 48% 42% / 1;
-  /* ✦ Theme/Badges/Soft/Lime/text/UI Core/Light */
-  --figma___badges-soft-mint-background: 112 56% 89% / 1;
-  /* ✦ Theme/Badges/Soft/Mint/background/UI Core/Light */
-  --figma___badges-soft-mint-text: 122 58% 38% / 1;
-  /* ✦ Theme/Badges/Soft/Mint/text/UI Core/Light */
-  --figma___badges-soft-orange-background: 24 100% 95% / 1;
-  /* ✦ Theme/Badges/Soft/Orange/background/UI Core/Light */
-  --figma___badges-soft-orange-text: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Soft/Orange/text/UI Core/Light */
-  --figma___badges-soft-pink-background: 328 100% 97% / 1;
-  /* ✦ Theme/Badges/Soft/Pink/background/UI Core/Light */
-  --figma___badges-soft-pink-text: 331 85% 55% / 1;
-  /* ✦ Theme/Badges/Soft/Pink/text/UI Core/Light */
-  --figma___badges-soft-plum-background: 262 100% 94% / 1;
-  /* ✦ Theme/Badges/Soft/Plum/background/UI Core/Light */
-  --figma___badges-soft-plum-text: 261 60% 56% / 1;
-  /* ✦ Theme/Badges/Soft/Plum/text/UI Core/Light */
-  --figma___badges-soft-purple-background: 262 100% 91% / 1;
-  /* ✦ Theme/Badges/Soft/Purple/background/UI Core/Light */
-  --figma___badges-soft-purple-text: 261 60% 56% / 1;
-  /* ✦ Theme/Badges/Soft/Purple/text/UI Core/Light */
-  --figma___badges-soft-red-background: 4 73% 96% / 1;
-  /* ✦ Theme/Badges/Soft/Red/background/UI Core/Light */
-  --figma___badges-soft-red-text: 4 78% 52% / 1;
-  /* ✦ Theme/Badges/Soft/Red/text/UI Core/Light */
-  --figma___badges-soft-ruby-background: 4 73% 96% / 1;
-  /* ✦ Theme/Badges/Soft/Ruby/background/UI Core/Light */
-  --figma___badges-soft-ruby-text: 4 78% 52% / 1;
-  /* ✦ Theme/Badges/Soft/Ruby/text/UI Core/Light */
-  --figma___badges-soft-sky-background: 194 100% 82% / 1;
-  /* ✦ Theme/Badges/Soft/Sky/background/UI Core/Light */
-  --figma___badges-soft-sky-text: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Soft/Sky/text/UI Core/Light */
-  --figma___badges-soft-teal-background: 183 97% 87% / 1;
-  /* ✦ Theme/Badges/Soft/Teal/background/UI Core/Light */
-  --figma___badges-soft-teal-text: 184 94% 39% / 1;
-  /* ✦ Theme/Badges/Soft/Teal/text/UI Core/Light */
-  --figma___badges-soft-violet-background: 258 100% 98% / 1;
-  /* ✦ Theme/Badges/Soft/Violet/background/UI Core/Light */
-  --figma___badges-soft-violet-text: 256 68% 56% / 1;
-  /* ✦ Theme/Badges/Soft/Violet/text/UI Core/Light */
-  --figma___badges-soft-yellow-background: 45 100% 95% / 1;
-  /* ✦ Theme/Badges/Soft/Yellow/background/UI Core/Light */
-  --figma___badges-soft-yellow-text: 41 98% 45% / 1;
-  /* ✦ Theme/Badges/Soft/Yellow/text/UI Core/Light */
-  --figma___badges-soft-accent-background: 192 96% 90% / 1;
-  /* ✦ Theme/Badges/Soft/accent/background/UI Core/Light */
-  --figma___badges-soft-accent-text: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Soft/accent/text/UI Core/Light */
-  --figma___badges-soft-error-background: 4 73% 96% / 1;
-  /* ✦ Theme/Badges/Soft/error/background/UI Core/Light */
-  --figma___badges-soft-error-text: 3 84% 38% / 1;
-  /* ✦ Theme/Badges/Soft/error/text/UI Core/Light */
-  --figma___badges-soft-info-background: 192 96% 90% / 1;
-  /* ✦ Theme/Badges/Soft/info/background/UI Core/Light */
-  --figma___badges-soft-info-text: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Soft/info/text/UI Core/Light */
-  --figma___badges-soft-success-background: 112 58% 93% / 1;
-  /* ✦ Theme/Badges/Soft/success/background/UI Core/Light */
-  --figma___badges-soft-success-text: 121 66% 31% / 1;
-  /* ✦ Theme/Badges/Soft/success/text/UI Core/Light */
-  --figma___badges-soft-warning-background: 24 100% 95% / 1;
-  /* ✦ Theme/Badges/Soft/warning/background/UI Core/Light */
-  --figma___badges-soft-warning-text: 22 100% 56% / 1;
-  /* ✦ Theme/Badges/Soft/warning/text/UI Core/Light */
-  --figma___badges-solid-amber-background: 41 100% 55% / 1;
-  /* ✦ Theme/Badges/Solid/Amber/background/UI Core/Light */
-  --figma___badges-solid-amber-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Amber/text/UI Core/Light */
-  --figma___badges-solid-blue-background: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Solid/Blue/background/UI Core/Light */
-  --figma___badges-solid-blue-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Blue/text/UI Core/Light */
-  --figma___badges-solid-bronze-background: 22 100% 56% / 1;
-  /* ✦ Theme/Badges/Solid/Bronze/background/UI Core/Light */
-  --figma___badges-solid-bronze-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Bronze/text/UI Core/Light */
-  --figma___badges-solid-brown-background: 22 100% 56% / 1;
-  /* ✦ Theme/Badges/Solid/Brown/background/UI Core/Light */
-  --figma___badges-solid-brown-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Brown/text/UI Core/Light */
-  --figma___badges-solid-crimson-background: 331 85% 55% / 1;
-  /* ✦ Theme/Badges/Solid/Crimson/background/UI Core/Light */
-  --figma___badges-solid-crimson-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Crimson/text/UI Core/Light */
-  --figma___badges-solid-cyan-background: 184 90% 44% / 1;
-  /* ✦ Theme/Badges/Solid/Cyan/background/UI Core/Light */
-  --figma___badges-solid-cyan-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Cyan/text/UI Core/Light */
-  --figma___badges-solid-gold-background: 22 100% 56% / 1;
-  /* ✦ Theme/Badges/Solid/Gold/background/UI Core/Light */
-  --figma___badges-solid-gold-text: 240 8% 5% / 1;
-  /* ✦ Theme/Badges/Solid/Gold/text/UI Core/Light */
-  --figma___badges-solid-grass-background: 122 58% 38% / 1;
-  /* ✦ Theme/Badges/Solid/Grass/background/UI Core/Light */
-  --figma___badges-solid-grass-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Grass/text/UI Core/Light */
-  --figma___badges-solid-green-background: 121 66% 31% / 1;
-  /* ✦ Theme/Badges/Solid/Green/background/UI Core/Light */
-  --figma___badges-solid-green-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Green/text/UI Core/Light */
-  --figma___badges-solid-indigo-background: 241 82% 66% / 1;
-  /* ✦ Theme/Badges/Solid/Indigo/background/UI Core/Light */
-  --figma___badges-solid-indigo-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Indigo/text/UI Core/Light */
-  --figma___badges-solid-iris-background: 256 68% 56% / 1;
-  /* ✦ Theme/Badges/Solid/Iris/background/UI Core/Light */
-  --figma___badges-solid-iris-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Iris/text/UI Core/Light */
-  --figma___badges-solid-jade-background: 122 44% 46% / 1;
-  /* ✦ Theme/Badges/Solid/Jade/background/UI Core/Light */
-  --figma___badges-solid-jade-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Jade/text/UI Core/Light */
-  --figma___badges-solid-lime-background: 92 48% 42% / 1;
-  /* ✦ Theme/Badges/Solid/Lime/background/UI Core/Light */
-  --figma___badges-solid-lime-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Lime/text/UI Core/Light */
-  --figma___badges-solid-mint-background: 122 44% 46% / 1;
-  /* ✦ Theme/Badges/Solid/Mint/background/UI Core/Light */
-  --figma___badges-solid-mint-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Mint/text/UI Core/Light */
-  --figma___badges-solid-orange-background: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Solid/Orange/background/UI Core/Light */
-  --figma___badges-solid-orange-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Orange/text/UI Core/Light */
-  --figma___badges-solid-pink-background: 331 85% 55% / 1;
-  /* ✦ Theme/Badges/Solid/Pink/background/UI Core/Light */
-  --figma___badges-solid-pink-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Pink/text/UI Core/Light */
-  --figma___badges-solid-plum-background: 261 60% 56% / 1;
-  /* ✦ Theme/Badges/Solid/Plum/background/UI Core/Light */
-  --figma___badges-solid-plum-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Plum/text/UI Core/Light */
-  --figma___badges-solid-purple-background: 261 60% 56% / 1;
-  /* ✦ Theme/Badges/Solid/Purple/background/UI Core/Light */
-  --figma___badges-solid-purple-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Purple/text/UI Core/Light */
-  --figma___badges-solid-red-background: 4 78% 52% / 1;
-  /* ✦ Theme/Badges/Solid/Red/background/UI Core/Light */
-  --figma___badges-solid-red-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Red/text/UI Core/Light */
-  --figma___badges-solid-ruby-background: 4 78% 52% / 1;
-  /* ✦ Theme/Badges/Solid/Ruby/background/UI Core/Light */
-  --figma___badges-solid-ruby-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Ruby/text/UI Core/Light */
-  --figma___badges-solid-sky-background: 194 100% 82% / 1;
-  /* ✦ Theme/Badges/Solid/Sky/background/UI Core/Light */
-  --figma___badges-solid-sky-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Sky/text/UI Core/Light */
-  --figma___badges-solid-success-background: 121 66% 31% / 1;
-  /* ✦ Theme/Badges/Solid/Success/background/UI Core/Light */
-  --figma___badges-solid-success-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Success/text/UI Core/Light */
-  --figma___badges-solid-teal-background: 184 90% 44% / 1;
-  /* ✦ Theme/Badges/Solid/Teal/background/UI Core/Light */
-  --figma___badges-solid-teal-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Teal/text/UI Core/Light */
-  --figma___badges-solid-violet-background: 256 68% 56% / 1;
-  /* ✦ Theme/Badges/Solid/Violet/background/UI Core/Light */
-  --figma___badges-solid-violet-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/Violet/text/UI Core/Light */
-  --figma___badges-solid-yellow-background: 45 98% 60% / 1;
-  /* ✦ Theme/Badges/Solid/Yellow/background/UI Core/Light */
-  --figma___badges-solid-yellow-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Yellow/text/UI Core/Light */
-  --figma___badges-solid-accent-background: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Solid/accent/background/UI Core/Light */
-  --figma___badges-solid-accent-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/accent/text/UI Core/Light */
-  --figma___badges-solid-info-background: 241 90% 64% / 1;
-  /* ✦ Theme/Badges/Solid/info/background/UI Core/Light */
-  --figma___badges-solid-info-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/info/text/UI Core/Light */
-  --figma___badges-solid-warning-background: 24 100% 57% / 1;
-  /* ✦ Theme/Badges/Solid/warning/background/UI Core/Light */
-  --figma___badges-solid-warning-text: 0 0% 100% / 1;
-  /* ✦ Theme/Badges/Solid/warning/text/UI Core/Light */
-  --figma___badges-surface-amber-background: 45 100% 95% / 1;
-  /* ✦ Theme/Badges/Surface/Amber/background/UI Core/Light */
-  --figma___badges-surface-amber-border: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Surface/Amber/border/UI Core/Light */
-  --figma___badges-surface-amber-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Surface/Amber/text/UI Core/Light */
-  --figma___badges-surface-blue-background: 195 100% 97% / 1;
-  /* ✦ Theme/Badges/Surface/Blue/background/UI Core/Light */
-  --figma___badges-surface-blue-border: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Blue/border/UI Core/Light */
-  --figma___badges-surface-blue-text: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Blue/text/UI Core/Light */
-  --figma___badges-surface-bronze-background: 24 100% 95% / 1;
-  /* ✦ Theme/Badges/Surface/Bronze/background/UI Core/Light */
-  --figma___badges-surface-bronze-border: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Surface/Bronze/border/UI Core/Light */
-  --figma___badges-surface-bronze-text: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Surface/Bronze/text/UI Core/Light */
-  --figma___badges-surface-brown-background: 27 100% 96% / 1;
-  /* ✦ Theme/Badges/Surface/Brown/background/UI Core/Light */
-  --figma___badges-surface-brown-border: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Surface/Brown/border/UI Core/Light */
-  --figma___badges-surface-brown-text: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Surface/Brown/text/UI Core/Light */
-  --figma___badges-surface-crimson-border: 331 85% 55% / 1;
-  /* ✦ Theme/Badges/Surface/Crimson/Border/UI Core/Light */
-  --figma___badges-surface-crimson-background: 328 100% 97% / 1;
-  /* ✦ Theme/Badges/Surface/Crimson/background/UI Core/Light */
-  --figma___badges-surface-crimson-text: 331 85% 55% / 1;
-  /* ✦ Theme/Badges/Surface/Crimson/text/UI Core/Light */
-  --figma___badges-surface-cyan-border: 184 94% 39% / 1;
-  /* ✦ Theme/Badges/Surface/Cyan/Border/UI Core/Light */
-  --figma___badges-surface-cyan-background: 183 97% 87% / 1;
-  /* ✦ Theme/Badges/Surface/Cyan/background/UI Core/Light */
-  --figma___badges-surface-cyan-text: 184 94% 39% / 1;
-  /* ✦ Theme/Badges/Surface/Cyan/text/UI Core/Light */
-  --figma___badges-surface-gold-border: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Surface/Gold/Border/UI Core/Light */
-  --figma___badges-surface-gold-background: 24 100% 95% / 1;
-  /* ✦ Theme/Badges/Surface/Gold/background/UI Core/Light */
-  --figma___badges-surface-gold-text: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Surface/Gold/text/UI Core/Light */
-  --figma___badges-surface-grass-border: 122 58% 38% / 1;
-  /* ✦ Theme/Badges/Surface/Grass/Border/UI Core/Light */
-  --figma___badges-surface-grass-background: 112 58% 93% / 1;
-  /* ✦ Theme/Badges/Surface/Grass/background/UI Core/Light */
-  --figma___badges-surface-grass-text: 122 58% 38% / 1;
-  /* ✦ Theme/Badges/Surface/Grass/text/UI Core/Light */
-  --figma___badges-surface-green-background: 112 56% 89% / 1;
-  /* ✦ Theme/Badges/Surface/Green/background/UI Core/Light */
-  --figma___badges-surface-green-border: 122 53% 55% / 1;
-  /* ✦ Theme/Badges/Surface/Green/border/UI Core/Light */
-  --figma___badges-surface-green-text: 122 53% 55% / 1;
-  /* ✦ Theme/Badges/Surface/Green/text/UI Core/Light */
-  --figma___badges-surface-indigo-background: 241 100% 90% / 1;
-  /* ✦ Theme/Badges/Surface/Indigo/background/UI Core/Light */
-  --figma___badges-surface-indigo-border: 241 82% 66% / 1;
-  /* ✦ Theme/Badges/Surface/Indigo/border/UI Core/Light */
-  --figma___badges-surface-indigo-text: 241 82% 66% / 1;
-  /* ✦ Theme/Badges/Surface/Indigo/text/UI Core/Light */
-  --figma___badges-surface-iris-border: 256 68% 56% / 1;
-  /* ✦ Theme/Badges/Surface/Iris/Border/UI Core/Light */
-  --figma___badges-surface-iris-background: 256 70% 95% / 1;
-  /* ✦ Theme/Badges/Surface/Iris/background/UI Core/Light */
-  --figma___badges-surface-iris-text: 256 68% 56% / 1;
-  /* ✦ Theme/Badges/Surface/Iris/text/UI Core/Light */
-  --figma___badges-surface-jade-border: 122 58% 38% / 1;
-  /* ✦ Theme/Badges/Surface/Jade/Border/UI Core/Light */
-  --figma___badges-surface-jade-background: 112 56% 89% / 1;
-  /* ✦ Theme/Badges/Surface/Jade/background/UI Core/Light */
-  --figma___badges-surface-jade-text: 122 58% 38% / 1;
-  /* ✦ Theme/Badges/Surface/Jade/text/UI Core/Light */
-  --figma___badges-surface-lime-border: 92 48% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Lime/Border/UI Core/Light */
-  --figma___badges-surface-lime-background: 89 67% 92% / 1;
-  /* ✦ Theme/Badges/Surface/Lime/background/UI Core/Light */
-  --figma___badges-surface-lime-text: 92 48% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Lime/text/UI Core/Light */
-  --figma___badges-surface-mint-background: 112 56% 89% / 1;
-  /* ✦ Theme/Badges/Surface/Mint/background/UI Core/Light */
-  --figma___badges-surface-mint-border: 122 58% 38% / 1;
-  /* ✦ Theme/Badges/Surface/Mint/border/UI Core/Light */
-  --figma___badges-surface-mint-text: 122 58% 38% / 1;
-  /* ✦ Theme/Badges/Surface/Mint/text/UI Core/Light */
-  --figma___badges-surface-orange-background: 24 100% 95% / 1;
-  /* ✦ Theme/Badges/Surface/Orange/background/UI Core/Light */
-  --figma___badges-surface-orange-border: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Surface/Orange/border/UI Core/Light */
-  --figma___badges-surface-orange-text: 25 100% 58% / 1;
-  /* ✦ Theme/Badges/Surface/Orange/text/UI Core/Light */
-  --figma___badges-surface-pink-background: 328 100% 97% / 1;
-  /* ✦ Theme/Badges/Surface/Pink/background/UI Core/Light */
-  --figma___badges-surface-pink-border: 331 85% 55% / 1;
-  /* ✦ Theme/Badges/Surface/Pink/border/UI Core/Light */
-  --figma___badges-surface-pink-text: 331 85% 55% / 1;
-  /* ✦ Theme/Badges/Surface/Pink/text/UI Core/Light */
-  --figma___badges-surface-plum-background: 262 100% 94% / 1;
-  /* ✦ Theme/Badges/Surface/Plum/background/UI Core/Light */
-  --figma___badges-surface-plum-border: 261 60% 56% / 1;
-  /* ✦ Theme/Badges/Surface/Plum/border/UI Core/Light */
-  --figma___badges-surface-plum-text: 261 60% 56% / 1;
-  /* ✦ Theme/Badges/Surface/Plum/text/UI Core/Light */
-  --figma___badges-surface-purple-background: 262 100% 91% / 1;
-  /* ✦ Theme/Badges/Surface/Purple/background/UI Core/Light */
-  --figma___badges-surface-purple-border: 261 60% 56% / 1;
-  /* ✦ Theme/Badges/Surface/Purple/border/UI Core/Light */
-  --figma___badges-surface-purple-text: 261 60% 56% / 1;
-  /* ✦ Theme/Badges/Surface/Purple/text/UI Core/Light */
-  --figma___badges-surface-red-background: 4 73% 96% / 1;
-  /* ✦ Theme/Badges/Surface/Red/background/UI Core/Light */
-  --figma___badges-surface-red-border: 4 78% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Red/border/UI Core/Light */
-  --figma___badges-surface-red-text: 4 78% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Red/text/UI Core/Light */
-  --figma___badges-surface-ruby-background: 4 73% 96% / 1;
-  /* ✦ Theme/Badges/Surface/Ruby/background/UI Core/Light */
-  --figma___badges-surface-ruby-border: 4 78% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Ruby/border/UI Core/Light */
-  --figma___badges-surface-ruby-text: 4 78% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Ruby/text/UI Core/Light */
-  --figma___badges-surface-sky-background: 194 100% 82% / 1;
-  /* ✦ Theme/Badges/Surface/Sky/background/UI Core/Light */
-  --figma___badges-surface-sky-border: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Sky/border/UI Core/Light */
-  --figma___badges-surface-sky-text: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Sky/text/UI Core/Light */
-  --figma___badges-surface-teal-background: 183 97% 87% / 1;
-  /* ✦ Theme/Badges/Surface/Teal/background/UI Core/Light */
-  --figma___badges-surface-teal-border: 184 94% 39% / 1;
-  /* ✦ Theme/Badges/Surface/Teal/border/UI Core/Light */
-  --figma___badges-surface-teal-text: 184 94% 39% / 1;
-  /* ✦ Theme/Badges/Surface/Teal/text/UI Core/Light */
-  --figma___badges-surface-violet-background: 258 100% 98% / 1;
-  /* ✦ Theme/Badges/Surface/Violet/background/UI Core/Light */
-  --figma___badges-surface-violet-border: 256 68% 56% / 1;
-  /* ✦ Theme/Badges/Surface/Violet/border/UI Core/Light */
-  --figma___badges-surface-violet-text: 256 68% 56% / 1;
-  /* ✦ Theme/Badges/Surface/Violet/text/UI Core/Light */
-  --figma___badges-surface-yellow-background: 45 100% 95% / 1;
-  /* ✦ Theme/Badges/Surface/Yellow/background/UI Core/Light */
-  --figma___badges-surface-yellow-border: 41 98% 45% / 1;
-  /* ✦ Theme/Badges/Surface/Yellow/border/UI Core/Light */
-  --figma___badges-surface-yellow-text: 41 98% 45% / 1;
-  /* ✦ Theme/Badges/Surface/Yellow/text/UI Core/Light */
-  --figma___badges-surface-accent-background: 195 100% 97% / 1;
-  /* ✦ Theme/Badges/Surface/accent/background/UI Core/Light */
-  --figma___badges-surface-accent-border: 213 100% 32% / 1;
-  /* ✦ Theme/Badges/Surface/accent/border/UI Core/Light */
-  --figma___badges-surface-accent-text: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Surface/accent/text/UI Core/Light */
-  --figma___badges-surface-error-background: 4 73% 96% / 1;
-  /* ✦ Theme/Badges/Surface/error/background/UI Core/Light */
-  --figma___badges-surface-error-border: 3 84% 38% / 1;
-  /* ✦ Theme/Badges/Surface/error/border/UI Core/Light */
-  --figma___badges-surface-error-text: 3 84% 38% / 1;
-  /* ✦ Theme/Badges/Surface/error/text/UI Core/Light */
-  --figma___badges-surface-info-background: 192 96% 90% / 1;
-  /* ✦ Theme/Badges/Surface/info/background/UI Core/Light */
-  --figma___badges-surface-info-border: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Surface/info/border/UI Core/Light */
-  --figma___badges-surface-info-text: 206 98% 42% / 1;
-  /* ✦ Theme/Badges/Surface/info/text/UI Core/Light */
-  --figma___badges-surface-success-background: 112 58% 93% / 1;
-  /* ✦ Theme/Badges/Surface/success/background/UI Core/Light */
-  --figma___badges-surface-success-border: 121 66% 31% / 1;
-  /* ✦ Theme/Badges/Surface/success/border/UI Core/Light */
-  --figma___badges-surface-success-text: 121 66% 31% / 1;
-  /* ✦ Theme/Badges/Surface/success/text/UI Core/Light */
-  --figma___badges-surface-warning-background: 24 100% 95% / 1;
-  /* ✦ Theme/Badges/Surface/warning/background/UI Core/Light */
-  --figma___badges-surface-warning-border: 22 100% 56% / 1;
-  /* ✦ Theme/Badges/Surface/warning/border/UI Core/Light */
-  --figma___badges-surface-warning-text: 22 100% 56% / 1;
-  /* ✦ Theme/Badges/Surface/warning/text/UI Core/Light */
-  --figma___border-disabled: 235 19% 87% / 1;
-  /* ✦ Theme/Border/Disabled/UI Core/Light */
-  --figma___border-hover: 213 100% 32% / 1;
-  /* ✦ Theme/Border/Hover/UI Core/Light */
-  --figma___border-primary: 235 19% 87% / 1;
-  /* ✦ Theme/Border/Primary/UI Core/Light */
-  --figma___border-secondary: 240 41% 97% / 1;
-  /* ✦ Theme/Border/Secondary/UI Core/Light */
-  --figma___border-selected: 206 98% 42% / 1;
-  /* ✦ Theme/Border/Selected/UI Core/Light */
-  --figma___breadcrumbs-current: 235 11% 47% / 1;
-  /* ✦ Theme/Breadcrumbs/current/UI Core/Light */
-  --figma___breadcrumbs-visited: 206 98% 42% / 1;
-  /* ✦ Theme/Breadcrumbs/visited/UI Core/Light */
-  --figma___button-ghost-accent-active: 213 100% 32% / 0;
-  /* ✦ Theme/Button/Ghost/Accent/Active/UI Core/Light */
-  --figma___button-ghost-accent-active-text: 213 100% 32% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Active text/UI Core/Light */
-  --figma___button-ghost-accent-hover: 213 100% 32% / 0;
-  /* ✦ Theme/Button/Ghost/Accent/Hover/UI Core/Light */
-  --figma___button-ghost-accent-hover-text: 213 100% 32% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Hover text/UI Core/Light */
-  --figma___button-ghost-accent-text-disabled: 206 98% 42% / 0.5;
-  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/UI Core/Light */
-  --figma___button-ghost-accent-text-primary: 206 98% 42% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Text-primary/UI Core/Light */
-  --figma___button-ghost-error-active: 4 75% 75% / 0;
-  /* ✦ Theme/Button/Ghost/Error/Active/UI Core/Light */
-  --figma___button-ghost-error-active-text: 3 79% 43% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Active Text/UI Core/Light */
-  --figma___button-ghost-error-hover: 4 74% 85% / 0;
-  /* ✦ Theme/Button/Ghost/Error/Hover/UI Core/Light */
-  --figma___button-ghost-error-hover-text: 3 79% 43% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Hover text/UI Core/Light */
-  --figma___button-ghost-error-text-disabled: 4 75% 75% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Text-disabled/UI Core/Light */
-  --figma___button-ghost-error-text-primary: 4 79% 45% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Text-primary/UI Core/Light */
-  --figma___button-ghost-neutral-active: 235 19% 87% / 0;
-  /* ✦ Theme/Button/Ghost/Neutral/Active/UI Core/Light */
-  --figma___button-ghost-neutral-active-text: 240 11% 15% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Active Text/UI Core/Light */
-  --figma___button-ghost-neutral-hover: 240 41% 97% / 0;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover/UI Core/Light */
-  --figma___button-ghost-neutral-hover-text: 240 11% 15% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover text/UI Core/Light */
-  --figma___button-ghost-neutral-text-disabled: 237 14% 73% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/UI Core/Light */
-  --figma___button-ghost-neutral-text-primary: 234 11% 35% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/UI Core/Light */
-  --figma___button-ghost-success-active: 139 99% 33% / 0;
-  /* ✦ Theme/Button/Ghost/Success/Active/UI Core/Light */
-  --figma___button-ghost-success-active-text: 121 66% 31% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Active Text/UI Core/Light */
-  --figma___button-ghost-success-hover: 139 98% 37% / 0;
-  /* ✦ Theme/Button/Ghost/Success/Hover/UI Core/Light */
-  --figma___button-ghost-success-hover-text: 121 66% 31% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Hover text/UI Core/Light */
-  --figma___button-ghost-success-text-disabled: 114 55% 75% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Text-disabled/UI Core/Light */
-  --figma___button-ghost-success-text-primary: 122 58% 38% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Text-primary/UI Core/Light */
-  --figma___button-outline-accent-active: 195 100% 97% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Active/UI Core/Light */
-  --figma___button-outline-accent-default-border: 206 98% 42% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Default border/UI Core/Light */
-  --figma___button-outline-accent-disabled-border: 206 98% 42% / 0.5;
-  /* ✦ Theme/Button/Outline/Accent/Disabled Border/UI Core/Light */
-  --figma___button-outline-accent-hover: 195 100% 97% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Hover/UI Core/Light */
-  --figma___button-outline-accent-text-disabled: 206 98% 42% / 0.5;
-  /* ✦ Theme/Button/Outline/Accent/Text-disabled/UI Core/Light */
-  --figma___button-outline-accent-text-primary: 206 98% 42% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Text-primary/UI Core/Light */
-  --figma___button-outline-error-active: 5 74% 94% / 1;
-  /* ✦ Theme/Button/Outline/Error/Active/UI Core/Light */
-  --figma___button-outline-error-default-border: 4 77% 48% / 1;
-  /* ✦ Theme/Button/Outline/Error/Default - border/UI Core/Light */
-  --figma___button-outline-error-disabled-border: 4 74% 85% / 1;
-  /* ✦ Theme/Button/Outline/Error/Disabled-border/UI Core/Light */
-  --figma___button-outline-error-hover: 5 74% 94% / 1;
-  /* ✦ Theme/Button/Outline/Error/Hover/UI Core/Light */
-  --figma___button-outline-error-text-disabled: 4 82% 63% / 1;
-  /* ✦ Theme/Button/Outline/Error/Text-disabled/UI Core/Light */
-  --figma___button-outline-error-text-primary: 3 79% 43% / 1;
-  /* ✦ Theme/Button/Outline/Error/Text-primary/UI Core/Light */
-  --figma___button-outline-neutral-active: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Active/UI Core/Light */
-  --figma___button-outline-neutral-default-border: 235 19% 87% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Default - border/UI Core/Light */
-  --figma___button-outline-neutral-disabled-border: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/UI Core/Light */
-  --figma___button-outline-neutral-hover: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Hover/UI Core/Light */
-  --figma___button-outline-neutral-text-disabled: 237 14% 73% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/UI Core/Light */
-  --figma___button-outline-neutral-text-primary: 236 11% 25% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Text-primary/UI Core/Light */
-  --figma___button-outline-success-active: 112 58% 93% / 1;
-  /* ✦ Theme/Button/Outline/Success/Active/UI Core/Light */
-  --figma___button-outline-success-default-border: 122 58% 38% / 1;
-  /* ✦ Theme/Button/Outline/Success/Default-border/UI Core/Light */
-  --figma___button-outline-success-disabled-border: 113 55% 82% / 1;
-  /* ✦ Theme/Button/Outline/Success/Disabled - border/UI Core/Light */
-  --figma___button-outline-success-hover: 112 58% 93% / 1;
-  /* ✦ Theme/Button/Outline/Success/Hover/UI Core/Light */
-  --figma___button-outline-success-text-disabled: 117 54% 68% / 1;
-  /* ✦ Theme/Button/Outline/Success/Text-disabled/UI Core/Light */
-  --figma___button-outline-success-text-primary: 121 66% 31% / 1;
-  /* ✦ Theme/Button/Outline/Success/Text-primary/UI Core/Light */
-  --figma___button-soft-accent-active: 192 96% 90% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Active/UI Core/Light */
-  --figma___button-soft-accent-disabled: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Disabled/UI Core/Light */
-  --figma___button-soft-accent-hover: 192 96% 90% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Hover/UI Core/Light */
-  --figma___button-soft-accent-text-disabled: 237 14% 73% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Text-disabled/UI Core/Light */
-  --figma___button-soft-accent-text-primary: 206 98% 42% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Text-primary/UI Core/Light */
-  --figma___button-soft-accent-default: 195 100% 97% / 1;
-  /* ✦ Theme/Button/Soft/Accent/default/UI Core/Light */
-  --figma___button-soft-error-active: 5 74% 94% / 1;
-  /* ✦ Theme/Button/Soft/Error/Active/UI Core/Light */
-  --figma___button-soft-error-disabled: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Soft/Error/Disabled/UI Core/Light */
-  --figma___button-soft-error-hover: 5 74% 94% / 1;
-  /* ✦ Theme/Button/Soft/Error/Hover/UI Core/Light */
-  --figma___button-soft-error-text-disabled: 237 14% 73% / 1;
-  /* ✦ Theme/Button/Soft/Error/Text-disabled/UI Core/Light */
-  --figma___button-soft-error-text-primary: 4 79% 45% / 1;
-  /* ✦ Theme/Button/Soft/Error/Text-primary/UI Core/Light */
-  --figma___button-soft-error-default: 4 73% 96% / 1;
-  /* ✦ Theme/Button/Soft/Error/default/UI Core/Light */
-  --figma___button-soft-neutral-active: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Active/UI Core/Light */
-  --figma___button-soft-neutral-disabled: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Disabled/UI Core/Light */
-  --figma___button-soft-neutral-hover: 235 19% 87% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Hover/UI Core/Light */
-  --figma___button-soft-neutral-text-disabled: 237 14% 73% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/UI Core/Light */
-  --figma___button-soft-neutral-text-primary: 236 11% 25% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Text-primary/UI Core/Light */
-  --figma___button-soft-neutral-default: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/default/UI Core/Light */
-  --figma___button-soft-success-active: 112 56% 89% / 1;
-  /* ✦ Theme/Button/Soft/Success/Active/UI Core/Light */
-  --figma___button-soft-success-disabled: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Soft/Success/Disabled/UI Core/Light */
-  --figma___button-soft-success-hover: 112 56% 89% / 1;
-  /* ✦ Theme/Button/Soft/Success/Hover/UI Core/Light */
-  --figma___button-soft-success-text-disabled: 237 14% 73% / 1;
-  /* ✦ Theme/Button/Soft/Success/Text-disabled/UI Core/Light */
-  --figma___button-soft-success-text-primary: 122 58% 38% / 1;
-  /* ✦ Theme/Button/Soft/Success/Text-primary/UI Core/Light */
-  --figma___button-soft-success-default: 112 58% 93% / 1;
-  /* ✦ Theme/Button/Soft/Success/default/UI Core/Light */
-  --figma___button-solid-accent-active: 206 98% 42% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Active/UI Core/Light */
-  --figma___button-solid-accent-disabled: 206 98% 42% / 0.5;
-  /* ✦ Theme/Button/Solid/Accent/Disabled/UI Core/Light */
-  --figma___button-solid-accent-hover: 213 100% 32% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Hover/UI Core/Light */
-  --figma___button-solid-accent-text-disabled: 0 0% 100% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Text-disabled/UI Core/Light */
-  --figma___button-solid-accent-text-primary: 0 0% 100% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Text-primary/UI Core/Light */
-  --figma___button-solid-accent-default: 206 98% 42% / 1;
-  /* ✦ Theme/Button/Solid/Accent/default/UI Core/Light */
-  --figma___button-solid-error-active: 4 77% 48% / 1;
-  /* ✦ Theme/Button/Solid/Error/Active/UI Core/Light */
-  --figma___button-solid-error-disabled: 4 75% 75% / 1;
-  /* ✦ Theme/Button/Solid/Error/Disabled/UI Core/Light */
-  --figma___button-solid-error-hover: 3 84% 38% / 1;
-  /* ✦ Theme/Button/Solid/Error/Hover/UI Core/Light */
-  --figma___button-solid-error-text-disabled: 0 0% 100% / 1;
-  /* ✦ Theme/Button/Solid/Error/Text-disabled/UI Core/Light */
-  --figma___button-solid-error-text-primary: 0 0% 100% / 1;
-  /* ✦ Theme/Button/Solid/Error/Text-primary/UI Core/Light */
-  --figma___button-solid-error-default: 4 77% 48% / 1;
-  /* ✦ Theme/Button/Solid/Error/default/UI Core/Light */
-  --figma___button-solid-neutral-active: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Active/UI Core/Light */
-  --figma___button-solid-neutral-disabled: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Disabled/UI Core/Light */
-  --figma___button-solid-neutral-hover: 235 19% 87% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Hover/UI Core/Light */
-  --figma___button-solid-neutral-text-disabled: 237 14% 73% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/UI Core/Light */
-  --figma___button-solid-neutral-text-primary: 236 11% 25% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Text-primary/UI Core/Light */
-  --figma___button-solid-neutral-default: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/default/UI Core/Light */
-  --figma___button-solid-success-active: 122 44% 46% / 1;
-  /* ✦ Theme/Button/Solid/Success/Active/UI Core/Light */
-  --figma___button-solid-success-disabled: 117 54% 68% / 1;
-  /* ✦ Theme/Button/Solid/Success/Disabled/UI Core/Light */
-  --figma___button-solid-success-hover: 121 66% 31% / 1;
-  /* ✦ Theme/Button/Solid/Success/Hover/UI Core/Light */
-  --figma___button-solid-success-text-disabled: 0 0% 100% / 1;
-  /* ✦ Theme/Button/Solid/Success/Text-disabled/UI Core/Light */
-  --figma___button-solid-success-text-primary: 0 0% 100% / 1;
-  /* ✦ Theme/Button/Solid/Success/Text-primary/UI Core/Light */
-  --figma___button-solid-success-default: 122 44% 46% / 1;
-  /* ✦ Theme/Button/Solid/Success/default/UI Core/Light */
-  --figma___button-surface-accent-active: 192 96% 90% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Active/UI Core/Light */
-  --figma___button-surface-accent-active-border: 194 100% 82% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Active border/UI Core/Light */
-  --figma___button-surface-accent-disabled: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Disabled/UI Core/Light */
-  --figma___button-surface-accent-hover: 192 96% 90% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Hover/UI Core/Light */
-  --figma___button-surface-accent-hover-border: 194 100% 82% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Hover Border/UI Core/Light */
-  --figma___button-surface-accent-text-disabled: 206 98% 42% / 0.5;
-  /* ✦ Theme/Button/Surface/Accent/Text-disabled/UI Core/Light */
-  --figma___button-surface-accent-text-primary: 206 98% 42% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Text-primary/UI Core/Light */
-  --figma___button-surface-accent-default: 195 100% 97% / 1;
-  /* ✦ Theme/Button/Surface/Accent/default/UI Core/Light */
-  --figma___button-surface-accent-default-border: 194 100% 82% / 1;
-  /* ✦ Theme/Button/Surface/Accent/default border/UI Core/Light */
-  --figma___button-surface-error-active: 5 74% 94% / 1;
-  /* ✦ Theme/Button/Surface/Error/Active/UI Core/Light */
-  --figma___button-surface-error-active-border: 4 74% 85% / 1;
-  /* ✦ Theme/Button/Surface/Error/Active border/UI Core/Light */
-  --figma___button-surface-error-disabled: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Surface/Error/Disabled/UI Core/Light */
-  --figma___button-surface-error-hover: 5 74% 94% / 1;
-  /* ✦ Theme/Button/Surface/Error/Hover/UI Core/Light */
-  --figma___button-surface-error-hover-border: 4 74% 85% / 1;
-  /* ✦ Theme/Button/Surface/Error/Hover border/UI Core/Light */
-  --figma___button-surface-error-text-disabled: 237 14% 73% / 1;
-  /* ✦ Theme/Button/Surface/Error/Text-disabled/UI Core/Light */
-  --figma___button-surface-error-text-primary: 4 79% 45% / 1;
-  /* ✦ Theme/Button/Surface/Error/Text-primary/UI Core/Light */
-  --figma___button-surface-error-border: 4 74% 85% / 1;
-  /* ✦ Theme/Button/Surface/Error/border/UI Core/Light */
-  --figma___button-surface-error-default: 4 73% 96% / 1;
-  /* ✦ Theme/Button/Surface/Error/default/UI Core/Light */
-  --figma___button-surface-neutral-active: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Active/UI Core/Light */
-  --figma___button-surface-neutral-disabled: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Disabled/UI Core/Light */
-  --figma___button-surface-neutral-hover: 210 25% 98% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Hover/UI Core/Light */
-  --figma___button-surface-neutral-text-disabled: 237 14% 73% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/UI Core/Light */
-  --figma___button-surface-neutral-text-primary: 236 11% 25% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Text-primary/UI Core/Light */
-  --figma___button-surface-neutral-border: 235 19% 87% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/border/UI Core/Light */
-  --figma___button-surface-neutral-default: 240 41% 97% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/default/UI Core/Light */
-  --figma___button-surface-success-active: 112 56% 89% / 1;
-  /* ✦ Theme/Button/Surface/Success/Active/UI Core/Light */
-  --figma___button-surface-success-disabled: 235 19% 87% / 1;
-  /* ✦ Theme/Button/Surface/Success/Disabled/UI Core/Light */
-  --figma___button-surface-success-hover: 112 56% 89% / 1;
-  /* ✦ Theme/Button/Surface/Success/Hover/UI Core/Light */
-  --figma___button-surface-success-hover-border: 122 53% 55% / 1;
-  /* ✦ Theme/Button/Surface/Success/Hover border/UI Core/Light */
-  --figma___button-surface-success-text-disabled: 237 14% 73% / 1;
-  /* ✦ Theme/Button/Surface/Success/Text-disabled/UI Core/Light */
-  --figma___button-surface-success-text-primary: 122 58% 38% / 1;
-  /* ✦ Theme/Button/Surface/Success/Text-primary/UI Core/Light */
-  --figma___button-surface-success-active-border: 122 53% 55% / 1;
-  /* ✦ Theme/Button/Surface/Success/active border/UI Core/Light */
-  --figma___button-surface-success-default: 112 58% 93% / 1;
-  /* ✦ Theme/Button/Surface/Success/default/UI Core/Light */
-  --figma___button-surface-success-default-border: 113 55% 82% / 1;
-  /* ✦ Theme/Button/Surface/Success/default border/UI Core/Light */
-  --figma___calendar-background: 0 0% 100% / 1;
-  /* ✦ Theme/Calendar/Background/UI Core/Light */
-  --figma___calendar-selected-date-background: 206 98% 42% / 1;
-  /* ✦ Theme/Calendar/Selected Date/Background/UI Core/Light */
-  --figma___calendar-selected-date-text: 0 0% 100% / 1;
-  /* ✦ Theme/Calendar/Selected Date/Text/UI Core/Light */
-  --figma___calendar-selected-range-background: 195 100% 97% / 1;
-  /* ✦ Theme/Calendar/Selected Range/Background/UI Core/Light */
-  --figma___calendar-selected-range-text: 206 98% 42% / 1;
-  /* ✦ Theme/Calendar/Selected Range/Text/UI Core/Light */
-  --figma___checkbox-background: 0 0% 100% / 0.8;
-  /* ✦ Theme/Checkbox/Background/UI Core/Light */
-  --figma___checkbox-paper: 0 0% 100% / 0.5;
-  /* ✦ Theme/Checkbox/Paper/UI Core/Light */
-  --figma___checkbox-surface-checked-active-active: 206 98% 42% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/UI Core/Light */
-  --figma___checkbox-surface-checked-active-check: 0 0% 100% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/UI Core/Light */
-  --figma___checkbox-surface-checked-active-hover: 206 98% 42% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/UI Core/Light */
-  --figma___checkbox-surface-checked-active-default-background: 206 98% 42% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/UI Core/Light */
-  --figma___checkbox-surface-checked-disabled-check: 0 0% 100% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/UI Core/Light */
-  --figma___checkbox-surface-checked-disabled-disabled: 238 13% 62% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/UI Core/Light */
-  --figma___checkbox-surface-checked-disabled-border: 238 13% 62% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/UI Core/Light */
-  --figma___checkbox-surface-intermediate-active-active-border: 206 98% 42% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/UI Core/Light */
-  --figma___checkbox-surface-intermediate-active-check: 0 0% 100% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/UI Core/Light */
-  --figma___checkbox-surface-intermediate-active-hover-border: 206 98% 42% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/UI Core/Light */
-  --figma___checkbox-surface-intermediate-active-default-background: 206 98% 42% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/UI Core/Light */
-  --figma___checkbox-surface-intermediate-active-default-border: 206 98% 42% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/UI Core/Light */
-  --figma___checkbox-surface-intermediate-disabled-check: 0 0% 100% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/UI Core/Light */
-  --figma___checkbox-surface-intermediate-disabled-disabled: 238 13% 62% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/UI Core/Light */
-  --figma___checkbox-surface-intermediate-disabled-border: 238 13% 62% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/UI Core/Light */
-  --figma___checkbox-surface-unchecked-active-active-border: 206 98% 42% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/UI Core/Light */
-  --figma___checkbox-surface-unchecked-active-hover-border: 213 100% 32% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/UI Core/Light */
-  --figma___checkbox-surface-unchecked-active-default-background: 0 0% 100% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/UI Core/Light */
-  --figma___checkbox-surface-unchecked-active-default-border: 206 98% 42% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/UI Core/Light */
-  --figma___checkbox-surface-unchecked-disabled-disabled: 240 41% 97% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/UI Core/Light */
-  --figma___checkbox-surface-unchecked-disabled-border: 235 19% 87% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/UI Core/Light */
-  --figma___checkbox-border: 235 19% 87% / 1;
-  /* ✦ Theme/Checkbox/border/UI Core/Light */
-  --figma___default-colors-black: 0 0% 0% / 1;
-  /* ✦ Theme/Default colors/black/UI Core/Light */
-  --figma___default-colors-dark-to-white: 0 0% 0% / 1;
-  /* ✦ Theme/Default colors/dark-to-white/UI Core/Light */
-  --figma___default-colors-white: 0 0% 100% / 1;
-  /* ✦ Theme/Default colors/white/UI Core/Light */
-  --figma___default-colors-white-to-dark: 0 0% 100% / 1;
-  /* ✦ Theme/Default colors/white-to-dark/UI Core/Light */
-  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
-  /* ✦ Theme/Dropdown/Dropdown Item/Default/UI Core/Light */
-  --figma___dropdown-dropdown-item-hover: 195 100% 97% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Hover/UI Core/Light */
-  --figma___dropdown-dropdown-item-selected: 206 98% 42% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Selected/UI Core/Light */
-  --figma___dropdown-text-shortcut-text-selected: 0 0% 100% / 0.8;
-  /* ✦ Theme/Dropdown/Text/Shortcut text selected/UI Core/Light */
-  --figma___dropdown-text-text-selected: 0 0% 100% / 1;
-  /* ✦ Theme/Dropdown/Text/Text Selected/UI Core/Light */
-  --figma___dropdown-text-hover: 206 98% 42% / 1;
-  /* ✦ Theme/Dropdown/Text/hover/UI Core/Light */
-  --figma___dropdown-background: 0 0% 100% / 1;
-  /* ✦ Theme/Dropdown/background/UI Core/Light */
-  --figma___dropdown-border: 0 0% 100% / 0;
-  /* ✦ Theme/Dropdown/border/UI Core/Light */
-  --figma___dropdown-separator: 240 41% 97% / 1;
-  /* ✦ Theme/Dropdown/separator/UI Core/Light */
-  --figma___filter-active: 235 19% 87% / 1;
-  /* ✦ Theme/Filter/Active/UI Core/Light */
-  --figma___filter-default: 0 0% 100% / 1;
-  /* ✦ Theme/Filter/Default/UI Core/Light */
-  --figma___filter-hover: 235 19% 87% / 1;
-  /* ✦ Theme/Filter/Hover/UI Core/Light */
-  --figma___inline-alert-banner-customisable: 240 41% 97% / 1;
-  /* ✦ Theme/Inline Alert Banner/Customisable/UI Core/Light */
-  --figma___inline-alert-banner-error: 4 73% 96% / 1;
-  /* ✦ Theme/Inline Alert Banner/Error/UI Core/Light */
-  --figma___inline-alert-banner-info: 195 100% 97% / 1;
-  /* ✦ Theme/Inline Alert Banner/Info/UI Core/Light */
-  --figma___inline-alert-banner-reminder: 46 100% 97% / 1;
-  /* ✦ Theme/Inline Alert Banner/Reminder/UI Core/Light */
-  --figma___inline-alert-banner-success: 112 58% 93% / 1;
-  /* ✦ Theme/Inline Alert Banner/Success/UI Core/Light */
-  --figma___inline-alert-banner-warning: 27 100% 96% / 1;
-  /* ✦ Theme/Inline Alert Banner/Warning/UI Core/Light */
-  --figma___modal-background: 0 0% 100% / 1;
-  /* ✦ Theme/Modal/Background/UI Core/Light */
-  --figma___modal-paper: 0 0% 100% / 1;
-  /* ✦ Theme/Modal/Paper/UI Core/Light */
-  --figma___modal-border: 0 0% 0% / 0;
-  /* ✦ Theme/Modal/border/UI Core/Light */
-  --figma___neutral-color-gray-1: 210 25% 98% / 1;
-  /* ✦ Theme/Neutral color/Gray/1/UI Core/Light */
-  --figma___neutral-color-gray-2: 240 41% 97% / 1;
-  /* ✦ Theme/Neutral color/Gray/2/UI Core/Light */
-  --figma___neutral-color-gray-3: 235 19% 87% / 1;
-  /* ✦ Theme/Neutral color/Gray/3/UI Core/Light */
-  --figma___neutral-color-gray-4: 237 14% 73% / 1;
-  /* ✦ Theme/Neutral color/Gray/4/UI Core/Light */
-  --figma___neutral-color-gray-5: 238 13% 62% / 1;
-  /* ✦ Theme/Neutral color/Gray/5/UI Core/Light */
-  --figma___neutral-color-gray-6: 235 11% 47% / 1;
-  /* ✦ Theme/Neutral color/Gray/6/UI Core/Light */
-  --figma___neutral-color-gray-7: 234 11% 35% / 1;
-  /* ✦ Theme/Neutral color/Gray/7/UI Core/Light */
-  --figma___neutral-color-gray-8: 236 11% 25% / 1;
-  /* ✦ Theme/Neutral color/Gray/8/UI Core/Light */
-  --figma___neutral-color-gray-9: 240 11% 15% / 1;
-  /* ✦ Theme/Neutral color/Gray/9/UI Core/Light */
-  --figma___neutral-color-gray-10: 240 8% 5% / 1;
-  /* ✦ Theme/Neutral color/Gray/10/UI Core/Light */
-  --figma___neutral-color-gray-alpha-1: 210 25% 98% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/1/UI Core/Light */
-  --figma___neutral-color-gray-alpha-2: 240 41% 97% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/2/UI Core/Light */
-  --figma___neutral-color-gray-alpha-3: 235 19% 87% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/3/UI Core/Light */
-  --figma___neutral-color-gray-alpha-4: 237 14% 73% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/4/UI Core/Light */
-  --figma___neutral-color-gray-alpha-5: 238 13% 62% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/5/UI Core/Light */
-  --figma___neutral-color-gray-alpha-6: 235 11% 47% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/6/UI Core/Light */
-  --figma___neutral-color-gray-alpha-7: 234 11% 35% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/7/UI Core/Light */
-  --figma___neutral-color-gray-alpha-8: 236 11% 25% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/8/UI Core/Light */
-  --figma___neutral-color-gray-alpha-9: 240 11% 15% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/9/UI Core/Light */
-  --figma___neutral-color-gray-alpha-10: 240 8% 5% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/10/UI Core/Light */
-  --figma___other-colors-ai-violet-1: 258 100% 98% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/1/UI Core/Light */
-  --figma___other-colors-ai-violet-2: 256 70% 95% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/2/UI Core/Light */
-  --figma___other-colors-ai-violet-3: 256 68% 89% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/3/UI Core/Light */
-  --figma___other-colors-ai-violet-4: 256 69% 84% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/4/UI Core/Light */
-  --figma___other-colors-ai-violet-5: 256 68% 78% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/5/UI Core/Light */
-  --figma___other-colors-ai-violet-6: 256 68% 73% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/6/UI Core/Light */
-  --figma___other-colors-ai-violet-7: 256 68% 62% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/7/UI Core/Light */
-  --figma___other-colors-ai-violet-8: 256 68% 56% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/8/UI Core/Light */
-  --figma___other-colors-ai-violet-9: 256 68% 51% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/9/UI Core/Light */
-  --figma___other-colors-ai-violet-10: 256 60% 46% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/10/UI Core/Light */
-  --figma___other-colors-ai-violet-alpha-1: 258 100% 98% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/1/UI Core/Light */
-  --figma___other-colors-ai-violet-alpha-2: 256 70% 95% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/2/UI Core/Light */
-  --figma___other-colors-ai-violet-alpha-3: 256 68% 89% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/3/UI Core/Light */
-  --figma___other-colors-ai-violet-alpha-4: 256 69% 84% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/4/UI Core/Light */
-  --figma___other-colors-ai-violet-alpha-5: 256 68% 78% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/5/UI Core/Light */
-  --figma___other-colors-ai-violet-alpha-6: 256 68% 73% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/6/UI Core/Light */
-  --figma___other-colors-ai-violet-alpha-7: 256 68% 62% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/7/UI Core/Light */
-  --figma___other-colors-ai-violet-alpha-8: 256 68% 56% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/8/UI Core/Light */
-  --figma___other-colors-ai-violet-alpha-9: 256 68% 51% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/9/UI Core/Light */
-  --figma___other-colors-ai-violet-alpha-10: 256 60% 46% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/10/UI Core/Light */
-  --figma___other-colors-blue-1: 240 100% 95% / 1;
-  /* ✦ Theme/Other Colors/Blue/1/UI Core/Light */
-  --figma___other-colors-blue-2: 241 100% 90% / 1;
-  /* ✦ Theme/Other Colors/Blue/2/UI Core/Light */
-  --figma___other-colors-blue-3: 241 100% 84% / 1;
-  /* ✦ Theme/Other Colors/Blue/3/UI Core/Light */
-  --figma___other-colors-blue-4: 241 100% 80% / 1;
-  /* ✦ Theme/Other Colors/Blue/4/UI Core/Light */
-  --figma___other-colors-blue-5: 240 100% 76% / 1;
-  /* ✦ Theme/Other Colors/Blue/5/UI Core/Light */
-  --figma___other-colors-blue-6: 241 82% 66% / 1;
-  /* ✦ Theme/Other Colors/Blue/6/UI Core/Light */
-  --figma___other-colors-blue-7: 241 90% 64% / 1;
-  /* ✦ Theme/Other Colors/Blue/7/UI Core/Light */
-  --figma___other-colors-blue-8: 241 69% 57% / 1;
-  /* ✦ Theme/Other Colors/Blue/8/UI Core/Light */
-  --figma___other-colors-blue-9: 240 51% 46% / 1;
-  /* ✦ Theme/Other Colors/Blue/9/UI Core/Light */
-  --figma___other-colors-blue-10: 241 54% 38% / 1;
-  /* ✦ Theme/Other Colors/Blue/10/UI Core/Light */
-  --figma___other-colors-blue-alpha-1: 195 100% 97% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/1/UI Core/Light */
-  --figma___other-colors-blue-alpha-2: 192 96% 90% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/2/UI Core/Light */
-  --figma___other-colors-blue-alpha-3: 194 100% 82% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/3/UI Core/Light */
-  --figma___other-colors-blue-alpha-4: 195 91% 60% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/4/UI Core/Light */
-  --figma___other-colors-blue-alpha-5: 194 100% 45% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/5/UI Core/Light */
-  --figma___other-colors-blue-alpha-6: 202 100% 45% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/6/UI Core/Light */
-  --figma___other-colors-blue-alpha-7: 206 98% 42% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/7/UI Core/Light */
-  --figma___other-colors-blue-alpha-8: 213 100% 32% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/8/UI Core/Light */
-  --figma___other-colors-blue-alpha-9: 213 82% 22% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/9/UI Core/Light */
-  --figma___other-colors-blue-alpha-10: 212 72% 10% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/10/UI Core/Light */
-  --figma___other-colors-indigo-1: 240 33% 99% / 1;
-  /* ✦ Theme/Other Colors/Indigo/1/UI Core/Light */
-  --figma___other-colors-indigo-2: 223 100% 99% / 1;
-  /* ✦ Theme/Other Colors/Indigo/2/UI Core/Light */
-  --figma___other-colors-indigo-3: 224 100% 97% / 1;
-  /* ✦ Theme/Other Colors/Indigo/3/UI Core/Light */
-  --figma___other-colors-indigo-4: 222 92% 95% / 1;
-  /* ✦ Theme/Other Colors/Indigo/4/UI Core/Light */
-  --figma___other-colors-indigo-5: 225 85% 92% / 1;
-  /* ✦ Theme/Other Colors/Indigo/5/UI Core/Light */
-  --figma___other-colors-indigo-6: 224 81% 88% / 1;
-  /* ✦ Theme/Other Colors/Indigo/6/UI Core/Light */
-  --figma___other-colors-indigo-7: 226 70% 55% / 1;
-  /* ✦ Theme/Other Colors/Indigo/7/UI Core/Light */
-  --figma___other-colors-indigo-8: 226 59% 51% / 1;
-  /* ✦ Theme/Other Colors/Indigo/8/UI Core/Light */
-  --figma___other-colors-indigo-9: 226 55% 45% / 1;
-  /* ✦ Theme/Other Colors/Indigo/9/UI Core/Light */
-  --figma___other-colors-indigo-10: 226 63% 17% / 1;
-  /* ✦ Theme/Other Colors/Indigo/10/UI Core/Light */
-  --figma___other-colors-indigo-alpha-1: 240 93% 26% / 0.01;
-  /* ✦ Theme/Other Colors/Indigo Alpha/1/UI Core/Light */
-  --figma___other-colors-indigo-alpha-2: 223 100% 51% / 0.03;
-  /* ✦ Theme/Other Colors/Indigo Alpha/2/UI Core/Light */
-  --figma___other-colors-indigo-alpha-3: 224 100% 50% / 0.06;
-  /* ✦ Theme/Other Colors/Indigo Alpha/3/UI Core/Light */
-  --figma___other-colors-indigo-alpha-4: 222 98% 48% / 0.1;
-  /* ✦ Theme/Other Colors/Indigo Alpha/4/UI Core/Light */
-  --figma___other-colors-indigo-alpha-5: 225 98% 46% / 0.15;
-  /* ✦ Theme/Other Colors/Indigo Alpha/5/UI Core/Light */
-  --figma___other-colors-indigo-alpha-6: 224 99% 45% / 0.22;
-  /* ✦ Theme/Other Colors/Indigo Alpha/6/UI Core/Light */
-  --figma___other-colors-indigo-alpha-7: 226 100% 41% / 0.76;
-  /* ✦ Theme/Other Colors/Indigo Alpha/7/UI Core/Light */
-  --figma___other-colors-indigo-alpha-8: 226 100% 37% / 0.77;
-  /* ✦ Theme/Other Colors/Indigo Alpha/8/UI Core/Light */
-  --figma___other-colors-indigo-alpha-9: 225 100% 14% / 0.88;
-  /* ✦ Theme/Other Colors/Indigo Alpha/9/UI Core/Light */
-  --figma___other-colors-indigo-alpha-10: 225 100% 14% / 0.88;
-  /* ✦ Theme/Other Colors/Indigo Alpha/10/UI Core/Light */
-  --figma___other-colors-mint-1: 168 71% 99% / 1;
-  /* ✦ Theme/Other Colors/Mint/1/UI Core/Light */
-  --figma___other-colors-mint-2: 164 88% 97% / 1;
-  /* ✦ Theme/Other Colors/Mint/2/UI Core/Light */
-  --figma___other-colors-mint-3: 164 79% 93% / 1;
-  /* ✦ Theme/Other Colors/Mint/3/UI Core/Light */
-  --figma___other-colors-mint-4: 165 73% 88% / 1;
-  /* ✦ Theme/Other Colors/Mint/4/UI Core/Light */
-  --figma___other-colors-mint-5: 166 60% 83% / 1;
-  /* ✦ Theme/Other Colors/Mint/5/UI Core/Light */
-  --figma___other-colors-mint-6: 166 50% 77% / 1;
-  /* ✦ Theme/Other Colors/Mint/6/UI Core/Light */
-  --figma___other-colors-mint-7: 167 70% 72% / 1;
-  /* ✦ Theme/Other Colors/Mint/7/UI Core/Light */
-  --figma___other-colors-mint-8: 167 62% 69% / 1;
-  /* ✦ Theme/Other Colors/Mint/8/UI Core/Light */
-  --figma___other-colors-mint-9: 172 50% 31% / 1;
-  /* ✦ Theme/Other Colors/Mint/9/UI Core/Light */
-  --figma___other-colors-mint-10: 171 51% 17% / 1;
-  /* ✦ Theme/Other Colors/Mint/10/UI Core/Light */
-  --figma___other-colors-mint-alpha-1: 168 95% 43% / 0.02;
-  /* ✦ Theme/Other Colors/Mint Alpha/1/UI Core/Light */
-  --figma___other-colors-mint-alpha-2: 164 99% 47% / 0.06;
-  /* ✦ Theme/Other Colors/Mint Alpha/2/UI Core/Light */
-  --figma___other-colors-mint-alpha-3: 164 99% 44% / 0.13;
-  /* ✦ Theme/Other Colors/Mint Alpha/3/UI Core/Light */
-  --figma___other-colors-mint-alpha-4: 165 100% 42% / 0.2;
-  /* ✦ Theme/Other Colors/Mint Alpha/4/UI Core/Light */
-  --figma___other-colors-mint-alpha-5: 166 100% 38% / 0.27;
-  /* ✦ Theme/Other Colors/Mint Alpha/5/UI Core/Light */
-  --figma___other-colors-mint-alpha-6: 166 99% 33% / 0.35;
-  /* ✦ Theme/Other Colors/Mint Alpha/6/UI Core/Light */
-  --figma___other-colors-mint-alpha-7: 167 100% 41% / 0.47;
-  /* ✦ Theme/Other Colors/Mint Alpha/7/UI Core/Light */
-  --figma___other-colors-mint-alpha-8: 167 100% 38% / 0.5;
-  /* ✦ Theme/Other Colors/Mint Alpha/8/UI Core/Light */
-  --figma___other-colors-mint-alpha-9: 172 100% 18% / 0.85;
-  /* ✦ Theme/Other Colors/Mint Alpha/9/UI Core/Light */
-  --figma___other-colors-mint-alpha-10: 171 100% 10% / 0.91;
-  /* ✦ Theme/Other Colors/Mint Alpha/10/UI Core/Light */
-  --figma___other-colors-orange-1: 27 100% 96% / 1;
-  /* ✦ Theme/Other Colors/Orange/1/UI Core/Light */
-  --figma___other-colors-orange-2: 24 100% 95% / 1;
-  /* ✦ Theme/Other Colors/Orange/2/UI Core/Light */
-  --figma___other-colors-orange-3: 25 100% 87% / 1;
-  /* ✦ Theme/Other Colors/Orange/3/UI Core/Light */
-  --figma___other-colors-orange-4: 25 100% 79% / 1;
-  /* ✦ Theme/Other Colors/Orange/4/UI Core/Light */
-  --figma___other-colors-orange-5: 25 100% 71% / 1;
-  /* ✦ Theme/Other Colors/Orange/5/UI Core/Light */
-  --figma___other-colors-orange-6: 25 100% 58% / 1;
-  /* ✦ Theme/Other Colors/Orange/6/UI Core/Light */
-  --figma___other-colors-orange-7: 24 100% 57% / 1;
-  /* ✦ Theme/Other Colors/Orange/7/UI Core/Light */
-  --figma___other-colors-orange-8: 22 100% 56% / 1;
-  /* ✦ Theme/Other Colors/Orange/8/UI Core/Light */
-  --figma___other-colors-orange-9: 20 100% 55% / 1;
-  /* ✦ Theme/Other Colors/Orange/9/UI Core/Light */
-  --figma___other-colors-orange-10: 17 100% 53% / 1;
-  /* ✦ Theme/Other Colors/Orange/10/UI Core/Light */
-  --figma___other-colors-orange-alpha-1: 27 100% 96% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/1/UI Core/Light */
-  --figma___other-colors-orange-alpha-2: 24 100% 95% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/2/UI Core/Light */
-  --figma___other-colors-orange-alpha-3: 25 100% 87% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/3/UI Core/Light */
-  --figma___other-colors-orange-alpha-4: 25 100% 79% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/4/UI Core/Light */
-  --figma___other-colors-orange-alpha-5: 25 100% 71% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/5/UI Core/Light */
-  --figma___other-colors-orange-alpha-6: 25 100% 58% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/6/UI Core/Light */
-  --figma___other-colors-orange-alpha-7: 24 100% 57% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/7/UI Core/Light */
-  --figma___other-colors-orange-alpha-8: 22 100% 56% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/8/UI Core/Light */
-  --figma___other-colors-orange-alpha-9: 20 100% 55% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/9/UI Core/Light */
-  --figma___other-colors-orange-alpha-10: 17 100% 53% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/10/UI Core/Light */
-  --figma___other-colors-yellow-1: 46 100% 97% / 1;
-  /* ✦ Theme/Other Colors/Yellow/1/UI Core/Light */
-  --figma___other-colors-yellow-2: 45 100% 95% / 1;
-  /* ✦ Theme/Other Colors/Yellow/2/UI Core/Light */
-  --figma___other-colors-yellow-3: 47 97% 88% / 1;
-  /* ✦ Theme/Other Colors/Yellow/3/UI Core/Light */
-  --figma___other-colors-yellow-4: 46 98% 81% / 1;
-  /* ✦ Theme/Other Colors/Yellow/4/UI Core/Light */
-  --figma___other-colors-yellow-5: 46 99% 73% / 1;
-  /* ✦ Theme/Other Colors/Yellow/5/UI Core/Light */
-  --figma___other-colors-yellow-6: 46 98% 61% / 1;
-  /* ✦ Theme/Other Colors/Yellow/6/UI Core/Light */
-  --figma___other-colors-yellow-7: 45 98% 60% / 1;
-  /* ✦ Theme/Other Colors/Yellow/7/UI Core/Light */
-  --figma___other-colors-yellow-8: 41 100% 55% / 1;
-  /* ✦ Theme/Other Colors/Yellow/8/UI Core/Light */
-  --figma___other-colors-yellow-9: 41 100% 50% / 1;
-  /* ✦ Theme/Other Colors/Yellow/9/UI Core/Light */
-  --figma___other-colors-yellow-10: 41 98% 45% / 1;
-  /* ✦ Theme/Other Colors/Yellow/10/UI Core/Light */
-  --figma___other-colors-yellow-alpha-1: 46 100% 97% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/1/UI Core/Light */
-  --figma___other-colors-yellow-alpha-2: 45 100% 95% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/2/UI Core/Light */
-  --figma___other-colors-yellow-alpha-3: 47 97% 88% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/3/UI Core/Light */
-  --figma___other-colors-yellow-alpha-4: 46 98% 81% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/4/UI Core/Light */
-  --figma___other-colors-yellow-alpha-5: 46 99% 73% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/5/UI Core/Light */
-  --figma___other-colors-yellow-alpha-6: 46 98% 61% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/6/UI Core/Light */
-  --figma___other-colors-yellow-alpha-7: 45 98% 60% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/7/UI Core/Light */
-  --figma___other-colors-yellow-alpha-8: 41 100% 55% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/8/UI Core/Light */
-  --figma___other-colors-yellow-alpha-9: 41 100% 50% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/9/UI Core/Light */
-  --figma___other-colors-yellow-alpha-10: 41 98% 45% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/10/UI Core/Light */
-  --figma___overlays-black-alpha-1: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/1/UI Core/Light */
-  --figma___overlays-black-alpha-2: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/2/UI Core/Light */
-  --figma___overlays-black-alpha-3: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/3/UI Core/Light */
-  --figma___overlays-black-alpha-4: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/4/UI Core/Light */
-  --figma___overlays-black-alpha-5: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/5/UI Core/Light */
-  --figma___overlays-black-alpha-6: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/6/UI Core/Light */
-  --figma___overlays-black-alpha-7: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/7/UI Core/Light */
-  --figma___overlays-black-alpha-8: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/8/UI Core/Light */
-  --figma___overlays-black-alpha-9: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/9/UI Core/Light */
-  --figma___overlays-black-alpha-10: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/10/UI Core/Light */
-  --figma___overlays-white-alpha-1: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/1/UI Core/Light */
-  --figma___overlays-white-alpha-2: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/2/UI Core/Light */
-  --figma___overlays-white-alpha-3: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/3/UI Core/Light */
-  --figma___overlays-white-alpha-4: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/4/UI Core/Light */
-  --figma___overlays-white-alpha-5: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/5/UI Core/Light */
-  --figma___overlays-white-alpha-6: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/6/UI Core/Light */
-  --figma___overlays-white-alpha-7: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/7/UI Core/Light */
-  --figma___overlays-white-alpha-8: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/8/UI Core/Light */
-  --figma___overlays-white-alpha-9: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/9/UI Core/Light */
-  --figma___overlays-white-alpha-10: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/10/UI Core/Light */
-  --figma___pagination-active-background: 202 100% 45% / 1;
-  /* ✦ Theme/Pagination/Active/Background/UI Core/Light */
-  --figma___pagination-active-border: 202 100% 45% / 0;
-  /* ✦ Theme/Pagination/Active/Border/UI Core/Light */
-  --figma___pagination-active-text: 0 0% 100% / 1;
-  /* ✦ Theme/Pagination/Active/Text/UI Core/Light */
-  --figma___pagination-background: 206 98% 42% / 0.21;
-  /* ✦ Theme/Pagination/Background/UI Core/Light */
-  --figma___pagination-default-background: 0 0% 100% / 1;
-  /* ✦ Theme/Pagination/Default/Background/UI Core/Light */
-  --figma___pagination-default-border: 0 0% 89% / 0;
-  /* ✦ Theme/Pagination/Default/Border/UI Core/Light */
-  --figma___pagination-default-text: 235 11% 47% / 1;
-  /* ✦ Theme/Pagination/Default/Text/UI Core/Light */
-  --figma___pagination-hover-background: 0 0% 100% / 1;
-  /* ✦ Theme/Pagination/Hover/Background/UI Core/Light */
-  --figma___pagination-hover-border: 206 98% 42% / 0;
-  /* ✦ Theme/Pagination/Hover/Border/UI Core/Light */
-  --figma___pagination-hover-text: 240 8% 5% / 1;
-  /* ✦ Theme/Pagination/Hover/Text/UI Core/Light */
-  --figma___pagination-pagination-shadow-1: 237 21% 20% / 0.04;
-  /* ✦ Theme/Pagination/Pagination shadow/1/UI Core/Light */
-  --figma___pagination-pagination-shadow-2: 236 8% 41% / 0.16;
-  /* ✦ Theme/Pagination/Pagination shadow/2/UI Core/Light */
-  --figma___primary-color-primary-accent-1: 195 100% 97% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/1/UI Core/Light */
-  --figma___primary-color-primary-accent-2: 192 96% 90% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/2/UI Core/Light */
-  --figma___primary-color-primary-accent-3: 194 100% 82% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/3/UI Core/Light */
-  --figma___primary-color-primary-accent-4: 195 91% 60% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/4/UI Core/Light */
-  --figma___primary-color-primary-accent-5: 194 100% 45% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/5/UI Core/Light */
-  --figma___primary-color-primary-accent-6: 202 100% 45% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/6/UI Core/Light */
-  --figma___primary-color-primary-accent-7: 206 98% 42% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/7/UI Core/Light */
-  --figma___primary-color-primary-accent-8: 213 100% 32% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/8/UI Core/Light */
-  --figma___primary-color-primary-accent-9: 213 82% 22% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/9/UI Core/Light */
-  --figma___primary-color-primary-accent-10: 212 72% 10% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/10/UI Core/Light */
-  --figma___primary-color-primary-alpha-1: 195 100% 97% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/1/UI Core/Light */
-  --figma___primary-color-primary-alpha-2: 192 96% 90% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/2/UI Core/Light */
-  --figma___primary-color-primary-alpha-3: 194 100% 82% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/3/UI Core/Light */
-  --figma___primary-color-primary-alpha-4: 195 91% 60% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/4/UI Core/Light */
-  --figma___primary-color-primary-alpha-5: 194 100% 45% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/5/UI Core/Light */
-  --figma___primary-color-primary-alpha-6: 202 100% 45% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/6/UI Core/Light */
-  --figma___primary-color-primary-alpha-7: 206 98% 42% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/7/UI Core/Light */
-  --figma___primary-color-primary-alpha-8: 213 100% 32% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/8/UI Core/Light */
-  --figma___primary-color-primary-alpha-9: 213 82% 22% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/9/UI Core/Light */
-  --figma___primary-color-primary-alpha-10: 212 72% 10% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/10/UI Core/Light */
-  --figma___radio-button-background: 0 0% 100% / 0.8;
-  /* ✦ Theme/Radio button/Background/UI Core/Light */
-  --figma___radio-button-checked-active-active-border: 206 98% 42% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active Border/UI Core/Light */
-  --figma___radio-button-checked-active-active-background: 206 98% 42% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active background/UI Core/Light */
-  --figma___radio-button-checked-active-dot: 0 0% 100% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Dot/UI Core/Light */
-  --figma___radio-button-checked-active-hover-background: 213 100% 32% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover background/UI Core/Light */
-  --figma___radio-button-checked-active-hover-border: 213 100% 32% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover border/UI Core/Light */
-  --figma___radio-button-checked-active-default-background: 206 98% 42% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default background/UI Core/Light */
-  --figma___radio-button-checked-active-default-border: 206 98% 42% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default border/UI Core/Light */
-  --figma___radio-button-checked-disabled-dot: 0 0% 100% / 1;
-  /* ✦ Theme/Radio button/Checked/Disabled/Dot/UI Core/Light */
-  --figma___radio-button-checked-disabled-background: 240 41% 97% / 1;
-  /* ✦ Theme/Radio button/Checked/Disabled/background/UI Core/Light */
-  --figma___radio-button-checked-disabled-border: 235 19% 87% / 1;
-  /* ✦ Theme/Radio button/Checked/Disabled/border/UI Core/Light */
-  --figma___radio-button-paper: 0 0% 100% / 0.5;
-  /* ✦ Theme/Radio button/Paper/UI Core/Light */
-  --figma___radio-button-unchecked-active-active-border: 206 98% 42% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/Active border/UI Core/Light */
-  --figma___radio-button-unchecked-active-hover-border: 213 100% 32% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/UI Core/Light */
-  --figma___radio-button-unchecked-active-default-background: 0 0% 100% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/default background/UI Core/Light */
-  --figma___radio-button-unchecked-active-default-border: 206 98% 42% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/default border/UI Core/Light */
-  --figma___radio-button-unchecked-disabled-background: 240 41% 97% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/background/UI Core/Light */
-  --figma___radio-button-unchecked-disabled-border: 235 19% 87% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/border/UI Core/Light */
-  --figma___radio-button-border: 235 19% 87% / 1;
-  /* ✦ Theme/Radio button/border/UI Core/Light */
-  --figma___secondary-crimson-crimson-1: 330 100% 98% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 1/UI Core/Light */
-  --figma___secondary-crimson-crimson-10: 331 83% 43% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 10/UI Core/Light */
-  --figma___secondary-crimson-crimson-2: 328 100% 97% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 2/UI Core/Light */
-  --figma___secondary-crimson-crimson-3: 332 100% 90% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 3/UI Core/Light */
-  --figma___secondary-crimson-crimson-4: 331 100% 84% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 4/UI Core/Light */
-  --figma___secondary-crimson-crimson-5: 332 100% 77% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 5/UI Core/Light */
-  --figma___secondary-crimson-crimson-6: 331 100% 64% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 6/UI Core/Light */
-  --figma___secondary-crimson-crimson-7: 331 91% 59% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 7/UI Core/Light */
-  --figma___secondary-crimson-crimson-8: 331 85% 55% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 8/UI Core/Light */
-  --figma___secondary-crimson-crimson-9: 331 75% 49% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 9/UI Core/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-1: 330 100% 98% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/UI Core/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-10: 331 75% 49% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/UI Core/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-11: 331 83% 43% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/UI Core/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-2: 328 100% 97% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/UI Core/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-3: 332 100% 90% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/UI Core/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-4: 331 100% 84% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/UI Core/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-5: 332 100% 77% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/UI Core/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-6: 331 100% 64% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/UI Core/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-8: 331 91% 59% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/UI Core/Light */
-  --figma___secondary-crimson-alpha-crimson-alpha-9: 331 85% 55% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/UI Core/Light */
-  --figma___secondary-lime-1: 87 67% 94% / 1;
-  /* ✦ Theme/Secondary/Lime/1/UI Core/Light */
-  --figma___secondary-lime-2: 89 67% 92% / 1;
-  /* ✦ Theme/Secondary/Lime/2/UI Core/Light */
-  --figma___secondary-lime-3: 88 50% 76% / 1;
-  /* ✦ Theme/Secondary/Lime/3/UI Core/Light */
-  --figma___secondary-lime-4: 88 60% 65% / 1;
-  /* ✦ Theme/Secondary/Lime/4/UI Core/Light */
-  --figma___secondary-lime-5: 88 50% 60% / 1;
-  /* ✦ Theme/Secondary/Lime/5/UI Core/Light */
-  --figma___secondary-lime-6: 79 100% 36% / 1;
-  /* ✦ Theme/Secondary/Lime/6/UI Core/Light */
-  --figma___secondary-lime-7: 88 54% 45% / 1;
-  /* ✦ Theme/Secondary/Lime/7/UI Core/Light */
-  --figma___secondary-lime-8: 92 48% 42% / 1;
-  /* ✦ Theme/Secondary/Lime/8/UI Core/Light */
-  --figma___secondary-lime-9: 95 49% 36% / 1;
-  /* ✦ Theme/Secondary/Lime/9/UI Core/Light */
-  --figma___secondary-lime-10: 103 40% 34% / 1;
-  /* ✦ Theme/Secondary/Lime/10/UI Core/Light */
-  --figma___secondary-lime-alpha-1: 87 67% 94% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/1/UI Core/Light */
-  --figma___secondary-lime-alpha-2: 89 67% 92% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/2/UI Core/Light */
-  --figma___secondary-lime-alpha-3: 88 50% 76% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/3/UI Core/Light */
-  --figma___secondary-lime-alpha-4: 88 60% 65% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/4/UI Core/Light */
-  --figma___secondary-lime-alpha-5: 88 50% 60% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/5/UI Core/Light */
-  --figma___secondary-lime-alpha-6: 79 100% 36% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/6/UI Core/Light */
-  --figma___secondary-lime-alpha-7: 88 54% 45% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/7/UI Core/Light */
-  --figma___secondary-lime-alpha-8: 92 48% 42% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/8/UI Core/Light */
-  --figma___secondary-lime-alpha-9: 95 49% 36% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/9/UI Core/Light */
-  --figma___secondary-lime-alpha-10: 103 40% 34% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/10/UI Core/Light */
-  --figma___secondary-purple-1: 262 100% 94% / 1;
-  /* ✦ Theme/Secondary/Purple/1/UI Core/Light */
-  --figma___secondary-purple-2: 262 100% 91% / 1;
-  /* ✦ Theme/Secondary/Purple/2/UI Core/Light */
-  --figma___secondary-purple-3: 262 100% 85% / 1;
-  /* ✦ Theme/Secondary/Purple/3/UI Core/Light */
-  --figma___secondary-purple-4: 262 100% 81% / 1;
-  /* ✦ Theme/Secondary/Purple/4/UI Core/Light */
-  --figma___secondary-purple-5: 262 95% 75% / 1;
-  /* ✦ Theme/Secondary/Purple/5/UI Core/Light */
-  --figma___secondary-purple-6: 261 60% 56% / 1;
-  /* ✦ Theme/Secondary/Purple/6/UI Core/Light */
-  --figma___secondary-purple-7: 262 55% 49% / 1;
-  /* ✦ Theme/Secondary/Purple/7/UI Core/Light */
-  --figma___secondary-purple-8: 262 60% 42% / 1;
-  /* ✦ Theme/Secondary/Purple/8/UI Core/Light */
-  --figma___secondary-purple-9: 262 57% 36% / 1;
-  /* ✦ Theme/Secondary/Purple/9/UI Core/Light */
-  --figma___secondary-purple-10: 270 86% 30% / 1;
-  /* ✦ Theme/Secondary/Purple/10/UI Core/Light */
-  --figma___secondary-purple-alpha-1: 262 100% 94% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/1/UI Core/Light */
-  --figma___secondary-purple-alpha-2: 262 100% 91% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/2/UI Core/Light */
-  --figma___secondary-purple-alpha-3: 262 100% 85% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/3/UI Core/Light */
-  --figma___secondary-purple-alpha-4: 262 100% 81% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/4/UI Core/Light */
-  --figma___secondary-purple-alpha-5: 262 95% 75% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/5/UI Core/Light */
-  --figma___secondary-purple-alpha-6: 261 60% 56% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/6/UI Core/Light */
-  --figma___secondary-purple-alpha-7: 262 55% 49% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/7/UI Core/Light */
-  --figma___secondary-purple-alpha-8: 262 60% 42% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/8/UI Core/Light */
-  --figma___secondary-purple-alpha-9: 262 57% 36% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/9/UI Core/Light */
-  --figma___secondary-purple-alpha-10: 270 86% 30% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/10/UI Core/Light */
-  --figma___secondary-teal-1: 183 96% 91% / 1;
-  /* ✦ Theme/Secondary/Teal/1/UI Core/Light */
-  --figma___secondary-teal-2: 183 97% 87% / 1;
-  /* ✦ Theme/Secondary/Teal/2/UI Core/Light */
-  --figma___secondary-teal-3: 182 74% 81% / 1;
-  /* ✦ Theme/Secondary/Teal/3/UI Core/Light */
-  --figma___secondary-teal-4: 184 71% 68% / 1;
-  /* ✦ Theme/Secondary/Teal/4/UI Core/Light */
-  --figma___secondary-teal-5: 184 70% 58% / 1;
-  /* ✦ Theme/Secondary/Teal/5/UI Core/Light */
-  --figma___secondary-teal-6: 184 90% 44% / 1;
-  /* ✦ Theme/Secondary/Teal/6/UI Core/Light */
-  --figma___secondary-teal-7: 184 97% 41% / 1;
-  /* ✦ Theme/Secondary/Teal/7/UI Core/Light */
-  --figma___secondary-teal-8: 184 94% 39% / 1;
-  /* ✦ Theme/Secondary/Teal/8/UI Core/Light */
-  --figma___secondary-teal-9: 184 95% 37% / 1;
-  /* ✦ Theme/Secondary/Teal/9/UI Core/Light */
-  --figma___secondary-teal-10: 184 92% 35% / 1;
-  /* ✦ Theme/Secondary/Teal/10/UI Core/Light */
-  --figma___secondary-teal-alpha-1: 183 96% 91% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/1/UI Core/Light */
-  --figma___secondary-teal-alpha-2: 183 97% 87% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/2/UI Core/Light */
-  --figma___secondary-teal-alpha-3: 182 74% 81% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/3/UI Core/Light */
-  --figma___secondary-teal-alpha-4: 184 71% 68% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/4/UI Core/Light */
-  --figma___secondary-teal-alpha-5: 184 70% 58% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/5/UI Core/Light */
-  --figma___secondary-teal-alpha-6: 184 90% 44% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/6/UI Core/Light */
-  --figma___secondary-teal-alpha-7: 184 97% 41% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/7/UI Core/Light */
-  --figma___secondary-teal-alpha-8: 184 94% 39% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/8/UI Core/Light */
-  --figma___secondary-teal-alpha-9: 184 95% 37% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/9/UI Core/Light */
-  --figma___secondary-teal-alpha-10: 184 92% 35% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/10/UI Core/Light */
-  --figma___shadow-shadow-button-1: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow - button/1/UI Core/Light */
-  --figma___shadow-shadow-button-2: 0 0% 100% / 0.31;
-  /* ✦ Theme/Shadow/Shadow - button/2/UI Core/Light */
-  --figma___shadow-shadow-button-3: 0 0% 100% / 0.46;
-  /* ✦ Theme/Shadow/Shadow - button/3/UI Core/Light */
-  --figma___shadow-shadow-button-4: 0 0% 100% / 0;
-  /* ✦ Theme/Shadow/Shadow - button/4/UI Core/Light */
-  --figma___shadow-shadow-1-1: 237 21% 20% / 0.08;
-  /* ✦ Theme/Shadow/Shadow 1/1/UI Core/Light */
-  --figma___shadow-shadow-2-1: 237 21% 20% / 0.04;
-  /* ✦ Theme/Shadow/Shadow 2/1/UI Core/Light */
-  --figma___shadow-shadow-2-2: 236 8% 41% / 0.16;
-  /* ✦ Theme/Shadow/Shadow 2/2/UI Core/Light */
-  --figma___shadow-shadow-2-3: 240 100% 12% / 0;
-  /* ✦ Theme/Shadow/Shadow 2/3/UI Core/Light */
-  --figma___shadow-shadow-3-1: 237 21% 20% / 0.04;
-  /* ✦ Theme/Shadow/Shadow 3/1/UI Core/Light */
-  --figma___shadow-shadow-3-2: 236 8% 41% / 0.16;
-  /* ✦ Theme/Shadow/Shadow 3/2/UI Core/Light */
-  --figma___shadow-shadow-3-3: 240 100% 12% / 0;
-  /* ✦ Theme/Shadow/Shadow 3/3/UI Core/Light */
-  --figma___shadow-shadow-4-1: 237 21% 20% / 0.04;
-  /* ✦ Theme/Shadow/Shadow 4/1/UI Core/Light */
-  --figma___shadow-shadow-4-2: 236 8% 41% / 0.16;
-  /* ✦ Theme/Shadow/Shadow 4/2/UI Core/Light */
-  --figma___shadow-shadow-5-1: 237 21% 20% / 0.04;
-  /* ✦ Theme/Shadow/Shadow 5/1/UI Core/Light */
-  --figma___shadow-shadow-5-2: 236 8% 41% / 0.16;
-  /* ✦ Theme/Shadow/Shadow 5/2/UI Core/Light */
-  --figma___shadow-shadow-6-1: 237 21% 20% / 0.04;
-  /* ✦ Theme/Shadow/Shadow 6/1/UI Core/Light */
-  --figma___shadow-shadow-6-2: 236 8% 41% / 0.16;
-  /* ✦ Theme/Shadow/Shadow 6/2/UI Core/Light */
-  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
-  /* ✦ Theme/Shadow/Shadow-button-active/1/UI Core/Light */
-  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
-  /* ✦ Theme/Shadow/Shadow-button-active/2/UI Core/Light */
-  --figma___shadow-shadow-button-active-3: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow-button-active/3/UI Core/Light */
-  --figma___shadow-shadow-button-active-4: 0 0% 0% / 0.08;
-  /* ✦ Theme/Shadow/Shadow-button-active/4/UI Core/Light */
-  --figma___side-nav-container-nav-background: 212 72% 10% / 1;
-  /* ✦ Theme/Side nav/Container/Nav-background/UI Core/Light */
-  --figma___side-nav-container-nav-border: 220 6% 90% / 0;
-  /* ✦ Theme/Side nav/Container/Nav-border/UI Core/Light */
-  --figma___side-nav-module-logo-text: 0 0% 100% / 1;
-  /* ✦ Theme/Side nav/Module Logo Text/UI Core/Light */
-  --figma___side-nav-nav-item-default-icon: 238 13% 62% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Default/Icon/UI Core/Light */
-  --figma___side-nav-nav-item-default-text: 237 14% 73% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Default/Text/UI Core/Light */
-  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
-  /* ✦ Theme/Side nav/Nav-item/Default/default/UI Core/Light */
-  --figma___side-nav-nav-item-hover-background: 215 46% 20% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Background/UI Core/Light */
-  --figma___side-nav-nav-item-hover-icon: 238 13% 62% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/UI Core/Light */
-  --figma___side-nav-nav-item-hover-text: 237 14% 73% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Text/UI Core/Light */
-  --figma___side-nav-nav-item-selected-background: 215 46% 20% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Background/UI Core/Light */
-  --figma___side-nav-nav-item-selected-icon: 195 91% 60% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/UI Core/Light */
-  --figma___side-nav-nav-item-selected-text: 195 91% 60% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Text/UI Core/Light */
-  --figma___side-nav-profile-role: 235 11% 47% / 1;
-  /* ✦ Theme/Side nav/Profile/Role/UI Core/Light */
-  --figma___side-nav-profile-text: 238 13% 62% / 1;
-  /* ✦ Theme/Side nav/Profile/Text/UI Core/Light */
-  --figma___side-nav-scope-selector-default-border: 234 11% 35% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Border/UI Core/Light */
-  --figma___side-nav-scope-selector-default-main-text-icon: 0 0% 100% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/UI Core/Light */
-  --figma___side-nav-scope-selector-default-scope-name: 238 13% 62% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/UI Core/Light */
-  --figma___side-nav-scope-selector-default-default: 0 0% 0% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/default/UI Core/Light */
-  --figma___side-nav-scope-selector-hover-border: 206 98% 42% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/UI Core/Light */
-  --figma___side-nav-scope-selector-hover-main-text-icon: 0 0% 100% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/UI Core/Light */
-  --figma___side-nav-scope-selector-hover-scope-name: 238 13% 62% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/UI Core/Light */
-  --figma___side-nav-scope-selector-hover-default: 0 0% 0% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/default/UI Core/Light */
-  --figma___side-nav-scope-selector-selected-border: 206 98% 42% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/UI Core/Light */
-  --figma___side-nav-scope-selector-selected-main-text-icon: 0 0% 100% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/UI Core/Light */
-  --figma___side-nav-scope-selector-selected-scope-name: 238 13% 62% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/UI Core/Light */
-  --figma___side-nav-scope-selector-selected-background: 0 0% 0% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/background/UI Core/Light */
-  --figma___side-nav-separator: 236 11% 25% / 1;
-  /* ✦ Theme/Side nav/Separator/UI Core/Light */
-  --figma___status-colors-error-1: 4 73% 96% / 1;
-  /* ✦ Theme/Status colors/Error/1/UI Core/Light */
-  --figma___status-colors-error-2: 5 74% 94% / 1;
-  /* ✦ Theme/Status colors/Error/2/UI Core/Light */
-  --figma___status-colors-error-3: 4 74% 85% / 1;
-  /* ✦ Theme/Status colors/Error/3/UI Core/Light */
-  --figma___status-colors-error-4: 4 75% 75% / 1;
-  /* ✦ Theme/Status colors/Error/4/UI Core/Light */
-  --figma___status-colors-error-5: 4 82% 63% / 1;
-  /* ✦ Theme/Status colors/Error/5/UI Core/Light */
-  --figma___status-colors-error-6: 4 78% 52% / 1;
-  /* ✦ Theme/Status colors/Error/6/UI Core/Light */
-  --figma___status-colors-error-7: 4 77% 48% / 1;
-  /* ✦ Theme/Status colors/Error/7/UI Core/Light */
-  --figma___status-colors-error-8: 4 79% 45% / 1;
-  /* ✦ Theme/Status colors/Error/8/UI Core/Light */
-  --figma___status-colors-error-9: 3 79% 43% / 1;
-  /* ✦ Theme/Status colors/Error/9/UI Core/Light */
-  --figma___status-colors-error-10: 3 84% 38% / 1;
-  /* ✦ Theme/Status colors/Error/10/UI Core/Light */
-  --figma___status-colors-error-alpha-1: 4 73% 96% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/1/UI Core/Light */
-  --figma___status-colors-error-alpha-2: 5 74% 94% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/2/UI Core/Light */
-  --figma___status-colors-error-alpha-3: 4 74% 85% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/3/UI Core/Light */
-  --figma___status-colors-error-alpha-4: 4 75% 75% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/4/UI Core/Light */
-  --figma___status-colors-error-alpha-5: 4 82% 63% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/5/UI Core/Light */
-  --figma___status-colors-error-alpha-6: 4 78% 52% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/6/UI Core/Light */
-  --figma___status-colors-error-alpha-7: 4 77% 48% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/7/UI Core/Light */
-  --figma___status-colors-error-alpha-8: 4 79% 45% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/8/UI Core/Light */
-  --figma___status-colors-error-alpha-9: 3 79% 43% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/9/UI Core/Light */
-  --figma___status-colors-error-alpha-10: 3 84% 38% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/10/UI Core/Light */
-  --figma___status-colors-info-1: 240 100% 95% / 1;
-  /* ✦ Theme/Status colors/Info/1/UI Core/Light */
-  --figma___status-colors-info-2: 241 100% 90% / 1;
-  /* ✦ Theme/Status colors/Info/2/UI Core/Light */
-  --figma___status-colors-info-3: 241 100% 84% / 1;
-  /* ✦ Theme/Status colors/Info/3/UI Core/Light */
-  --figma___status-colors-info-4: 241 100% 80% / 1;
-  /* ✦ Theme/Status colors/Info/4/UI Core/Light */
-  --figma___status-colors-info-5: 240 100% 76% / 1;
-  /* ✦ Theme/Status colors/Info/5/UI Core/Light */
-  --figma___status-colors-info-6: 241 82% 66% / 1;
-  /* ✦ Theme/Status colors/Info/6/UI Core/Light */
-  --figma___status-colors-info-7: 241 90% 64% / 1;
-  /* ✦ Theme/Status colors/Info/7/UI Core/Light */
-  --figma___status-colors-info-8: 241 69% 57% / 1;
-  /* ✦ Theme/Status colors/Info/8/UI Core/Light */
-  --figma___status-colors-info-9: 240 51% 46% / 1;
-  /* ✦ Theme/Status colors/Info/9/UI Core/Light */
-  --figma___status-colors-info-10: 241 54% 38% / 1;
-  /* ✦ Theme/Status colors/Info/10/UI Core/Light */
-  --figma___status-colors-info-alpha-1: 240 100% 95% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/1/UI Core/Light */
-  --figma___status-colors-info-alpha-2: 241 100% 90% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/2/UI Core/Light */
-  --figma___status-colors-info-alpha-3: 241 100% 84% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/3/UI Core/Light */
-  --figma___status-colors-info-alpha-4: 241 100% 80% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/4/UI Core/Light */
-  --figma___status-colors-info-alpha-5: 240 100% 76% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/5/UI Core/Light */
-  --figma___status-colors-info-alpha-6: 241 82% 66% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/6/UI Core/Light */
-  --figma___status-colors-info-alpha-7: 241 90% 64% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/7/UI Core/Light */
-  --figma___status-colors-info-alpha-8: 241 69% 57% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/8/UI Core/Light */
-  --figma___status-colors-info-alpha-9: 240 51% 46% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/9/UI Core/Light */
-  --figma___status-colors-info-alpha-10: 241 54% 38% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/10/UI Core/Light */
-  --figma___status-colors-success-1: 112 58% 93% / 1;
-  /* ✦ Theme/Status colors/Success/1/UI Core/Light */
-  --figma___status-colors-success-2: 112 56% 89% / 1;
-  /* ✦ Theme/Status colors/Success/2/UI Core/Light */
-  --figma___status-colors-success-3: 113 55% 82% / 1;
-  /* ✦ Theme/Status colors/Success/3/UI Core/Light */
-  --figma___status-colors-success-4: 114 55% 75% / 1;
-  /* ✦ Theme/Status colors/Success/4/UI Core/Light */
-  --figma___status-colors-success-5: 117 54% 68% / 1;
-  /* ✦ Theme/Status colors/Success/5/UI Core/Light */
-  --figma___status-colors-success-6: 122 53% 55% / 1;
-  /* ✦ Theme/Status colors/Success/6/UI Core/Light */
-  --figma___status-colors-success-7: 122 44% 46% / 1;
-  /* ✦ Theme/Status colors/Success/7/UI Core/Light */
-  --figma___status-colors-success-8: 122 58% 38% / 1;
-  /* ✦ Theme/Status colors/Success/8/UI Core/Light */
-  --figma___status-colors-success-9: 121 66% 31% / 1;
-  /* ✦ Theme/Status colors/Success/9/UI Core/Light */
-  --figma___status-colors-success-10: 121 51% 24% / 1;
-  /* ✦ Theme/Status colors/Success/10/UI Core/Light */
-  --figma___status-colors-success-alpha-1: 140 95% 39% / 0.02;
-  /* ✦ Theme/Status colors/Success Alpha/1/UI Core/Light */
-  --figma___status-colors-success-alpha-2: 139 98% 37% / 0.09;
-  /* ✦ Theme/Status colors/Success Alpha/2/UI Core/Light */
-  --figma___status-colors-success-alpha-3: 139 98% 37% / 0.09;
-  /* ✦ Theme/Status colors/Success Alpha/3/UI Core/Light */
-  --figma___status-colors-success-alpha-4: 139 99% 33% / 0.13;
-  /* ✦ Theme/Status colors/Success Alpha/4/UI Core/Light */
-  --figma___status-colors-success-alpha-5: 141 100% 30% / 0.2;
-  /* ✦ Theme/Status colors/Success Alpha/5/UI Core/Light */
-  --figma___status-colors-success-alpha-6: 142 99% 29% / 0.29;
-  /* ✦ Theme/Status colors/Success Alpha/6/UI Core/Light */
-  --figma___status-colors-success-alpha-7: 151 100% 29% / 0.64;
-  /* ✦ Theme/Status colors/Success Alpha/7/UI Core/Light */
-  --figma___status-colors-success-alpha-8: 151 100% 28% / 0.81;
-  /* ✦ Theme/Status colors/Success Alpha/8/UI Core/Light */
-  --figma___status-colors-success-alpha-9: 153 100% 21% / 0.91;
-  /* ✦ Theme/Status colors/Success Alpha/9/UI Core/Light */
-  --figma___status-colors-success-alpha-10: 155 100% 7% / 0.9;
-  /* ✦ Theme/Status colors/Success Alpha/10/UI Core/Light */
-  --figma___status-colors-warning-1: 27 100% 96% / 1;
-  /* ✦ Theme/Status colors/Warning/1/UI Core/Light */
-  --figma___status-colors-warning-2: 24 100% 95% / 1;
-  /* ✦ Theme/Status colors/Warning/2/UI Core/Light */
-  --figma___status-colors-warning-3: 25 100% 87% / 1;
-  /* ✦ Theme/Status colors/Warning/3/UI Core/Light */
-  --figma___status-colors-warning-4: 25 100% 79% / 1;
-  /* ✦ Theme/Status colors/Warning/4/UI Core/Light */
-  --figma___status-colors-warning-5: 25 100% 71% / 1;
-  /* ✦ Theme/Status colors/Warning/5/UI Core/Light */
-  --figma___status-colors-warning-6: 25 100% 58% / 1;
-  /* ✦ Theme/Status colors/Warning/6/UI Core/Light */
-  --figma___status-colors-warning-7: 24 100% 57% / 1;
-  /* ✦ Theme/Status colors/Warning/7/UI Core/Light */
-  --figma___status-colors-warning-8: 22 100% 56% / 1;
-  /* ✦ Theme/Status colors/Warning/8/UI Core/Light */
-  --figma___status-colors-warning-9: 20 100% 55% / 1;
-  /* ✦ Theme/Status colors/Warning/9/UI Core/Light */
-  --figma___status-colors-warning-10: 17 100% 53% / 1;
-  /* ✦ Theme/Status colors/Warning/10/UI Core/Light */
-  --figma___status-colors-warning-alpha-1: 27 100% 96% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/1/UI Core/Light */
-  --figma___status-colors-warning-alpha-2: 24 100% 95% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/2/UI Core/Light */
-  --figma___status-colors-warning-alpha-3: 25 100% 87% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/3/UI Core/Light */
-  --figma___status-colors-warning-alpha-4: 25 100% 79% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/4/UI Core/Light */
-  --figma___status-colors-warning-alpha-5: 25 100% 71% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/5/UI Core/Light */
-  --figma___status-colors-warning-alpha-6: 25 100% 58% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/6/UI Core/Light */
-  --figma___status-colors-warning-alpha-7: 24 100% 57% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/7/UI Core/Light */
-  --figma___status-colors-warning-alpha-8: 22 100% 56% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/8/UI Core/Light */
-  --figma___status-colors-warning-alpha-9: 20 100% 55% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/9/UI Core/Light */
-  --figma___status-colors-warning-alpha-10: 17 100% 53% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/10/UI Core/Light */
-  --figma___switch-background: 0 0% 100% / 0.8;
-  /* ✦ Theme/Switch/Background/UI Core/Light */
-  --figma___switch-checked-active-thumb-thumb-background: 0 0% 100% / 1;
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/UI Core/Light */
-  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/UI Core/Light */
-  --figma___switch-checked-active-background: 206 98% 42% / 1;
-  /* ✦ Theme/Switch/Checked/Active/background/UI Core/Light */
-  --figma___switch-checked-active-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Checked/Active/border/UI Core/Light */
-  --figma___switch-checked-default-thumb-thumb-background: 0 0% 100% / 1;
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/UI Core/Light */
-  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/UI Core/Light */
-  --figma___switch-checked-default-default-background: 206 98% 42% / 1;
-  /* ✦ Theme/Switch/Checked/Default/default background/UI Core/Light */
-  --figma___switch-checked-default-default-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Checked/Default/default border/UI Core/Light */
-  --figma___switch-checked-disabled-thumb-thumb-background: 0 0% 100% / 1;
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/UI Core/Light */
-  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/UI Core/Light */
-  --figma___switch-checked-disabled-background: 206 98% 42% / 0.5;
-  /* ✦ Theme/Switch/Checked/Disabled/background/UI Core/Light */
-  --figma___switch-checked-disabled-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/border/UI Core/Light */
-  --figma___switch-checked-hover-thumb-thumb-background: 0 0% 100% / 1;
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/UI Core/Light */
-  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/UI Core/Light */
-  --figma___switch-checked-hover-background: 213 100% 32% / 1;
-  /* ✦ Theme/Switch/Checked/Hover/background/UI Core/Light */
-  --figma___switch-checked-hover-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/border/UI Core/Light */
-  --figma___switch-paper: 0 0% 100% / 0.5;
-  /* ✦ Theme/Switch/Paper/UI Core/Light */
-  --figma___switch-unchecked-active-thumb-thumb-background: 0 0% 100% / 1;
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/UI Core/Light */
-  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/UI Core/Light */
-  --figma___switch-unchecked-active-background: 235 19% 87% / 1;
-  /* ✦ Theme/Switch/Unchecked/Active/background/UI Core/Light */
-  --figma___switch-unchecked-active-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Unchecked/Active/border/UI Core/Light */
-  --figma___switch-unchecked-default-thumb-thumb-background: 0 0% 100% / 1;
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/UI Core/Light */
-  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/UI Core/Light */
-  --figma___switch-unchecked-default-default-background: 235 19% 87% / 1;
-  /* ✦ Theme/Switch/Unchecked/Default/default background/UI Core/Light */
-  --figma___switch-unchecked-default-default-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Unchecked/Default/default border/UI Core/Light */
-  --figma___switch-unchecked-disabled-thumb-thumb-background: 0 0% 100% / 1;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/UI Core/Light */
-  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/UI Core/Light */
-  --figma___switch-unchecked-disabled-background: 240 41% 97% / 1;
-  /* ✦ Theme/Switch/Unchecked/Disabled/background/UI Core/Light */
-  --figma___switch-unchecked-disabled-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Unchecked/Disabled/border/UI Core/Light */
-  --figma___switch-unchecked-hover-thumb-thumb-background: 0 0% 100% / 1;
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/UI Core/Light */
-  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/UI Core/Light */
-  --figma___switch-unchecked-hover-background: 237 14% 73% / 1;
-  /* ✦ Theme/Switch/Unchecked/Hover/background/UI Core/Light */
-  --figma___switch-unchecked-hover-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Unchecked/Hover/border/UI Core/Light */
-  --figma___switch-border: 235 19% 87% / 1;
-  /* ✦ Theme/Switch/border/UI Core/Light */
-  --figma___tabs-number-active-background: 206 98% 42% / 1;
-  /* ✦ Theme/Tabs/Number/Active/Background/UI Core/Light */
-  --figma___tabs-number-active-text: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Number/Active/text/UI Core/Light */
-  --figma___tabs-number-default-hover-background: 240 41% 97% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/Background/UI Core/Light */
-  --figma___tabs-number-default-hover-text: 235 11% 47% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/text/UI Core/Light */
-  --figma___tabs-pills-active-active: 195 100% 97% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Active/UI Core/Light */
-  --figma___tabs-pills-active-text: 213 100% 32% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Text/UI Core/Light */
-  --figma___tabs-pills-active-border-grad-1: 0 0% 100% / 0;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 1/UI Core/Light */
-  --figma___tabs-pills-active-border-grad-2: 0 0% 100% / 0;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 2/UI Core/Light */
-  --figma___tabs-pills-backgrounds: 235 19% 87% / 1;
-  /* ✦ Theme/Tabs/Pills/Backgrounds/UI Core/Light */
-  --figma___tabs-pills-default-background: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Pills/Default/Background/UI Core/Light */
-  --figma___tabs-pills-default-text: 236 11% 25% / 1;
-  /* ✦ Theme/Tabs/Pills/Default/Text/UI Core/Light */
-  --figma___tabs-pills-hover-background: 195 100% 97% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Background/UI Core/Light */
-  --figma___tabs-pills-hover-text: 236 11% 25% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Text/UI Core/Light */
-  --figma___tabs-pills-number-active-background: 206 98% 42% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/Background/UI Core/Light */
-  --figma___tabs-pills-number-active-text: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/text/UI Core/Light */
-  --figma___tabs-pills-border-grad-1: 235 19% 87% / 1;
-  /* ✦ Theme/Tabs/Pills/border grad 1/UI Core/Light */
-  --figma___tabs-pills-border-grad-2: 235 19% 87% / 1;
-  /* ✦ Theme/Tabs/Pills/border grad 2/UI Core/Light */
-  --figma___tabs-primary-active-text: 240 8% 5% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Text/UI Core/Light */
-  --figma___tabs-primary-active-underline: 206 98% 42% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Underline/UI Core/Light */
-  --figma___tabs-primary-border: 206 98% 42% / 1;
-  /* ✦ Theme/Tabs/Primary/Border/UI Core/Light */
-  --figma___tabs-primary-default-background: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Primary/Default/Background/UI Core/Light */
-  --figma___tabs-primary-default-text: 236 11% 25% / 1;
-  /* ✦ Theme/Tabs/Primary/Default/Text/UI Core/Light */
-  --figma___tabs-primary-hover-background: 0 0% 100% / 0;
-  /* ✦ Theme/Tabs/Primary/Hover/Background/UI Core/Light */
-  --figma___tabs-primary-hover-text: 206 98% 42% / 1;
-  /* ✦ Theme/Tabs/Primary/Hover/Text/UI Core/Light */
-  --figma___tabs-primary-pills-pills: 213 82% 22% / 1;
-  /* ✦ Theme/Tabs/Primary/Pills/Pills/UI Core/Light */
-  --figma___text-disabled: 237 14% 73% / 1;
-  /* ✦ Theme/Text/Disabled/UI Core/Light */
-  --figma___text-links: 206 98% 42% / 1;
-  /* ✦ Theme/Text/Links/UI Core/Light */
-  --figma___text-secondary: 236 11% 25% / 1;
-  /* ✦ Theme/Text/Secondary/UI Core/Light */
-  --figma___text-tertiary: 235 11% 47% / 1;
-  /* ✦ Theme/Text/Tertiary/UI Core/Light */
-  --figma___text-primary: 240 8% 5% / 1;
-  /* ✦ Theme/Text/primary/UI Core/Light */
-  --figma___textfield-assistive-text-primary: 235 11% 47% / 1;
-  /* ✦ Theme/Textfield/Assistive Text/Primary/UI Core/Light */
-  --figma___textfield-background: 0 0% 100% / 1;
-  /* ✦ Theme/Textfield/Background/UI Core/Light */
-  --figma___textfield-input-field-background: 0 0% 100% / 1;
-  /* ✦ Theme/Textfield/Input Field/Background/UI Core/Light */
-  --figma___textfield-input-field-default: 235 19% 87% / 1;
-  /* ✦ Theme/Textfield/Input Field/Default/UI Core/Light */
-  --figma___textfield-input-field-error: 4 77% 48% / 1;
-  /* ✦ Theme/Textfield/Input Field/Error/UI Core/Light */
-  --figma___textfield-input-field-hover: 206 98% 42% / 1;
-  /* ✦ Theme/Textfield/Input Field/Hover/UI Core/Light */
-  --figma___textfield-label-info-icon: 206 98% 42% / 1;
-  /* ✦ Theme/Textfield/Label/Info Icon/UI Core/Light */
-  --figma___textfield-label-link: 206 98% 42% / 1;
-  /* ✦ Theme/Textfield/Label/Link/UI Core/Light */
-  --figma___textfield-label-main: 236 11% 25% / 1;
-  /* ✦ Theme/Textfield/Label/Main/UI Core/Light */
-  --figma___textfield-label-optional: 235 11% 47% / 1;
-  /* ✦ Theme/Textfield/Label/Optional/UI Core/Light */
-  --figma___textfield-pin-soft-background: 240 41% 97% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/Background/UI Core/Light */
-  --figma___textfield-pin-soft-border: 235 19% 87% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/border/UI Core/Light */
-  --figma___textfield-pin-soft-pin: 206 98% 42% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/pin/UI Core/Light */
-  --figma___textfield-pin-surface-background: 240 41% 97% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/Background/UI Core/Light */
-  --figma___textfield-pin-surface-border: 235 19% 87% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/border/UI Core/Light */
-  --figma___textfield-pin-surface-pin: 206 98% 42% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/pin/UI Core/Light */
-  --figma___tooltip-background: 215 46% 20% / 1;
-  /* ✦ Theme/Tooltip/Background/UI Core/Light */
-  --figma___tooltip-body-text: 0 0% 100% / 1;
-  /* ✦ Theme/Tooltip/Body Text/UI Core/Light */
-  --figma___tooltip-dismissable-icon: 234 11% 35% / 1;
-  /* ✦ Theme/Tooltip/Dismissable icon/UI Core/Light */
-  --figma___tooltip-tooltip-title: 0 0% 100% / 1;
-  /* ✦ Theme/Tooltip/Tooltip Title/UI Core/Light */
+  --figma___colors-alerts-status-error-1: 4 73% 96% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/1/UI Core/Light */
+  --figma___colors-alerts-status-error-2: 5 74% 94% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/2/UI Core/Light */
+  --figma___colors-alerts-status-error-3: 4 74% 85% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/3/UI Core/Light */
+  --figma___colors-alerts-status-error-4: 4 75% 75% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/4/UI Core/Light */
+  --figma___colors-alerts-status-error-5: 4 82% 63% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/5/UI Core/Light */
+  --figma___colors-alerts-status-error-6: 4 78% 52% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/6/UI Core/Light */
+  --figma___colors-alerts-status-error-7: 4 77% 48% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/7/UI Core/Light */
+  --figma___colors-alerts-status-error-8: 4 79% 45% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/8/UI Core/Light */
+  --figma___colors-alerts-status-error-9: 3 79% 43% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/9/UI Core/Light */
+  --figma___colors-alerts-status-error-10: 3 84% 38% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/10/UI Core/Light */
+  --figma___colors-alerts-status-error-alpha-1: 4 73% 96% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/1/UI Core/Light */
+  --figma___colors-alerts-status-error-alpha-2: 5 74% 94% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/2/UI Core/Light */
+  --figma___colors-alerts-status-error-alpha-3: 4 74% 85% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/3/UI Core/Light */
+  --figma___colors-alerts-status-error-alpha-4: 4 75% 75% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/4/UI Core/Light */
+  --figma___colors-alerts-status-error-alpha-5: 4 82% 63% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/5/UI Core/Light */
+  --figma___colors-alerts-status-error-alpha-6: 4 78% 52% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/6/UI Core/Light */
+  --figma___colors-alerts-status-error-alpha-7: 4 77% 48% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/7/UI Core/Light */
+  --figma___colors-alerts-status-error-alpha-8: 4 79% 45% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/8/UI Core/Light */
+  --figma___colors-alerts-status-error-alpha-9: 3 79% 43% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/9/UI Core/Light */
+  --figma___colors-alerts-status-error-alpha-10: 3 84% 38% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/10/UI Core/Light */
+  --figma___colors-alerts-status-info-1: 240 100% 95% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/1/UI Core/Light */
+  --figma___colors-alerts-status-info-2: 241 100% 90% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/2/UI Core/Light */
+  --figma___colors-alerts-status-info-3: 241 100% 84% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/3/UI Core/Light */
+  --figma___colors-alerts-status-info-4: 241 100% 80% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/4/UI Core/Light */
+  --figma___colors-alerts-status-info-5: 240 100% 76% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/5/UI Core/Light */
+  --figma___colors-alerts-status-info-6: 241 82% 66% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/6/UI Core/Light */
+  --figma___colors-alerts-status-info-7: 241 90% 64% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/7/UI Core/Light */
+  --figma___colors-alerts-status-info-8: 241 69% 57% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/8/UI Core/Light */
+  --figma___colors-alerts-status-info-9: 240 51% 46% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/9/UI Core/Light */
+  --figma___colors-alerts-status-info-10: 241 54% 38% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/10/UI Core/Light */
+  --figma___colors-alerts-status-info-alpha-1: 240 100% 95% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/1/UI Core/Light */
+  --figma___colors-alerts-status-info-alpha-2: 241 100% 90% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/2/UI Core/Light */
+  --figma___colors-alerts-status-info-alpha-3: 241 100% 84% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/3/UI Core/Light */
+  --figma___colors-alerts-status-info-alpha-4: 241 100% 80% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/4/UI Core/Light */
+  --figma___colors-alerts-status-info-alpha-5: 240 100% 76% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/5/UI Core/Light */
+  --figma___colors-alerts-status-info-alpha-6: 241 82% 66% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/6/UI Core/Light */
+  --figma___colors-alerts-status-info-alpha-7: 241 90% 64% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/7/UI Core/Light */
+  --figma___colors-alerts-status-info-alpha-8: 241 69% 57% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/8/UI Core/Light */
+  --figma___colors-alerts-status-info-alpha-9: 240 51% 46% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/9/UI Core/Light */
+  --figma___colors-alerts-status-info-alpha-10: 241 54% 38% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/10/UI Core/Light */
+  --figma___colors-alerts-status-success-1: 112 58% 93% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/1/UI Core/Light */
+  --figma___colors-alerts-status-success-2: 112 56% 89% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/2/UI Core/Light */
+  --figma___colors-alerts-status-success-3: 113 55% 82% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/3/UI Core/Light */
+  --figma___colors-alerts-status-success-4: 114 55% 75% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/4/UI Core/Light */
+  --figma___colors-alerts-status-success-5: 117 54% 68% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/5/UI Core/Light */
+  --figma___colors-alerts-status-success-6: 122 53% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/6/UI Core/Light */
+  --figma___colors-alerts-status-success-7: 122 44% 46% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/7/UI Core/Light */
+  --figma___colors-alerts-status-success-8: 122 58% 38% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/8/UI Core/Light */
+  --figma___colors-alerts-status-success-9: 121 66% 31% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/9/UI Core/Light */
+  --figma___colors-alerts-status-success-10: 121 51% 24% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/10/UI Core/Light */
+  --figma___colors-alerts-status-success-alpha-1: 140 95% 39% / 0.02; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/1/UI Core/Light */
+  --figma___colors-alerts-status-success-alpha-2: 139 98% 37% / 0.09; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/2/UI Core/Light */
+  --figma___colors-alerts-status-success-alpha-3: 139 98% 37% / 0.09; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/3/UI Core/Light */
+  --figma___colors-alerts-status-success-alpha-4: 139 99% 33% / 0.13; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/4/UI Core/Light */
+  --figma___colors-alerts-status-success-alpha-5: 141 100% 30% / 0.2; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/5/UI Core/Light */
+  --figma___colors-alerts-status-success-alpha-6: 142 99% 29% / 0.29; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/6/UI Core/Light */
+  --figma___colors-alerts-status-success-alpha-7: 151 100% 29% / 0.64; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/7/UI Core/Light */
+  --figma___colors-alerts-status-success-alpha-8: 151 100% 28% / 0.81; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/8/UI Core/Light */
+  --figma___colors-alerts-status-success-alpha-9: 153 100% 21% / 0.91; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/9/UI Core/Light */
+  --figma___colors-alerts-status-success-alpha-10: 155 100% 7% / 0.9; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/10/UI Core/Light */
+  --figma___colors-alerts-status-warning-1: 27 100% 96% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/1/UI Core/Light */
+  --figma___colors-alerts-status-warning-2: 24 100% 95% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/2/UI Core/Light */
+  --figma___colors-alerts-status-warning-3: 25 100% 87% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/3/UI Core/Light */
+  --figma___colors-alerts-status-warning-4: 25 100% 79% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/4/UI Core/Light */
+  --figma___colors-alerts-status-warning-5: 25 100% 71% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/5/UI Core/Light */
+  --figma___colors-alerts-status-warning-6: 25 100% 58% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/6/UI Core/Light */
+  --figma___colors-alerts-status-warning-7: 24 100% 57% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/7/UI Core/Light */
+  --figma___colors-alerts-status-warning-8: 22 100% 56% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/8/UI Core/Light */
+  --figma___colors-alerts-status-warning-9: 20 100% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/9/UI Core/Light */
+  --figma___colors-alerts-status-warning-10: 17 100% 53% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/10/UI Core/Light */
+  --figma___colors-alerts-status-warning-alpha-1: 27 100% 96% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/1/UI Core/Light */
+  --figma___colors-alerts-status-warning-alpha-2: 24 100% 95% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/2/UI Core/Light */
+  --figma___colors-alerts-status-warning-alpha-3: 25 100% 87% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/3/UI Core/Light */
+  --figma___colors-alerts-status-warning-alpha-4: 25 100% 79% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/4/UI Core/Light */
+  --figma___colors-alerts-status-warning-alpha-5: 25 100% 71% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/5/UI Core/Light */
+  --figma___colors-alerts-status-warning-alpha-6: 25 100% 58% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/6/UI Core/Light */
+  --figma___colors-alerts-status-warning-alpha-7: 24 100% 57% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/7/UI Core/Light */
+  --figma___colors-alerts-status-warning-alpha-8: 22 100% 56% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/8/UI Core/Light */
+  --figma___colors-alerts-status-warning-alpha-9: 20 100% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/9/UI Core/Light */
+  --figma___colors-alerts-status-warning-alpha-10: 17 100% 53% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/10/UI Core/Light */
+  --figma___colors-charts-ai-violet-1: 258 100% 98% / 1; /* ✦ Theme/Colors/Charts/AI Violet/1/UI Core/Light */
+  --figma___colors-charts-ai-violet-2: 256 70% 95% / 1; /* ✦ Theme/Colors/Charts/AI Violet/2/UI Core/Light */
+  --figma___colors-charts-ai-violet-3: 256 68% 89% / 1; /* ✦ Theme/Colors/Charts/AI Violet/3/UI Core/Light */
+  --figma___colors-charts-ai-violet-4: 256 69% 84% / 1; /* ✦ Theme/Colors/Charts/AI Violet/4/UI Core/Light */
+  --figma___colors-charts-ai-violet-5: 256 68% 78% / 1; /* ✦ Theme/Colors/Charts/AI Violet/5/UI Core/Light */
+  --figma___colors-charts-ai-violet-6: 256 68% 73% / 1; /* ✦ Theme/Colors/Charts/AI Violet/6/UI Core/Light */
+  --figma___colors-charts-ai-violet-7: 256 68% 62% / 1; /* ✦ Theme/Colors/Charts/AI Violet/7/UI Core/Light */
+  --figma___colors-charts-ai-violet-8: 256 68% 56% / 1; /* ✦ Theme/Colors/Charts/AI Violet/8/UI Core/Light */
+  --figma___colors-charts-ai-violet-9: 256 68% 51% / 1; /* ✦ Theme/Colors/Charts/AI Violet/9/UI Core/Light */
+  --figma___colors-charts-ai-violet-10: 256 60% 46% / 1; /* ✦ Theme/Colors/Charts/AI Violet/10/UI Core/Light */
+  --figma___colors-charts-ai-violet-alpha-1: 258 100% 98% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/1/UI Core/Light */
+  --figma___colors-charts-ai-violet-alpha-2: 256 70% 95% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/2/UI Core/Light */
+  --figma___colors-charts-ai-violet-alpha-3: 256 68% 89% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/3/UI Core/Light */
+  --figma___colors-charts-ai-violet-alpha-4: 256 69% 84% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/4/UI Core/Light */
+  --figma___colors-charts-ai-violet-alpha-5: 256 68% 78% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/5/UI Core/Light */
+  --figma___colors-charts-ai-violet-alpha-6: 256 68% 73% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/6/UI Core/Light */
+  --figma___colors-charts-ai-violet-alpha-7: 256 68% 62% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/7/UI Core/Light */
+  --figma___colors-charts-ai-violet-alpha-8: 256 68% 56% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/8/UI Core/Light */
+  --figma___colors-charts-ai-violet-alpha-9: 256 68% 51% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/9/UI Core/Light */
+  --figma___colors-charts-ai-violet-alpha-10: 256 60% 46% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/10/UI Core/Light */
+  --figma___colors-charts-blue-1: 240 100% 95% / 1; /* ✦ Theme/Colors/Charts/Blue/1/UI Core/Light */
+  --figma___colors-charts-blue-2: 241 100% 90% / 1; /* ✦ Theme/Colors/Charts/Blue/2/UI Core/Light */
+  --figma___colors-charts-blue-3: 241 100% 84% / 1; /* ✦ Theme/Colors/Charts/Blue/3/UI Core/Light */
+  --figma___colors-charts-blue-4: 241 100% 80% / 1; /* ✦ Theme/Colors/Charts/Blue/4/UI Core/Light */
+  --figma___colors-charts-blue-5: 240 100% 76% / 1; /* ✦ Theme/Colors/Charts/Blue/5/UI Core/Light */
+  --figma___colors-charts-blue-6: 241 82% 66% / 1; /* ✦ Theme/Colors/Charts/Blue/6/UI Core/Light */
+  --figma___colors-charts-blue-7: 241 90% 64% / 1; /* ✦ Theme/Colors/Charts/Blue/7/UI Core/Light */
+  --figma___colors-charts-blue-8: 241 69% 57% / 1; /* ✦ Theme/Colors/Charts/Blue/8/UI Core/Light */
+  --figma___colors-charts-blue-9: 240 51% 46% / 1; /* ✦ Theme/Colors/Charts/Blue/9/UI Core/Light */
+  --figma___colors-charts-blue-10: 241 54% 38% / 1; /* ✦ Theme/Colors/Charts/Blue/10/UI Core/Light */
+  --figma___colors-charts-blue-alpha-1: 195 100% 97% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/1/UI Core/Light */
+  --figma___colors-charts-blue-alpha-2: 192 96% 90% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/2/UI Core/Light */
+  --figma___colors-charts-blue-alpha-3: 194 100% 82% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/3/UI Core/Light */
+  --figma___colors-charts-blue-alpha-4: 195 91% 60% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/4/UI Core/Light */
+  --figma___colors-charts-blue-alpha-5: 194 100% 45% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/5/UI Core/Light */
+  --figma___colors-charts-blue-alpha-6: 202 100% 45% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/6/UI Core/Light */
+  --figma___colors-charts-blue-alpha-7: 206 98% 42% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/7/UI Core/Light */
+  --figma___colors-charts-blue-alpha-8: 213 100% 32% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/8/UI Core/Light */
+  --figma___colors-charts-blue-alpha-9: 213 82% 22% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/9/UI Core/Light */
+  --figma___colors-charts-blue-alpha-10: 212 72% 10% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/10/UI Core/Light */
+  --figma___colors-charts-indigo-1: 240 33% 99% / 1; /* ✦ Theme/Colors/Charts/Indigo/1/UI Core/Light */
+  --figma___colors-charts-indigo-2: 223 100% 99% / 1; /* ✦ Theme/Colors/Charts/Indigo/2/UI Core/Light */
+  --figma___colors-charts-indigo-3: 224 100% 97% / 1; /* ✦ Theme/Colors/Charts/Indigo/3/UI Core/Light */
+  --figma___colors-charts-indigo-4: 222 92% 95% / 1; /* ✦ Theme/Colors/Charts/Indigo/4/UI Core/Light */
+  --figma___colors-charts-indigo-5: 225 85% 92% / 1; /* ✦ Theme/Colors/Charts/Indigo/5/UI Core/Light */
+  --figma___colors-charts-indigo-6: 224 81% 88% / 1; /* ✦ Theme/Colors/Charts/Indigo/6/UI Core/Light */
+  --figma___colors-charts-indigo-7: 226 70% 55% / 1; /* ✦ Theme/Colors/Charts/Indigo/7/UI Core/Light */
+  --figma___colors-charts-indigo-8: 226 59% 51% / 1; /* ✦ Theme/Colors/Charts/Indigo/8/UI Core/Light */
+  --figma___colors-charts-indigo-9: 226 55% 45% / 1; /* ✦ Theme/Colors/Charts/Indigo/9/UI Core/Light */
+  --figma___colors-charts-indigo-10: 226 63% 17% / 1; /* ✦ Theme/Colors/Charts/Indigo/10/UI Core/Light */
+  --figma___colors-charts-indigo-alpha-1: 240 93% 26% / 0.01; /* ✦ Theme/Colors/Charts/Indigo Alpha/1/UI Core/Light */
+  --figma___colors-charts-indigo-alpha-2: 223 100% 51% / 0.03; /* ✦ Theme/Colors/Charts/Indigo Alpha/2/UI Core/Light */
+  --figma___colors-charts-indigo-alpha-3: 224 100% 50% / 0.06; /* ✦ Theme/Colors/Charts/Indigo Alpha/3/UI Core/Light */
+  --figma___colors-charts-indigo-alpha-4: 222 98% 48% / 0.1; /* ✦ Theme/Colors/Charts/Indigo Alpha/4/UI Core/Light */
+  --figma___colors-charts-indigo-alpha-5: 225 98% 46% / 0.15; /* ✦ Theme/Colors/Charts/Indigo Alpha/5/UI Core/Light */
+  --figma___colors-charts-indigo-alpha-6: 224 99% 45% / 0.22; /* ✦ Theme/Colors/Charts/Indigo Alpha/6/UI Core/Light */
+  --figma___colors-charts-indigo-alpha-7: 226 100% 41% / 0.76; /* ✦ Theme/Colors/Charts/Indigo Alpha/7/UI Core/Light */
+  --figma___colors-charts-indigo-alpha-8: 226 100% 37% / 0.77; /* ✦ Theme/Colors/Charts/Indigo Alpha/8/UI Core/Light */
+  --figma___colors-charts-indigo-alpha-9: 225 100% 14% / 0.88; /* ✦ Theme/Colors/Charts/Indigo Alpha/9/UI Core/Light */
+  --figma___colors-charts-indigo-alpha-10: 225 100% 14% / 0.88; /* ✦ Theme/Colors/Charts/Indigo Alpha/10/UI Core/Light */
+  --figma___colors-charts-mint-1: 168 71% 99% / 1; /* ✦ Theme/Colors/Charts/Mint/1/UI Core/Light */
+  --figma___colors-charts-mint-2: 164 88% 97% / 1; /* ✦ Theme/Colors/Charts/Mint/2/UI Core/Light */
+  --figma___colors-charts-mint-3: 164 79% 93% / 1; /* ✦ Theme/Colors/Charts/Mint/3/UI Core/Light */
+  --figma___colors-charts-mint-4: 165 73% 88% / 1; /* ✦ Theme/Colors/Charts/Mint/4/UI Core/Light */
+  --figma___colors-charts-mint-5: 166 60% 83% / 1; /* ✦ Theme/Colors/Charts/Mint/5/UI Core/Light */
+  --figma___colors-charts-mint-6: 166 44% 67% / 1; /* ✦ Theme/Colors/Charts/Mint/6/UI Core/Light */
+  --figma___colors-charts-mint-7: 167 70% 72% / 1; /* ✦ Theme/Colors/Charts/Mint/7/UI Core/Light */
+  --figma___colors-charts-mint-8: 167 62% 69% / 1; /* ✦ Theme/Colors/Charts/Mint/8/UI Core/Light */
+  --figma___colors-charts-mint-9: 172 50% 31% / 1; /* ✦ Theme/Colors/Charts/Mint/9/UI Core/Light */
+  --figma___colors-charts-mint-10: 171 51% 17% / 1; /* ✦ Theme/Colors/Charts/Mint/10/UI Core/Light */
+  --figma___colors-charts-mint-alpha-1: 168 95% 43% / 0.02; /* ✦ Theme/Colors/Charts/Mint Alpha/1/UI Core/Light */
+  --figma___colors-charts-mint-alpha-2: 164 99% 47% / 0.06; /* ✦ Theme/Colors/Charts/Mint Alpha/2/UI Core/Light */
+  --figma___colors-charts-mint-alpha-3: 164 99% 44% / 0.13; /* ✦ Theme/Colors/Charts/Mint Alpha/3/UI Core/Light */
+  --figma___colors-charts-mint-alpha-4: 165 100% 42% / 0.2; /* ✦ Theme/Colors/Charts/Mint Alpha/4/UI Core/Light */
+  --figma___colors-charts-mint-alpha-5: 166 100% 38% / 0.27; /* ✦ Theme/Colors/Charts/Mint Alpha/5/UI Core/Light */
+  --figma___colors-charts-mint-alpha-6: 166 99% 33% / 0.35; /* ✦ Theme/Colors/Charts/Mint Alpha/6/UI Core/Light */
+  --figma___colors-charts-mint-alpha-7: 167 100% 41% / 0.47; /* ✦ Theme/Colors/Charts/Mint Alpha/7/UI Core/Light */
+  --figma___colors-charts-mint-alpha-8: 167 100% 38% / 0.5; /* ✦ Theme/Colors/Charts/Mint Alpha/8/UI Core/Light */
+  --figma___colors-charts-mint-alpha-9: 172 100% 18% / 0.85; /* ✦ Theme/Colors/Charts/Mint Alpha/9/UI Core/Light */
+  --figma___colors-charts-mint-alpha-10: 171 100% 10% / 0.91; /* ✦ Theme/Colors/Charts/Mint Alpha/10/UI Core/Light */
+  --figma___colors-charts-orange-1: 27 100% 96% / 1; /* ✦ Theme/Colors/Charts/Orange/1/UI Core/Light */
+  --figma___colors-charts-orange-2: 24 100% 95% / 1; /* ✦ Theme/Colors/Charts/Orange/2/UI Core/Light */
+  --figma___colors-charts-orange-3: 25 100% 87% / 1; /* ✦ Theme/Colors/Charts/Orange/3/UI Core/Light */
+  --figma___colors-charts-orange-4: 25 100% 79% / 1; /* ✦ Theme/Colors/Charts/Orange/4/UI Core/Light */
+  --figma___colors-charts-orange-5: 25 100% 71% / 1; /* ✦ Theme/Colors/Charts/Orange/5/UI Core/Light */
+  --figma___colors-charts-orange-6: 25 100% 58% / 1; /* ✦ Theme/Colors/Charts/Orange/6/UI Core/Light */
+  --figma___colors-charts-orange-7: 24 100% 57% / 1; /* ✦ Theme/Colors/Charts/Orange/7/UI Core/Light */
+  --figma___colors-charts-orange-8: 22 100% 56% / 1; /* ✦ Theme/Colors/Charts/Orange/8/UI Core/Light */
+  --figma___colors-charts-orange-9: 20 100% 55% / 1; /* ✦ Theme/Colors/Charts/Orange/9/UI Core/Light */
+  --figma___colors-charts-orange-10: 17 100% 53% / 1; /* ✦ Theme/Colors/Charts/Orange/10/UI Core/Light */
+  --figma___colors-charts-orange-alpha-1: 27 100% 96% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/1/UI Core/Light */
+  --figma___colors-charts-orange-alpha-2: 24 100% 95% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/2/UI Core/Light */
+  --figma___colors-charts-orange-alpha-3: 25 100% 87% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/3/UI Core/Light */
+  --figma___colors-charts-orange-alpha-4: 25 100% 79% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/4/UI Core/Light */
+  --figma___colors-charts-orange-alpha-5: 25 100% 71% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/5/UI Core/Light */
+  --figma___colors-charts-orange-alpha-6: 25 100% 58% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/6/UI Core/Light */
+  --figma___colors-charts-orange-alpha-7: 24 100% 57% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/7/UI Core/Light */
+  --figma___colors-charts-orange-alpha-8: 22 100% 56% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/8/UI Core/Light */
+  --figma___colors-charts-orange-alpha-9: 20 100% 55% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/9/UI Core/Light */
+  --figma___colors-charts-orange-alpha-10: 17 100% 53% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/10/UI Core/Light */
+  --figma___colors-charts-yellow-1: 45 100% 96% / 1; /* ✦ Theme/Colors/Charts/Yellow/1/UI Core/Light */
+  --figma___colors-charts-yellow-2: 45 96% 89% / 1; /* ✦ Theme/Colors/Charts/Yellow/2/UI Core/Light */
+  --figma___colors-charts-yellow-3: 44 98% 77% / 1; /* ✦ Theme/Colors/Charts/Yellow/3/UI Core/Light */
+  --figma___colors-charts-yellow-4: 42 99% 65% / 1; /* ✦ Theme/Colors/Charts/Yellow/4/UI Core/Light */
+  --figma___colors-charts-yellow-5: 45 98% 60% / 1; /* ✦ Theme/Colors/Charts/Yellow/5/UI Core/Light */
+  --figma___colors-charts-yellow-6: 46 98% 61% / 1; /* ✦ Theme/Colors/Charts/Yellow/6/UI Core/Light */
+  --figma___colors-charts-yellow-7: 45 98% 60% / 1; /* ✦ Theme/Colors/Charts/Yellow/7/UI Core/Light */
+  --figma___colors-charts-yellow-8: 41 100% 55% / 1; /* ✦ Theme/Colors/Charts/Yellow/8/UI Core/Light */
+  --figma___colors-charts-yellow-9: 41 100% 50% / 1; /* ✦ Theme/Colors/Charts/Yellow/9/UI Core/Light */
+  --figma___colors-charts-yellow-10: 41 98% 45% / 1; /* ✦ Theme/Colors/Charts/Yellow/10/UI Core/Light */
+  --figma___colors-charts-yellow-alpha-1: 45 100% 96% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/1/UI Core/Light */
+  --figma___colors-charts-yellow-alpha-2: 45 96% 89% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/2/UI Core/Light */
+  --figma___colors-charts-yellow-alpha-3: 44 98% 77% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/3/UI Core/Light */
+  --figma___colors-charts-yellow-alpha-4: 42 99% 65% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/4/UI Core/Light */
+  --figma___colors-charts-yellow-alpha-5: 45 98% 60% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/5/UI Core/Light */
+  --figma___colors-charts-yellow-alpha-6: 46 98% 61% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/6/UI Core/Light */
+  --figma___colors-charts-yellow-alpha-7: 45 98% 60% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/7/UI Core/Light */
+  --figma___colors-charts-yellow-alpha-8: 41 100% 55% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/8/UI Core/Light */
+  --figma___colors-charts-yellow-alpha-9: 41 100% 50% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/9/UI Core/Light */
+  --figma___colors-charts-yellow-alpha-10: 41 98% 45% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/10/UI Core/Light */
+  --figma___colors-default-black-fixed: 0 0% 0% / 1; /* ✦ Theme/Colors/Default/Black (fixed)/UI Core/Light */
+  --figma___colors-default-brand-color: 194 100% 45% / 1; /* ✦ Theme/Colors/Default/Brand Color/UI Core/Light */
+  --figma___colors-default-dark-to-white: 0 0% 0% / 1; /* ✦ Theme/Colors/Default/Dark-to-white/UI Core/Light */
+  --figma___colors-default-white-fixed: 0 0% 100% / 1; /* ✦ Theme/Colors/Default/White (fixed)/UI Core/Light */
+  --figma___colors-default-white-to-dark: 0 0% 100% / 1; /* ✦ Theme/Colors/Default/White-to-dark/UI Core/Light */
+  --figma___colors-module-ccm-100: 180 100% 96% / 1; /* ✦ Theme/Colors/Module/CCM/100/UI Core/Light */
+  --figma___colors-module-ccm-200: 181 99% 40% / 1; /* ✦ Theme/Colors/Module/CCM/200/UI Core/Light */
+  --figma___colors-module-ccm-300: 179 56% 32% / 1; /* ✦ Theme/Colors/Module/CCM/300/UI Core/Light */
+  --figma___colors-module-cd-100: 102 100% 97% / 1; /* ✦ Theme/Colors/Module/CD/100/UI Core/Light */
+  --figma___colors-module-cd-200: 110 40% 50% / 1; /* ✦ Theme/Colors/Module/CD/200/UI Core/Light */
+  --figma___colors-module-cd-300: 110 62% 32% / 1; /* ✦ Theme/Colors/Module/CD/300/UI Core/Light */
+  --figma___colors-module-ce-100: 334 100% 97% / 1; /* ✦ Theme/Colors/Module/CE/100/UI Core/Light */
+  --figma___colors-module-ce-200: 335 100% 50% / 1; /* ✦ Theme/Colors/Module/CE/200/UI Core/Light */
+  --figma___colors-module-ce-300: 335 100% 30% / 1; /* ✦ Theme/Colors/Module/CE/300/UI Core/Light */
+  --figma___colors-module-ci-100: 201 100% 94% / 1; /* ✦ Theme/Colors/Module/CI/100/UI Core/Light */
+  --figma___colors-module-ci-200: 200 88% 56% / 1; /* ✦ Theme/Colors/Module/CI/200/UI Core/Light */
+  --figma___colors-module-ci-300: 203 94% 37% / 1; /* ✦ Theme/Colors/Module/CI/300/UI Core/Light */
+  --figma___colors-module-ff-100: 41 81% 94% / 1; /* ✦ Theme/Colors/Module/FF/100/UI Core/Light */
+  --figma___colors-module-ff-200: 29 86% 54% / 1; /* ✦ Theme/Colors/Module/FF/200/UI Core/Light */
+  --figma___colors-module-ff-300: 26 91% 39% / 1; /* ✦ Theme/Colors/Module/FF/300/UI Core/Light */
+  --figma___colors-module-srm-100: 261 100% 97% / 1; /* ✦ Theme/Colors/Module/SRM/100/UI Core/Light */
+  --figma___colors-module-srm-200: 262 95% 75% / 1; /* ✦ Theme/Colors/Module/SRM/200/UI Core/Light */
+  --figma___colors-module-srm-300: 262 55% 49% / 1; /* ✦ Theme/Colors/Module/SRM/300/UI Core/Light */
+  --figma___colors-module-ssca-100: 0 100% 97% / 1; /* ✦ Theme/Colors/Module/SSCA/100/UI Core/Light */
+  --figma___colors-module-ssca-200: 0 58% 53% / 1; /* ✦ Theme/Colors/Module/SSCA/200/UI Core/Light */
+  --figma___colors-module-ssca-300: 0 98% 36% / 1; /* ✦ Theme/Colors/Module/SSCA/300/UI Core/Light */
+  --figma___colors-module-sto-100: 228 100% 96% / 1; /* ✦ Theme/Colors/Module/STO/100/UI Core/Light */
+  --figma___colors-module-sto-200: 216 100% 64% / 1; /* ✦ Theme/Colors/Module/STO/200/UI Core/Light */
+  --figma___colors-module-sto-300: 245 90% 53% / 1; /* ✦ Theme/Colors/Module/STO/300/UI Core/Light */
+  --figma___colors-neutral-gray-1: 210 25% 98% / 1; /* ✦ Theme/Colors/Neutral/Gray/1/UI Core/Light */
+  --figma___colors-neutral-gray-2: 240 41% 97% / 1; /* ✦ Theme/Colors/Neutral/Gray/2/UI Core/Light */
+  --figma___colors-neutral-gray-3: 235 19% 87% / 1; /* ✦ Theme/Colors/Neutral/Gray/3/UI Core/Light */
+  --figma___colors-neutral-gray-4: 237 14% 73% / 1; /* ✦ Theme/Colors/Neutral/Gray/4/UI Core/Light */
+  --figma___colors-neutral-gray-5: 238 13% 62% / 1; /* ✦ Theme/Colors/Neutral/Gray/5/UI Core/Light */
+  --figma___colors-neutral-gray-6: 235 11% 47% / 1; /* ✦ Theme/Colors/Neutral/Gray/6/UI Core/Light */
+  --figma___colors-neutral-gray-7: 234 11% 35% / 1; /* ✦ Theme/Colors/Neutral/Gray/7/UI Core/Light */
+  --figma___colors-neutral-gray-8: 236 11% 25% / 1; /* ✦ Theme/Colors/Neutral/Gray/8/UI Core/Light */
+  --figma___colors-neutral-gray-9: 240 11% 15% / 1; /* ✦ Theme/Colors/Neutral/Gray/9/UI Core/Light */
+  --figma___colors-neutral-gray-10: 240 8% 5% / 1; /* ✦ Theme/Colors/Neutral/Gray/10/UI Core/Light */
+  --figma___colors-neutral-gray-alpha-1: 210 25% 98% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/1/UI Core/Light */
+  --figma___colors-neutral-gray-alpha-2: 240 41% 97% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/2/UI Core/Light */
+  --figma___colors-neutral-gray-alpha-3: 235 19% 87% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/3/UI Core/Light */
+  --figma___colors-neutral-gray-alpha-4: 237 14% 73% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/4/UI Core/Light */
+  --figma___colors-neutral-gray-alpha-5: 238 13% 62% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/5/UI Core/Light */
+  --figma___colors-neutral-gray-alpha-6: 235 11% 47% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/6/UI Core/Light */
+  --figma___colors-neutral-gray-alpha-7: 234 11% 35% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/7/UI Core/Light */
+  --figma___colors-neutral-gray-alpha-8: 236 11% 25% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/8/UI Core/Light */
+  --figma___colors-neutral-gray-alpha-9: 240 11% 15% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/9/UI Core/Light */
+  --figma___colors-neutral-gray-alpha-10: 240 8% 5% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/10/UI Core/Light */
+  --figma___colors-primary-primary-accent-1: 195 100% 97% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/1/UI Core/Light */
+  --figma___colors-primary-primary-accent-2: 192 96% 90% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/2/UI Core/Light */
+  --figma___colors-primary-primary-accent-3: 194 100% 82% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/3/UI Core/Light */
+  --figma___colors-primary-primary-accent-4: 195 91% 60% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/4/UI Core/Light */
+  --figma___colors-primary-primary-accent-5: 194 100% 45% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/5/UI Core/Light */
+  --figma___colors-primary-primary-accent-6: 202 100% 45% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/6/UI Core/Light */
+  --figma___colors-primary-primary-accent-7: 206 98% 42% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/7/UI Core/Light */
+  --figma___colors-primary-primary-accent-8: 213 100% 32% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/8/UI Core/Light */
+  --figma___colors-primary-primary-accent-9: 213 82% 22% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/9/UI Core/Light */
+  --figma___colors-primary-primary-accent-10: 212 72% 10% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/10/UI Core/Light */
+  --figma___colors-primary-primary-alpha-1: 195 100% 97% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/1/UI Core/Light */
+  --figma___colors-primary-primary-alpha-2: 192 96% 90% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/2/UI Core/Light */
+  --figma___colors-primary-primary-alpha-3: 194 100% 82% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/3/UI Core/Light */
+  --figma___colors-primary-primary-alpha-4: 195 91% 60% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/4/UI Core/Light */
+  --figma___colors-primary-primary-alpha-5: 194 100% 45% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/5/UI Core/Light */
+  --figma___colors-primary-primary-alpha-6: 202 100% 45% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/6/UI Core/Light */
+  --figma___colors-primary-primary-alpha-7: 206 98% 42% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/7/UI Core/Light */
+  --figma___colors-primary-primary-alpha-8: 213 100% 32% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/8/UI Core/Light */
+  --figma___colors-primary-primary-alpha-9: 213 82% 22% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/9/UI Core/Light */
+  --figma___colors-primary-primary-alpha-10: 212 72% 10% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/10/UI Core/Light */
+  --figma___colors-secondary-crimson-crimson-1: 330 100% 98% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 1/UI Core/Light */
+  --figma___colors-secondary-crimson-crimson-10: 331 83% 43% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 10/UI Core/Light */
+  --figma___colors-secondary-crimson-crimson-2: 328 100% 97% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 2/UI Core/Light */
+  --figma___colors-secondary-crimson-crimson-3: 332 100% 90% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 3/UI Core/Light */
+  --figma___colors-secondary-crimson-crimson-4: 331 100% 84% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 4/UI Core/Light */
+  --figma___colors-secondary-crimson-crimson-5: 332 100% 77% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 5/UI Core/Light */
+  --figma___colors-secondary-crimson-crimson-6: 331 100% 64% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 6/UI Core/Light */
+  --figma___colors-secondary-crimson-crimson-7: 331 91% 59% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 7/UI Core/Light */
+  --figma___colors-secondary-crimson-crimson-8: 331 85% 55% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 8/UI Core/Light */
+  --figma___colors-secondary-crimson-crimson-9: 331 75% 49% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 9/UI Core/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-1: 330 100% 98% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 1/UI Core/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-10: 331 75% 49% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 10/UI Core/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-11: 331 83% 43% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 11/UI Core/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-2: 328 100% 97% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 2/UI Core/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-3: 332 100% 90% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 3/UI Core/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-4: 331 100% 84% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 4/UI Core/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-5: 332 100% 77% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 5/UI Core/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-6: 331 100% 64% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 6/UI Core/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-8: 331 91% 59% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 8/UI Core/Light */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-9: 331 85% 55% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 9/UI Core/Light */
+  --figma___colors-secondary-lime-1: 87 67% 94% / 1; /* ✦ Theme/Colors/Secondary/Lime/1/UI Core/Light */
+  --figma___colors-secondary-lime-2: 89 67% 92% / 1; /* ✦ Theme/Colors/Secondary/Lime/2/UI Core/Light */
+  --figma___colors-secondary-lime-3: 88 50% 76% / 1; /* ✦ Theme/Colors/Secondary/Lime/3/UI Core/Light */
+  --figma___colors-secondary-lime-4: 88 60% 65% / 1; /* ✦ Theme/Colors/Secondary/Lime/4/UI Core/Light */
+  --figma___colors-secondary-lime-5: 88 50% 60% / 1; /* ✦ Theme/Colors/Secondary/Lime/5/UI Core/Light */
+  --figma___colors-secondary-lime-6: 79 100% 36% / 1; /* ✦ Theme/Colors/Secondary/Lime/6/UI Core/Light */
+  --figma___colors-secondary-lime-7: 88 54% 45% / 1; /* ✦ Theme/Colors/Secondary/Lime/7/UI Core/Light */
+  --figma___colors-secondary-lime-8: 92 48% 42% / 1; /* ✦ Theme/Colors/Secondary/Lime/8/UI Core/Light */
+  --figma___colors-secondary-lime-9: 95 49% 36% / 1; /* ✦ Theme/Colors/Secondary/Lime/9/UI Core/Light */
+  --figma___colors-secondary-lime-10: 103 40% 34% / 1; /* ✦ Theme/Colors/Secondary/Lime/10/UI Core/Light */
+  --figma___colors-secondary-lime-alpha-1: 87 67% 94% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/1/UI Core/Light */
+  --figma___colors-secondary-lime-alpha-2: 89 67% 92% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/2/UI Core/Light */
+  --figma___colors-secondary-lime-alpha-3: 88 50% 76% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/3/UI Core/Light */
+  --figma___colors-secondary-lime-alpha-4: 88 60% 65% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/4/UI Core/Light */
+  --figma___colors-secondary-lime-alpha-5: 88 50% 60% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/5/UI Core/Light */
+  --figma___colors-secondary-lime-alpha-6: 79 100% 36% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/6/UI Core/Light */
+  --figma___colors-secondary-lime-alpha-7: 88 54% 45% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/7/UI Core/Light */
+  --figma___colors-secondary-lime-alpha-8: 92 48% 42% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/8/UI Core/Light */
+  --figma___colors-secondary-lime-alpha-9: 95 49% 36% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/9/UI Core/Light */
+  --figma___colors-secondary-lime-alpha-10: 103 40% 34% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/10/UI Core/Light */
+  --figma___colors-secondary-purple-1: 262 100% 94% / 1; /* ✦ Theme/Colors/Secondary/Purple/1/UI Core/Light */
+  --figma___colors-secondary-purple-2: 262 100% 91% / 1; /* ✦ Theme/Colors/Secondary/Purple/2/UI Core/Light */
+  --figma___colors-secondary-purple-3: 262 100% 85% / 1; /* ✦ Theme/Colors/Secondary/Purple/3/UI Core/Light */
+  --figma___colors-secondary-purple-4: 262 100% 81% / 1; /* ✦ Theme/Colors/Secondary/Purple/4/UI Core/Light */
+  --figma___colors-secondary-purple-5: 262 95% 75% / 1; /* ✦ Theme/Colors/Secondary/Purple/5/UI Core/Light */
+  --figma___colors-secondary-purple-6: 261 60% 56% / 1; /* ✦ Theme/Colors/Secondary/Purple/6/UI Core/Light */
+  --figma___colors-secondary-purple-7: 262 55% 49% / 1; /* ✦ Theme/Colors/Secondary/Purple/7/UI Core/Light */
+  --figma___colors-secondary-purple-8: 262 60% 42% / 1; /* ✦ Theme/Colors/Secondary/Purple/8/UI Core/Light */
+  --figma___colors-secondary-purple-9: 262 57% 36% / 1; /* ✦ Theme/Colors/Secondary/Purple/9/UI Core/Light */
+  --figma___colors-secondary-purple-10: 270 86% 30% / 1; /* ✦ Theme/Colors/Secondary/Purple/10/UI Core/Light */
+  --figma___colors-secondary-purple-alpha-1: 262 100% 94% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/1/UI Core/Light */
+  --figma___colors-secondary-purple-alpha-2: 262 100% 91% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/2/UI Core/Light */
+  --figma___colors-secondary-purple-alpha-3: 262 100% 85% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/3/UI Core/Light */
+  --figma___colors-secondary-purple-alpha-4: 262 100% 81% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/4/UI Core/Light */
+  --figma___colors-secondary-purple-alpha-5: 262 95% 75% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/5/UI Core/Light */
+  --figma___colors-secondary-purple-alpha-6: 261 60% 56% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/6/UI Core/Light */
+  --figma___colors-secondary-purple-alpha-7: 262 55% 49% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/7/UI Core/Light */
+  --figma___colors-secondary-purple-alpha-8: 262 60% 42% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/8/UI Core/Light */
+  --figma___colors-secondary-purple-alpha-9: 262 57% 36% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/9/UI Core/Light */
+  --figma___colors-secondary-purple-alpha-10: 270 86% 30% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/10/UI Core/Light */
+  --figma___colors-secondary-teal-1: 183 96% 91% / 1; /* ✦ Theme/Colors/Secondary/Teal/1/UI Core/Light */
+  --figma___colors-secondary-teal-2: 183 97% 87% / 1; /* ✦ Theme/Colors/Secondary/Teal/2/UI Core/Light */
+  --figma___colors-secondary-teal-3: 182 74% 81% / 1; /* ✦ Theme/Colors/Secondary/Teal/3/UI Core/Light */
+  --figma___colors-secondary-teal-4: 184 71% 68% / 1; /* ✦ Theme/Colors/Secondary/Teal/4/UI Core/Light */
+  --figma___colors-secondary-teal-5: 184 70% 58% / 1; /* ✦ Theme/Colors/Secondary/Teal/5/UI Core/Light */
+  --figma___colors-secondary-teal-6: 184 90% 44% / 1; /* ✦ Theme/Colors/Secondary/Teal/6/UI Core/Light */
+  --figma___colors-secondary-teal-7: 184 97% 41% / 1; /* ✦ Theme/Colors/Secondary/Teal/7/UI Core/Light */
+  --figma___colors-secondary-teal-8: 184 94% 39% / 1; /* ✦ Theme/Colors/Secondary/Teal/8/UI Core/Light */
+  --figma___colors-secondary-teal-9: 184 95% 37% / 1; /* ✦ Theme/Colors/Secondary/Teal/9/UI Core/Light */
+  --figma___colors-secondary-teal-10: 184 92% 35% / 1; /* ✦ Theme/Colors/Secondary/Teal/10/UI Core/Light */
+  --figma___colors-secondary-teal-alpha-1: 183 96% 91% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/1/UI Core/Light */
+  --figma___colors-secondary-teal-alpha-2: 183 97% 87% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/2/UI Core/Light */
+  --figma___colors-secondary-teal-alpha-3: 182 74% 81% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/3/UI Core/Light */
+  --figma___colors-secondary-teal-alpha-4: 184 71% 68% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/4/UI Core/Light */
+  --figma___colors-secondary-teal-alpha-5: 184 70% 58% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/5/UI Core/Light */
+  --figma___colors-secondary-teal-alpha-6: 184 90% 44% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/6/UI Core/Light */
+  --figma___colors-secondary-teal-alpha-7: 184 97% 41% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/7/UI Core/Light */
+  --figma___colors-secondary-teal-alpha-8: 184 94% 39% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/8/UI Core/Light */
+  --figma___colors-secondary-teal-alpha-9: 184 95% 37% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/9/UI Core/Light */
+  --figma___colors-secondary-teal-alpha-10: 184 92% 35% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/10/UI Core/Light */
+  --figma___overlays-black-alpha-1: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/1/UI Core/Light */
+  --figma___overlays-black-alpha-2: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/2/UI Core/Light */
+  --figma___overlays-black-alpha-3: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/3/UI Core/Light */
+  --figma___overlays-black-alpha-4: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/4/UI Core/Light */
+  --figma___overlays-black-alpha-5: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/5/UI Core/Light */
+  --figma___overlays-black-alpha-6: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/6/UI Core/Light */
+  --figma___overlays-black-alpha-7: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/7/UI Core/Light */
+  --figma___overlays-black-alpha-8: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/8/UI Core/Light */
+  --figma___overlays-black-alpha-9: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/9/UI Core/Light */
+  --figma___overlays-black-alpha-10: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/10/UI Core/Light */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/1/UI Core/Light */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/2/UI Core/Light */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/3/UI Core/Light */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/4/UI Core/Light */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/5/UI Core/Light */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/6/UI Core/Light */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/7/UI Core/Light */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/8/UI Core/Light */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/9/UI Core/Light */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/10/UI Core/Light */
+  --figma___semantic-background-backdrop: 212 72% 10% / 0.75; /* ✦ Theme/Semantic/Background/Backdrop/UI Core/Light */
+  --figma___semantic-background-cards-and-rows-default: 0 0% 100% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Default/UI Core/Light */
+  --figma___semantic-background-cards-and-rows-hover: 216 100% 99% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Hover/UI Core/Light */
+  --figma___semantic-background-cards-and-rows-primary-blue-selected: 206 98% 42% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Primary-blue-selected/UI Core/Light */
+  --figma___semantic-background-cards-and-rows-selected: 216 100% 99% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Selected/UI Core/Light */
+  --figma___semantic-background-header-page-header: 0 0% 100% / 1; /* ✦ Theme/Semantic/Background/Header/Page Header/UI Core/Light */
+  --figma___semantic-background-header-table-header: 0 0% 100% / 1; /* ✦ Theme/Semantic/Background/Header/Table Header/UI Core/Light */
+  --figma___semantic-background-paper: 216 100% 99% / 1; /* ✦ Theme/Semantic/Background/Paper/UI Core/Light */
+  --figma___semantic-background-primary: 216 100% 99% / 1; /* ✦ Theme/Semantic/Background/Primary/UI Core/Light */
+  --figma___semantic-background-solid: 0 0% 100% / 1; /* ✦ Theme/Semantic/Background/Solid/UI Core/Light */
+  --figma___semantic-border-disabled: 235 19% 87% / 1; /* ✦ Theme/Semantic/Border/Disabled/UI Core/Light */
+  --figma___semantic-border-hover: 213 100% 32% / 1; /* ✦ Theme/Semantic/Border/Hover/UI Core/Light */
+  --figma___semantic-border-primary: 235 19% 87% / 1; /* ✦ Theme/Semantic/Border/Primary/UI Core/Light */
+  --figma___semantic-border-secondary: 240 41% 97% / 1; /* ✦ Theme/Semantic/Border/Secondary/UI Core/Light */
+  --figma___semantic-border-selected: 206 98% 42% / 1; /* ✦ Theme/Semantic/Border/Selected/UI Core/Light */
+  --figma___semantic-text-disabled: 237 14% 73% / 1; /* ✦ Theme/Semantic/Text/Disabled/UI Core/Light */
+  --figma___semantic-text-links: 206 98% 42% / 1; /* ✦ Theme/Semantic/Text/Links/UI Core/Light */
+  --figma___semantic-text-secondary: 236 11% 25% / 1; /* ✦ Theme/Semantic/Text/Secondary/UI Core/Light */
+  --figma___semantic-text-tertiary: 235 11% 47% / 1; /* ✦ Theme/Semantic/Text/Tertiary/UI Core/Light */
+  --figma___semantic-text-primary: 240 8% 5% / 1; /* ✦ Theme/Semantic/Text/primary/UI Core/Light */
 }
 
 /* Color variables - dark mode */
 .ui-core-dark {
-  --figma___background-backdrop: 212 72% 10% / 0.75;
-  /* ✦ Theme/Background/Backdrop/UI Core/Dark */
-  --figma___background-cards-and-rows-default: 0 0% 0% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Default/UI Core/Dark */
-  --figma___background-cards-and-rows-hover: 240 4% 10% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Hover/UI Core/Dark */
-  --figma___background-cards-and-rows-primary-blue-selected: 206 100% 50% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/UI Core/Dark */
-  --figma___background-cards-and-rows-selected: 240 4% 10% / 1;
-  /* ✦ Theme/Background/Cards and Rows/Selected/UI Core/Dark */
-  --figma___background-header-page-header: 0 0% 0% / 1;
-  /* ✦ Theme/Background/Header/Page Header/UI Core/Dark */
-  --figma___background-header-table-header: 0 0% 0% / 1;
-  /* ✦ Theme/Background/Header/Table Header/UI Core/Dark */
-  --figma___background-paper: 240 4% 10% / 1;
-  /* ✦ Theme/Background/Paper/UI Core/Dark */
-  --figma___background-primary: 240 4% 10% / 1;
-  /* ✦ Theme/Background/Primary/UI Core/Dark */
-  --figma___background-solid: 0 0% 0% / 1;
-  /* ✦ Theme/Background/Solid/UI Core/Dark */
-  --figma___badges-soft-amber-background: 54 100% 17% / 1;
-  /* ✦ Theme/Badges/Soft/Amber/background/UI Core/Dark */
-  --figma___badges-soft-amber-text: 210 25% 98% / 1;
-  /* ✦ Theme/Badges/Soft/Amber/text/UI Core/Dark */
-  --figma___badges-soft-blue-background: 215 46% 20% / 1;
-  /* ✦ Theme/Badges/Soft/Blue/background/UI Core/Dark */
-  --figma___badges-soft-blue-text: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Soft/Blue/text/UI Core/Dark */
-  --figma___badges-soft-bronze-background: 30 69% 18% / 1;
-  /* ✦ Theme/Badges/Soft/Bronze/background/UI Core/Dark */
-  --figma___badges-soft-bronze-text: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Soft/Bronze/text/UI Core/Dark */
-  --figma___badges-soft-brown-background: 32 67% 12% / 1;
-  /* ✦ Theme/Badges/Soft/Brown/background/UI Core/Dark */
-  --figma___badges-soft-brown-text: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Soft/Brown/text/UI Core/Dark */
-  --figma___badges-soft-crimson-background: 330 100% 25% / 1;
-  /* ✦ Theme/Badges/Soft/Crimson/background/UI Core/Dark */
-  --figma___badges-soft-crimson-text: 326 77% 77% / 1;
-  /* ✦ Theme/Badges/Soft/Crimson/text/UI Core/Dark */
-  --figma___badges-soft-cyan-background: 180 100% 20% / 1;
-  /* ✦ Theme/Badges/Soft/Cyan/background/UI Core/Dark */
-  --figma___badges-soft-cyan-text: 180 77% 77% / 1;
-  /* ✦ Theme/Badges/Soft/Cyan/text/UI Core/Dark */
-  --figma___badges-soft-gold-background: 30 69% 18% / 1;
-  /* ✦ Theme/Badges/Soft/Gold/background/UI Core/Dark */
-  --figma___badges-soft-gold-text: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Soft/Gold/text/UI Core/Dark */
-  --figma___badges-soft-grass-background: 122 64% 11% / 1;
-  /* ✦ Theme/Badges/Soft/Grass/background/UI Core/Dark */
-  --figma___badges-soft-grass-text: 118 49% 70% / 1;
-  /* ✦ Theme/Badges/Soft/Grass/text/UI Core/Dark */
-  --figma___badges-soft-green-background: 127 73% 15% / 1;
-  /* ✦ Theme/Badges/Soft/Green/background/UI Core/Dark */
-  --figma___badges-soft-green-text: 124 36% 52% / 1;
-  /* ✦ Theme/Badges/Soft/Green/text/UI Core/Dark */
-  --figma___badges-soft-indigo-background: 241 52% 28% / 1;
-  /* ✦ Theme/Badges/Soft/Indigo/background/UI Core/Dark */
-  --figma___badges-soft-indigo-text: 239 48% 52% / 1;
-  /* ✦ Theme/Badges/Soft/Indigo/text/UI Core/Dark */
-  --figma___badges-soft-iris-background: 254 74% 37% / 1;
-  /* ✦ Theme/Badges/Soft/Iris/background/UI Core/Dark */
-  --figma___badges-soft-iris-text: 251 80% 74% / 1;
-  /* ✦ Theme/Badges/Soft/Iris/text/UI Core/Dark */
-  --figma___badges-soft-jade-background: 127 73% 15% / 1;
-  /* ✦ Theme/Badges/Soft/Jade/background/UI Core/Dark */
-  --figma___badges-soft-jade-text: 118 49% 70% / 1;
-  /* ✦ Theme/Badges/Soft/Jade/text/UI Core/Dark */
-  --figma___badges-soft-lime-background: 84 100% 25% / 1;
-  /* ✦ Theme/Badges/Soft/Lime/background/UI Core/Dark */
-  --figma___badges-soft-lime-text: 120 34% 85% / 1;
-  /* ✦ Theme/Badges/Soft/Lime/text/UI Core/Dark */
-  --figma___badges-soft-mint-background: 127 73% 15% / 1;
-  /* ✦ Theme/Badges/Soft/Mint/background/UI Core/Dark */
-  --figma___badges-soft-mint-text: 118 49% 70% / 1;
-  /* ✦ Theme/Badges/Soft/Mint/text/UI Core/Dark */
-  --figma___badges-soft-orange-background: 30 69% 18% / 1;
-  /* ✦ Theme/Badges/Soft/Orange/background/UI Core/Dark */
-  --figma___badges-soft-orange-text: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Soft/Orange/text/UI Core/Dark */
-  --figma___badges-soft-pink-background: 330 100% 25% / 1;
-  /* ✦ Theme/Badges/Soft/Pink/background/UI Core/Dark */
-  --figma___badges-soft-pink-text: 326 77% 77% / 1;
-  /* ✦ Theme/Badges/Soft/Pink/text/UI Core/Dark */
-  --figma___badges-soft-plum-background: 264 100% 20% / 1;
-  /* ✦ Theme/Badges/Soft/Plum/background/UI Core/Dark */
-  --figma___badges-soft-plum-text: 264 67% 52% / 1;
-  /* ✦ Theme/Badges/Soft/Plum/text/UI Core/Dark */
-  --figma___badges-soft-purple-background: 264 100% 25% / 1;
-  /* ✦ Theme/Badges/Soft/Purple/background/UI Core/Dark */
-  --figma___badges-soft-purple-text: 264 67% 52% / 1;
-  /* ✦ Theme/Badges/Soft/Purple/text/UI Core/Dark */
-  --figma___badges-soft-red-background: 0 67% 12% / 1;
-  /* ✦ Theme/Badges/Soft/Red/background/UI Core/Dark */
-  --figma___badges-soft-red-text: 0 68% 42% / 1;
-  /* ✦ Theme/Badges/Soft/Red/text/UI Core/Dark */
-  --figma___badges-soft-ruby-background: 0 67% 12% / 1;
-  /* ✦ Theme/Badges/Soft/Ruby/background/UI Core/Dark */
-  --figma___badges-soft-ruby-text: 0 68% 42% / 1;
-  /* ✦ Theme/Badges/Soft/Ruby/text/UI Core/Dark */
-  --figma___badges-soft-sky-background: 214 58% 16% / 1;
-  /* ✦ Theme/Badges/Soft/Sky/background/UI Core/Dark */
-  --figma___badges-soft-sky-text: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Soft/Sky/text/UI Core/Dark */
-  --figma___badges-soft-teal-background: 180 100% 20% / 1;
-  /* ✦ Theme/Badges/Soft/Teal/background/UI Core/Dark */
-  --figma___badges-soft-teal-text: 180 77% 77% / 1;
-  /* ✦ Theme/Badges/Soft/Teal/text/UI Core/Dark */
-  --figma___badges-soft-violet-background: 256 82% 30% / 1;
-  /* ✦ Theme/Badges/Soft/Violet/background/UI Core/Dark */
-  --figma___badges-soft-violet-text: 251 80% 74% / 1;
-  /* ✦ Theme/Badges/Soft/Violet/text/UI Core/Dark */
-  --figma___badges-soft-yellow-background: 54 100% 17% / 1;
-  /* ✦ Theme/Badges/Soft/Yellow/background/UI Core/Dark */
-  --figma___badges-soft-yellow-text: 47 89% 89% / 1;
-  /* ✦ Theme/Badges/Soft/Yellow/text/UI Core/Dark */
-  --figma___badges-soft-accent-background: 216 50% 12% / 1;
-  /* ✦ Theme/Badges/Soft/accent/background/UI Core/Dark */
-  --figma___badges-soft-accent-text: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Soft/accent/text/UI Core/Dark */
-  --figma___badges-soft-error-background: 0 67% 12% / 1;
-  /* ✦ Theme/Badges/Soft/error/background/UI Core/Dark */
-  --figma___badges-soft-error-text: 0 100% 70% / 1;
-  /* ✦ Theme/Badges/Soft/error/text/UI Core/Dark */
-  --figma___badges-soft-info-background: 216 50% 12% / 1;
-  /* ✦ Theme/Badges/Soft/info/background/UI Core/Dark */
-  --figma___badges-soft-info-text: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Soft/info/text/UI Core/Dark */
-  --figma___badges-soft-success-background: 122 64% 11% / 1;
-  /* ✦ Theme/Badges/Soft/success/background/UI Core/Dark */
-  --figma___badges-soft-success-text: 117 62% 79% / 1;
-  /* ✦ Theme/Badges/Soft/success/text/UI Core/Dark */
-  --figma___badges-soft-warning-background: 30 69% 18% / 1;
-  /* ✦ Theme/Badges/Soft/warning/background/UI Core/Dark */
-  --figma___badges-soft-warning-text: 19 79% 54% / 1;
-  /* ✦ Theme/Badges/Soft/warning/text/UI Core/Dark */
-  --figma___badges-solid-amber-background: 54 92% 69% / 1;
-  /* ✦ Theme/Badges/Solid/Amber/background/UI Core/Dark */
-  --figma___badges-solid-amber-text: 210 25% 98% / 1;
-  /* ✦ Theme/Badges/Solid/Amber/text/UI Core/Dark */
-  --figma___badges-solid-blue-background: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Solid/Blue/background/UI Core/Dark */
-  --figma___badges-solid-blue-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Blue/text/UI Core/Dark */
-  --figma___badges-solid-bronze-background: 19 79% 54% / 1;
-  /* ✦ Theme/Badges/Solid/Bronze/background/UI Core/Dark */
-  --figma___badges-solid-bronze-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Bronze/text/UI Core/Dark */
-  --figma___badges-solid-brown-background: 19 79% 54% / 1;
-  /* ✦ Theme/Badges/Solid/Brown/background/UI Core/Dark */
-  --figma___badges-solid-brown-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Brown/text/UI Core/Dark */
-  --figma___badges-solid-crimson-background: 326 77% 77% / 1;
-  /* ✦ Theme/Badges/Solid/Crimson/background/UI Core/Dark */
-  --figma___badges-solid-crimson-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Crimson/text/UI Core/Dark */
-  --figma___badges-solid-cyan-background: 180 60% 50% / 1;
-  /* ✦ Theme/Badges/Solid/Cyan/background/UI Core/Dark */
-  --figma___badges-solid-cyan-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Cyan/text/UI Core/Dark */
-  --figma___badges-solid-gold-background: 19 79% 54% / 1;
-  /* ✦ Theme/Badges/Solid/Gold/background/UI Core/Dark */
-  --figma___badges-solid-gold-text: 0 0% 82% / 1;
-  /* ✦ Theme/Badges/Solid/Gold/text/UI Core/Dark */
-  --figma___badges-solid-grass-background: 118 49% 70% / 1;
-  /* ✦ Theme/Badges/Solid/Grass/background/UI Core/Dark */
-  --figma___badges-solid-grass-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Grass/text/UI Core/Dark */
-  --figma___badges-solid-green-background: 117 62% 79% / 1;
-  /* ✦ Theme/Badges/Solid/Green/background/UI Core/Dark */
-  --figma___badges-solid-green-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Green/text/UI Core/Dark */
-  --figma___badges-solid-indigo-background: 239 48% 52% / 1;
-  /* ✦ Theme/Badges/Solid/Indigo/background/UI Core/Dark */
-  --figma___badges-solid-indigo-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Indigo/text/UI Core/Dark */
-  --figma___badges-solid-iris-background: 251 80% 74% / 1;
-  /* ✦ Theme/Badges/Solid/Iris/background/UI Core/Dark */
-  --figma___badges-solid-iris-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Iris/text/UI Core/Dark */
-  --figma___badges-solid-jade-background: 121 42% 62% / 1;
-  /* ✦ Theme/Badges/Solid/Jade/background/UI Core/Dark */
-  --figma___badges-solid-jade-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Jade/text/UI Core/Dark */
-  --figma___badges-solid-lime-background: 120 34% 85% / 1;
-  /* ✦ Theme/Badges/Solid/Lime/background/UI Core/Dark */
-  --figma___badges-solid-lime-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Lime/text/UI Core/Dark */
-  --figma___badges-solid-mint-background: 121 42% 62% / 1;
-  /* ✦ Theme/Badges/Solid/Mint/background/UI Core/Dark */
-  --figma___badges-solid-mint-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Mint/text/UI Core/Dark */
-  --figma___badges-solid-orange-background: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Solid/Orange/background/UI Core/Dark */
-  --figma___badges-solid-orange-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Orange/text/UI Core/Dark */
-  --figma___badges-solid-pink-background: 326 77% 77% / 1;
-  /* ✦ Theme/Badges/Solid/Pink/background/UI Core/Dark */
-  --figma___badges-solid-pink-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Pink/text/UI Core/Dark */
-  --figma___badges-solid-plum-background: 264 67% 52% / 1;
-  /* ✦ Theme/Badges/Solid/Plum/background/UI Core/Dark */
-  --figma___badges-solid-plum-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Plum/text/UI Core/Dark */
-  --figma___badges-solid-purple-background: 264 67% 52% / 1;
-  /* ✦ Theme/Badges/Solid/Purple/background/UI Core/Dark */
-  --figma___badges-solid-purple-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Purple/text/UI Core/Dark */
-  --figma___badges-solid-red-background: 0 68% 42% / 1;
-  /* ✦ Theme/Badges/Solid/Red/background/UI Core/Dark */
-  --figma___badges-solid-red-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Red/text/UI Core/Dark */
-  --figma___badges-solid-ruby-background: 0 68% 42% / 1;
-  /* ✦ Theme/Badges/Solid/Ruby/background/UI Core/Dark */
-  --figma___badges-solid-ruby-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Ruby/text/UI Core/Dark */
-  --figma___badges-solid-sky-background: 214 58% 16% / 1;
-  /* ✦ Theme/Badges/Solid/Sky/background/UI Core/Dark */
-  --figma___badges-solid-sky-text: 210 25% 98% / 1;
-  /* ✦ Theme/Badges/Solid/Sky/text/UI Core/Dark */
-  --figma___badges-solid-success-background: 117 62% 79% / 1;
-  /* ✦ Theme/Badges/Solid/Success/background/UI Core/Dark */
-  --figma___badges-solid-success-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Success/text/UI Core/Dark */
-  --figma___badges-solid-teal-background: 180 60% 50% / 1;
-  /* ✦ Theme/Badges/Solid/Teal/background/UI Core/Dark */
-  --figma___badges-solid-teal-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Teal/text/UI Core/Dark */
-  --figma___badges-solid-violet-background: 251 80% 74% / 1;
-  /* ✦ Theme/Badges/Solid/Violet/background/UI Core/Dark */
-  --figma___badges-solid-violet-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/Violet/text/UI Core/Dark */
-  --figma___badges-solid-yellow-background: 55 92% 58% / 1;
-  /* ✦ Theme/Badges/Solid/Yellow/background/UI Core/Dark */
-  --figma___badges-solid-yellow-text: 210 25% 98% / 1;
-  /* ✦ Theme/Badges/Solid/Yellow/text/UI Core/Dark */
-  --figma___badges-solid-accent-background: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Solid/accent/background/UI Core/Dark */
-  --figma___badges-solid-accent-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/accent/text/UI Core/Dark */
-  --figma___badges-solid-info-background: 240 59% 59% / 1;
-  /* ✦ Theme/Badges/Solid/info/background/UI Core/Dark */
-  --figma___badges-solid-info-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/info/text/UI Core/Dark */
-  --figma___badges-solid-warning-background: 19 67% 48% / 1;
-  /* ✦ Theme/Badges/Solid/warning/background/UI Core/Dark */
-  --figma___badges-solid-warning-text: 0 0% 0% / 1;
-  /* ✦ Theme/Badges/Solid/warning/text/UI Core/Dark */
-  --figma___badges-surface-amber-background: 54 100% 17% / 1;
-  /* ✦ Theme/Badges/Surface/Amber/background/UI Core/Dark */
-  --figma___badges-surface-amber-border: 210 25% 98% / 1;
-  /* ✦ Theme/Badges/Surface/Amber/border/UI Core/Dark */
-  --figma___badges-surface-amber-text: 210 25% 98% / 1;
-  /* ✦ Theme/Badges/Surface/Amber/text/UI Core/Dark */
-  --figma___badges-surface-blue-background: 215 46% 20% / 1;
-  /* ✦ Theme/Badges/Surface/Blue/background/UI Core/Dark */
-  --figma___badges-surface-blue-border: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Surface/Blue/border/UI Core/Dark */
-  --figma___badges-surface-blue-text: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Surface/Blue/text/UI Core/Dark */
-  --figma___badges-surface-bronze-background: 30 69% 18% / 1;
-  /* ✦ Theme/Badges/Surface/Bronze/background/UI Core/Dark */
-  --figma___badges-surface-bronze-border: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Bronze/border/UI Core/Dark */
-  --figma___badges-surface-bronze-text: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Bronze/text/UI Core/Dark */
-  --figma___badges-surface-brown-background: 32 67% 12% / 1;
-  /* ✦ Theme/Badges/Surface/Brown/background/UI Core/Dark */
-  --figma___badges-surface-brown-border: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Brown/border/UI Core/Dark */
-  --figma___badges-surface-brown-text: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Brown/text/UI Core/Dark */
-  --figma___badges-surface-crimson-border: 326 77% 77% / 1;
-  /* ✦ Theme/Badges/Surface/Crimson/Border/UI Core/Dark */
-  --figma___badges-surface-crimson-background: 330 100% 25% / 1;
-  /* ✦ Theme/Badges/Surface/Crimson/background/UI Core/Dark */
-  --figma___badges-surface-crimson-text: 326 77% 77% / 1;
-  /* ✦ Theme/Badges/Surface/Crimson/text/UI Core/Dark */
-  --figma___badges-surface-cyan-border: 180 77% 77% / 1;
-  /* ✦ Theme/Badges/Surface/Cyan/Border/UI Core/Dark */
-  --figma___badges-surface-cyan-background: 180 100% 20% / 1;
-  /* ✦ Theme/Badges/Surface/Cyan/background/UI Core/Dark */
-  --figma___badges-surface-cyan-text: 180 77% 77% / 1;
-  /* ✦ Theme/Badges/Surface/Cyan/text/UI Core/Dark */
-  --figma___badges-surface-gold-border: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Gold/Border/UI Core/Dark */
-  --figma___badges-surface-gold-background: 30 69% 18% / 1;
-  /* ✦ Theme/Badges/Surface/Gold/background/UI Core/Dark */
-  --figma___badges-surface-gold-text: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Gold/text/UI Core/Dark */
-  --figma___badges-surface-grass-border: 118 49% 70% / 1;
-  /* ✦ Theme/Badges/Surface/Grass/Border/UI Core/Dark */
-  --figma___badges-surface-grass-background: 122 64% 11% / 1;
-  /* ✦ Theme/Badges/Surface/Grass/background/UI Core/Dark */
-  --figma___badges-surface-grass-text: 118 49% 70% / 1;
-  /* ✦ Theme/Badges/Surface/Grass/text/UI Core/Dark */
-  --figma___badges-surface-green-background: 127 73% 15% / 1;
-  /* ✦ Theme/Badges/Surface/Green/background/UI Core/Dark */
-  --figma___badges-surface-green-border: 124 36% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Green/border/UI Core/Dark */
-  --figma___badges-surface-green-text: 124 36% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Green/text/UI Core/Dark */
-  --figma___badges-surface-indigo-background: 241 52% 28% / 1;
-  /* ✦ Theme/Badges/Surface/Indigo/background/UI Core/Dark */
-  --figma___badges-surface-indigo-border: 239 48% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Indigo/border/UI Core/Dark */
-  --figma___badges-surface-indigo-text: 239 48% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Indigo/text/UI Core/Dark */
-  --figma___badges-surface-iris-border: 251 80% 74% / 1;
-  /* ✦ Theme/Badges/Surface/Iris/Border/UI Core/Dark */
-  --figma___badges-surface-iris-background: 254 74% 37% / 1;
-  /* ✦ Theme/Badges/Surface/Iris/background/UI Core/Dark */
-  --figma___badges-surface-iris-text: 251 80% 74% / 1;
-  /* ✦ Theme/Badges/Surface/Iris/text/UI Core/Dark */
-  --figma___badges-surface-jade-border: 118 49% 70% / 1;
-  /* ✦ Theme/Badges/Surface/Jade/Border/UI Core/Dark */
-  --figma___badges-surface-jade-background: 127 73% 15% / 1;
-  /* ✦ Theme/Badges/Surface/Jade/background/UI Core/Dark */
-  --figma___badges-surface-jade-text: 118 49% 70% / 1;
-  /* ✦ Theme/Badges/Surface/Jade/text/UI Core/Dark */
-  --figma___badges-surface-lime-border: 120 34% 85% / 1;
-  /* ✦ Theme/Badges/Surface/Lime/Border/UI Core/Dark */
-  --figma___badges-surface-lime-background: 84 100% 25% / 1;
-  /* ✦ Theme/Badges/Surface/Lime/background/UI Core/Dark */
-  --figma___badges-surface-lime-text: 120 34% 85% / 1;
-  /* ✦ Theme/Badges/Surface/Lime/text/UI Core/Dark */
-  --figma___badges-surface-mint-background: 127 73% 15% / 1;
-  /* ✦ Theme/Badges/Surface/Mint/background/UI Core/Dark */
-  --figma___badges-surface-mint-border: 118 49% 70% / 1;
-  /* ✦ Theme/Badges/Surface/Mint/border/UI Core/Dark */
-  --figma___badges-surface-mint-text: 118 49% 70% / 1;
-  /* ✦ Theme/Badges/Surface/Mint/text/UI Core/Dark */
-  --figma___badges-surface-orange-background: 30 69% 18% / 1;
-  /* ✦ Theme/Badges/Surface/Orange/background/UI Core/Dark */
-  --figma___badges-surface-orange-border: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Orange/border/UI Core/Dark */
-  --figma___badges-surface-orange-text: 18 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Orange/text/UI Core/Dark */
-  --figma___badges-surface-pink-background: 330 100% 25% / 1;
-  /* ✦ Theme/Badges/Surface/Pink/background/UI Core/Dark */
-  --figma___badges-surface-pink-border: 326 77% 77% / 1;
-  /* ✦ Theme/Badges/Surface/Pink/border/UI Core/Dark */
-  --figma___badges-surface-pink-text: 326 77% 77% / 1;
-  /* ✦ Theme/Badges/Surface/Pink/text/UI Core/Dark */
-  --figma___badges-surface-plum-background: 264 100% 20% / 1;
-  /* ✦ Theme/Badges/Surface/Plum/background/UI Core/Dark */
-  --figma___badges-surface-plum-border: 264 67% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Plum/border/UI Core/Dark */
-  --figma___badges-surface-plum-text: 264 67% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Plum/text/UI Core/Dark */
-  --figma___badges-surface-purple-background: 264 100% 25% / 1;
-  /* ✦ Theme/Badges/Surface/Purple/background/UI Core/Dark */
-  --figma___badges-surface-purple-border: 264 67% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Purple/border/UI Core/Dark */
-  --figma___badges-surface-purple-text: 264 67% 52% / 1;
-  /* ✦ Theme/Badges/Surface/Purple/text/UI Core/Dark */
-  --figma___badges-surface-red-background: 0 67% 12% / 1;
-  /* ✦ Theme/Badges/Surface/Red/background/UI Core/Dark */
-  --figma___badges-surface-red-border: 0 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Red/border/UI Core/Dark */
-  --figma___badges-surface-red-text: 0 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Red/text/UI Core/Dark */
-  --figma___badges-surface-ruby-background: 0 67% 12% / 1;
-  /* ✦ Theme/Badges/Surface/Ruby/background/UI Core/Dark */
-  --figma___badges-surface-ruby-border: 0 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Ruby/border/UI Core/Dark */
-  --figma___badges-surface-ruby-text: 0 68% 42% / 1;
-  /* ✦ Theme/Badges/Surface/Ruby/text/UI Core/Dark */
-  --figma___badges-surface-sky-background: 214 58% 16% / 1;
-  /* ✦ Theme/Badges/Surface/Sky/background/UI Core/Dark */
-  --figma___badges-surface-sky-border: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Surface/Sky/border/UI Core/Dark */
-  --figma___badges-surface-sky-text: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Surface/Sky/text/UI Core/Dark */
-  --figma___badges-surface-teal-background: 180 100% 20% / 1;
-  /* ✦ Theme/Badges/Surface/Teal/background/UI Core/Dark */
-  --figma___badges-surface-teal-border: 180 77% 77% / 1;
-  /* ✦ Theme/Badges/Surface/Teal/border/UI Core/Dark */
-  --figma___badges-surface-teal-text: 180 77% 77% / 1;
-  /* ✦ Theme/Badges/Surface/Teal/text/UI Core/Dark */
-  --figma___badges-surface-violet-background: 256 82% 30% / 1;
-  /* ✦ Theme/Badges/Surface/Violet/background/UI Core/Dark */
-  --figma___badges-surface-violet-border: 251 80% 74% / 1;
-  /* ✦ Theme/Badges/Surface/Violet/border/UI Core/Dark */
-  --figma___badges-surface-violet-text: 251 80% 74% / 1;
-  /* ✦ Theme/Badges/Surface/Violet/text/UI Core/Dark */
-  --figma___badges-surface-yellow-background: 54 100% 17% / 1;
-  /* ✦ Theme/Badges/Surface/Yellow/background/UI Core/Dark */
-  --figma___badges-surface-yellow-border: 47 89% 89% / 1;
-  /* ✦ Theme/Badges/Surface/Yellow/border/UI Core/Dark */
-  --figma___badges-surface-yellow-text: 47 89% 89% / 1;
-  /* ✦ Theme/Badges/Surface/Yellow/text/UI Core/Dark */
-  --figma___badges-surface-accent-background: 215 46% 20% / 1;
-  /* ✦ Theme/Badges/Surface/accent/background/UI Core/Dark */
-  --figma___badges-surface-accent-border: 206 100% 62% / 1;
-  /* ✦ Theme/Badges/Surface/accent/border/UI Core/Dark */
-  --figma___badges-surface-accent-text: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Surface/accent/text/UI Core/Dark */
-  --figma___badges-surface-error-background: 0 67% 12% / 1;
-  /* ✦ Theme/Badges/Surface/error/background/UI Core/Dark */
-  --figma___badges-surface-error-border: 0 100% 70% / 1;
-  /* ✦ Theme/Badges/Surface/error/border/UI Core/Dark */
-  --figma___badges-surface-error-text: 0 100% 70% / 1;
-  /* ✦ Theme/Badges/Surface/error/text/UI Core/Dark */
-  --figma___badges-surface-info-background: 216 50% 12% / 1;
-  /* ✦ Theme/Badges/Surface/info/background/UI Core/Dark */
-  --figma___badges-surface-info-border: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Surface/info/border/UI Core/Dark */
-  --figma___badges-surface-info-text: 206 100% 50% / 1;
-  /* ✦ Theme/Badges/Surface/info/text/UI Core/Dark */
-  --figma___badges-surface-success-background: 122 64% 11% / 1;
-  /* ✦ Theme/Badges/Surface/success/background/UI Core/Dark */
-  --figma___badges-surface-success-border: 117 62% 79% / 1;
-  /* ✦ Theme/Badges/Surface/success/border/UI Core/Dark */
-  --figma___badges-surface-success-text: 117 62% 79% / 1;
-  /* ✦ Theme/Badges/Surface/success/text/UI Core/Dark */
-  --figma___badges-surface-warning-background: 30 69% 18% / 1;
-  /* ✦ Theme/Badges/Surface/warning/background/UI Core/Dark */
-  --figma___badges-surface-warning-border: 19 79% 54% / 1;
-  /* ✦ Theme/Badges/Surface/warning/border/UI Core/Dark */
-  --figma___badges-surface-warning-text: 19 79% 54% / 1;
-  /* ✦ Theme/Badges/Surface/warning/text/UI Core/Dark */
-  --figma___border-disabled: 0 0% 16% / 1;
-  /* ✦ Theme/Border/Disabled/UI Core/Dark */
-  --figma___border-hover: 206 100% 62% / 1;
-  /* ✦ Theme/Border/Hover/UI Core/Dark */
-  --figma___border-primary: 0 0% 16% / 1;
-  /* ✦ Theme/Border/Primary/UI Core/Dark */
-  --figma___border-secondary: 0 0% 11% / 1;
-  /* ✦ Theme/Border/Secondary/UI Core/Dark */
-  --figma___border-selected: 206 100% 50% / 1;
-  /* ✦ Theme/Border/Selected/UI Core/Dark */
-  --figma___breadcrumbs-current: 0 0% 35% / 1;
-  /* ✦ Theme/Breadcrumbs/current/UI Core/Dark */
-  --figma___breadcrumbs-visited: 206 100% 50% / 1;
-  /* ✦ Theme/Breadcrumbs/visited/UI Core/Dark */
-  --figma___button-ghost-accent-active: 213 100% 32% / 0;
-  /* ✦ Theme/Button/Ghost/Accent/Active/UI Core/Dark */
-  --figma___button-ghost-accent-active-text: 206 100% 62% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Active text/UI Core/Dark */
-  --figma___button-ghost-accent-hover: 213 100% 32% / 0;
-  /* ✦ Theme/Button/Ghost/Accent/Hover/UI Core/Dark */
-  --figma___button-ghost-accent-hover-text: 206 100% 62% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Hover text/UI Core/Dark */
-  --figma___button-ghost-accent-text-disabled: 206 98% 42% / 0.5;
-  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/UI Core/Dark */
-  --figma___button-ghost-accent-text-primary: 206 100% 50% / 1;
-  /* ✦ Theme/Button/Ghost/Accent/Text-primary/UI Core/Dark */
-  --figma___button-ghost-error-active: 4 75% 75% / 0;
-  /* ✦ Theme/Button/Ghost/Error/Active/UI Core/Dark */
-  --figma___button-ghost-error-active-text: 0 100% 62% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Active Text/UI Core/Dark */
-  --figma___button-ghost-error-hover: 4 74% 85% / 0;
-  /* ✦ Theme/Button/Ghost/Error/Hover/UI Core/Dark */
-  --figma___button-ghost-error-hover-text: 0 100% 62% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Hover text/UI Core/Dark */
-  --figma___button-ghost-error-text-disabled: 0 68% 30% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Text-disabled/UI Core/Dark */
-  --figma___button-ghost-error-text-primary: 0 78% 55% / 1;
-  /* ✦ Theme/Button/Ghost/Error/Text-primary/UI Core/Dark */
-  --figma___button-ghost-neutral-active: 235 19% 87% / 0;
-  /* ✦ Theme/Button/Ghost/Neutral/Active/UI Core/Dark */
-  --figma___button-ghost-neutral-active-text: 0 0% 69% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Active Text/UI Core/Dark */
-  --figma___button-ghost-neutral-hover: 240 41% 97% / 0;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover/UI Core/Dark */
-  --figma___button-ghost-neutral-hover-text: 0 0% 69% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Hover text/UI Core/Dark */
-  --figma___button-ghost-neutral-text-disabled: 0 0% 23% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/UI Core/Dark */
-  --figma___button-ghost-neutral-text-primary: 0 0% 42% / 1;
-  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/UI Core/Dark */
-  --figma___button-ghost-success-active: 139 99% 33% / 0;
-  /* ✦ Theme/Button/Ghost/Success/Active/UI Core/Dark */
-  --figma___button-ghost-success-active-text: 117 62% 79% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Active Text/UI Core/Dark */
-  --figma___button-ghost-success-hover: 139 98% 37% / 0;
-  /* ✦ Theme/Button/Ghost/Success/Hover/UI Core/Dark */
-  --figma___button-ghost-success-hover-text: 117 62% 79% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Hover text/UI Core/Dark */
-  --figma___button-ghost-success-text-disabled: 122 55% 32% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Text-disabled/UI Core/Dark */
-  --figma___button-ghost-success-text-primary: 118 49% 70% / 1;
-  /* ✦ Theme/Button/Ghost/Success/Text-primary/UI Core/Dark */
-  --figma___button-outline-accent-active: 215 46% 20% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Active/UI Core/Dark */
-  --figma___button-outline-accent-default-border: 206 100% 50% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Default border/UI Core/Dark */
-  --figma___button-outline-accent-disabled-border: 206 98% 42% / 0.5;
-  /* ✦ Theme/Button/Outline/Accent/Disabled Border/UI Core/Dark */
-  --figma___button-outline-accent-hover: 215 46% 20% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Hover/UI Core/Dark */
-  --figma___button-outline-accent-text-disabled: 206 98% 42% / 0.5;
-  /* ✦ Theme/Button/Outline/Accent/Text-disabled/UI Core/Dark */
-  --figma___button-outline-accent-text-primary: 206 100% 50% / 1;
-  /* ✦ Theme/Button/Outline/Accent/Text-primary/UI Core/Dark */
-  --figma___button-outline-error-active: 0 67% 18% / 1;
-  /* ✦ Theme/Button/Outline/Error/Active/UI Core/Dark */
-  --figma___button-outline-error-default-border: 0 67% 48% / 1;
-  /* ✦ Theme/Button/Outline/Error/Default - border/UI Core/Dark */
-  --figma___button-outline-error-disabled-border: 0 67% 24% / 1;
-  /* ✦ Theme/Button/Outline/Error/Disabled-border/UI Core/Dark */
-  --figma___button-outline-error-hover: 0 67% 18% / 1;
-  /* ✦ Theme/Button/Outline/Error/Hover/UI Core/Dark */
-  --figma___button-outline-error-text-disabled: 0 68% 36% / 1;
-  /* ✦ Theme/Button/Outline/Error/Text-disabled/UI Core/Dark */
-  --figma___button-outline-error-text-primary: 0 100% 62% / 1;
-  /* ✦ Theme/Button/Outline/Error/Text-primary/UI Core/Dark */
-  --figma___button-outline-neutral-active: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Active/UI Core/Dark */
-  --figma___button-outline-neutral-default-border: 0 0% 16% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Default - border/UI Core/Dark */
-  --figma___button-outline-neutral-disabled-border: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/UI Core/Dark */
-  --figma___button-outline-neutral-hover: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Hover/UI Core/Dark */
-  --figma___button-outline-neutral-text-disabled: 0 0% 23% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/UI Core/Dark */
-  --figma___button-outline-neutral-text-primary: 0 0% 54% / 1;
-  /* ✦ Theme/Button/Outline/Neutral/Text-primary/UI Core/Dark */
-  --figma___button-outline-success-active: 122 64% 11% / 1;
-  /* ✦ Theme/Button/Outline/Success/Active/UI Core/Dark */
-  --figma___button-outline-success-default-border: 118 49% 70% / 1;
-  /* ✦ Theme/Button/Outline/Success/Default-border/UI Core/Dark */
-  --figma___button-outline-success-disabled-border: 123 67% 24% / 1;
-  /* ✦ Theme/Button/Outline/Success/Disabled - border/UI Core/Dark */
-  --figma___button-outline-success-hover: 122 64% 11% / 1;
-  /* ✦ Theme/Button/Outline/Success/Hover/UI Core/Dark */
-  --figma___button-outline-success-text-disabled: 122 50% 36% / 1;
-  /* ✦ Theme/Button/Outline/Success/Text-disabled/UI Core/Dark */
-  --figma___button-outline-success-text-primary: 117 62% 79% / 1;
-  /* ✦ Theme/Button/Outline/Success/Text-primary/UI Core/Dark */
-  --figma___button-soft-accent-active: 216 50% 12% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Active/UI Core/Dark */
-  --figma___button-soft-accent-disabled: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Disabled/UI Core/Dark */
-  --figma___button-soft-accent-hover: 216 50% 12% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Hover/UI Core/Dark */
-  --figma___button-soft-accent-text-disabled: 0 0% 23% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Text-disabled/UI Core/Dark */
-  --figma___button-soft-accent-text-primary: 206 100% 50% / 1;
-  /* ✦ Theme/Button/Soft/Accent/Text-primary/UI Core/Dark */
-  --figma___button-soft-accent-default: 215 46% 20% / 1;
-  /* ✦ Theme/Button/Soft/Accent/default/UI Core/Dark */
-  --figma___button-soft-error-active: 0 67% 18% / 1;
-  /* ✦ Theme/Button/Soft/Error/Active/UI Core/Dark */
-  --figma___button-soft-error-disabled: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Soft/Error/Disabled/UI Core/Dark */
-  --figma___button-soft-error-hover: 0 67% 18% / 1;
-  /* ✦ Theme/Button/Soft/Error/Hover/UI Core/Dark */
-  --figma___button-soft-error-text-disabled: 0 0% 23% / 1;
-  /* ✦ Theme/Button/Soft/Error/Text-disabled/UI Core/Dark */
-  --figma___button-soft-error-text-primary: 0 78% 55% / 1;
-  /* ✦ Theme/Button/Soft/Error/Text-primary/UI Core/Dark */
-  --figma___button-soft-error-default: 0 67% 12% / 1;
-  /* ✦ Theme/Button/Soft/Error/default/UI Core/Dark */
-  --figma___button-soft-neutral-active: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Active/UI Core/Dark */
-  --figma___button-soft-neutral-disabled: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Disabled/UI Core/Dark */
-  --figma___button-soft-neutral-hover: 0 0% 16% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Hover/UI Core/Dark */
-  --figma___button-soft-neutral-text-disabled: 0 0% 23% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/UI Core/Dark */
-  --figma___button-soft-neutral-text-primary: 0 0% 54% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/Text-primary/UI Core/Dark */
-  --figma___button-soft-neutral-default: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Soft/Neutral/default/UI Core/Dark */
-  --figma___button-soft-success-active: 127 73% 15% / 1;
-  /* ✦ Theme/Button/Soft/Success/Active/UI Core/Dark */
-  --figma___button-soft-success-disabled: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Soft/Success/Disabled/UI Core/Dark */
-  --figma___button-soft-success-hover: 127 73% 15% / 1;
-  /* ✦ Theme/Button/Soft/Success/Hover/UI Core/Dark */
-  --figma___button-soft-success-text-disabled: 0 0% 23% / 1;
-  /* ✦ Theme/Button/Soft/Success/Text-disabled/UI Core/Dark */
-  --figma___button-soft-success-text-primary: 118 49% 70% / 1;
-  /* ✦ Theme/Button/Soft/Success/Text-primary/UI Core/Dark */
-  --figma___button-soft-success-default: 122 64% 11% / 1;
-  /* ✦ Theme/Button/Soft/Success/default/UI Core/Dark */
-  --figma___button-solid-accent-active: 206 100% 50% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Active/UI Core/Dark */
-  --figma___button-solid-accent-disabled: 206 98% 42% / 0.5;
-  /* ✦ Theme/Button/Solid/Accent/Disabled/UI Core/Dark */
-  --figma___button-solid-accent-hover: 206 100% 62% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Hover/UI Core/Dark */
-  --figma___button-solid-accent-text-disabled: 0 0% 0% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Text-disabled/UI Core/Dark */
-  --figma___button-solid-accent-text-primary: 0 0% 100% / 1;
-  /* ✦ Theme/Button/Solid/Accent/Text-primary/UI Core/Dark */
-  --figma___button-solid-accent-default: 206 100% 50% / 1;
-  /* ✦ Theme/Button/Solid/Accent/default/UI Core/Dark */
-  --figma___button-solid-error-active: 0 67% 48% / 1;
-  /* ✦ Theme/Button/Solid/Error/Active/UI Core/Dark */
-  --figma___button-solid-error-disabled: 0 68% 30% / 1;
-  /* ✦ Theme/Button/Solid/Error/Disabled/UI Core/Dark */
-  --figma___button-solid-error-hover: 0 100% 70% / 1;
-  /* ✦ Theme/Button/Solid/Error/Hover/UI Core/Dark */
-  --figma___button-solid-error-text-disabled: 0 0% 0% / 1;
-  /* ✦ Theme/Button/Solid/Error/Text-disabled/UI Core/Dark */
-  --figma___button-solid-error-text-primary: 0 0% 100% / 1;
-  /* ✦ Theme/Button/Solid/Error/Text-primary/UI Core/Dark */
-  --figma___button-solid-error-default: 0 67% 48% / 1;
-  /* ✦ Theme/Button/Solid/Error/default/UI Core/Dark */
-  --figma___button-solid-neutral-active: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Active/UI Core/Dark */
-  --figma___button-solid-neutral-disabled: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Disabled/UI Core/Dark */
-  --figma___button-solid-neutral-hover: 0 0% 16% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Hover/UI Core/Dark */
-  --figma___button-solid-neutral-text-disabled: 0 0% 23% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/UI Core/Dark */
-  --figma___button-solid-neutral-text-primary: 0 0% 54% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/Text-primary/UI Core/Dark */
-  --figma___button-solid-neutral-default: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Solid/Neutral/default/UI Core/Dark */
-  --figma___button-solid-success-active: 121 42% 62% / 1;
-  /* ✦ Theme/Button/Solid/Success/Active/UI Core/Dark */
-  --figma___button-solid-success-disabled: 122 50% 36% / 1;
-  /* ✦ Theme/Button/Solid/Success/Disabled/UI Core/Dark */
-  --figma___button-solid-success-hover: 117 62% 79% / 1;
-  /* ✦ Theme/Button/Solid/Success/Hover/UI Core/Dark */
-  --figma___button-solid-success-text-disabled: 0 0% 0% / 1;
-  /* ✦ Theme/Button/Solid/Success/Text-disabled/UI Core/Dark */
-  --figma___button-solid-success-text-primary: 0 0% 100% / 1;
-  /* ✦ Theme/Button/Solid/Success/Text-primary/UI Core/Dark */
-  --figma___button-solid-success-default: 121 42% 62% / 1;
-  /* ✦ Theme/Button/Solid/Success/default/UI Core/Dark */
-  --figma___button-surface-accent-active: 216 50% 12% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Active/UI Core/Dark */
-  --figma___button-surface-accent-active-border: 214 58% 16% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Active border/UI Core/Dark */
-  --figma___button-surface-accent-disabled: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Disabled/UI Core/Dark */
-  --figma___button-surface-accent-hover: 216 50% 12% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Hover/UI Core/Dark */
-  --figma___button-surface-accent-hover-border: 214 58% 16% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Hover Border/UI Core/Dark */
-  --figma___button-surface-accent-text-disabled: 206 98% 42% / 0.5;
-  /* ✦ Theme/Button/Surface/Accent/Text-disabled/UI Core/Dark */
-  --figma___button-surface-accent-text-primary: 206 100% 50% / 1;
-  /* ✦ Theme/Button/Surface/Accent/Text-primary/UI Core/Dark */
-  --figma___button-surface-accent-default: 215 46% 20% / 1;
-  /* ✦ Theme/Button/Surface/Accent/default/UI Core/Dark */
-  --figma___button-surface-accent-default-border: 214 58% 16% / 1;
-  /* ✦ Theme/Button/Surface/Accent/default border/UI Core/Dark */
-  --figma___button-surface-error-active: 0 67% 18% / 1;
-  /* ✦ Theme/Button/Surface/Error/Active/UI Core/Dark */
-  --figma___button-surface-error-active-border: 0 67% 24% / 1;
-  /* ✦ Theme/Button/Surface/Error/Active border/UI Core/Dark */
-  --figma___button-surface-error-disabled: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Surface/Error/Disabled/UI Core/Dark */
-  --figma___button-surface-error-hover: 0 67% 18% / 1;
-  /* ✦ Theme/Button/Surface/Error/Hover/UI Core/Dark */
-  --figma___button-surface-error-hover-border: 0 67% 24% / 1;
-  /* ✦ Theme/Button/Surface/Error/Hover border/UI Core/Dark */
-  --figma___button-surface-error-text-disabled: 0 0% 23% / 1;
-  /* ✦ Theme/Button/Surface/Error/Text-disabled/UI Core/Dark */
-  --figma___button-surface-error-text-primary: 0 78% 55% / 1;
-  /* ✦ Theme/Button/Surface/Error/Text-primary/UI Core/Dark */
-  --figma___button-surface-error-border: 0 67% 24% / 1;
-  /* ✦ Theme/Button/Surface/Error/border/UI Core/Dark */
-  --figma___button-surface-error-default: 0 67% 12% / 1;
-  /* ✦ Theme/Button/Surface/Error/default/UI Core/Dark */
-  --figma___button-surface-neutral-active: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Active/UI Core/Dark */
-  --figma___button-surface-neutral-disabled: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Disabled/UI Core/Dark */
-  --figma___button-surface-neutral-hover: 0 0% 7% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Hover/UI Core/Dark */
-  --figma___button-surface-neutral-text-disabled: 0 0% 23% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/UI Core/Dark */
-  --figma___button-surface-neutral-text-primary: 0 0% 54% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/Text-primary/UI Core/Dark */
-  --figma___button-surface-neutral-border: 0 0% 16% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/border/UI Core/Dark */
-  --figma___button-surface-neutral-default: 0 0% 11% / 1;
-  /* ✦ Theme/Button/Surface/Neutral/default/UI Core/Dark */
-  --figma___button-surface-success-active: 127 73% 15% / 1;
-  /* ✦ Theme/Button/Surface/Success/Active/UI Core/Dark */
-  --figma___button-surface-success-disabled: 0 0% 16% / 1;
-  /* ✦ Theme/Button/Surface/Success/Disabled/UI Core/Dark */
-  --figma___button-surface-success-hover: 127 73% 15% / 1;
-  /* ✦ Theme/Button/Surface/Success/Hover/UI Core/Dark */
-  --figma___button-surface-success-hover-border: 124 36% 52% / 1;
-  /* ✦ Theme/Button/Surface/Success/Hover border/UI Core/Dark */
-  --figma___button-surface-success-text-disabled: 0 0% 23% / 1;
-  /* ✦ Theme/Button/Surface/Success/Text-disabled/UI Core/Dark */
-  --figma___button-surface-success-text-primary: 118 49% 70% / 1;
-  /* ✦ Theme/Button/Surface/Success/Text-primary/UI Core/Dark */
-  --figma___button-surface-success-active-border: 124 36% 52% / 1;
-  /* ✦ Theme/Button/Surface/Success/active border/UI Core/Dark */
-  --figma___button-surface-success-default: 122 64% 11% / 1;
-  /* ✦ Theme/Button/Surface/Success/default/UI Core/Dark */
-  --figma___button-surface-success-default-border: 123 67% 24% / 1;
-  /* ✦ Theme/Button/Surface/Success/default border/UI Core/Dark */
-  --figma___calendar-background: 0 0% 0% / 1;
-  /* ✦ Theme/Calendar/Background/UI Core/Dark */
-  --figma___calendar-selected-date-background: 206 100% 50% / 1;
-  /* ✦ Theme/Calendar/Selected Date/Background/UI Core/Dark */
-  --figma___calendar-selected-date-text: 0 0% 0% / 1;
-  /* ✦ Theme/Calendar/Selected Date/Text/UI Core/Dark */
-  --figma___calendar-selected-range-background: 215 46% 20% / 1;
-  /* ✦ Theme/Calendar/Selected Range/Background/UI Core/Dark */
-  --figma___calendar-selected-range-text: 206 100% 50% / 1;
-  /* ✦ Theme/Calendar/Selected Range/Text/UI Core/Dark */
-  --figma___checkbox-background: 236 19% 14% / 0.5;
-  /* ✦ Theme/Checkbox/Background/UI Core/Dark */
-  --figma___checkbox-paper: 0 0% 100% / 0.03;
-  /* ✦ Theme/Checkbox/Paper/UI Core/Dark */
-  --figma___checkbox-surface-checked-active-active: 206 100% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/UI Core/Dark */
-  --figma___checkbox-surface-checked-active-check: 0 0% 0% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/UI Core/Dark */
-  --figma___checkbox-surface-checked-active-hover: 206 100% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/UI Core/Dark */
-  --figma___checkbox-surface-checked-active-default-background: 206 100% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/UI Core/Dark */
-  --figma___checkbox-surface-checked-disabled-check: 0 0% 0% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/UI Core/Dark */
-  --figma___checkbox-surface-checked-disabled-disabled: 0 0% 29% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/UI Core/Dark */
-  --figma___checkbox-surface-checked-disabled-border: 0 0% 29% / 1;
-  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/UI Core/Dark */
-  --figma___checkbox-surface-intermediate-active-active-border: 206 100% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/UI Core/Dark */
-  --figma___checkbox-surface-intermediate-active-check: 0 0% 0% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/UI Core/Dark */
-  --figma___checkbox-surface-intermediate-active-hover-border: 206 100% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/UI Core/Dark */
-  --figma___checkbox-surface-intermediate-active-default-background: 206 100% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/UI Core/Dark */
-  --figma___checkbox-surface-intermediate-active-default-border: 206 100% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/UI Core/Dark */
-  --figma___checkbox-surface-intermediate-disabled-check: 0 0% 0% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/UI Core/Dark */
-  --figma___checkbox-surface-intermediate-disabled-disabled: 0 0% 29% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/UI Core/Dark */
-  --figma___checkbox-surface-intermediate-disabled-border: 0 0% 29% / 1;
-  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/UI Core/Dark */
-  --figma___checkbox-surface-unchecked-active-active-border: 206 100% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/UI Core/Dark */
-  --figma___checkbox-surface-unchecked-active-hover-border: 206 100% 62% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/UI Core/Dark */
-  --figma___checkbox-surface-unchecked-active-default-background: 0 0% 0% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/UI Core/Dark */
-  --figma___checkbox-surface-unchecked-active-default-border: 206 100% 50% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/UI Core/Dark */
-  --figma___checkbox-surface-unchecked-disabled-disabled: 0 0% 11% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/UI Core/Dark */
-  --figma___checkbox-surface-unchecked-disabled-border: 0 0% 16% / 1;
-  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/UI Core/Dark */
-  --figma___checkbox-border: 0 0% 16% / 1;
-  /* ✦ Theme/Checkbox/border/UI Core/Dark */
-  --figma___default-colors-black: 210 25% 98% / 1;
-  /* ✦ Theme/Default colors/black/UI Core/Dark */
-  --figma___default-colors-dark-to-white: 210 25% 98% / 1;
-  /* ✦ Theme/Default colors/dark-to-white/UI Core/Dark */
-  --figma___default-colors-white: 0 0% 0% / 1;
-  /* ✦ Theme/Default colors/white/UI Core/Dark */
-  --figma___default-colors-white-to-dark: 0 0% 0% / 1;
-  /* ✦ Theme/Default colors/white-to-dark/UI Core/Dark */
-  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
-  /* ✦ Theme/Dropdown/Dropdown Item/Default/UI Core/Dark */
-  --figma___dropdown-dropdown-item-hover: 215 46% 20% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Hover/UI Core/Dark */
-  --figma___dropdown-dropdown-item-selected: 206 100% 50% / 1;
-  /* ✦ Theme/Dropdown/Dropdown Item/Selected/UI Core/Dark */
-  --figma___dropdown-text-shortcut-text-selected: 0 0% 100% / 0.8;
-  /* ✦ Theme/Dropdown/Text/Shortcut text selected/UI Core/Dark */
-  --figma___dropdown-text-text-selected: 0 0% 100% / 1;
-  /* ✦ Theme/Dropdown/Text/Text Selected/UI Core/Dark */
-  --figma___dropdown-text-hover: 206 100% 50% / 1;
-  /* ✦ Theme/Dropdown/Text/hover/UI Core/Dark */
-  --figma___dropdown-background: 0 0% 0% / 1;
-  /* ✦ Theme/Dropdown/background/UI Core/Dark */
-  --figma___dropdown-border: 0 0% 100% / 0;
-  /* ✦ Theme/Dropdown/border/UI Core/Dark */
-  --figma___dropdown-separator: 0 0% 11% / 1;
-  /* ✦ Theme/Dropdown/separator/UI Core/Dark */
-  --figma___filter-active: 0 0% 16% / 1;
-  /* ✦ Theme/Filter/Active/UI Core/Dark */
-  --figma___filter-default: 0 0% 0% / 1;
-  /* ✦ Theme/Filter/Default/UI Core/Dark */
-  --figma___filter-hover: 0 0% 16% / 1;
-  /* ✦ Theme/Filter/Hover/UI Core/Dark */
-  --figma___inline-alert-banner-customisable: 0 0% 11% / 1;
-  /* ✦ Theme/Inline Alert Banner/Customisable/UI Core/Dark */
-  --figma___inline-alert-banner-error: 0 67% 12% / 1;
-  /* ✦ Theme/Inline Alert Banner/Error/UI Core/Dark */
-  --figma___inline-alert-banner-info: 215 46% 20% / 1;
-  /* ✦ Theme/Inline Alert Banner/Info/UI Core/Dark */
-  --figma___inline-alert-banner-reminder: 54 100% 8% / 1;
-  /* ✦ Theme/Inline Alert Banner/Reminder/UI Core/Dark */
-  --figma___inline-alert-banner-success: 122 64% 11% / 1;
-  /* ✦ Theme/Inline Alert Banner/Success/UI Core/Dark */
-  --figma___inline-alert-banner-warning: 32 67% 12% / 1;
-  /* ✦ Theme/Inline Alert Banner/Warning/UI Core/Dark */
-  --figma___modal-background: 0 0% 0% / 1;
-  /* ✦ Theme/Modal/Background/UI Core/Dark */
-  --figma___modal-paper: 0 0% 0% / 1;
-  /* ✦ Theme/Modal/Paper/UI Core/Dark */
-  --figma___modal-border: 0 0% 0% / 0;
-  /* ✦ Theme/Modal/border/UI Core/Dark */
-  --figma___neutral-color-gray-1: 0 0% 7% / 1;
-  /* ✦ Theme/Neutral color/Gray/1/UI Core/Dark */
-  --figma___neutral-color-gray-2: 0 0% 11% / 1;
-  /* ✦ Theme/Neutral color/Gray/2/UI Core/Dark */
-  --figma___neutral-color-gray-3: 0 0% 16% / 1;
-  /* ✦ Theme/Neutral color/Gray/3/UI Core/Dark */
-  --figma___neutral-color-gray-4: 0 0% 23% / 1;
-  /* ✦ Theme/Neutral color/Gray/4/UI Core/Dark */
-  --figma___neutral-color-gray-5: 0 0% 29% / 1;
-  /* ✦ Theme/Neutral color/Gray/5/UI Core/Dark */
-  --figma___neutral-color-gray-6: 0 0% 35% / 1;
-  /* ✦ Theme/Neutral color/Gray/6/UI Core/Dark */
-  --figma___neutral-color-gray-7: 0 0% 42% / 1;
-  /* ✦ Theme/Neutral color/Gray/7/UI Core/Dark */
-  --figma___neutral-color-gray-8: 0 0% 54% / 1;
-  /* ✦ Theme/Neutral color/Gray/8/UI Core/Dark */
-  --figma___neutral-color-gray-9: 0 0% 69% / 1;
-  /* ✦ Theme/Neutral color/Gray/9/UI Core/Dark */
-  --figma___neutral-color-gray-10: 0 0% 82% / 1;
-  /* ✦ Theme/Neutral color/Gray/10/UI Core/Dark */
-  --figma___neutral-color-gray-alpha-1: 0 0% 7% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/1/UI Core/Dark */
-  --figma___neutral-color-gray-alpha-2: 0 0% 11% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/2/UI Core/Dark */
-  --figma___neutral-color-gray-alpha-3: 0 0% 16% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/3/UI Core/Dark */
-  --figma___neutral-color-gray-alpha-4: 0 0% 23% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/4/UI Core/Dark */
-  --figma___neutral-color-gray-alpha-5: 0 0% 29% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/5/UI Core/Dark */
-  --figma___neutral-color-gray-alpha-6: 0 0% 35% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/6/UI Core/Dark */
-  --figma___neutral-color-gray-alpha-7: 0 0% 42% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/7/UI Core/Dark */
-  --figma___neutral-color-gray-alpha-8: 0 0% 54% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/8/UI Core/Dark */
-  --figma___neutral-color-gray-alpha-9: 0 0% 69% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/9/UI Core/Dark */
-  --figma___neutral-color-gray-alpha-10: 0 0% 82% / 1;
-  /* ✦ Theme/Neutral color/Gray Alpha/10/UI Core/Dark */
-  --figma___other-colors-ai-violet-1: 256 82% 30% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/1/UI Core/Dark */
-  --figma___other-colors-ai-violet-2: 254 74% 37% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/2/UI Core/Dark */
-  --figma___other-colors-ai-violet-3: 254 68% 42% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/3/UI Core/Dark */
-  --figma___other-colors-ai-violet-4: 254 64% 48% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/4/UI Core/Dark */
-  --figma___other-colors-ai-violet-5: 252 70% 59% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/5/UI Core/Dark */
-  --figma___other-colors-ai-violet-6: 251 73% 64% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/6/UI Core/Dark */
-  --figma___other-colors-ai-violet-7: 252 76% 69% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/7/UI Core/Dark */
-  --figma___other-colors-ai-violet-8: 251 80% 74% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/8/UI Core/Dark */
-  --figma___other-colors-ai-violet-9: 252 85% 79% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/9/UI Core/Dark */
-  --figma___other-colors-ai-violet-10: 253 100% 84% / 1;
-  /* ✦ Theme/Other Colors/AI Violet/10/UI Core/Dark */
-  --figma___other-colors-ai-violet-alpha-1: 256 82% 30% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/1/UI Core/Dark */
-  --figma___other-colors-ai-violet-alpha-2: 254 74% 37% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/2/UI Core/Dark */
-  --figma___other-colors-ai-violet-alpha-3: 254 68% 42% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/3/UI Core/Dark */
-  --figma___other-colors-ai-violet-alpha-4: 254 64% 48% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/4/UI Core/Dark */
-  --figma___other-colors-ai-violet-alpha-5: 252 70% 59% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/5/UI Core/Dark */
-  --figma___other-colors-ai-violet-alpha-6: 251 73% 64% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/6/UI Core/Dark */
-  --figma___other-colors-ai-violet-alpha-7: 252 76% 69% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/7/UI Core/Dark */
-  --figma___other-colors-ai-violet-alpha-8: 251 80% 74% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/8/UI Core/Dark */
-  --figma___other-colors-ai-violet-alpha-9: 252 85% 79% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/9/UI Core/Dark */
-  --figma___other-colors-ai-violet-alpha-10: 253 100% 84% / 1;
-  /* ✦ Theme/Other Colors/AI Violet Alpha/10/UI Core/Dark */
-  --figma___other-colors-blue-1: 241 53% 23% / 1;
-  /* ✦ Theme/Other Colors/Blue/1/UI Core/Dark */
-  --figma___other-colors-blue-2: 241 52% 28% / 1;
-  /* ✦ Theme/Other Colors/Blue/2/UI Core/Dark */
-  --figma___other-colors-blue-3: 241 51% 33% / 1;
-  /* ✦ Theme/Other Colors/Blue/3/UI Core/Dark */
-  --figma___other-colors-blue-4: 241 49% 39% / 1;
-  /* ✦ Theme/Other Colors/Blue/4/UI Core/Dark */
-  --figma___other-colors-blue-5: 241 48% 44% / 1;
-  /* ✦ Theme/Other Colors/Blue/5/UI Core/Dark */
-  --figma___other-colors-blue-6: 239 48% 52% / 1;
-  /* ✦ Theme/Other Colors/Blue/6/UI Core/Dark */
-  --figma___other-colors-blue-7: 240 59% 59% / 1;
-  /* ✦ Theme/Other Colors/Blue/7/UI Core/Dark */
-  --figma___other-colors-blue-8: 240 74% 67% / 1;
-  /* ✦ Theme/Other Colors/Blue/8/UI Core/Dark */
-  --figma___other-colors-blue-9: 240 100% 77% / 1;
-  /* ✦ Theme/Other Colors/Blue/9/UI Core/Dark */
-  --figma___other-colors-blue-10: 240 100% 83% / 1;
-  /* ✦ Theme/Other Colors/Blue/10/UI Core/Dark */
-  --figma___other-colors-blue-alpha-1: 215 46% 20% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/1/UI Core/Dark */
-  --figma___other-colors-blue-alpha-2: 216 50% 12% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/2/UI Core/Dark */
-  --figma___other-colors-blue-alpha-3: 214 58% 16% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/3/UI Core/Dark */
-  --figma___other-colors-blue-alpha-4: 213 67% 21% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/4/UI Core/Dark */
-  --figma___other-colors-blue-alpha-5: 194 100% 45% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/5/UI Core/Dark */
-  --figma___other-colors-blue-alpha-6: 212 72% 25% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/6/UI Core/Dark */
-  --figma___other-colors-blue-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/7/UI Core/Dark */
-  --figma___other-colors-blue-alpha-8: 206 100% 62% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/8/UI Core/Dark */
-  --figma___other-colors-blue-alpha-9: 205 100% 71% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/9/UI Core/Dark */
-  --figma___other-colors-blue-alpha-10: 212 72% 10% / 1;
-  /* ✦ Theme/Other Colors/Blue Alpha/10/UI Core/Dark */
-  --figma___other-colors-indigo-1: 226 25% 10% / 1;
-  /* ✦ Theme/Other Colors/Indigo/1/UI Core/Dark */
-  --figma___other-colors-indigo-2: 230 36% 13% / 1;
-  /* ✦ Theme/Other Colors/Indigo/2/UI Core/Dark */
-  --figma___other-colors-indigo-3: 228 43% 18% / 1;
-  /* ✦ Theme/Other Colors/Indigo/3/UI Core/Dark */
-  --figma___other-colors-indigo-4: 228 45% 21% / 1;
-  /* ✦ Theme/Other Colors/Indigo/4/UI Core/Dark */
-  --figma___other-colors-indigo-5: 227 48% 24% / 1;
-  /* ✦ Theme/Other Colors/Indigo/5/UI Core/Dark */
-  --figma___other-colors-indigo-6: 225 51% 29% / 1;
-  /* ✦ Theme/Other Colors/Indigo/6/UI Core/Dark */
-  --figma___other-colors-indigo-7: 226 70% 55% / 1;
-  /* ✦ Theme/Other Colors/Indigo/7/UI Core/Dark */
-  --figma___other-colors-indigo-8: 230 74% 63% / 1;
-  /* ✦ Theme/Other Colors/Indigo/8/UI Core/Dark */
-  --figma___other-colors-indigo-9: 235 100% 80% / 1;
-  /* ✦ Theme/Other Colors/Indigo/9/UI Core/Dark */
-  --figma___other-colors-indigo-10: 236 94% 93% / 1;
-  /* ✦ Theme/Other Colors/Indigo/10/UI Core/Dark */
-  --figma___other-colors-indigo-alpha-1: 240 100% 49% / 0.04;
-  /* ✦ Theme/Other Colors/Indigo Alpha/1/UI Core/Dark */
-  --figma___other-colors-indigo-alpha-2: 232 100% 50% / 0.09;
-  /* ✦ Theme/Other Colors/Indigo Alpha/2/UI Core/Dark */
-  --figma___other-colors-indigo-alpha-3: 228 100% 57% / 0.18;
-  /* ✦ Theme/Other Colors/Indigo Alpha/3/UI Core/Dark */
-  --figma___other-colors-indigo-alpha-4: 228 99% 59% / 0.24;
-  /* ✦ Theme/Other Colors/Indigo Alpha/4/UI Core/Dark */
-  --figma___other-colors-indigo-alpha-5: 227 99% 60% / 0.29;
-  /* ✦ Theme/Other Colors/Indigo Alpha/5/UI Core/Dark */
-  --figma___other-colors-indigo-alpha-6: 225 100% 61% / 0.37;
-  /* ✦ Theme/Other Colors/Indigo Alpha/6/UI Core/Dark */
-  --figma___other-colors-indigo-alpha-7: 226 100% 63% / 0.85;
-  /* ✦ Theme/Other Colors/Indigo Alpha/7/UI Core/Dark */
-  --figma___other-colors-indigo-alpha-8: 230 100% 70% / 0.9;
-  /* ✦ Theme/Other Colors/Indigo Alpha/8/UI Core/Dark */
-  --figma___other-colors-indigo-alpha-9: 236 100% 94% / 1;
-  /* ✦ Theme/Other Colors/Indigo Alpha/9/UI Core/Dark */
-  --figma___other-colors-indigo-alpha-10: 236 100% 94% / 1;
-  /* ✦ Theme/Other Colors/Indigo Alpha/10/UI Core/Dark */
-  --figma___other-colors-mint-1: 173 52% 6% / 1;
-  /* ✦ Theme/Other Colors/Mint/1/UI Core/Dark */
-  --figma___other-colors-mint-2: 174 51% 8% / 1;
-  /* ✦ Theme/Other Colors/Mint/2/UI Core/Dark */
-  --figma___other-colors-mint-3: 176 52% 11% / 1;
-  /* ✦ Theme/Other Colors/Mint/3/UI Core/Dark */
-  --figma___other-colors-mint-4: 173 56% 13% / 1;
-  /* ✦ Theme/Other Colors/Mint/4/UI Core/Dark */
-  --figma___other-colors-mint-5: 173 57% 15% / 1;
-  /* ✦ Theme/Other Colors/Mint/5/UI Core/Dark */
-  --figma___other-colors-mint-6: 173 58% 18% / 1;
-  /* ✦ Theme/Other Colors/Mint/6/UI Core/Dark */
-  --figma___other-colors-mint-7: 167 70% 72% / 1;
-  /* ✦ Theme/Other Colors/Mint/7/UI Core/Dark */
-  --figma___other-colors-mint-8: 163 80% 77% / 1;
-  /* ✦ Theme/Other Colors/Mint/8/UI Core/Dark */
-  --figma___other-colors-mint-9: 167 70% 58% / 1;
-  /* ✦ Theme/Other Colors/Mint/9/UI Core/Dark */
-  --figma___other-colors-mint-10: 156 71% 86% / 1;
-  /* ✦ Theme/Other Colors/Mint/10/UI Core/Dark */
-  --figma___other-colors-mint-alpha-1: 120 100% 44% / 0;
-  /* ✦ Theme/Other Colors/Mint Alpha/1/UI Core/Dark */
-  --figma___other-colors-mint-alpha-2: 165 100% 49% / 0.03;
-  /* ✦ Theme/Other Colors/Mint Alpha/2/UI Core/Dark */
-  --figma___other-colors-mint-alpha-3: 174 100% 50% / 0.07;
-  /* ✦ Theme/Other Colors/Mint Alpha/3/UI Core/Dark */
-  --figma___other-colors-mint-alpha-4: 172 100% 50% / 0.11;
-  /* ✦ Theme/Other Colors/Mint Alpha/4/UI Core/Dark */
-  --figma___other-colors-mint-alpha-5: 172 100% 50% / 0.15;
-  /* ✦ Theme/Other Colors/Mint Alpha/5/UI Core/Dark */
-  --figma___other-colors-mint-alpha-6: 173 100% 50% / 0.21;
-  /* ✦ Theme/Other Colors/Mint Alpha/6/UI Core/Dark */
-  --figma___other-colors-mint-alpha-7: 167 100% 78% / 0.91;
-  /* ✦ Theme/Other Colors/Mint Alpha/7/UI Core/Dark */
-  --figma___other-colors-mint-alpha-8: 163 100% 81% / 0.95;
-  /* ✦ Theme/Other Colors/Mint Alpha/8/UI Core/Dark */
-  --figma___other-colors-mint-alpha-9: 167 100% 66% / 0.86;
-  /* ✦ Theme/Other Colors/Mint Alpha/9/UI Core/Dark */
-  --figma___other-colors-mint-alpha-10: 155 100% 90% / 0.96;
-  /* ✦ Theme/Other Colors/Mint Alpha/10/UI Core/Dark */
-  --figma___other-colors-orange-1: 32 67% 12% / 1;
-  /* ✦ Theme/Other Colors/Orange/1/UI Core/Dark */
-  --figma___other-colors-orange-2: 30 69% 18% / 1;
-  /* ✦ Theme/Other Colors/Orange/2/UI Core/Dark */
-  --figma___other-colors-orange-3: 27 69% 24% / 1;
-  /* ✦ Theme/Other Colors/Orange/3/UI Core/Dark */
-  --figma___other-colors-orange-4: 26 68% 30% / 1;
-  /* ✦ Theme/Other Colors/Orange/4/UI Core/Dark */
-  --figma___other-colors-orange-5: 17 68% 36% / 1;
-  /* ✦ Theme/Other Colors/Orange/5/UI Core/Dark */
-  --figma___other-colors-orange-6: 18 68% 42% / 1;
-  /* ✦ Theme/Other Colors/Orange/6/UI Core/Dark */
-  --figma___other-colors-orange-7: 19 67% 48% / 1;
-  /* ✦ Theme/Other Colors/Orange/7/UI Core/Dark */
-  --figma___other-colors-orange-8: 19 79% 54% / 1;
-  /* ✦ Theme/Other Colors/Orange/8/UI Core/Dark */
-  --figma___other-colors-orange-9: 19 100% 60% / 1;
-  /* ✦ Theme/Other Colors/Orange/9/UI Core/Dark */
-  --figma___other-colors-orange-10: 19 100% 64% / 1;
-  /* ✦ Theme/Other Colors/Orange/10/UI Core/Dark */
-  --figma___other-colors-orange-alpha-1: 32 67% 12% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/1/UI Core/Dark */
-  --figma___other-colors-orange-alpha-2: 30 69% 18% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/2/UI Core/Dark */
-  --figma___other-colors-orange-alpha-3: 27 69% 24% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/3/UI Core/Dark */
-  --figma___other-colors-orange-alpha-4: 26 68% 30% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/4/UI Core/Dark */
-  --figma___other-colors-orange-alpha-5: 17 68% 36% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/5/UI Core/Dark */
-  --figma___other-colors-orange-alpha-6: 18 68% 42% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/6/UI Core/Dark */
-  --figma___other-colors-orange-alpha-7: 19 67% 48% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/7/UI Core/Dark */
-  --figma___other-colors-orange-alpha-8: 19 79% 54% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/8/UI Core/Dark */
-  --figma___other-colors-orange-alpha-9: 19 100% 60% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/9/UI Core/Dark */
-  --figma___other-colors-orange-alpha-10: 19 100% 64% / 1;
-  /* ✦ Theme/Other Colors/Orange Alpha/10/UI Core/Dark */
-  --figma___other-colors-yellow-1: 54 100% 8% / 1;
-  /* ✦ Theme/Other Colors/Yellow/1/UI Core/Dark */
-  --figma___other-colors-yellow-2: 54 100% 17% / 1;
-  /* ✦ Theme/Other Colors/Yellow/2/UI Core/Dark */
-  --figma___other-colors-yellow-3: 54 100% 25% / 1;
-  /* ✦ Theme/Other Colors/Yellow/3/UI Core/Dark */
-  --figma___other-colors-yellow-4: 54 100% 33% / 1;
-  /* ✦ Theme/Other Colors/Yellow/4/UI Core/Dark */
-  --figma___other-colors-yellow-5: 54 100% 41% / 1;
-  /* ✦ Theme/Other Colors/Yellow/5/UI Core/Dark */
-  --figma___other-colors-yellow-6: 55 100% 48% / 1;
-  /* ✦ Theme/Other Colors/Yellow/6/UI Core/Dark */
-  --figma___other-colors-yellow-7: 55 92% 58% / 1;
-  /* ✦ Theme/Other Colors/Yellow/7/UI Core/Dark */
-  --figma___other-colors-yellow-8: 54 92% 69% / 1;
-  /* ✦ Theme/Other Colors/Yellow/8/UI Core/Dark */
-  --figma___other-colors-yellow-9: 53 91% 79% / 1;
-  /* ✦ Theme/Other Colors/Yellow/9/UI Core/Dark */
-  --figma___other-colors-yellow-10: 47 89% 89% / 1;
-  /* ✦ Theme/Other Colors/Yellow/10/UI Core/Dark */
-  --figma___other-colors-yellow-alpha-1: 54 100% 8% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/1/UI Core/Dark */
-  --figma___other-colors-yellow-alpha-2: 54 100% 17% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/2/UI Core/Dark */
-  --figma___other-colors-yellow-alpha-3: 54 100% 25% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/3/UI Core/Dark */
-  --figma___other-colors-yellow-alpha-4: 54 100% 33% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/4/UI Core/Dark */
-  --figma___other-colors-yellow-alpha-5: 54 100% 41% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/5/UI Core/Dark */
-  --figma___other-colors-yellow-alpha-6: 55 100% 48% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/6/UI Core/Dark */
-  --figma___other-colors-yellow-alpha-7: 55 92% 58% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/7/UI Core/Dark */
-  --figma___other-colors-yellow-alpha-8: 54 92% 69% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/8/UI Core/Dark */
-  --figma___other-colors-yellow-alpha-9: 53 91% 79% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/9/UI Core/Dark */
-  --figma___other-colors-yellow-alpha-10: 47 89% 89% / 1;
-  /* ✦ Theme/Other Colors/Yellow Alpha/10/UI Core/Dark */
-  --figma___overlays-black-alpha-1: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/1/UI Core/Dark */
-  --figma___overlays-black-alpha-2: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/2/UI Core/Dark */
-  --figma___overlays-black-alpha-3: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/3/UI Core/Dark */
-  --figma___overlays-black-alpha-4: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/4/UI Core/Dark */
-  --figma___overlays-black-alpha-5: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/5/UI Core/Dark */
-  --figma___overlays-black-alpha-6: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/6/UI Core/Dark */
-  --figma___overlays-black-alpha-7: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/7/UI Core/Dark */
-  --figma___overlays-black-alpha-8: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/8/UI Core/Dark */
-  --figma___overlays-black-alpha-9: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/9/UI Core/Dark */
-  --figma___overlays-black-alpha-10: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/Black Alpha/10/UI Core/Dark */
-  --figma___overlays-white-alpha-1: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/1/UI Core/Dark */
-  --figma___overlays-white-alpha-2: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/2/UI Core/Dark */
-  --figma___overlays-white-alpha-3: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/3/UI Core/Dark */
-  --figma___overlays-white-alpha-4: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/4/UI Core/Dark */
-  --figma___overlays-white-alpha-5: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/5/UI Core/Dark */
-  --figma___overlays-white-alpha-6: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/6/UI Core/Dark */
-  --figma___overlays-white-alpha-7: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/7/UI Core/Dark */
-  --figma___overlays-white-alpha-8: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/8/UI Core/Dark */
-  --figma___overlays-white-alpha-9: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/9/UI Core/Dark */
-  --figma___overlays-white-alpha-10: 0 0% 100% / 1;
-  /* ✦ Theme/Overlays/White Alpha/10/UI Core/Dark */
-  --figma___pagination-active-background: 212 72% 25% / 1;
-  /* ✦ Theme/Pagination/Active/Background/UI Core/Dark */
-  --figma___pagination-active-border: 202 100% 45% / 0;
-  /* ✦ Theme/Pagination/Active/Border/UI Core/Dark */
-  --figma___pagination-active-text: 0 0% 0% / 1;
-  /* ✦ Theme/Pagination/Active/Text/UI Core/Dark */
-  --figma___pagination-background: 206 98% 42% / 0.21;
-  /* ✦ Theme/Pagination/Background/UI Core/Dark */
-  --figma___pagination-default-background: 0 0% 0% / 1;
-  /* ✦ Theme/Pagination/Default/Background/UI Core/Dark */
-  --figma___pagination-default-border: 0 0% 89% / 0;
-  /* ✦ Theme/Pagination/Default/Border/UI Core/Dark */
-  --figma___pagination-default-text: 0 0% 35% / 1;
-  /* ✦ Theme/Pagination/Default/Text/UI Core/Dark */
-  --figma___pagination-hover-background: 0 0% 0% / 1;
-  /* ✦ Theme/Pagination/Hover/Background/UI Core/Dark */
-  --figma___pagination-hover-border: 206 98% 42% / 0;
-  /* ✦ Theme/Pagination/Hover/Border/UI Core/Dark */
-  --figma___pagination-hover-text: 0 0% 82% / 1;
-  /* ✦ Theme/Pagination/Hover/Text/UI Core/Dark */
-  --figma___pagination-pagination-shadow-1: 237 21% 20% / 0.04;
-  /* ✦ Theme/Pagination/Pagination shadow/1/UI Core/Dark */
-  --figma___pagination-pagination-shadow-2: 236 8% 41% / 0.16;
-  /* ✦ Theme/Pagination/Pagination shadow/2/UI Core/Dark */
-  --figma___primary-color-primary-accent-1: 215 46% 20% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/1/UI Core/Dark */
-  --figma___primary-color-primary-accent-2: 216 50% 12% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/2/UI Core/Dark */
-  --figma___primary-color-primary-accent-3: 214 58% 16% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/3/UI Core/Dark */
-  --figma___primary-color-primary-accent-4: 213 67% 21% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/4/UI Core/Dark */
-  --figma___primary-color-primary-accent-5: 194 100% 45% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/5/UI Core/Dark */
-  --figma___primary-color-primary-accent-6: 212 72% 25% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/6/UI Core/Dark */
-  --figma___primary-color-primary-accent-7: 206 100% 50% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/7/UI Core/Dark */
-  --figma___primary-color-primary-accent-8: 206 100% 62% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/8/UI Core/Dark */
-  --figma___primary-color-primary-accent-9: 205 100% 71% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/9/UI Core/Dark */
-  --figma___primary-color-primary-accent-10: 212 72% 10% / 1;
-  /* ✦ Theme/Primary Color/Primary Accent/10/UI Core/Dark */
-  --figma___primary-color-primary-alpha-1: 215 46% 20% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/1/UI Core/Dark */
-  --figma___primary-color-primary-alpha-2: 216 50% 12% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/2/UI Core/Dark */
-  --figma___primary-color-primary-alpha-3: 214 58% 16% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/3/UI Core/Dark */
-  --figma___primary-color-primary-alpha-4: 213 67% 21% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/4/UI Core/Dark */
-  --figma___primary-color-primary-alpha-5: 194 100% 45% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/5/UI Core/Dark */
-  --figma___primary-color-primary-alpha-6: 212 72% 25% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/6/UI Core/Dark */
-  --figma___primary-color-primary-alpha-7: 206 100% 50% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/7/UI Core/Dark */
-  --figma___primary-color-primary-alpha-8: 206 100% 62% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/8/UI Core/Dark */
-  --figma___primary-color-primary-alpha-9: 205 100% 71% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/9/UI Core/Dark */
-  --figma___primary-color-primary-alpha-10: 212 72% 10% / 1;
-  /* ✦ Theme/Primary Color/Primary Alpha/10/UI Core/Dark */
-  --figma___radio-button-background: 236 19% 14% / 0.5;
-  /* ✦ Theme/Radio button/Background/UI Core/Dark */
-  --figma___radio-button-checked-active-active-border: 206 100% 50% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active Border/UI Core/Dark */
-  --figma___radio-button-checked-active-active-background: 206 100% 50% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Active background/UI Core/Dark */
-  --figma___radio-button-checked-active-dot: 0 0% 0% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Dot/UI Core/Dark */
-  --figma___radio-button-checked-active-hover-background: 206 100% 62% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover background/UI Core/Dark */
-  --figma___radio-button-checked-active-hover-border: 206 100% 62% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/Hover border/UI Core/Dark */
-  --figma___radio-button-checked-active-default-background: 206 100% 50% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default background/UI Core/Dark */
-  --figma___radio-button-checked-active-default-border: 206 100% 50% / 1;
-  /* ✦ Theme/Radio button/Checked/Active/default border/UI Core/Dark */
-  --figma___radio-button-checked-disabled-dot: 0 0% 0% / 1;
-  /* ✦ Theme/Radio button/Checked/Disabled/Dot/UI Core/Dark */
-  --figma___radio-button-checked-disabled-background: 0 0% 11% / 1;
-  /* ✦ Theme/Radio button/Checked/Disabled/background/UI Core/Dark */
-  --figma___radio-button-checked-disabled-border: 0 0% 16% / 1;
-  /* ✦ Theme/Radio button/Checked/Disabled/border/UI Core/Dark */
-  --figma___radio-button-paper: 0 0% 100% / 0.03;
-  /* ✦ Theme/Radio button/Paper/UI Core/Dark */
-  --figma___radio-button-unchecked-active-active-border: 206 100% 50% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/Active border/UI Core/Dark */
-  --figma___radio-button-unchecked-active-hover-border: 206 100% 62% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/UI Core/Dark */
-  --figma___radio-button-unchecked-active-default-background: 0 0% 0% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/default background/UI Core/Dark */
-  --figma___radio-button-unchecked-active-default-border: 206 100% 50% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Active/default border/UI Core/Dark */
-  --figma___radio-button-unchecked-disabled-background: 0 0% 11% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/background/UI Core/Dark */
-  --figma___radio-button-unchecked-disabled-border: 0 0% 16% / 1;
-  /* ✦ Theme/Radio button/Unchecked/Disabled/border/UI Core/Dark */
-  --figma___radio-button-border: 0 0% 16% / 1;
-  /* ✦ Theme/Radio button/border/UI Core/Dark */
-  --figma___secondary-crimson-crimson-1: 330 100% 20% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 1/UI Core/Dark */
-  --figma___secondary-crimson-crimson-10: 327 79% 95% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 10/UI Core/Dark */
-  --figma___secondary-crimson-crimson-2: 330 100% 25% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 2/UI Core/Dark */
-  --figma___secondary-crimson-crimson-3: 330 100% 30% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 3/UI Core/Dark */
-  --figma___secondary-crimson-crimson-4: 330 100% 35% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 4/UI Core/Dark */
-  --figma___secondary-crimson-crimson-5: 330 100% 40% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 5/UI Core/Dark */
-  --figma___secondary-crimson-crimson-6: 332 67% 52% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 6/UI Core/Dark */
-  --figma___secondary-crimson-crimson-7: 335 66% 64% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 7/UI Core/Dark */
-  --figma___secondary-crimson-crimson-8: 326 77% 77% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 8/UI Core/Dark */
-  --figma___secondary-crimson-crimson-9: 331 67% 88% / 1;
-  /* ✦ Theme/Secondary/Crimson/Crimson 9/UI Core/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-1: 330 100% 20% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/UI Core/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-10: 331 67% 88% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/UI Core/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-11: 327 79% 95% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/UI Core/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-2: 330 100% 25% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/UI Core/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-3: 330 100% 30% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/UI Core/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-4: 330 100% 35% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/UI Core/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-5: 330 100% 40% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/UI Core/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-6: 332 67% 52% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/UI Core/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-8: 335 66% 64% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/UI Core/Dark */
-  --figma___secondary-crimson-alpha-crimson-alpha-9: 326 77% 77% / 1;
-  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/UI Core/Dark */
-  --figma___secondary-lime-1: 84 100% 20% / 1;
-  /* ✦ Theme/Secondary/Lime/1/UI Core/Dark */
-  --figma___secondary-lime-2: 84 100% 25% / 1;
-  /* ✦ Theme/Secondary/Lime/2/UI Core/Dark */
-  --figma___secondary-lime-3: 83 100% 30% / 1;
-  /* ✦ Theme/Secondary/Lime/3/UI Core/Dark */
-  --figma___secondary-lime-4: 83 100% 35% / 1;
-  /* ✦ Theme/Secondary/Lime/4/UI Core/Dark */
-  --figma___secondary-lime-5: 82 100% 40% / 1;
-  /* ✦ Theme/Secondary/Lime/5/UI Core/Dark */
-  --figma___secondary-lime-6: 95 66% 64% / 1;
-  /* ✦ Theme/Secondary/Lime/6/UI Core/Dark */
-  --figma___secondary-lime-7: 100 61% 75% / 1;
-  /* ✦ Theme/Secondary/Lime/7/UI Core/Dark */
-  --figma___secondary-lime-8: 120 34% 85% / 1;
-  /* ✦ Theme/Secondary/Lime/8/UI Core/Dark */
-  --figma___secondary-lime-9: 120 33% 92% / 1;
-  /* ✦ Theme/Secondary/Lime/9/UI Core/Dark */
-  --figma___secondary-lime-10: 120 53% 97% / 1;
-  /* ✦ Theme/Secondary/Lime/10/UI Core/Dark */
-  --figma___secondary-lime-alpha-1: 84 100% 20% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/1/UI Core/Dark */
-  --figma___secondary-lime-alpha-2: 84 100% 25% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/2/UI Core/Dark */
-  --figma___secondary-lime-alpha-3: 83 100% 30% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/3/UI Core/Dark */
-  --figma___secondary-lime-alpha-4: 83 100% 35% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/4/UI Core/Dark */
-  --figma___secondary-lime-alpha-5: 82 100% 40% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/5/UI Core/Dark */
-  --figma___secondary-lime-alpha-6: 95 66% 64% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/6/UI Core/Dark */
-  --figma___secondary-lime-alpha-7: 100 61% 75% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/7/UI Core/Dark */
-  --figma___secondary-lime-alpha-8: 120 34% 85% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/8/UI Core/Dark */
-  --figma___secondary-lime-alpha-9: 120 33% 92% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/9/UI Core/Dark */
-  --figma___secondary-lime-alpha-10: 120 53% 97% / 1;
-  /* ✦ Theme/Secondary/Lime Alpha/10/UI Core/Dark */
-  --figma___secondary-purple-1: 264 100% 20% / 1;
-  /* ✦ Theme/Secondary/Purple/1/UI Core/Dark */
-  --figma___secondary-purple-2: 264 100% 25% / 1;
-  /* ✦ Theme/Secondary/Purple/2/UI Core/Dark */
-  --figma___secondary-purple-3: 264 100% 30% / 1;
-  /* ✦ Theme/Secondary/Purple/3/UI Core/Dark */
-  --figma___secondary-purple-4: 264 100% 35% / 1;
-  /* ✦ Theme/Secondary/Purple/4/UI Core/Dark */
-  --figma___secondary-purple-5: 264 100% 40% / 1;
-  /* ✦ Theme/Secondary/Purple/5/UI Core/Dark */
-  --figma___secondary-purple-6: 264 67% 52% / 1;
-  /* ✦ Theme/Secondary/Purple/6/UI Core/Dark */
-  --figma___secondary-purple-7: 265 66% 64% / 1;
-  /* ✦ Theme/Secondary/Purple/7/UI Core/Dark */
-  --figma___secondary-purple-8: 258 77% 77% / 1;
-  /* ✦ Theme/Secondary/Purple/8/UI Core/Dark */
-  --figma___secondary-purple-9: 253 85% 89% / 1;
-  /* ✦ Theme/Secondary/Purple/9/UI Core/Dark */
-  --figma___secondary-purple-10: 273 79% 95% / 1;
-  /* ✦ Theme/Secondary/Purple/10/UI Core/Dark */
-  --figma___secondary-purple-alpha-1: 264 100% 20% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/1/UI Core/Dark */
-  --figma___secondary-purple-alpha-2: 264 100% 25% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/2/UI Core/Dark */
-  --figma___secondary-purple-alpha-3: 264 100% 30% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/3/UI Core/Dark */
-  --figma___secondary-purple-alpha-4: 264 100% 35% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/4/UI Core/Dark */
-  --figma___secondary-purple-alpha-5: 264 100% 40% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/5/UI Core/Dark */
-  --figma___secondary-purple-alpha-6: 264 67% 52% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/6/UI Core/Dark */
-  --figma___secondary-purple-alpha-7: 265 66% 64% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/7/UI Core/Dark */
-  --figma___secondary-purple-alpha-8: 258 77% 77% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/8/UI Core/Dark */
-  --figma___secondary-purple-alpha-9: 253 85% 89% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/9/UI Core/Dark */
-  --figma___secondary-purple-alpha-10: 273 79% 95% / 1;
-  /* ✦ Theme/Secondary/Purple Alpha/10/UI Core/Dark */
-  --figma___secondary-teal-1: 180 100% 15% / 1;
-  /* ✦ Theme/Secondary/Teal/1/UI Core/Dark */
-  --figma___secondary-teal-2: 180 100% 20% / 1;
-  /* ✦ Theme/Secondary/Teal/2/UI Core/Dark */
-  --figma___secondary-teal-3: 180 100% 25% / 1;
-  /* ✦ Theme/Secondary/Teal/3/UI Core/Dark */
-  --figma___secondary-teal-4: 180 100% 30% / 1;
-  /* ✦ Theme/Secondary/Teal/4/UI Core/Dark */
-  --figma___secondary-teal-5: 180 100% 35% / 1;
-  /* ✦ Theme/Secondary/Teal/5/UI Core/Dark */
-  --figma___secondary-teal-6: 180 60% 50% / 1;
-  /* ✦ Theme/Secondary/Teal/6/UI Core/Dark */
-  --figma___secondary-teal-7: 180 66% 64% / 1;
-  /* ✦ Theme/Secondary/Teal/7/UI Core/Dark */
-  --figma___secondary-teal-8: 180 77% 77% / 1;
-  /* ✦ Theme/Secondary/Teal/8/UI Core/Dark */
-  --figma___secondary-teal-9: 180 85% 89% / 1;
-  /* ✦ Theme/Secondary/Teal/9/UI Core/Dark */
-  --figma___secondary-teal-10: 180 85% 95% / 1;
-  /* ✦ Theme/Secondary/Teal/10/UI Core/Dark */
-  --figma___secondary-teal-alpha-1: 180 100% 15% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/1/UI Core/Dark */
-  --figma___secondary-teal-alpha-2: 180 100% 20% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/2/UI Core/Dark */
-  --figma___secondary-teal-alpha-3: 180 100% 25% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/3/UI Core/Dark */
-  --figma___secondary-teal-alpha-4: 180 100% 30% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/4/UI Core/Dark */
-  --figma___secondary-teal-alpha-5: 180 100% 35% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/5/UI Core/Dark */
-  --figma___secondary-teal-alpha-6: 180 60% 50% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/6/UI Core/Dark */
-  --figma___secondary-teal-alpha-7: 180 66% 64% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/7/UI Core/Dark */
-  --figma___secondary-teal-alpha-8: 180 77% 77% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/8/UI Core/Dark */
-  --figma___secondary-teal-alpha-9: 180 85% 89% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/9/UI Core/Dark */
-  --figma___secondary-teal-alpha-10: 180 85% 95% / 1;
-  /* ✦ Theme/Secondary/Teal Alpha/10/UI Core/Dark */
-  --figma___shadow-shadow-button-1: 0 0% 0% / 0.5;
-  /* ✦ Theme/Shadow/Shadow - button/1/UI Core/Dark */
-  --figma___shadow-shadow-button-2: 0 0% 100% / 0.31;
-  /* ✦ Theme/Shadow/Shadow - button/2/UI Core/Dark */
-  --figma___shadow-shadow-button-3: 0 0% 100% / 0.31;
-  /* ✦ Theme/Shadow/Shadow - button/3/UI Core/Dark */
-  --figma___shadow-shadow-button-4: 0 0% 0% / 0.11;
-  /* ✦ Theme/Shadow/Shadow - button/4/UI Core/Dark */
-  --figma___shadow-shadow-1-1: 0 0% 0% / 0.13;
-  /* ✦ Theme/Shadow/Shadow 1/1/UI Core/Dark */
-  --figma___shadow-shadow-2-1: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 2/1/UI Core/Dark */
-  --figma___shadow-shadow-2-2: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 2/2/UI Core/Dark */
-  --figma___shadow-shadow-2-3: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 2/3/UI Core/Dark */
-  --figma___shadow-shadow-3-1: 0 0% 0% / 0.45;
-  /* ✦ Theme/Shadow/Shadow 3/1/UI Core/Dark */
-  --figma___shadow-shadow-3-2: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow 3/2/UI Core/Dark */
-  --figma___shadow-shadow-3-3: 0 0% 0% / 0.11;
-  /* ✦ Theme/Shadow/Shadow 3/3/UI Core/Dark */
-  --figma___shadow-shadow-4-1: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow 4/1/UI Core/Dark */
-  --figma___shadow-shadow-4-2: 0 0% 0% / 0.17;
-  /* ✦ Theme/Shadow/Shadow 4/2/UI Core/Dark */
-  --figma___shadow-shadow-5-1: 0 0% 0% / 0.5;
-  /* ✦ Theme/Shadow/Shadow 5/1/UI Core/Dark */
-  --figma___shadow-shadow-5-2: 0 0% 0% / 0.27;
-  /* ✦ Theme/Shadow/Shadow 5/2/UI Core/Dark */
-  --figma___shadow-shadow-6-1: 0 0% 0% / 0.88;
-  /* ✦ Theme/Shadow/Shadow 6/1/UI Core/Dark */
-  --figma___shadow-shadow-6-2: 0 0% 0% / 0.61;
-  /* ✦ Theme/Shadow/Shadow 6/2/UI Core/Dark */
-  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
-  /* ✦ Theme/Shadow/Shadow-button-active/1/UI Core/Dark */
-  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
-  /* ✦ Theme/Shadow/Shadow-button-active/2/UI Core/Dark */
-  --figma___shadow-shadow-button-active-3: 0 0% 100% / 0.27;
-  /* ✦ Theme/Shadow/Shadow-button-active/3/UI Core/Dark */
-  --figma___shadow-shadow-button-active-4: 0 0% 100% / 0.11;
-  /* ✦ Theme/Shadow/Shadow-button-active/4/UI Core/Dark */
-  --figma___side-nav-container-nav-background: 212 72% 10% / 1;
-  /* ✦ Theme/Side nav/Container/Nav-background/UI Core/Dark */
-  --figma___side-nav-container-nav-border: 220 6% 90% / 0;
-  /* ✦ Theme/Side nav/Container/Nav-border/UI Core/Dark */
-  --figma___side-nav-module-logo-text: 0 0% 100% / 1;
-  /* ✦ Theme/Side nav/Module Logo Text/UI Core/Dark */
-  --figma___side-nav-nav-item-default-icon: 0 0% 29% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Default/Icon/UI Core/Dark */
-  --figma___side-nav-nav-item-default-text: 0 0% 23% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Default/Text/UI Core/Dark */
-  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
-  /* ✦ Theme/Side nav/Nav-item/Default/default/UI Core/Dark */
-  --figma___side-nav-nav-item-hover-background: 195 100% 97% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Background/UI Core/Dark */
-  --figma___side-nav-nav-item-hover-icon: 0 0% 29% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/UI Core/Dark */
-  --figma___side-nav-nav-item-hover-text: 0 0% 23% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Hover/Text/UI Core/Dark */
-  --figma___side-nav-nav-item-selected-background: 215 46% 20% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Background/UI Core/Dark */
-  --figma___side-nav-nav-item-selected-icon: 213 67% 21% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/UI Core/Dark */
-  --figma___side-nav-nav-item-selected-text: 213 67% 21% / 1;
-  /* ✦ Theme/Side nav/Nav-item/Selected/Text/UI Core/Dark */
-  --figma___side-nav-profile-role: 0 0% 35% / 1;
-  /* ✦ Theme/Side nav/Profile/Role/UI Core/Dark */
-  --figma___side-nav-profile-text: 0 0% 29% / 1;
-  /* ✦ Theme/Side nav/Profile/Text/UI Core/Dark */
-  --figma___side-nav-scope-selector-default-border: 0 0% 42% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Border/UI Core/Dark */
-  --figma___side-nav-scope-selector-default-main-text-icon: 0 0% 0% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/UI Core/Dark */
-  --figma___side-nav-scope-selector-default-scope-name: 0 0% 29% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/UI Core/Dark */
-  --figma___side-nav-scope-selector-default-default: 0 0% 0% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Default/default/UI Core/Dark */
-  --figma___side-nav-scope-selector-hover-border: 206 100% 50% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/UI Core/Dark */
-  --figma___side-nav-scope-selector-hover-main-text-icon: 0 0% 0% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/UI Core/Dark */
-  --figma___side-nav-scope-selector-hover-scope-name: 0 0% 29% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/UI Core/Dark */
-  --figma___side-nav-scope-selector-hover-default: 0 0% 0% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Hover/default/UI Core/Dark */
-  --figma___side-nav-scope-selector-selected-border: 206 100% 50% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/UI Core/Dark */
-  --figma___side-nav-scope-selector-selected-main-text-icon: 0 0% 0% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/UI Core/Dark */
-  --figma___side-nav-scope-selector-selected-scope-name: 0 0% 29% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/UI Core/Dark */
-  --figma___side-nav-scope-selector-selected-background: 0 0% 0% / 1;
-  /* ✦ Theme/Side nav/Scope Selector/Selected/background/UI Core/Dark */
-  --figma___side-nav-separator: 0 0% 54% / 1;
-  /* ✦ Theme/Side nav/Separator/UI Core/Dark */
-  --figma___status-colors-error-1: 0 67% 12% / 1;
-  /* ✦ Theme/Status colors/Error/1/UI Core/Dark */
-  --figma___status-colors-error-2: 0 67% 18% / 1;
-  /* ✦ Theme/Status colors/Error/2/UI Core/Dark */
-  --figma___status-colors-error-3: 0 67% 24% / 1;
-  /* ✦ Theme/Status colors/Error/3/UI Core/Dark */
-  --figma___status-colors-error-4: 0 68% 30% / 1;
-  /* ✦ Theme/Status colors/Error/4/UI Core/Dark */
-  --figma___status-colors-error-5: 0 68% 36% / 1;
-  /* ✦ Theme/Status colors/Error/5/UI Core/Dark */
-  --figma___status-colors-error-6: 0 68% 42% / 1;
-  /* ✦ Theme/Status colors/Error/6/UI Core/Dark */
-  --figma___status-colors-error-7: 0 67% 48% / 1;
-  /* ✦ Theme/Status colors/Error/7/UI Core/Dark */
-  --figma___status-colors-error-8: 0 78% 55% / 1;
-  /* ✦ Theme/Status colors/Error/8/UI Core/Dark */
-  --figma___status-colors-error-9: 0 100% 62% / 1;
-  /* ✦ Theme/Status colors/Error/9/UI Core/Dark */
-  --figma___status-colors-error-10: 0 100% 70% / 1;
-  /* ✦ Theme/Status colors/Error/10/UI Core/Dark */
-  --figma___status-colors-error-alpha-1: 0 67% 12% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/1/UI Core/Dark */
-  --figma___status-colors-error-alpha-2: 0 67% 18% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/2/UI Core/Dark */
-  --figma___status-colors-error-alpha-3: 0 67% 24% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/3/UI Core/Dark */
-  --figma___status-colors-error-alpha-4: 0 68% 30% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/4/UI Core/Dark */
-  --figma___status-colors-error-alpha-5: 0 68% 36% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/5/UI Core/Dark */
-  --figma___status-colors-error-alpha-6: 0 68% 42% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/6/UI Core/Dark */
-  --figma___status-colors-error-alpha-7: 0 67% 48% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/7/UI Core/Dark */
-  --figma___status-colors-error-alpha-8: 0 78% 55% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/8/UI Core/Dark */
-  --figma___status-colors-error-alpha-9: 0 100% 62% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/9/UI Core/Dark */
-  --figma___status-colors-error-alpha-10: 0 100% 70% / 1;
-  /* ✦ Theme/Status colors/Error Alpha/10/UI Core/Dark */
-  --figma___status-colors-info-1: 241 53% 23% / 1;
-  /* ✦ Theme/Status colors/Info/1/UI Core/Dark */
-  --figma___status-colors-info-2: 241 52% 28% / 1;
-  /* ✦ Theme/Status colors/Info/2/UI Core/Dark */
-  --figma___status-colors-info-3: 241 51% 33% / 1;
-  /* ✦ Theme/Status colors/Info/3/UI Core/Dark */
-  --figma___status-colors-info-4: 241 49% 39% / 1;
-  /* ✦ Theme/Status colors/Info/4/UI Core/Dark */
-  --figma___status-colors-info-5: 241 48% 44% / 1;
-  /* ✦ Theme/Status colors/Info/5/UI Core/Dark */
-  --figma___status-colors-info-6: 239 48% 52% / 1;
-  /* ✦ Theme/Status colors/Info/6/UI Core/Dark */
-  --figma___status-colors-info-7: 240 59% 59% / 1;
-  /* ✦ Theme/Status colors/Info/7/UI Core/Dark */
-  --figma___status-colors-info-8: 240 74% 67% / 1;
-  /* ✦ Theme/Status colors/Info/8/UI Core/Dark */
-  --figma___status-colors-info-9: 240 100% 77% / 1;
-  /* ✦ Theme/Status colors/Info/9/UI Core/Dark */
-  --figma___status-colors-info-10: 240 100% 83% / 1;
-  /* ✦ Theme/Status colors/Info/10/UI Core/Dark */
-  --figma___status-colors-info-alpha-1: 241 53% 23% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/1/UI Core/Dark */
-  --figma___status-colors-info-alpha-2: 241 52% 28% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/2/UI Core/Dark */
-  --figma___status-colors-info-alpha-3: 241 51% 33% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/3/UI Core/Dark */
-  --figma___status-colors-info-alpha-4: 241 49% 39% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/4/UI Core/Dark */
-  --figma___status-colors-info-alpha-5: 241 48% 44% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/5/UI Core/Dark */
-  --figma___status-colors-info-alpha-6: 239 48% 52% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/6/UI Core/Dark */
-  --figma___status-colors-info-alpha-7: 240 59% 59% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/7/UI Core/Dark */
-  --figma___status-colors-info-alpha-8: 240 74% 67% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/8/UI Core/Dark */
-  --figma___status-colors-info-alpha-9: 240 100% 77% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/9/UI Core/Dark */
-  --figma___status-colors-info-alpha-10: 240 100% 83% / 1;
-  /* ✦ Theme/Status colors/Info Alpha/10/UI Core/Dark */
-  --figma___status-colors-success-1: 122 64% 11% / 1;
-  /* ✦ Theme/Status colors/Success/1/UI Core/Dark */
-  --figma___status-colors-success-2: 127 73% 15% / 1;
-  /* ✦ Theme/Status colors/Success/2/UI Core/Dark */
-  --figma___status-colors-success-3: 123 67% 24% / 1;
-  /* ✦ Theme/Status colors/Success/3/UI Core/Dark */
-  --figma___status-colors-success-4: 122 55% 32% / 1;
-  /* ✦ Theme/Status colors/Success/4/UI Core/Dark */
-  --figma___status-colors-success-5: 122 50% 36% / 1;
-  /* ✦ Theme/Status colors/Success/5/UI Core/Dark */
-  --figma___status-colors-success-6: 124 36% 52% / 1;
-  /* ✦ Theme/Status colors/Success/6/UI Core/Dark */
-  --figma___status-colors-success-7: 121 42% 62% / 1;
-  /* ✦ Theme/Status colors/Success/7/UI Core/Dark */
-  --figma___status-colors-success-8: 118 49% 70% / 1;
-  /* ✦ Theme/Status colors/Success/8/UI Core/Dark */
-  --figma___status-colors-success-9: 117 62% 79% / 1;
-  /* ✦ Theme/Status colors/Success/9/UI Core/Dark */
-  --figma___status-colors-success-10: 119 66% 85% / 1;
-  /* ✦ Theme/Status colors/Success/10/UI Core/Dark */
-  --figma___status-colors-success-alpha-1: 120 100% 44% / 0;
-  /* ✦ Theme/Status colors/Success Alpha/1/UI Core/Dark */
-  --figma___status-colors-success-alpha-2: 120 100% 49% / 0.02;
-  /* ✦ Theme/Status colors/Success Alpha/2/UI Core/Dark */
-  --figma___status-colors-success-alpha-3: 149 100% 49% / 0.07;
-  /* ✦ Theme/Status colors/Success Alpha/3/UI Core/Dark */
-  --figma___status-colors-success-alpha-4: 154 100% 50% / 0.11;
-  /* ✦ Theme/Status colors/Success Alpha/4/UI Core/Dark */
-  --figma___status-colors-success-alpha-5: 153 99% 53% / 0.15;
-  /* ✦ Theme/Status colors/Success Alpha/5/UI Core/Dark */
-  --figma___status-colors-success-alpha-6: 155 99% 55% / 0.2;
-  /* ✦ Theme/Status colors/Success Alpha/6/UI Core/Dark */
-  --figma___status-colors-success-alpha-7: 151 100% 63% / 0.5;
-  /* ✦ Theme/Status colors/Success Alpha/7/UI Core/Dark */
-  --figma___status-colors-success-alpha-8: 151 100% 62% / 0.61;
-  /* ✦ Theme/Status colors/Success Alpha/8/UI Core/Dark */
-  --figma___status-colors-success-alpha-9: 151 100% 64% / 0.82;
-  /* ✦ Theme/Status colors/Success Alpha/9/UI Core/Dark */
-  --figma___status-colors-success-alpha-10: 144 100% 87% / 0.94;
-  /* ✦ Theme/Status colors/Success Alpha/10/UI Core/Dark */
-  --figma___status-colors-warning-1: 32 67% 12% / 1;
-  /* ✦ Theme/Status colors/Warning/1/UI Core/Dark */
-  --figma___status-colors-warning-2: 30 69% 18% / 1;
-  /* ✦ Theme/Status colors/Warning/2/UI Core/Dark */
-  --figma___status-colors-warning-3: 27 69% 24% / 1;
-  /* ✦ Theme/Status colors/Warning/3/UI Core/Dark */
-  --figma___status-colors-warning-4: 26 68% 30% / 1;
-  /* ✦ Theme/Status colors/Warning/4/UI Core/Dark */
-  --figma___status-colors-warning-5: 17 68% 36% / 1;
-  /* ✦ Theme/Status colors/Warning/5/UI Core/Dark */
-  --figma___status-colors-warning-6: 18 68% 42% / 1;
-  /* ✦ Theme/Status colors/Warning/6/UI Core/Dark */
-  --figma___status-colors-warning-7: 19 67% 48% / 1;
-  /* ✦ Theme/Status colors/Warning/7/UI Core/Dark */
-  --figma___status-colors-warning-8: 19 79% 54% / 1;
-  /* ✦ Theme/Status colors/Warning/8/UI Core/Dark */
-  --figma___status-colors-warning-9: 19 100% 60% / 1;
-  /* ✦ Theme/Status colors/Warning/9/UI Core/Dark */
-  --figma___status-colors-warning-10: 19 100% 64% / 1;
-  /* ✦ Theme/Status colors/Warning/10/UI Core/Dark */
-  --figma___status-colors-warning-alpha-1: 32 67% 12% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/1/UI Core/Dark */
-  --figma___status-colors-warning-alpha-2: 30 69% 18% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/2/UI Core/Dark */
-  --figma___status-colors-warning-alpha-3: 27 69% 24% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/3/UI Core/Dark */
-  --figma___status-colors-warning-alpha-4: 26 68% 30% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/4/UI Core/Dark */
-  --figma___status-colors-warning-alpha-5: 17 68% 36% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/5/UI Core/Dark */
-  --figma___status-colors-warning-alpha-6: 18 68% 42% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/6/UI Core/Dark */
-  --figma___status-colors-warning-alpha-7: 19 67% 48% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/7/UI Core/Dark */
-  --figma___status-colors-warning-alpha-8: 19 79% 54% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/8/UI Core/Dark */
-  --figma___status-colors-warning-alpha-9: 19 100% 60% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/9/UI Core/Dark */
-  --figma___status-colors-warning-alpha-10: 19 100% 64% / 1;
-  /* ✦ Theme/Status colors/Warning Alpha/10/UI Core/Dark */
-  --figma___switch-background: 236 19% 14% / 0.5;
-  /* ✦ Theme/Switch/Background/UI Core/Dark */
-  --figma___switch-checked-active-thumb-thumb-background: 0 0% 0% / 1;
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/UI Core/Dark */
-  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/UI Core/Dark */
-  --figma___switch-checked-active-background: 206 100% 50% / 1;
-  /* ✦ Theme/Switch/Checked/Active/background/UI Core/Dark */
-  --figma___switch-checked-active-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Checked/Active/border/UI Core/Dark */
-  --figma___switch-checked-default-thumb-thumb-background: 0 0% 0% / 1;
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/UI Core/Dark */
-  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/UI Core/Dark */
-  --figma___switch-checked-default-default-background: 206 100% 50% / 1;
-  /* ✦ Theme/Switch/Checked/Default/default background/UI Core/Dark */
-  --figma___switch-checked-default-default-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Checked/Default/default border/UI Core/Dark */
-  --figma___switch-checked-disabled-thumb-thumb-background: 0 0% 0% / 1;
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/UI Core/Dark */
-  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/UI Core/Dark */
-  --figma___switch-checked-disabled-background: 206 98% 42% / 0.5;
-  /* ✦ Theme/Switch/Checked/Disabled/background/UI Core/Dark */
-  --figma___switch-checked-disabled-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Checked/Disabled/border/UI Core/Dark */
-  --figma___switch-checked-hover-thumb-thumb-background: 0 0% 0% / 1;
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/UI Core/Dark */
-  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/UI Core/Dark */
-  --figma___switch-checked-hover-background: 206 100% 62% / 1;
-  /* ✦ Theme/Switch/Checked/Hover/background/UI Core/Dark */
-  --figma___switch-checked-hover-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Checked/Hover/border/UI Core/Dark */
-  --figma___switch-paper: 0 0% 100% / 0.03;
-  /* ✦ Theme/Switch/Paper/UI Core/Dark */
-  --figma___switch-unchecked-active-thumb-thumb-background: 0 0% 0% / 1;
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/UI Core/Dark */
-  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/UI Core/Dark */
-  --figma___switch-unchecked-active-background: 0 0% 16% / 1;
-  /* ✦ Theme/Switch/Unchecked/Active/background/UI Core/Dark */
-  --figma___switch-unchecked-active-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Unchecked/Active/border/UI Core/Dark */
-  --figma___switch-unchecked-default-thumb-thumb-background: 0 0% 0% / 1;
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/UI Core/Dark */
-  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/UI Core/Dark */
-  --figma___switch-unchecked-default-default-background: 0 0% 16% / 1;
-  /* ✦ Theme/Switch/Unchecked/Default/default background/UI Core/Dark */
-  --figma___switch-unchecked-default-default-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Unchecked/Default/default border/UI Core/Dark */
-  --figma___switch-unchecked-disabled-thumb-thumb-background: 0 0% 0% / 1;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/UI Core/Dark */
-  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/UI Core/Dark */
-  --figma___switch-unchecked-disabled-background: 0 0% 11% / 1;
-  /* ✦ Theme/Switch/Unchecked/Disabled/background/UI Core/Dark */
-  --figma___switch-unchecked-disabled-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Unchecked/Disabled/border/UI Core/Dark */
-  --figma___switch-unchecked-hover-thumb-thumb-background: 0 0% 0% / 1;
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/UI Core/Dark */
-  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
-  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/UI Core/Dark */
-  --figma___switch-unchecked-hover-background: 0 0% 23% / 1;
-  /* ✦ Theme/Switch/Unchecked/Hover/background/UI Core/Dark */
-  --figma___switch-unchecked-hover-border: 0 0% 0% / 0;
-  /* ✦ Theme/Switch/Unchecked/Hover/border/UI Core/Dark */
-  --figma___switch-border: 0 0% 16% / 1;
-  /* ✦ Theme/Switch/border/UI Core/Dark */
-  --figma___tabs-number-active-background: 206 100% 50% / 1;
-  /* ✦ Theme/Tabs/Number/Active/Background/UI Core/Dark */
-  --figma___tabs-number-active-text: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Number/Active/text/UI Core/Dark */
-  --figma___tabs-number-default-hover-background: 0 0% 11% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/Background/UI Core/Dark */
-  --figma___tabs-number-default-hover-text: 0 0% 35% / 1;
-  /* ✦ Theme/Tabs/Number/Default & Hover/text/UI Core/Dark */
-  --figma___tabs-pills-active-active: 215 46% 20% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Active/UI Core/Dark */
-  --figma___tabs-pills-active-text: 206 100% 62% / 1;
-  /* ✦ Theme/Tabs/Pills/Active/Text/UI Core/Dark */
-  --figma___tabs-pills-active-border-grad-1: 0 0% 100% / 0;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 1/UI Core/Dark */
-  --figma___tabs-pills-active-border-grad-2: 0 0% 100% / 0;
-  /* ✦ Theme/Tabs/Pills/Active/border grad 2/UI Core/Dark */
-  --figma___tabs-pills-backgrounds: 0 0% 16% / 1;
-  /* ✦ Theme/Tabs/Pills/Backgrounds/UI Core/Dark */
-  --figma___tabs-pills-default-background: 0 0% 0% / 1;
-  /* ✦ Theme/Tabs/Pills/Default/Background/UI Core/Dark */
-  --figma___tabs-pills-default-text: 0 0% 54% / 1;
-  /* ✦ Theme/Tabs/Pills/Default/Text/UI Core/Dark */
-  --figma___tabs-pills-hover-background: 215 46% 20% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Background/UI Core/Dark */
-  --figma___tabs-pills-hover-text: 0 0% 54% / 1;
-  /* ✦ Theme/Tabs/Pills/Hover/Text/UI Core/Dark */
-  --figma___tabs-pills-number-active-background: 206 100% 50% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/Background/UI Core/Dark */
-  --figma___tabs-pills-number-active-text: 0 0% 100% / 1;
-  /* ✦ Theme/Tabs/Pills/Number/Active/text/UI Core/Dark */
-  --figma___tabs-pills-border-grad-1: 0 0% 16% / 1;
-  /* ✦ Theme/Tabs/Pills/border grad 1/UI Core/Dark */
-  --figma___tabs-pills-border-grad-2: 0 0% 16% / 1;
-  /* ✦ Theme/Tabs/Pills/border grad 2/UI Core/Dark */
-  --figma___tabs-primary-active-text: 0 0% 82% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Text/UI Core/Dark */
-  --figma___tabs-primary-active-underline: 206 100% 50% / 1;
-  /* ✦ Theme/Tabs/Primary/Active/Underline/UI Core/Dark */
-  --figma___tabs-primary-border: 206 100% 50% / 1;
-  /* ✦ Theme/Tabs/Primary/Border/UI Core/Dark */
-  --figma___tabs-primary-default-background: 0 0% 0% / 1;
-  /* ✦ Theme/Tabs/Primary/Default/Background/UI Core/Dark */
-  --figma___tabs-primary-default-text: 0 0% 54% / 1;
-  /* ✦ Theme/Tabs/Primary/Default/Text/UI Core/Dark */
-  --figma___tabs-primary-hover-background: 0 0% 100% / 0;
-  /* ✦ Theme/Tabs/Primary/Hover/Background/UI Core/Dark */
-  --figma___tabs-primary-hover-text: 206 100% 50% / 1;
-  /* ✦ Theme/Tabs/Primary/Hover/Text/UI Core/Dark */
-  --figma___tabs-primary-pills-pills: 205 100% 71% / 1;
-  /* ✦ Theme/Tabs/Primary/Pills/Pills/UI Core/Dark */
-  --figma___text-disabled: 0 0% 23% / 1;
-  /* ✦ Theme/Text/Disabled/UI Core/Dark */
-  --figma___text-links: 206 100% 50% / 1;
-  /* ✦ Theme/Text/Links/UI Core/Dark */
-  --figma___text-secondary: 0 0% 54% / 1;
-  /* ✦ Theme/Text/Secondary/UI Core/Dark */
-  --figma___text-tertiary: 0 0% 35% / 1;
-  /* ✦ Theme/Text/Tertiary/UI Core/Dark */
-  --figma___text-primary: 0 0% 82% / 1;
-  /* ✦ Theme/Text/primary/UI Core/Dark */
-  --figma___textfield-assistive-text-primary: 0 0% 35% / 1;
-  /* ✦ Theme/Textfield/Assistive Text/Primary/UI Core/Dark */
-  --figma___textfield-background: 0 0% 0% / 0.5;
-  /* ✦ Theme/Textfield/Background/UI Core/Dark */
-  --figma___textfield-input-field-background: 0 0% 0% / 1;
-  /* ✦ Theme/Textfield/Input Field/Background/UI Core/Dark */
-  --figma___textfield-input-field-default: 0 0% 16% / 1;
-  /* ✦ Theme/Textfield/Input Field/Default/UI Core/Dark */
-  --figma___textfield-input-field-error: 0 67% 48% / 1;
-  /* ✦ Theme/Textfield/Input Field/Error/UI Core/Dark */
-  --figma___textfield-input-field-hover: 206 100% 50% / 1;
-  /* ✦ Theme/Textfield/Input Field/Hover/UI Core/Dark */
-  --figma___textfield-label-info-icon: 206 100% 50% / 1;
-  /* ✦ Theme/Textfield/Label/Info Icon/UI Core/Dark */
-  --figma___textfield-label-link: 206 100% 50% / 1;
-  /* ✦ Theme/Textfield/Label/Link/UI Core/Dark */
-  --figma___textfield-label-main: 0 0% 54% / 1;
-  /* ✦ Theme/Textfield/Label/Main/UI Core/Dark */
-  --figma___textfield-label-optional: 0 0% 35% / 1;
-  /* ✦ Theme/Textfield/Label/Optional/UI Core/Dark */
-  --figma___textfield-pin-soft-background: 0 0% 11% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/Background/UI Core/Dark */
-  --figma___textfield-pin-soft-border: 0 0% 16% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/border/UI Core/Dark */
-  --figma___textfield-pin-soft-pin: 206 100% 50% / 1;
-  /* ✦ Theme/Textfield/Pin/Soft/pin/UI Core/Dark */
-  --figma___textfield-pin-surface-background: 0 0% 11% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/Background/UI Core/Dark */
-  --figma___textfield-pin-surface-border: 0 0% 16% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/border/UI Core/Dark */
-  --figma___textfield-pin-surface-pin: 206 100% 50% / 1;
-  /* ✦ Theme/Textfield/Pin/Surface/pin/UI Core/Dark */
-  --figma___tooltip-background: 195 100% 97% / 1;
-  /* ✦ Theme/Tooltip/Background/UI Core/Dark */
-  --figma___tooltip-body-text: 0 0% 0% / 1;
-  /* ✦ Theme/Tooltip/Body Text/UI Core/Dark */
-  --figma___tooltip-dismissable-icon: 0 0% 42% / 1;
-  /* ✦ Theme/Tooltip/Dismissable icon/UI Core/Dark */
-  --figma___tooltip-tooltip-title: 0 0% 0% / 1;
-  /* ✦ Theme/Tooltip/Tooltip Title/UI Core/Dark */
+  --figma___colors-alerts-status-error-1: 0 67% 12% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/1/UI Core/Dark */
+  --figma___colors-alerts-status-error-2: 0 67% 18% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/2/UI Core/Dark */
+  --figma___colors-alerts-status-error-3: 0 67% 24% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/3/UI Core/Dark */
+  --figma___colors-alerts-status-error-4: 0 68% 30% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/4/UI Core/Dark */
+  --figma___colors-alerts-status-error-5: 0 68% 36% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/5/UI Core/Dark */
+  --figma___colors-alerts-status-error-6: 0 68% 42% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/6/UI Core/Dark */
+  --figma___colors-alerts-status-error-7: 0 67% 48% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/7/UI Core/Dark */
+  --figma___colors-alerts-status-error-8: 0 78% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/8/UI Core/Dark */
+  --figma___colors-alerts-status-error-9: 0 100% 62% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/9/UI Core/Dark */
+  --figma___colors-alerts-status-error-10: 0 100% 70% / 1; /* ✦ Theme/Colors/Alerts & Status/Error/10/UI Core/Dark */
+  --figma___colors-alerts-status-error-alpha-1: 0 67% 12% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/1/UI Core/Dark */
+  --figma___colors-alerts-status-error-alpha-2: 0 67% 18% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/2/UI Core/Dark */
+  --figma___colors-alerts-status-error-alpha-3: 0 67% 24% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/3/UI Core/Dark */
+  --figma___colors-alerts-status-error-alpha-4: 0 68% 30% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/4/UI Core/Dark */
+  --figma___colors-alerts-status-error-alpha-5: 0 68% 36% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/5/UI Core/Dark */
+  --figma___colors-alerts-status-error-alpha-6: 0 68% 42% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/6/UI Core/Dark */
+  --figma___colors-alerts-status-error-alpha-7: 0 67% 48% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/7/UI Core/Dark */
+  --figma___colors-alerts-status-error-alpha-8: 0 78% 55% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/8/UI Core/Dark */
+  --figma___colors-alerts-status-error-alpha-9: 0 100% 62% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/9/UI Core/Dark */
+  --figma___colors-alerts-status-error-alpha-10: 0 100% 70% / 1; /* ✦ Theme/Colors/Alerts & Status/Error Alpha/10/UI Core/Dark */
+  --figma___colors-alerts-status-info-1: 241 53% 23% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/1/UI Core/Dark */
+  --figma___colors-alerts-status-info-2: 241 52% 28% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/2/UI Core/Dark */
+  --figma___colors-alerts-status-info-3: 241 51% 33% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/3/UI Core/Dark */
+  --figma___colors-alerts-status-info-4: 241 49% 39% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/4/UI Core/Dark */
+  --figma___colors-alerts-status-info-5: 241 48% 44% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/5/UI Core/Dark */
+  --figma___colors-alerts-status-info-6: 239 48% 52% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/6/UI Core/Dark */
+  --figma___colors-alerts-status-info-7: 240 59% 59% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/7/UI Core/Dark */
+  --figma___colors-alerts-status-info-8: 240 74% 67% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/8/UI Core/Dark */
+  --figma___colors-alerts-status-info-9: 240 100% 77% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/9/UI Core/Dark */
+  --figma___colors-alerts-status-info-10: 240 100% 83% / 1; /* ✦ Theme/Colors/Alerts & Status/Info/10/UI Core/Dark */
+  --figma___colors-alerts-status-info-alpha-1: 241 53% 23% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/1/UI Core/Dark */
+  --figma___colors-alerts-status-info-alpha-2: 241 52% 28% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/2/UI Core/Dark */
+  --figma___colors-alerts-status-info-alpha-3: 241 51% 33% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/3/UI Core/Dark */
+  --figma___colors-alerts-status-info-alpha-4: 241 49% 39% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/4/UI Core/Dark */
+  --figma___colors-alerts-status-info-alpha-5: 241 48% 44% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/5/UI Core/Dark */
+  --figma___colors-alerts-status-info-alpha-6: 239 48% 52% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/6/UI Core/Dark */
+  --figma___colors-alerts-status-info-alpha-7: 240 59% 59% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/7/UI Core/Dark */
+  --figma___colors-alerts-status-info-alpha-8: 240 74% 67% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/8/UI Core/Dark */
+  --figma___colors-alerts-status-info-alpha-9: 240 100% 77% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/9/UI Core/Dark */
+  --figma___colors-alerts-status-info-alpha-10: 240 100% 83% / 1; /* ✦ Theme/Colors/Alerts & Status/Info Alpha/10/UI Core/Dark */
+  --figma___colors-alerts-status-success-1: 122 64% 11% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/1/UI Core/Dark */
+  --figma___colors-alerts-status-success-2: 127 73% 15% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/2/UI Core/Dark */
+  --figma___colors-alerts-status-success-3: 123 67% 24% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/3/UI Core/Dark */
+  --figma___colors-alerts-status-success-4: 122 55% 32% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/4/UI Core/Dark */
+  --figma___colors-alerts-status-success-5: 122 50% 36% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/5/UI Core/Dark */
+  --figma___colors-alerts-status-success-6: 124 36% 52% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/6/UI Core/Dark */
+  --figma___colors-alerts-status-success-7: 121 42% 62% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/7/UI Core/Dark */
+  --figma___colors-alerts-status-success-8: 118 49% 70% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/8/UI Core/Dark */
+  --figma___colors-alerts-status-success-9: 117 62% 79% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/9/UI Core/Dark */
+  --figma___colors-alerts-status-success-10: 119 66% 85% / 1; /* ✦ Theme/Colors/Alerts & Status/Success/10/UI Core/Dark */
+  --figma___colors-alerts-status-success-alpha-1: 120 100% 44% / 0; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/1/UI Core/Dark */
+  --figma___colors-alerts-status-success-alpha-2: 120 100% 49% / 0.02; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/2/UI Core/Dark */
+  --figma___colors-alerts-status-success-alpha-3: 149 100% 49% / 0.07; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/3/UI Core/Dark */
+  --figma___colors-alerts-status-success-alpha-4: 154 100% 50% / 0.11; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/4/UI Core/Dark */
+  --figma___colors-alerts-status-success-alpha-5: 153 99% 53% / 0.15; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/5/UI Core/Dark */
+  --figma___colors-alerts-status-success-alpha-6: 155 99% 55% / 0.2; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/6/UI Core/Dark */
+  --figma___colors-alerts-status-success-alpha-7: 151 100% 63% / 0.5; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/7/UI Core/Dark */
+  --figma___colors-alerts-status-success-alpha-8: 151 100% 62% / 0.61; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/8/UI Core/Dark */
+  --figma___colors-alerts-status-success-alpha-9: 151 100% 64% / 0.82; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/9/UI Core/Dark */
+  --figma___colors-alerts-status-success-alpha-10: 144 100% 87% / 0.94; /* ✦ Theme/Colors/Alerts & Status/Success Alpha/10/UI Core/Dark */
+  --figma___colors-alerts-status-warning-1: 32 67% 12% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/1/UI Core/Dark */
+  --figma___colors-alerts-status-warning-2: 30 69% 18% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/2/UI Core/Dark */
+  --figma___colors-alerts-status-warning-3: 27 69% 24% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/3/UI Core/Dark */
+  --figma___colors-alerts-status-warning-4: 26 68% 30% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/4/UI Core/Dark */
+  --figma___colors-alerts-status-warning-5: 17 68% 36% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/5/UI Core/Dark */
+  --figma___colors-alerts-status-warning-6: 18 68% 42% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/6/UI Core/Dark */
+  --figma___colors-alerts-status-warning-7: 19 67% 48% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/7/UI Core/Dark */
+  --figma___colors-alerts-status-warning-8: 19 79% 54% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/8/UI Core/Dark */
+  --figma___colors-alerts-status-warning-9: 19 100% 60% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/9/UI Core/Dark */
+  --figma___colors-alerts-status-warning-10: 19 100% 64% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning/10/UI Core/Dark */
+  --figma___colors-alerts-status-warning-alpha-1: 32 67% 12% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/1/UI Core/Dark */
+  --figma___colors-alerts-status-warning-alpha-2: 30 69% 18% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/2/UI Core/Dark */
+  --figma___colors-alerts-status-warning-alpha-3: 27 69% 24% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/3/UI Core/Dark */
+  --figma___colors-alerts-status-warning-alpha-4: 26 68% 30% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/4/UI Core/Dark */
+  --figma___colors-alerts-status-warning-alpha-5: 17 68% 36% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/5/UI Core/Dark */
+  --figma___colors-alerts-status-warning-alpha-6: 18 68% 42% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/6/UI Core/Dark */
+  --figma___colors-alerts-status-warning-alpha-7: 19 67% 48% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/7/UI Core/Dark */
+  --figma___colors-alerts-status-warning-alpha-8: 19 79% 54% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/8/UI Core/Dark */
+  --figma___colors-alerts-status-warning-alpha-9: 19 100% 60% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/9/UI Core/Dark */
+  --figma___colors-alerts-status-warning-alpha-10: 19 100% 64% / 1; /* ✦ Theme/Colors/Alerts & Status/Warning Alpha/10/UI Core/Dark */
+  --figma___colors-charts-ai-violet-1: 256 82% 30% / 1; /* ✦ Theme/Colors/Charts/AI Violet/1/UI Core/Dark */
+  --figma___colors-charts-ai-violet-2: 254 74% 37% / 1; /* ✦ Theme/Colors/Charts/AI Violet/2/UI Core/Dark */
+  --figma___colors-charts-ai-violet-3: 254 68% 42% / 1; /* ✦ Theme/Colors/Charts/AI Violet/3/UI Core/Dark */
+  --figma___colors-charts-ai-violet-4: 254 64% 48% / 1; /* ✦ Theme/Colors/Charts/AI Violet/4/UI Core/Dark */
+  --figma___colors-charts-ai-violet-5: 252 70% 59% / 1; /* ✦ Theme/Colors/Charts/AI Violet/5/UI Core/Dark */
+  --figma___colors-charts-ai-violet-6: 251 73% 64% / 1; /* ✦ Theme/Colors/Charts/AI Violet/6/UI Core/Dark */
+  --figma___colors-charts-ai-violet-7: 252 76% 69% / 1; /* ✦ Theme/Colors/Charts/AI Violet/7/UI Core/Dark */
+  --figma___colors-charts-ai-violet-8: 251 80% 74% / 1; /* ✦ Theme/Colors/Charts/AI Violet/8/UI Core/Dark */
+  --figma___colors-charts-ai-violet-9: 252 85% 79% / 1; /* ✦ Theme/Colors/Charts/AI Violet/9/UI Core/Dark */
+  --figma___colors-charts-ai-violet-10: 253 100% 84% / 1; /* ✦ Theme/Colors/Charts/AI Violet/10/UI Core/Dark */
+  --figma___colors-charts-ai-violet-alpha-1: 256 82% 30% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/1/UI Core/Dark */
+  --figma___colors-charts-ai-violet-alpha-2: 254 74% 37% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/2/UI Core/Dark */
+  --figma___colors-charts-ai-violet-alpha-3: 254 68% 42% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/3/UI Core/Dark */
+  --figma___colors-charts-ai-violet-alpha-4: 254 64% 48% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/4/UI Core/Dark */
+  --figma___colors-charts-ai-violet-alpha-5: 252 70% 59% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/5/UI Core/Dark */
+  --figma___colors-charts-ai-violet-alpha-6: 251 73% 64% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/6/UI Core/Dark */
+  --figma___colors-charts-ai-violet-alpha-7: 252 76% 69% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/7/UI Core/Dark */
+  --figma___colors-charts-ai-violet-alpha-8: 251 80% 74% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/8/UI Core/Dark */
+  --figma___colors-charts-ai-violet-alpha-9: 252 85% 79% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/9/UI Core/Dark */
+  --figma___colors-charts-ai-violet-alpha-10: 253 100% 84% / 1; /* ✦ Theme/Colors/Charts/AI Violet Alpha/10/UI Core/Dark */
+  --figma___colors-charts-blue-1: 241 53% 23% / 1; /* ✦ Theme/Colors/Charts/Blue/1/UI Core/Dark */
+  --figma___colors-charts-blue-2: 241 52% 28% / 1; /* ✦ Theme/Colors/Charts/Blue/2/UI Core/Dark */
+  --figma___colors-charts-blue-3: 241 51% 33% / 1; /* ✦ Theme/Colors/Charts/Blue/3/UI Core/Dark */
+  --figma___colors-charts-blue-4: 241 49% 39% / 1; /* ✦ Theme/Colors/Charts/Blue/4/UI Core/Dark */
+  --figma___colors-charts-blue-5: 241 48% 44% / 1; /* ✦ Theme/Colors/Charts/Blue/5/UI Core/Dark */
+  --figma___colors-charts-blue-6: 239 48% 52% / 1; /* ✦ Theme/Colors/Charts/Blue/6/UI Core/Dark */
+  --figma___colors-charts-blue-7: 240 59% 59% / 1; /* ✦ Theme/Colors/Charts/Blue/7/UI Core/Dark */
+  --figma___colors-charts-blue-8: 240 74% 67% / 1; /* ✦ Theme/Colors/Charts/Blue/8/UI Core/Dark */
+  --figma___colors-charts-blue-9: 240 100% 77% / 1; /* ✦ Theme/Colors/Charts/Blue/9/UI Core/Dark */
+  --figma___colors-charts-blue-10: 240 100% 83% / 1; /* ✦ Theme/Colors/Charts/Blue/10/UI Core/Dark */
+  --figma___colors-charts-blue-alpha-1: 215 46% 20% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/1/UI Core/Dark */
+  --figma___colors-charts-blue-alpha-2: 216 50% 12% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/2/UI Core/Dark */
+  --figma___colors-charts-blue-alpha-3: 214 58% 16% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/3/UI Core/Dark */
+  --figma___colors-charts-blue-alpha-4: 213 67% 21% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/4/UI Core/Dark */
+  --figma___colors-charts-blue-alpha-5: 194 100% 45% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/5/UI Core/Dark */
+  --figma___colors-charts-blue-alpha-6: 212 72% 25% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/6/UI Core/Dark */
+  --figma___colors-charts-blue-alpha-7: 206 100% 50% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/7/UI Core/Dark */
+  --figma___colors-charts-blue-alpha-8: 206 100% 62% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/8/UI Core/Dark */
+  --figma___colors-charts-blue-alpha-9: 205 100% 71% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/9/UI Core/Dark */
+  --figma___colors-charts-blue-alpha-10: 212 72% 10% / 1; /* ✦ Theme/Colors/Charts/Blue Alpha/10/UI Core/Dark */
+  --figma___colors-charts-indigo-1: 226 25% 10% / 1; /* ✦ Theme/Colors/Charts/Indigo/1/UI Core/Dark */
+  --figma___colors-charts-indigo-2: 230 36% 13% / 1; /* ✦ Theme/Colors/Charts/Indigo/2/UI Core/Dark */
+  --figma___colors-charts-indigo-3: 228 43% 18% / 1; /* ✦ Theme/Colors/Charts/Indigo/3/UI Core/Dark */
+  --figma___colors-charts-indigo-4: 228 45% 21% / 1; /* ✦ Theme/Colors/Charts/Indigo/4/UI Core/Dark */
+  --figma___colors-charts-indigo-5: 227 48% 24% / 1; /* ✦ Theme/Colors/Charts/Indigo/5/UI Core/Dark */
+  --figma___colors-charts-indigo-6: 225 51% 29% / 1; /* ✦ Theme/Colors/Charts/Indigo/6/UI Core/Dark */
+  --figma___colors-charts-indigo-7: 226 70% 55% / 1; /* ✦ Theme/Colors/Charts/Indigo/7/UI Core/Dark */
+  --figma___colors-charts-indigo-8: 230 74% 63% / 1; /* ✦ Theme/Colors/Charts/Indigo/8/UI Core/Dark */
+  --figma___colors-charts-indigo-9: 235 100% 80% / 1; /* ✦ Theme/Colors/Charts/Indigo/9/UI Core/Dark */
+  --figma___colors-charts-indigo-10: 236 94% 93% / 1; /* ✦ Theme/Colors/Charts/Indigo/10/UI Core/Dark */
+  --figma___colors-charts-indigo-alpha-1: 240 100% 49% / 0.04; /* ✦ Theme/Colors/Charts/Indigo Alpha/1/UI Core/Dark */
+  --figma___colors-charts-indigo-alpha-2: 232 100% 50% / 0.09; /* ✦ Theme/Colors/Charts/Indigo Alpha/2/UI Core/Dark */
+  --figma___colors-charts-indigo-alpha-3: 228 100% 57% / 0.18; /* ✦ Theme/Colors/Charts/Indigo Alpha/3/UI Core/Dark */
+  --figma___colors-charts-indigo-alpha-4: 228 99% 59% / 0.24; /* ✦ Theme/Colors/Charts/Indigo Alpha/4/UI Core/Dark */
+  --figma___colors-charts-indigo-alpha-5: 227 99% 60% / 0.29; /* ✦ Theme/Colors/Charts/Indigo Alpha/5/UI Core/Dark */
+  --figma___colors-charts-indigo-alpha-6: 225 100% 61% / 0.37; /* ✦ Theme/Colors/Charts/Indigo Alpha/6/UI Core/Dark */
+  --figma___colors-charts-indigo-alpha-7: 226 100% 63% / 0.85; /* ✦ Theme/Colors/Charts/Indigo Alpha/7/UI Core/Dark */
+  --figma___colors-charts-indigo-alpha-8: 230 100% 70% / 0.9; /* ✦ Theme/Colors/Charts/Indigo Alpha/8/UI Core/Dark */
+  --figma___colors-charts-indigo-alpha-9: 236 100% 94% / 1; /* ✦ Theme/Colors/Charts/Indigo Alpha/9/UI Core/Dark */
+  --figma___colors-charts-indigo-alpha-10: 236 100% 94% / 1; /* ✦ Theme/Colors/Charts/Indigo Alpha/10/UI Core/Dark */
+  --figma___colors-charts-mint-1: 173 52% 6% / 1; /* ✦ Theme/Colors/Charts/Mint/1/UI Core/Dark */
+  --figma___colors-charts-mint-2: 174 51% 8% / 1; /* ✦ Theme/Colors/Charts/Mint/2/UI Core/Dark */
+  --figma___colors-charts-mint-3: 176 52% 11% / 1; /* ✦ Theme/Colors/Charts/Mint/3/UI Core/Dark */
+  --figma___colors-charts-mint-4: 173 56% 13% / 1; /* ✦ Theme/Colors/Charts/Mint/4/UI Core/Dark */
+  --figma___colors-charts-mint-5: 173 57% 15% / 1; /* ✦ Theme/Colors/Charts/Mint/5/UI Core/Dark */
+  --figma___colors-charts-mint-6: 173 60% 24% / 1; /* ✦ Theme/Colors/Charts/Mint/6/UI Core/Dark */
+  --figma___colors-charts-mint-7: 167 70% 72% / 1; /* ✦ Theme/Colors/Charts/Mint/7/UI Core/Dark */
+  --figma___colors-charts-mint-8: 163 80% 77% / 1; /* ✦ Theme/Colors/Charts/Mint/8/UI Core/Dark */
+  --figma___colors-charts-mint-9: 167 70% 58% / 1; /* ✦ Theme/Colors/Charts/Mint/9/UI Core/Dark */
+  --figma___colors-charts-mint-10: 156 71% 86% / 1; /* ✦ Theme/Colors/Charts/Mint/10/UI Core/Dark */
+  --figma___colors-charts-mint-alpha-1: 120 100% 44% / 0; /* ✦ Theme/Colors/Charts/Mint Alpha/1/UI Core/Dark */
+  --figma___colors-charts-mint-alpha-2: 165 100% 49% / 0.03; /* ✦ Theme/Colors/Charts/Mint Alpha/2/UI Core/Dark */
+  --figma___colors-charts-mint-alpha-3: 174 100% 50% / 0.07; /* ✦ Theme/Colors/Charts/Mint Alpha/3/UI Core/Dark */
+  --figma___colors-charts-mint-alpha-4: 172 100% 50% / 0.11; /* ✦ Theme/Colors/Charts/Mint Alpha/4/UI Core/Dark */
+  --figma___colors-charts-mint-alpha-5: 172 100% 50% / 0.15; /* ✦ Theme/Colors/Charts/Mint Alpha/5/UI Core/Dark */
+  --figma___colors-charts-mint-alpha-6: 173 100% 50% / 0.21; /* ✦ Theme/Colors/Charts/Mint Alpha/6/UI Core/Dark */
+  --figma___colors-charts-mint-alpha-7: 167 100% 78% / 0.91; /* ✦ Theme/Colors/Charts/Mint Alpha/7/UI Core/Dark */
+  --figma___colors-charts-mint-alpha-8: 163 100% 81% / 0.95; /* ✦ Theme/Colors/Charts/Mint Alpha/8/UI Core/Dark */
+  --figma___colors-charts-mint-alpha-9: 167 100% 66% / 0.86; /* ✦ Theme/Colors/Charts/Mint Alpha/9/UI Core/Dark */
+  --figma___colors-charts-mint-alpha-10: 155 100% 90% / 0.96; /* ✦ Theme/Colors/Charts/Mint Alpha/10/UI Core/Dark */
+  --figma___colors-charts-orange-1: 32 67% 12% / 1; /* ✦ Theme/Colors/Charts/Orange/1/UI Core/Dark */
+  --figma___colors-charts-orange-2: 30 69% 18% / 1; /* ✦ Theme/Colors/Charts/Orange/2/UI Core/Dark */
+  --figma___colors-charts-orange-3: 27 69% 24% / 1; /* ✦ Theme/Colors/Charts/Orange/3/UI Core/Dark */
+  --figma___colors-charts-orange-4: 26 68% 30% / 1; /* ✦ Theme/Colors/Charts/Orange/4/UI Core/Dark */
+  --figma___colors-charts-orange-5: 17 68% 36% / 1; /* ✦ Theme/Colors/Charts/Orange/5/UI Core/Dark */
+  --figma___colors-charts-orange-6: 18 68% 42% / 1; /* ✦ Theme/Colors/Charts/Orange/6/UI Core/Dark */
+  --figma___colors-charts-orange-7: 19 67% 48% / 1; /* ✦ Theme/Colors/Charts/Orange/7/UI Core/Dark */
+  --figma___colors-charts-orange-8: 19 79% 54% / 1; /* ✦ Theme/Colors/Charts/Orange/8/UI Core/Dark */
+  --figma___colors-charts-orange-9: 19 100% 60% / 1; /* ✦ Theme/Colors/Charts/Orange/9/UI Core/Dark */
+  --figma___colors-charts-orange-10: 19 100% 64% / 1; /* ✦ Theme/Colors/Charts/Orange/10/UI Core/Dark */
+  --figma___colors-charts-orange-alpha-1: 32 67% 12% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/1/UI Core/Dark */
+  --figma___colors-charts-orange-alpha-2: 30 69% 18% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/2/UI Core/Dark */
+  --figma___colors-charts-orange-alpha-3: 27 69% 24% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/3/UI Core/Dark */
+  --figma___colors-charts-orange-alpha-4: 26 68% 30% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/4/UI Core/Dark */
+  --figma___colors-charts-orange-alpha-5: 17 68% 36% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/5/UI Core/Dark */
+  --figma___colors-charts-orange-alpha-6: 18 68% 42% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/6/UI Core/Dark */
+  --figma___colors-charts-orange-alpha-7: 19 67% 48% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/7/UI Core/Dark */
+  --figma___colors-charts-orange-alpha-8: 19 79% 54% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/8/UI Core/Dark */
+  --figma___colors-charts-orange-alpha-9: 19 100% 60% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/9/UI Core/Dark */
+  --figma___colors-charts-orange-alpha-10: 19 100% 64% / 1; /* ✦ Theme/Colors/Charts/Orange Alpha/10/UI Core/Dark */
+  --figma___colors-charts-yellow-1: 54 100% 8% / 1; /* ✦ Theme/Colors/Charts/Yellow/1/UI Core/Dark */
+  --figma___colors-charts-yellow-2: 54 100% 17% / 1; /* ✦ Theme/Colors/Charts/Yellow/2/UI Core/Dark */
+  --figma___colors-charts-yellow-3: 54 100% 25% / 1; /* ✦ Theme/Colors/Charts/Yellow/3/UI Core/Dark */
+  --figma___colors-charts-yellow-4: 54 100% 33% / 1; /* ✦ Theme/Colors/Charts/Yellow/4/UI Core/Dark */
+  --figma___colors-charts-yellow-5: 54 100% 41% / 1; /* ✦ Theme/Colors/Charts/Yellow/5/UI Core/Dark */
+  --figma___colors-charts-yellow-6: 55 100% 48% / 1; /* ✦ Theme/Colors/Charts/Yellow/6/UI Core/Dark */
+  --figma___colors-charts-yellow-7: 55 92% 58% / 1; /* ✦ Theme/Colors/Charts/Yellow/7/UI Core/Dark */
+  --figma___colors-charts-yellow-8: 54 92% 69% / 1; /* ✦ Theme/Colors/Charts/Yellow/8/UI Core/Dark */
+  --figma___colors-charts-yellow-9: 53 91% 79% / 1; /* ✦ Theme/Colors/Charts/Yellow/9/UI Core/Dark */
+  --figma___colors-charts-yellow-10: 47 89% 89% / 1; /* ✦ Theme/Colors/Charts/Yellow/10/UI Core/Dark */
+  --figma___colors-charts-yellow-alpha-1: 54 100% 8% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/1/UI Core/Dark */
+  --figma___colors-charts-yellow-alpha-2: 54 100% 17% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/2/UI Core/Dark */
+  --figma___colors-charts-yellow-alpha-3: 54 100% 25% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/3/UI Core/Dark */
+  --figma___colors-charts-yellow-alpha-4: 54 100% 33% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/4/UI Core/Dark */
+  --figma___colors-charts-yellow-alpha-5: 54 100% 41% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/5/UI Core/Dark */
+  --figma___colors-charts-yellow-alpha-6: 55 100% 48% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/6/UI Core/Dark */
+  --figma___colors-charts-yellow-alpha-7: 55 92% 58% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/7/UI Core/Dark */
+  --figma___colors-charts-yellow-alpha-8: 54 92% 69% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/8/UI Core/Dark */
+  --figma___colors-charts-yellow-alpha-9: 53 91% 79% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/9/UI Core/Dark */
+  --figma___colors-charts-yellow-alpha-10: 47 89% 89% / 1; /* ✦ Theme/Colors/Charts/Yellow Alpha/10/UI Core/Dark */
+  --figma___colors-default-black-fixed: 210 25% 98% / 1; /* ✦ Theme/Colors/Default/Black (fixed)/UI Core/Dark */
+  --figma___colors-default-brand-color: 194 100% 45% / 1; /* ✦ Theme/Colors/Default/Brand Color/UI Core/Dark */
+  --figma___colors-default-dark-to-white: 210 25% 98% / 1; /* ✦ Theme/Colors/Default/Dark-to-white/UI Core/Dark */
+  --figma___colors-default-white-fixed: 0 0% 0% / 1; /* ✦ Theme/Colors/Default/White (fixed)/UI Core/Dark */
+  --figma___colors-default-white-to-dark: 0 0% 0% / 1; /* ✦ Theme/Colors/Default/White-to-dark/UI Core/Dark */
+  --figma___colors-module-ccm-100: 179 56% 32% / 1; /* ✦ Theme/Colors/Module/CCM/100/UI Core/Dark */
+  --figma___colors-module-ccm-200: 181 99% 40% / 1; /* ✦ Theme/Colors/Module/CCM/200/UI Core/Dark */
+  --figma___colors-module-ccm-300: 180 100% 96% / 1; /* ✦ Theme/Colors/Module/CCM/300/UI Core/Dark */
+  --figma___colors-module-cd-100: 110 62% 32% / 1; /* ✦ Theme/Colors/Module/CD/100/UI Core/Dark */
+  --figma___colors-module-cd-200: 110 40% 50% / 1; /* ✦ Theme/Colors/Module/CD/200/UI Core/Dark */
+  --figma___colors-module-cd-300: 102 100% 97% / 1; /* ✦ Theme/Colors/Module/CD/300/UI Core/Dark */
+  --figma___colors-module-ce-100: 335 100% 30% / 1; /* ✦ Theme/Colors/Module/CE/100/UI Core/Dark */
+  --figma___colors-module-ce-200: 335 100% 50% / 1; /* ✦ Theme/Colors/Module/CE/200/UI Core/Dark */
+  --figma___colors-module-ce-300: 334 100% 97% / 1; /* ✦ Theme/Colors/Module/CE/300/UI Core/Dark */
+  --figma___colors-module-ci-100: 203 94% 37% / 1; /* ✦ Theme/Colors/Module/CI/100/UI Core/Dark */
+  --figma___colors-module-ci-200: 200 88% 56% / 1; /* ✦ Theme/Colors/Module/CI/200/UI Core/Dark */
+  --figma___colors-module-ci-300: 201 100% 94% / 1; /* ✦ Theme/Colors/Module/CI/300/UI Core/Dark */
+  --figma___colors-module-ff-100: 26 91% 39% / 1; /* ✦ Theme/Colors/Module/FF/100/UI Core/Dark */
+  --figma___colors-module-ff-200: 29 86% 54% / 1; /* ✦ Theme/Colors/Module/FF/200/UI Core/Dark */
+  --figma___colors-module-ff-300: 41 81% 94% / 1; /* ✦ Theme/Colors/Module/FF/300/UI Core/Dark */
+  --figma___colors-module-srm-100: 262 55% 49% / 1; /* ✦ Theme/Colors/Module/SRM/100/UI Core/Dark */
+  --figma___colors-module-srm-200: 262 95% 75% / 1; /* ✦ Theme/Colors/Module/SRM/200/UI Core/Dark */
+  --figma___colors-module-srm-300: 261 100% 97% / 1; /* ✦ Theme/Colors/Module/SRM/300/UI Core/Dark */
+  --figma___colors-module-ssca-100: 0 98% 36% / 1; /* ✦ Theme/Colors/Module/SSCA/100/UI Core/Dark */
+  --figma___colors-module-ssca-200: 0 58% 53% / 1; /* ✦ Theme/Colors/Module/SSCA/200/UI Core/Dark */
+  --figma___colors-module-ssca-300: 0 100% 97% / 1; /* ✦ Theme/Colors/Module/SSCA/300/UI Core/Dark */
+  --figma___colors-module-sto-100: 245 90% 53% / 1; /* ✦ Theme/Colors/Module/STO/100/UI Core/Dark */
+  --figma___colors-module-sto-200: 216 100% 64% / 1; /* ✦ Theme/Colors/Module/STO/200/UI Core/Dark */
+  --figma___colors-module-sto-300: 228 100% 96% / 1; /* ✦ Theme/Colors/Module/STO/300/UI Core/Dark */
+  --figma___colors-neutral-gray-1: 0 0% 7% / 1; /* ✦ Theme/Colors/Neutral/Gray/1/UI Core/Dark */
+  --figma___colors-neutral-gray-2: 0 0% 11% / 1; /* ✦ Theme/Colors/Neutral/Gray/2/UI Core/Dark */
+  --figma___colors-neutral-gray-3: 0 0% 16% / 1; /* ✦ Theme/Colors/Neutral/Gray/3/UI Core/Dark */
+  --figma___colors-neutral-gray-4: 0 0% 23% / 1; /* ✦ Theme/Colors/Neutral/Gray/4/UI Core/Dark */
+  --figma___colors-neutral-gray-5: 0 0% 29% / 1; /* ✦ Theme/Colors/Neutral/Gray/5/UI Core/Dark */
+  --figma___colors-neutral-gray-6: 0 0% 35% / 1; /* ✦ Theme/Colors/Neutral/Gray/6/UI Core/Dark */
+  --figma___colors-neutral-gray-7: 0 0% 42% / 1; /* ✦ Theme/Colors/Neutral/Gray/7/UI Core/Dark */
+  --figma___colors-neutral-gray-8: 0 0% 54% / 1; /* ✦ Theme/Colors/Neutral/Gray/8/UI Core/Dark */
+  --figma___colors-neutral-gray-9: 0 0% 69% / 1; /* ✦ Theme/Colors/Neutral/Gray/9/UI Core/Dark */
+  --figma___colors-neutral-gray-10: 0 0% 82% / 1; /* ✦ Theme/Colors/Neutral/Gray/10/UI Core/Dark */
+  --figma___colors-neutral-gray-alpha-1: 0 0% 7% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/1/UI Core/Dark */
+  --figma___colors-neutral-gray-alpha-2: 0 0% 11% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/2/UI Core/Dark */
+  --figma___colors-neutral-gray-alpha-3: 0 0% 16% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/3/UI Core/Dark */
+  --figma___colors-neutral-gray-alpha-4: 0 0% 23% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/4/UI Core/Dark */
+  --figma___colors-neutral-gray-alpha-5: 0 0% 29% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/5/UI Core/Dark */
+  --figma___colors-neutral-gray-alpha-6: 0 0% 35% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/6/UI Core/Dark */
+  --figma___colors-neutral-gray-alpha-7: 0 0% 42% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/7/UI Core/Dark */
+  --figma___colors-neutral-gray-alpha-8: 0 0% 54% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/8/UI Core/Dark */
+  --figma___colors-neutral-gray-alpha-9: 0 0% 69% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/9/UI Core/Dark */
+  --figma___colors-neutral-gray-alpha-10: 0 0% 82% / 1; /* ✦ Theme/Colors/Neutral/Gray Alpha/10/UI Core/Dark */
+  --figma___colors-primary-primary-accent-1: 215 46% 20% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/1/UI Core/Dark */
+  --figma___colors-primary-primary-accent-2: 216 50% 12% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/2/UI Core/Dark */
+  --figma___colors-primary-primary-accent-3: 214 58% 16% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/3/UI Core/Dark */
+  --figma___colors-primary-primary-accent-4: 213 67% 21% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/4/UI Core/Dark */
+  --figma___colors-primary-primary-accent-5: 194 100% 45% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/5/UI Core/Dark */
+  --figma___colors-primary-primary-accent-6: 212 72% 25% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/6/UI Core/Dark */
+  --figma___colors-primary-primary-accent-7: 206 100% 50% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/7/UI Core/Dark */
+  --figma___colors-primary-primary-accent-8: 206 100% 62% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/8/UI Core/Dark */
+  --figma___colors-primary-primary-accent-9: 205 100% 71% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/9/UI Core/Dark */
+  --figma___colors-primary-primary-accent-10: 212 72% 10% / 1; /* ✦ Theme/Colors/Primary/Primary Accent/10/UI Core/Dark */
+  --figma___colors-primary-primary-alpha-1: 215 46% 20% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/1/UI Core/Dark */
+  --figma___colors-primary-primary-alpha-2: 216 50% 12% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/2/UI Core/Dark */
+  --figma___colors-primary-primary-alpha-3: 214 58% 16% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/3/UI Core/Dark */
+  --figma___colors-primary-primary-alpha-4: 213 67% 21% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/4/UI Core/Dark */
+  --figma___colors-primary-primary-alpha-5: 194 100% 45% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/5/UI Core/Dark */
+  --figma___colors-primary-primary-alpha-6: 212 72% 25% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/6/UI Core/Dark */
+  --figma___colors-primary-primary-alpha-7: 206 100% 50% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/7/UI Core/Dark */
+  --figma___colors-primary-primary-alpha-8: 206 100% 62% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/8/UI Core/Dark */
+  --figma___colors-primary-primary-alpha-9: 205 100% 71% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/9/UI Core/Dark */
+  --figma___colors-primary-primary-alpha-10: 212 72% 10% / 1; /* ✦ Theme/Colors/Primary/Primary Alpha/10/UI Core/Dark */
+  --figma___colors-secondary-crimson-crimson-1: 330 100% 20% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 1/UI Core/Dark */
+  --figma___colors-secondary-crimson-crimson-10: 327 79% 95% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 10/UI Core/Dark */
+  --figma___colors-secondary-crimson-crimson-2: 330 100% 25% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 2/UI Core/Dark */
+  --figma___colors-secondary-crimson-crimson-3: 330 100% 30% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 3/UI Core/Dark */
+  --figma___colors-secondary-crimson-crimson-4: 330 100% 35% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 4/UI Core/Dark */
+  --figma___colors-secondary-crimson-crimson-5: 330 100% 40% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 5/UI Core/Dark */
+  --figma___colors-secondary-crimson-crimson-6: 332 67% 52% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 6/UI Core/Dark */
+  --figma___colors-secondary-crimson-crimson-7: 335 66% 64% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 7/UI Core/Dark */
+  --figma___colors-secondary-crimson-crimson-8: 326 77% 77% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 8/UI Core/Dark */
+  --figma___colors-secondary-crimson-crimson-9: 331 67% 88% / 1; /* ✦ Theme/Colors/Secondary/Crimson/Crimson 9/UI Core/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-1: 330 100% 20% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 1/UI Core/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-10: 331 67% 88% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 10/UI Core/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-11: 327 79% 95% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 11/UI Core/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-2: 330 100% 25% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 2/UI Core/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-3: 330 100% 30% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 3/UI Core/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-4: 330 100% 35% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 4/UI Core/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-5: 330 100% 40% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 5/UI Core/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-6: 332 67% 52% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 6/UI Core/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-8: 335 66% 64% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 8/UI Core/Dark */
+  --figma___colors-secondary-crimson-alpha-crimson-alpha-9: 326 77% 77% / 1; /* ✦ Theme/Colors/Secondary/Crimson Alpha/Crimson Alpha 9/UI Core/Dark */
+  --figma___colors-secondary-lime-1: 84 100% 20% / 1; /* ✦ Theme/Colors/Secondary/Lime/1/UI Core/Dark */
+  --figma___colors-secondary-lime-2: 84 100% 25% / 1; /* ✦ Theme/Colors/Secondary/Lime/2/UI Core/Dark */
+  --figma___colors-secondary-lime-3: 83 100% 30% / 1; /* ✦ Theme/Colors/Secondary/Lime/3/UI Core/Dark */
+  --figma___colors-secondary-lime-4: 83 100% 35% / 1; /* ✦ Theme/Colors/Secondary/Lime/4/UI Core/Dark */
+  --figma___colors-secondary-lime-5: 82 100% 40% / 1; /* ✦ Theme/Colors/Secondary/Lime/5/UI Core/Dark */
+  --figma___colors-secondary-lime-6: 95 66% 64% / 1; /* ✦ Theme/Colors/Secondary/Lime/6/UI Core/Dark */
+  --figma___colors-secondary-lime-7: 100 61% 75% / 1; /* ✦ Theme/Colors/Secondary/Lime/7/UI Core/Dark */
+  --figma___colors-secondary-lime-8: 120 34% 85% / 1; /* ✦ Theme/Colors/Secondary/Lime/8/UI Core/Dark */
+  --figma___colors-secondary-lime-9: 120 33% 92% / 1; /* ✦ Theme/Colors/Secondary/Lime/9/UI Core/Dark */
+  --figma___colors-secondary-lime-10: 120 53% 97% / 1; /* ✦ Theme/Colors/Secondary/Lime/10/UI Core/Dark */
+  --figma___colors-secondary-lime-alpha-1: 84 100% 20% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/1/UI Core/Dark */
+  --figma___colors-secondary-lime-alpha-2: 84 100% 25% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/2/UI Core/Dark */
+  --figma___colors-secondary-lime-alpha-3: 83 100% 30% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/3/UI Core/Dark */
+  --figma___colors-secondary-lime-alpha-4: 83 100% 35% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/4/UI Core/Dark */
+  --figma___colors-secondary-lime-alpha-5: 82 100% 40% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/5/UI Core/Dark */
+  --figma___colors-secondary-lime-alpha-6: 95 66% 64% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/6/UI Core/Dark */
+  --figma___colors-secondary-lime-alpha-7: 100 61% 75% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/7/UI Core/Dark */
+  --figma___colors-secondary-lime-alpha-8: 120 34% 85% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/8/UI Core/Dark */
+  --figma___colors-secondary-lime-alpha-9: 120 33% 92% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/9/UI Core/Dark */
+  --figma___colors-secondary-lime-alpha-10: 120 53% 97% / 1; /* ✦ Theme/Colors/Secondary/Lime Alpha/10/UI Core/Dark */
+  --figma___colors-secondary-purple-1: 264 100% 20% / 1; /* ✦ Theme/Colors/Secondary/Purple/1/UI Core/Dark */
+  --figma___colors-secondary-purple-2: 264 100% 25% / 1; /* ✦ Theme/Colors/Secondary/Purple/2/UI Core/Dark */
+  --figma___colors-secondary-purple-3: 264 100% 30% / 1; /* ✦ Theme/Colors/Secondary/Purple/3/UI Core/Dark */
+  --figma___colors-secondary-purple-4: 264 100% 35% / 1; /* ✦ Theme/Colors/Secondary/Purple/4/UI Core/Dark */
+  --figma___colors-secondary-purple-5: 264 100% 40% / 1; /* ✦ Theme/Colors/Secondary/Purple/5/UI Core/Dark */
+  --figma___colors-secondary-purple-6: 264 67% 52% / 1; /* ✦ Theme/Colors/Secondary/Purple/6/UI Core/Dark */
+  --figma___colors-secondary-purple-7: 265 66% 64% / 1; /* ✦ Theme/Colors/Secondary/Purple/7/UI Core/Dark */
+  --figma___colors-secondary-purple-8: 258 77% 77% / 1; /* ✦ Theme/Colors/Secondary/Purple/8/UI Core/Dark */
+  --figma___colors-secondary-purple-9: 253 85% 89% / 1; /* ✦ Theme/Colors/Secondary/Purple/9/UI Core/Dark */
+  --figma___colors-secondary-purple-10: 273 79% 95% / 1; /* ✦ Theme/Colors/Secondary/Purple/10/UI Core/Dark */
+  --figma___colors-secondary-purple-alpha-1: 264 100% 20% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/1/UI Core/Dark */
+  --figma___colors-secondary-purple-alpha-2: 264 100% 25% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/2/UI Core/Dark */
+  --figma___colors-secondary-purple-alpha-3: 264 100% 30% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/3/UI Core/Dark */
+  --figma___colors-secondary-purple-alpha-4: 264 100% 35% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/4/UI Core/Dark */
+  --figma___colors-secondary-purple-alpha-5: 264 100% 40% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/5/UI Core/Dark */
+  --figma___colors-secondary-purple-alpha-6: 264 67% 52% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/6/UI Core/Dark */
+  --figma___colors-secondary-purple-alpha-7: 265 66% 64% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/7/UI Core/Dark */
+  --figma___colors-secondary-purple-alpha-8: 258 77% 77% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/8/UI Core/Dark */
+  --figma___colors-secondary-purple-alpha-9: 253 85% 89% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/9/UI Core/Dark */
+  --figma___colors-secondary-purple-alpha-10: 273 79% 95% / 1; /* ✦ Theme/Colors/Secondary/Purple Alpha/10/UI Core/Dark */
+  --figma___colors-secondary-teal-1: 180 100% 15% / 1; /* ✦ Theme/Colors/Secondary/Teal/1/UI Core/Dark */
+  --figma___colors-secondary-teal-2: 180 100% 20% / 1; /* ✦ Theme/Colors/Secondary/Teal/2/UI Core/Dark */
+  --figma___colors-secondary-teal-3: 180 100% 25% / 1; /* ✦ Theme/Colors/Secondary/Teal/3/UI Core/Dark */
+  --figma___colors-secondary-teal-4: 180 100% 30% / 1; /* ✦ Theme/Colors/Secondary/Teal/4/UI Core/Dark */
+  --figma___colors-secondary-teal-5: 180 100% 35% / 1; /* ✦ Theme/Colors/Secondary/Teal/5/UI Core/Dark */
+  --figma___colors-secondary-teal-6: 180 60% 50% / 1; /* ✦ Theme/Colors/Secondary/Teal/6/UI Core/Dark */
+  --figma___colors-secondary-teal-7: 180 66% 64% / 1; /* ✦ Theme/Colors/Secondary/Teal/7/UI Core/Dark */
+  --figma___colors-secondary-teal-8: 180 77% 77% / 1; /* ✦ Theme/Colors/Secondary/Teal/8/UI Core/Dark */
+  --figma___colors-secondary-teal-9: 180 85% 89% / 1; /* ✦ Theme/Colors/Secondary/Teal/9/UI Core/Dark */
+  --figma___colors-secondary-teal-10: 180 85% 95% / 1; /* ✦ Theme/Colors/Secondary/Teal/10/UI Core/Dark */
+  --figma___colors-secondary-teal-alpha-1: 180 100% 15% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/1/UI Core/Dark */
+  --figma___colors-secondary-teal-alpha-2: 180 100% 20% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/2/UI Core/Dark */
+  --figma___colors-secondary-teal-alpha-3: 180 100% 25% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/3/UI Core/Dark */
+  --figma___colors-secondary-teal-alpha-4: 180 100% 30% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/4/UI Core/Dark */
+  --figma___colors-secondary-teal-alpha-5: 180 100% 35% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/5/UI Core/Dark */
+  --figma___colors-secondary-teal-alpha-6: 180 60% 50% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/6/UI Core/Dark */
+  --figma___colors-secondary-teal-alpha-7: 180 66% 64% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/7/UI Core/Dark */
+  --figma___colors-secondary-teal-alpha-8: 180 77% 77% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/8/UI Core/Dark */
+  --figma___colors-secondary-teal-alpha-9: 180 85% 89% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/9/UI Core/Dark */
+  --figma___colors-secondary-teal-alpha-10: 180 85% 95% / 1; /* ✦ Theme/Colors/Secondary/Teal Alpha/10/UI Core/Dark */
+  --figma___overlays-black-alpha-1: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/1/UI Core/Dark */
+  --figma___overlays-black-alpha-2: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/2/UI Core/Dark */
+  --figma___overlays-black-alpha-3: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/3/UI Core/Dark */
+  --figma___overlays-black-alpha-4: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/4/UI Core/Dark */
+  --figma___overlays-black-alpha-5: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/5/UI Core/Dark */
+  --figma___overlays-black-alpha-6: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/6/UI Core/Dark */
+  --figma___overlays-black-alpha-7: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/7/UI Core/Dark */
+  --figma___overlays-black-alpha-8: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/8/UI Core/Dark */
+  --figma___overlays-black-alpha-9: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/9/UI Core/Dark */
+  --figma___overlays-black-alpha-10: 0 0% 100% / 1; /* ✦ Theme/Overlays/Black Alpha/10/UI Core/Dark */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/1/UI Core/Dark */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/2/UI Core/Dark */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/3/UI Core/Dark */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/4/UI Core/Dark */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/5/UI Core/Dark */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/6/UI Core/Dark */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/7/UI Core/Dark */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/8/UI Core/Dark */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/9/UI Core/Dark */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 1; /* ✦ Theme/Overlays/White Alpha/10/UI Core/Dark */
+  --figma___semantic-background-backdrop: 212 72% 10% / 0.75; /* ✦ Theme/Semantic/Background/Backdrop/UI Core/Dark */
+  --figma___semantic-background-cards-and-rows-default: 0 0% 0% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Default/UI Core/Dark */
+  --figma___semantic-background-cards-and-rows-hover: 240 4% 10% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Hover/UI Core/Dark */
+  --figma___semantic-background-cards-and-rows-primary-blue-selected: 206 100% 50% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Primary-blue-selected/UI Core/Dark */
+  --figma___semantic-background-cards-and-rows-selected: 240 4% 10% / 1; /* ✦ Theme/Semantic/Background/Cards and Rows/Selected/UI Core/Dark */
+  --figma___semantic-background-header-page-header: 0 0% 0% / 1; /* ✦ Theme/Semantic/Background/Header/Page Header/UI Core/Dark */
+  --figma___semantic-background-header-table-header: 0 0% 0% / 1; /* ✦ Theme/Semantic/Background/Header/Table Header/UI Core/Dark */
+  --figma___semantic-background-paper: 240 4% 10% / 1; /* ✦ Theme/Semantic/Background/Paper/UI Core/Dark */
+  --figma___semantic-background-primary: 240 4% 10% / 1; /* ✦ Theme/Semantic/Background/Primary/UI Core/Dark */
+  --figma___semantic-background-solid: 0 0% 0% / 1; /* ✦ Theme/Semantic/Background/Solid/UI Core/Dark */
+  --figma___semantic-border-disabled: 0 0% 16% / 1; /* ✦ Theme/Semantic/Border/Disabled/UI Core/Dark */
+  --figma___semantic-border-hover: 206 100% 62% / 1; /* ✦ Theme/Semantic/Border/Hover/UI Core/Dark */
+  --figma___semantic-border-primary: 0 0% 16% / 1; /* ✦ Theme/Semantic/Border/Primary/UI Core/Dark */
+  --figma___semantic-border-secondary: 0 0% 11% / 1; /* ✦ Theme/Semantic/Border/Secondary/UI Core/Dark */
+  --figma___semantic-border-selected: 206 100% 50% / 1; /* ✦ Theme/Semantic/Border/Selected/UI Core/Dark */
+  --figma___semantic-text-disabled: 0 0% 23% / 1; /* ✦ Theme/Semantic/Text/Disabled/UI Core/Dark */
+  --figma___semantic-text-links: 206 100% 50% / 1; /* ✦ Theme/Semantic/Text/Links/UI Core/Dark */
+  --figma___semantic-text-secondary: 0 0% 54% / 1; /* ✦ Theme/Semantic/Text/Secondary/UI Core/Dark */
+  --figma___semantic-text-tertiary: 0 0% 35% / 1; /* ✦ Theme/Semantic/Text/Tertiary/UI Core/Dark */
+  --figma___semantic-text-primary: 0 0% 82% / 1; /* ✦ Theme/Semantic/Text/primary/UI Core/Dark */
 }

--- a/packages/canary/src/style-tokens/themes/ui-core.css
+++ b/packages/canary/src/style-tokens/themes/ui-core.css
@@ -1,0 +1,3767 @@
+/* Non color variables */
+:root {
+  --figma___badges-badge-radius: 4px;
+  /* ✦ Theme/Badges/badge-radius/UI Core/Mode 1 */
+  --figma___grids-extra-large-1920-col: 12px;
+  /* ✦ Theme/Grids/Extra Large (> 1920)/Col/UI Core/Mode 1 */
+  --figma___grids-extra-large-1920-gutters: 20px;
+  /* ✦ Theme/Grids/Extra Large (> 1920)/Gutters/UI Core/Mode 1 */
+  --figma___grids-extra-large-1920-width: 138px;
+  /* ✦ Theme/Grids/Extra Large (> 1920)/Width/UI Core/Mode 1 */
+  --figma___grids-extra-small-0-to-480-col: 2px;
+  /* ✦ Theme/Grids/Extra Small (0 to 480)/Col/UI Core/Mode 1 */
+  --figma___grids-extra-small-0-to-480-gutters: 16px;
+  /* ✦ Theme/Grids/Extra Small (0 to 480)/Gutters/UI Core/Mode 1 */
+  --figma___grids-extra-small-0-to-480-margins: 16px;
+  /* ✦ Theme/Grids/Extra Small (0 to 480)/Margins/UI Core/Mode 1 */
+  --figma___grids-large-1280-to-1920-col: 12px;
+  /* ✦ Theme/Grids/Large (1280 to 1920)/Col/UI Core/Mode 1 */
+  --figma___grids-large-1280-to-1920-gutters: 20px;
+  /* ✦ Theme/Grids/Large (1280 to 1920)/Gutters/UI Core/Mode 1 */
+  --figma___grids-large-1280-to-1920-margins: 24px;
+  /* ✦ Theme/Grids/Large (1280 to 1920)/Margins/UI Core/Mode 1 */
+  --figma___grids-medium-576-to-1279-col: 8px;
+  /* ✦ Theme/Grids/Medium (576 to 1279)/Col/UI Core/Mode 1 */
+  --figma___grids-medium-576-to-1279-gutters: 16px;
+  /* ✦ Theme/Grids/Medium (576 to 1279)/Gutters/UI Core/Mode 1 */
+  --figma___grids-medium-576-to-1279-margins: 24px;
+  /* ✦ Theme/Grids/Medium (576 to 1279)/Margins/UI Core/Mode 1 */
+  --figma___grids-small-480-to-575-col: 8px;
+  /* ✦ Theme/Grids/Small (480 to 575)/Col/UI Core/Mode 1 */
+  --figma___grids-small-480-to-575-gutters: 16px;
+  /* ✦ Theme/Grids/Small (480 to 575)/Gutters/UI Core/Mode 1 */
+  --figma___grids-small-480-to-575-margins: 24px;
+  /* ✦ Theme/Grids/Small (480 to 575)/Margins/UI Core/Mode 1 */
+  --figma___height-button-height-1: 24px;
+  /* ✦ Theme/Height/button-height-1/UI Core/Mode 1 */
+  --figma___height-button-height-2: 32px;
+  /* ✦ Theme/Height/button-height-2/UI Core/Mode 1 */
+  --figma___height-button-height-3: 40px;
+  /* ✦ Theme/Height/button-height-3/UI Core/Mode 1 */
+  --figma___height-button-height-4: 48px;
+  /* ✦ Theme/Height/button-height-4/UI Core/Mode 1 */
+  --figma___height-menu-item-height-1: 24px;
+  /* ✦ Theme/Height/menu-item-height-1/UI Core/Mode 1 */
+  --figma___height-menu-item-height-2: 32px;
+  /* ✦ Theme/Height/menu-item-height-2/UI Core/Mode 1 */
+  --figma___height-table-cell-min-height-1: 36px;
+  /* ✦ Theme/Height/table-cell-min-height-1/UI Core/Mode 1 */
+  --figma___height-table-cell-min-height-2: 44px;
+  /* ✦ Theme/Height/table-cell-min-height-2/UI Core/Mode 1 */
+  --figma___height-table-cell-min-height-3: 48px;
+  /* ✦ Theme/Height/table-cell-min-height-3/UI Core/Mode 1 */
+  --figma___padding-main-content-padding: 0px;
+  /* ✦ Theme/Padding/Main content padding/UI Core/Mode 1 */
+  --figma___padding-table-cell-padding-1: 8px;
+  /* ✦ Theme/Padding/table-cell-padding-1/UI Core/Mode 1 */
+  --figma___padding-table-cell-padding-2: 12px;
+  /* ✦ Theme/Padding/table-cell-padding-2/UI Core/Mode 1 */
+  --figma___padding-table-cell-padding-3: 16px;
+  /* ✦ Theme/Padding/table-cell-padding-3/UI Core/Mode 1 */
+  --figma___pagination-active-border-radius: 0px;
+  /* ✦ Theme/Pagination/Active/Border-radius/UI Core/Mode 1 */
+  --figma___pagination-border-radius: 8px;
+  /* ✦ Theme/Pagination/Border-radius/UI Core/Mode 1 */
+  --figma___pagination-default-border-radius: 0px;
+  /* ✦ Theme/Pagination/Default/Border-radius/UI Core/Mode 1 */
+  --figma___pagination-gap: 1px;
+  /* ✦ Theme/Pagination/Gap/UI Core/Mode 1 */
+  --figma___pagination-hover-border-radius: 0px;
+  /* ✦ Theme/Pagination/Hover/Border-radius/UI Core/Mode 1 */
+  --figma___radius-1: 3px;
+  /* ✦ Theme/Radius/1/UI Core/Mode 1 */
+  --figma___radius-2: 4px;
+  /* ✦ Theme/Radius/2/UI Core/Mode 1 */
+  --figma___radius-3: 6px;
+  /* ✦ Theme/Radius/3/UI Core/Mode 1 */
+  --figma___radius-4: 8px;
+  /* ✦ Theme/Radius/4/UI Core/Mode 1 */
+  --figma___radius-5: 12px;
+  /* ✦ Theme/Radius/5/UI Core/Mode 1 */
+  --figma___radius-6: 16px;
+  /* ✦ Theme/Radius/6/UI Core/Mode 1 */
+  --figma___radius-1-max: 3px;
+  /* ✦ Theme/Radius/1-max/UI Core/Mode 1 */
+  --figma___radius-2-max: 4px;
+  /* ✦ Theme/Radius/2-max/UI Core/Mode 1 */
+  --figma___radius-3-max: 6px;
+  /* ✦ Theme/Radius/3-max/UI Core/Mode 1 */
+  --figma___radius-4-max: 8px;
+  /* ✦ Theme/Radius/4-max/UI Core/Mode 1 */
+  --figma___radius-5-max: 12px;
+  /* ✦ Theme/Radius/5-max/UI Core/Mode 1 */
+  --figma___radius-6-max: 16px;
+  /* ✦ Theme/Radius/6-max/UI Core/Mode 1 */
+  --figma___radius-main-content-radius: 0px;
+  /* ✦ Theme/Radius/Main content radius/UI Core/Mode 1 */
+  --figma___radius-full: 9999px;
+  /* ✦ Theme/Radius/full/UI Core/Mode 1 */
+  --figma___space-1: 4px;
+  /* ✦ Theme/Space/1/UI Core/Mode 1 */
+  --figma___space-2: 8px;
+  /* ✦ Theme/Space/2/UI Core/Mode 1 */
+  --figma___space-3: 12px;
+  /* ✦ Theme/Space/3/UI Core/Mode 1 */
+  --figma___space-4: 16px;
+  /* ✦ Theme/Space/4/UI Core/Mode 1 */
+  --figma___space-5: 24px;
+  /* ✦ Theme/Space/5/UI Core/Mode 1 */
+  --figma___space-6: 32px;
+  /* ✦ Theme/Space/6/UI Core/Mode 1 */
+  --figma___space-7: 40px;
+  /* ✦ Theme/Space/7/UI Core/Mode 1 */
+  --figma___space-8: 48px;
+  /* ✦ Theme/Space/8/UI Core/Mode 1 */
+  --figma___space-9: 64px;
+  /* ✦ Theme/Space/9/UI Core/Mode 1 */
+  --figma___switch-thumb-size-1: 12px;
+  /* ✦ Theme/Switch/Thumb Size/1/UI Core/Mode 1 */
+  --figma___switch-thumb-size-2: 16px;
+  /* ✦ Theme/Switch/Thumb Size/2/UI Core/Mode 1 */
+  --figma___switch-thumb-size-3: 20px;
+  /* ✦ Theme/Switch/Thumb Size/3/UI Core/Mode 1 */
+  --figma___tabs-pills-border-radius: 4px;
+  /* ✦ Theme/Tabs/Pills/border-radius/UI Core/Mode 1 */
+  --figma___tabs-pills-padding: 1px;
+  /* ✦ Theme/Tabs/Pills/padding/UI Core/Mode 1 */
+  --figma___tabs-pills-pill-border-radius: 0px;
+  /* ✦ Theme/Tabs/Pills/pill border radius/UI Core/Mode 1 */
+  --figma___textfield-assistive-text-assistive-text: 12px;
+  /* ✦ Theme/Textfield/Assistive Text/Assistive Text/UI Core/Mode 1 */
+  --figma___textfield-gap: 4px;
+  /* ✦ Theme/Textfield/Gap/UI Core/Mode 1 */
+  --figma___textfield-input-field-textfield-height: 32px;
+  /* ✦ Theme/Textfield/Input Field/Textfield Height/UI Core/Mode 1 */
+}
+
+/* Color variables - light mode */
+.ui-core-light {
+  --figma___background-backdrop: 212 72% 10% / 0.75;
+  /* ✦ Theme/Background/Backdrop/UI Core/Light */
+  --figma___background-cards-and-rows-default: 0 0% 100% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Default/UI Core/Light */
+  --figma___background-cards-and-rows-hover: 216 100% 99% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Hover/UI Core/Light */
+  --figma___background-cards-and-rows-primary-blue-selected: 206 98% 42% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/UI Core/Light */
+  --figma___background-cards-and-rows-selected: 216 100% 99% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Selected/UI Core/Light */
+  --figma___background-header-page-header: 0 0% 100% / 1;
+  /* ✦ Theme/Background/Header/Page Header/UI Core/Light */
+  --figma___background-header-table-header: 0 0% 100% / 1;
+  /* ✦ Theme/Background/Header/Table Header/UI Core/Light */
+  --figma___background-paper: 216 100% 99% / 1;
+  /* ✦ Theme/Background/Paper/UI Core/Light */
+  --figma___background-primary: 216 100% 99% / 1;
+  /* ✦ Theme/Background/Primary/UI Core/Light */
+  --figma___background-solid: 0 0% 100% / 1;
+  /* ✦ Theme/Background/Solid/UI Core/Light */
+  --figma___badges-soft-amber-background: 45 100% 95% / 1;
+  /* ✦ Theme/Badges/Soft/Amber/background/UI Core/Light */
+  --figma___badges-soft-amber-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Soft/Amber/text/UI Core/Light */
+  --figma___badges-soft-blue-background: 195 100% 97% / 1;
+  /* ✦ Theme/Badges/Soft/Blue/background/UI Core/Light */
+  --figma___badges-soft-blue-text: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Soft/Blue/text/UI Core/Light */
+  --figma___badges-soft-bronze-background: 24 100% 95% / 1;
+  /* ✦ Theme/Badges/Soft/Bronze/background/UI Core/Light */
+  --figma___badges-soft-bronze-text: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Soft/Bronze/text/UI Core/Light */
+  --figma___badges-soft-brown-background: 27 100% 96% / 1;
+  /* ✦ Theme/Badges/Soft/Brown/background/UI Core/Light */
+  --figma___badges-soft-brown-text: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Soft/Brown/text/UI Core/Light */
+  --figma___badges-soft-crimson-background: 328 100% 97% / 1;
+  /* ✦ Theme/Badges/Soft/Crimson/background/UI Core/Light */
+  --figma___badges-soft-crimson-text: 331 85% 55% / 1;
+  /* ✦ Theme/Badges/Soft/Crimson/text/UI Core/Light */
+  --figma___badges-soft-cyan-background: 183 97% 87% / 1;
+  /* ✦ Theme/Badges/Soft/Cyan/background/UI Core/Light */
+  --figma___badges-soft-cyan-text: 184 94% 39% / 1;
+  /* ✦ Theme/Badges/Soft/Cyan/text/UI Core/Light */
+  --figma___badges-soft-gold-background: 24 100% 95% / 1;
+  /* ✦ Theme/Badges/Soft/Gold/background/UI Core/Light */
+  --figma___badges-soft-gold-text: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Soft/Gold/text/UI Core/Light */
+  --figma___badges-soft-grass-background: 112 58% 93% / 1;
+  /* ✦ Theme/Badges/Soft/Grass/background/UI Core/Light */
+  --figma___badges-soft-grass-text: 122 58% 38% / 1;
+  /* ✦ Theme/Badges/Soft/Grass/text/UI Core/Light */
+  --figma___badges-soft-green-background: 112 56% 89% / 1;
+  /* ✦ Theme/Badges/Soft/Green/background/UI Core/Light */
+  --figma___badges-soft-green-text: 122 53% 55% / 1;
+  /* ✦ Theme/Badges/Soft/Green/text/UI Core/Light */
+  --figma___badges-soft-indigo-background: 241 100% 90% / 1;
+  /* ✦ Theme/Badges/Soft/Indigo/background/UI Core/Light */
+  --figma___badges-soft-indigo-text: 241 82% 66% / 1;
+  /* ✦ Theme/Badges/Soft/Indigo/text/UI Core/Light */
+  --figma___badges-soft-iris-background: 256 70% 95% / 1;
+  /* ✦ Theme/Badges/Soft/Iris/background/UI Core/Light */
+  --figma___badges-soft-iris-text: 256 68% 56% / 1;
+  /* ✦ Theme/Badges/Soft/Iris/text/UI Core/Light */
+  --figma___badges-soft-jade-background: 112 56% 89% / 1;
+  /* ✦ Theme/Badges/Soft/Jade/background/UI Core/Light */
+  --figma___badges-soft-jade-text: 122 58% 38% / 1;
+  /* ✦ Theme/Badges/Soft/Jade/text/UI Core/Light */
+  --figma___badges-soft-lime-background: 89 67% 92% / 1;
+  /* ✦ Theme/Badges/Soft/Lime/background/UI Core/Light */
+  --figma___badges-soft-lime-text: 92 48% 42% / 1;
+  /* ✦ Theme/Badges/Soft/Lime/text/UI Core/Light */
+  --figma___badges-soft-mint-background: 112 56% 89% / 1;
+  /* ✦ Theme/Badges/Soft/Mint/background/UI Core/Light */
+  --figma___badges-soft-mint-text: 122 58% 38% / 1;
+  /* ✦ Theme/Badges/Soft/Mint/text/UI Core/Light */
+  --figma___badges-soft-orange-background: 24 100% 95% / 1;
+  /* ✦ Theme/Badges/Soft/Orange/background/UI Core/Light */
+  --figma___badges-soft-orange-text: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Soft/Orange/text/UI Core/Light */
+  --figma___badges-soft-pink-background: 328 100% 97% / 1;
+  /* ✦ Theme/Badges/Soft/Pink/background/UI Core/Light */
+  --figma___badges-soft-pink-text: 331 85% 55% / 1;
+  /* ✦ Theme/Badges/Soft/Pink/text/UI Core/Light */
+  --figma___badges-soft-plum-background: 262 100% 94% / 1;
+  /* ✦ Theme/Badges/Soft/Plum/background/UI Core/Light */
+  --figma___badges-soft-plum-text: 261 60% 56% / 1;
+  /* ✦ Theme/Badges/Soft/Plum/text/UI Core/Light */
+  --figma___badges-soft-purple-background: 262 100% 91% / 1;
+  /* ✦ Theme/Badges/Soft/Purple/background/UI Core/Light */
+  --figma___badges-soft-purple-text: 261 60% 56% / 1;
+  /* ✦ Theme/Badges/Soft/Purple/text/UI Core/Light */
+  --figma___badges-soft-red-background: 4 73% 96% / 1;
+  /* ✦ Theme/Badges/Soft/Red/background/UI Core/Light */
+  --figma___badges-soft-red-text: 4 78% 52% / 1;
+  /* ✦ Theme/Badges/Soft/Red/text/UI Core/Light */
+  --figma___badges-soft-ruby-background: 4 73% 96% / 1;
+  /* ✦ Theme/Badges/Soft/Ruby/background/UI Core/Light */
+  --figma___badges-soft-ruby-text: 4 78% 52% / 1;
+  /* ✦ Theme/Badges/Soft/Ruby/text/UI Core/Light */
+  --figma___badges-soft-sky-background: 194 100% 82% / 1;
+  /* ✦ Theme/Badges/Soft/Sky/background/UI Core/Light */
+  --figma___badges-soft-sky-text: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Soft/Sky/text/UI Core/Light */
+  --figma___badges-soft-teal-background: 183 97% 87% / 1;
+  /* ✦ Theme/Badges/Soft/Teal/background/UI Core/Light */
+  --figma___badges-soft-teal-text: 184 94% 39% / 1;
+  /* ✦ Theme/Badges/Soft/Teal/text/UI Core/Light */
+  --figma___badges-soft-violet-background: 258 100% 98% / 1;
+  /* ✦ Theme/Badges/Soft/Violet/background/UI Core/Light */
+  --figma___badges-soft-violet-text: 256 68% 56% / 1;
+  /* ✦ Theme/Badges/Soft/Violet/text/UI Core/Light */
+  --figma___badges-soft-yellow-background: 45 100% 95% / 1;
+  /* ✦ Theme/Badges/Soft/Yellow/background/UI Core/Light */
+  --figma___badges-soft-yellow-text: 41 98% 45% / 1;
+  /* ✦ Theme/Badges/Soft/Yellow/text/UI Core/Light */
+  --figma___badges-soft-accent-background: 192 96% 90% / 1;
+  /* ✦ Theme/Badges/Soft/accent/background/UI Core/Light */
+  --figma___badges-soft-accent-text: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Soft/accent/text/UI Core/Light */
+  --figma___badges-soft-error-background: 4 73% 96% / 1;
+  /* ✦ Theme/Badges/Soft/error/background/UI Core/Light */
+  --figma___badges-soft-error-text: 3 84% 38% / 1;
+  /* ✦ Theme/Badges/Soft/error/text/UI Core/Light */
+  --figma___badges-soft-info-background: 192 96% 90% / 1;
+  /* ✦ Theme/Badges/Soft/info/background/UI Core/Light */
+  --figma___badges-soft-info-text: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Soft/info/text/UI Core/Light */
+  --figma___badges-soft-success-background: 112 58% 93% / 1;
+  /* ✦ Theme/Badges/Soft/success/background/UI Core/Light */
+  --figma___badges-soft-success-text: 121 66% 31% / 1;
+  /* ✦ Theme/Badges/Soft/success/text/UI Core/Light */
+  --figma___badges-soft-warning-background: 24 100% 95% / 1;
+  /* ✦ Theme/Badges/Soft/warning/background/UI Core/Light */
+  --figma___badges-soft-warning-text: 22 100% 56% / 1;
+  /* ✦ Theme/Badges/Soft/warning/text/UI Core/Light */
+  --figma___badges-solid-amber-background: 41 100% 55% / 1;
+  /* ✦ Theme/Badges/Solid/Amber/background/UI Core/Light */
+  --figma___badges-solid-amber-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Amber/text/UI Core/Light */
+  --figma___badges-solid-blue-background: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Solid/Blue/background/UI Core/Light */
+  --figma___badges-solid-blue-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Blue/text/UI Core/Light */
+  --figma___badges-solid-bronze-background: 22 100% 56% / 1;
+  /* ✦ Theme/Badges/Solid/Bronze/background/UI Core/Light */
+  --figma___badges-solid-bronze-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Bronze/text/UI Core/Light */
+  --figma___badges-solid-brown-background: 22 100% 56% / 1;
+  /* ✦ Theme/Badges/Solid/Brown/background/UI Core/Light */
+  --figma___badges-solid-brown-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Brown/text/UI Core/Light */
+  --figma___badges-solid-crimson-background: 331 85% 55% / 1;
+  /* ✦ Theme/Badges/Solid/Crimson/background/UI Core/Light */
+  --figma___badges-solid-crimson-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Crimson/text/UI Core/Light */
+  --figma___badges-solid-cyan-background: 184 90% 44% / 1;
+  /* ✦ Theme/Badges/Solid/Cyan/background/UI Core/Light */
+  --figma___badges-solid-cyan-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Cyan/text/UI Core/Light */
+  --figma___badges-solid-gold-background: 22 100% 56% / 1;
+  /* ✦ Theme/Badges/Solid/Gold/background/UI Core/Light */
+  --figma___badges-solid-gold-text: 240 8% 5% / 1;
+  /* ✦ Theme/Badges/Solid/Gold/text/UI Core/Light */
+  --figma___badges-solid-grass-background: 122 58% 38% / 1;
+  /* ✦ Theme/Badges/Solid/Grass/background/UI Core/Light */
+  --figma___badges-solid-grass-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Grass/text/UI Core/Light */
+  --figma___badges-solid-green-background: 121 66% 31% / 1;
+  /* ✦ Theme/Badges/Solid/Green/background/UI Core/Light */
+  --figma___badges-solid-green-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Green/text/UI Core/Light */
+  --figma___badges-solid-indigo-background: 241 82% 66% / 1;
+  /* ✦ Theme/Badges/Solid/Indigo/background/UI Core/Light */
+  --figma___badges-solid-indigo-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Indigo/text/UI Core/Light */
+  --figma___badges-solid-iris-background: 256 68% 56% / 1;
+  /* ✦ Theme/Badges/Solid/Iris/background/UI Core/Light */
+  --figma___badges-solid-iris-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Iris/text/UI Core/Light */
+  --figma___badges-solid-jade-background: 122 44% 46% / 1;
+  /* ✦ Theme/Badges/Solid/Jade/background/UI Core/Light */
+  --figma___badges-solid-jade-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Jade/text/UI Core/Light */
+  --figma___badges-solid-lime-background: 92 48% 42% / 1;
+  /* ✦ Theme/Badges/Solid/Lime/background/UI Core/Light */
+  --figma___badges-solid-lime-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Lime/text/UI Core/Light */
+  --figma___badges-solid-mint-background: 122 44% 46% / 1;
+  /* ✦ Theme/Badges/Solid/Mint/background/UI Core/Light */
+  --figma___badges-solid-mint-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Mint/text/UI Core/Light */
+  --figma___badges-solid-orange-background: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Solid/Orange/background/UI Core/Light */
+  --figma___badges-solid-orange-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Orange/text/UI Core/Light */
+  --figma___badges-solid-pink-background: 331 85% 55% / 1;
+  /* ✦ Theme/Badges/Solid/Pink/background/UI Core/Light */
+  --figma___badges-solid-pink-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Pink/text/UI Core/Light */
+  --figma___badges-solid-plum-background: 261 60% 56% / 1;
+  /* ✦ Theme/Badges/Solid/Plum/background/UI Core/Light */
+  --figma___badges-solid-plum-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Plum/text/UI Core/Light */
+  --figma___badges-solid-purple-background: 261 60% 56% / 1;
+  /* ✦ Theme/Badges/Solid/Purple/background/UI Core/Light */
+  --figma___badges-solid-purple-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Purple/text/UI Core/Light */
+  --figma___badges-solid-red-background: 4 78% 52% / 1;
+  /* ✦ Theme/Badges/Solid/Red/background/UI Core/Light */
+  --figma___badges-solid-red-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Red/text/UI Core/Light */
+  --figma___badges-solid-ruby-background: 4 78% 52% / 1;
+  /* ✦ Theme/Badges/Solid/Ruby/background/UI Core/Light */
+  --figma___badges-solid-ruby-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Ruby/text/UI Core/Light */
+  --figma___badges-solid-sky-background: 194 100% 82% / 1;
+  /* ✦ Theme/Badges/Solid/Sky/background/UI Core/Light */
+  --figma___badges-solid-sky-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Sky/text/UI Core/Light */
+  --figma___badges-solid-success-background: 121 66% 31% / 1;
+  /* ✦ Theme/Badges/Solid/Success/background/UI Core/Light */
+  --figma___badges-solid-success-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Success/text/UI Core/Light */
+  --figma___badges-solid-teal-background: 184 90% 44% / 1;
+  /* ✦ Theme/Badges/Solid/Teal/background/UI Core/Light */
+  --figma___badges-solid-teal-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Teal/text/UI Core/Light */
+  --figma___badges-solid-violet-background: 256 68% 56% / 1;
+  /* ✦ Theme/Badges/Solid/Violet/background/UI Core/Light */
+  --figma___badges-solid-violet-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/Violet/text/UI Core/Light */
+  --figma___badges-solid-yellow-background: 45 98% 60% / 1;
+  /* ✦ Theme/Badges/Solid/Yellow/background/UI Core/Light */
+  --figma___badges-solid-yellow-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Yellow/text/UI Core/Light */
+  --figma___badges-solid-accent-background: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Solid/accent/background/UI Core/Light */
+  --figma___badges-solid-accent-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/accent/text/UI Core/Light */
+  --figma___badges-solid-info-background: 241 90% 64% / 1;
+  /* ✦ Theme/Badges/Solid/info/background/UI Core/Light */
+  --figma___badges-solid-info-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/info/text/UI Core/Light */
+  --figma___badges-solid-warning-background: 24 100% 57% / 1;
+  /* ✦ Theme/Badges/Solid/warning/background/UI Core/Light */
+  --figma___badges-solid-warning-text: 0 0% 100% / 1;
+  /* ✦ Theme/Badges/Solid/warning/text/UI Core/Light */
+  --figma___badges-surface-amber-background: 45 100% 95% / 1;
+  /* ✦ Theme/Badges/Surface/Amber/background/UI Core/Light */
+  --figma___badges-surface-amber-border: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Surface/Amber/border/UI Core/Light */
+  --figma___badges-surface-amber-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Surface/Amber/text/UI Core/Light */
+  --figma___badges-surface-blue-background: 195 100% 97% / 1;
+  /* ✦ Theme/Badges/Surface/Blue/background/UI Core/Light */
+  --figma___badges-surface-blue-border: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Blue/border/UI Core/Light */
+  --figma___badges-surface-blue-text: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Blue/text/UI Core/Light */
+  --figma___badges-surface-bronze-background: 24 100% 95% / 1;
+  /* ✦ Theme/Badges/Surface/Bronze/background/UI Core/Light */
+  --figma___badges-surface-bronze-border: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Surface/Bronze/border/UI Core/Light */
+  --figma___badges-surface-bronze-text: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Surface/Bronze/text/UI Core/Light */
+  --figma___badges-surface-brown-background: 27 100% 96% / 1;
+  /* ✦ Theme/Badges/Surface/Brown/background/UI Core/Light */
+  --figma___badges-surface-brown-border: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Surface/Brown/border/UI Core/Light */
+  --figma___badges-surface-brown-text: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Surface/Brown/text/UI Core/Light */
+  --figma___badges-surface-crimson-border: 331 85% 55% / 1;
+  /* ✦ Theme/Badges/Surface/Crimson/Border/UI Core/Light */
+  --figma___badges-surface-crimson-background: 328 100% 97% / 1;
+  /* ✦ Theme/Badges/Surface/Crimson/background/UI Core/Light */
+  --figma___badges-surface-crimson-text: 331 85% 55% / 1;
+  /* ✦ Theme/Badges/Surface/Crimson/text/UI Core/Light */
+  --figma___badges-surface-cyan-border: 184 94% 39% / 1;
+  /* ✦ Theme/Badges/Surface/Cyan/Border/UI Core/Light */
+  --figma___badges-surface-cyan-background: 183 97% 87% / 1;
+  /* ✦ Theme/Badges/Surface/Cyan/background/UI Core/Light */
+  --figma___badges-surface-cyan-text: 184 94% 39% / 1;
+  /* ✦ Theme/Badges/Surface/Cyan/text/UI Core/Light */
+  --figma___badges-surface-gold-border: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Surface/Gold/Border/UI Core/Light */
+  --figma___badges-surface-gold-background: 24 100% 95% / 1;
+  /* ✦ Theme/Badges/Surface/Gold/background/UI Core/Light */
+  --figma___badges-surface-gold-text: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Surface/Gold/text/UI Core/Light */
+  --figma___badges-surface-grass-border: 122 58% 38% / 1;
+  /* ✦ Theme/Badges/Surface/Grass/Border/UI Core/Light */
+  --figma___badges-surface-grass-background: 112 58% 93% / 1;
+  /* ✦ Theme/Badges/Surface/Grass/background/UI Core/Light */
+  --figma___badges-surface-grass-text: 122 58% 38% / 1;
+  /* ✦ Theme/Badges/Surface/Grass/text/UI Core/Light */
+  --figma___badges-surface-green-background: 112 56% 89% / 1;
+  /* ✦ Theme/Badges/Surface/Green/background/UI Core/Light */
+  --figma___badges-surface-green-border: 122 53% 55% / 1;
+  /* ✦ Theme/Badges/Surface/Green/border/UI Core/Light */
+  --figma___badges-surface-green-text: 122 53% 55% / 1;
+  /* ✦ Theme/Badges/Surface/Green/text/UI Core/Light */
+  --figma___badges-surface-indigo-background: 241 100% 90% / 1;
+  /* ✦ Theme/Badges/Surface/Indigo/background/UI Core/Light */
+  --figma___badges-surface-indigo-border: 241 82% 66% / 1;
+  /* ✦ Theme/Badges/Surface/Indigo/border/UI Core/Light */
+  --figma___badges-surface-indigo-text: 241 82% 66% / 1;
+  /* ✦ Theme/Badges/Surface/Indigo/text/UI Core/Light */
+  --figma___badges-surface-iris-border: 256 68% 56% / 1;
+  /* ✦ Theme/Badges/Surface/Iris/Border/UI Core/Light */
+  --figma___badges-surface-iris-background: 256 70% 95% / 1;
+  /* ✦ Theme/Badges/Surface/Iris/background/UI Core/Light */
+  --figma___badges-surface-iris-text: 256 68% 56% / 1;
+  /* ✦ Theme/Badges/Surface/Iris/text/UI Core/Light */
+  --figma___badges-surface-jade-border: 122 58% 38% / 1;
+  /* ✦ Theme/Badges/Surface/Jade/Border/UI Core/Light */
+  --figma___badges-surface-jade-background: 112 56% 89% / 1;
+  /* ✦ Theme/Badges/Surface/Jade/background/UI Core/Light */
+  --figma___badges-surface-jade-text: 122 58% 38% / 1;
+  /* ✦ Theme/Badges/Surface/Jade/text/UI Core/Light */
+  --figma___badges-surface-lime-border: 92 48% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Lime/Border/UI Core/Light */
+  --figma___badges-surface-lime-background: 89 67% 92% / 1;
+  /* ✦ Theme/Badges/Surface/Lime/background/UI Core/Light */
+  --figma___badges-surface-lime-text: 92 48% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Lime/text/UI Core/Light */
+  --figma___badges-surface-mint-background: 112 56% 89% / 1;
+  /* ✦ Theme/Badges/Surface/Mint/background/UI Core/Light */
+  --figma___badges-surface-mint-border: 122 58% 38% / 1;
+  /* ✦ Theme/Badges/Surface/Mint/border/UI Core/Light */
+  --figma___badges-surface-mint-text: 122 58% 38% / 1;
+  /* ✦ Theme/Badges/Surface/Mint/text/UI Core/Light */
+  --figma___badges-surface-orange-background: 24 100% 95% / 1;
+  /* ✦ Theme/Badges/Surface/Orange/background/UI Core/Light */
+  --figma___badges-surface-orange-border: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Surface/Orange/border/UI Core/Light */
+  --figma___badges-surface-orange-text: 25 100% 58% / 1;
+  /* ✦ Theme/Badges/Surface/Orange/text/UI Core/Light */
+  --figma___badges-surface-pink-background: 328 100% 97% / 1;
+  /* ✦ Theme/Badges/Surface/Pink/background/UI Core/Light */
+  --figma___badges-surface-pink-border: 331 85% 55% / 1;
+  /* ✦ Theme/Badges/Surface/Pink/border/UI Core/Light */
+  --figma___badges-surface-pink-text: 331 85% 55% / 1;
+  /* ✦ Theme/Badges/Surface/Pink/text/UI Core/Light */
+  --figma___badges-surface-plum-background: 262 100% 94% / 1;
+  /* ✦ Theme/Badges/Surface/Plum/background/UI Core/Light */
+  --figma___badges-surface-plum-border: 261 60% 56% / 1;
+  /* ✦ Theme/Badges/Surface/Plum/border/UI Core/Light */
+  --figma___badges-surface-plum-text: 261 60% 56% / 1;
+  /* ✦ Theme/Badges/Surface/Plum/text/UI Core/Light */
+  --figma___badges-surface-purple-background: 262 100% 91% / 1;
+  /* ✦ Theme/Badges/Surface/Purple/background/UI Core/Light */
+  --figma___badges-surface-purple-border: 261 60% 56% / 1;
+  /* ✦ Theme/Badges/Surface/Purple/border/UI Core/Light */
+  --figma___badges-surface-purple-text: 261 60% 56% / 1;
+  /* ✦ Theme/Badges/Surface/Purple/text/UI Core/Light */
+  --figma___badges-surface-red-background: 4 73% 96% / 1;
+  /* ✦ Theme/Badges/Surface/Red/background/UI Core/Light */
+  --figma___badges-surface-red-border: 4 78% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Red/border/UI Core/Light */
+  --figma___badges-surface-red-text: 4 78% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Red/text/UI Core/Light */
+  --figma___badges-surface-ruby-background: 4 73% 96% / 1;
+  /* ✦ Theme/Badges/Surface/Ruby/background/UI Core/Light */
+  --figma___badges-surface-ruby-border: 4 78% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Ruby/border/UI Core/Light */
+  --figma___badges-surface-ruby-text: 4 78% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Ruby/text/UI Core/Light */
+  --figma___badges-surface-sky-background: 194 100% 82% / 1;
+  /* ✦ Theme/Badges/Surface/Sky/background/UI Core/Light */
+  --figma___badges-surface-sky-border: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Sky/border/UI Core/Light */
+  --figma___badges-surface-sky-text: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Sky/text/UI Core/Light */
+  --figma___badges-surface-teal-background: 183 97% 87% / 1;
+  /* ✦ Theme/Badges/Surface/Teal/background/UI Core/Light */
+  --figma___badges-surface-teal-border: 184 94% 39% / 1;
+  /* ✦ Theme/Badges/Surface/Teal/border/UI Core/Light */
+  --figma___badges-surface-teal-text: 184 94% 39% / 1;
+  /* ✦ Theme/Badges/Surface/Teal/text/UI Core/Light */
+  --figma___badges-surface-violet-background: 258 100% 98% / 1;
+  /* ✦ Theme/Badges/Surface/Violet/background/UI Core/Light */
+  --figma___badges-surface-violet-border: 256 68% 56% / 1;
+  /* ✦ Theme/Badges/Surface/Violet/border/UI Core/Light */
+  --figma___badges-surface-violet-text: 256 68% 56% / 1;
+  /* ✦ Theme/Badges/Surface/Violet/text/UI Core/Light */
+  --figma___badges-surface-yellow-background: 45 100% 95% / 1;
+  /* ✦ Theme/Badges/Surface/Yellow/background/UI Core/Light */
+  --figma___badges-surface-yellow-border: 41 98% 45% / 1;
+  /* ✦ Theme/Badges/Surface/Yellow/border/UI Core/Light */
+  --figma___badges-surface-yellow-text: 41 98% 45% / 1;
+  /* ✦ Theme/Badges/Surface/Yellow/text/UI Core/Light */
+  --figma___badges-surface-accent-background: 195 100% 97% / 1;
+  /* ✦ Theme/Badges/Surface/accent/background/UI Core/Light */
+  --figma___badges-surface-accent-border: 213 100% 32% / 1;
+  /* ✦ Theme/Badges/Surface/accent/border/UI Core/Light */
+  --figma___badges-surface-accent-text: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Surface/accent/text/UI Core/Light */
+  --figma___badges-surface-error-background: 4 73% 96% / 1;
+  /* ✦ Theme/Badges/Surface/error/background/UI Core/Light */
+  --figma___badges-surface-error-border: 3 84% 38% / 1;
+  /* ✦ Theme/Badges/Surface/error/border/UI Core/Light */
+  --figma___badges-surface-error-text: 3 84% 38% / 1;
+  /* ✦ Theme/Badges/Surface/error/text/UI Core/Light */
+  --figma___badges-surface-info-background: 192 96% 90% / 1;
+  /* ✦ Theme/Badges/Surface/info/background/UI Core/Light */
+  --figma___badges-surface-info-border: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Surface/info/border/UI Core/Light */
+  --figma___badges-surface-info-text: 206 98% 42% / 1;
+  /* ✦ Theme/Badges/Surface/info/text/UI Core/Light */
+  --figma___badges-surface-success-background: 112 58% 93% / 1;
+  /* ✦ Theme/Badges/Surface/success/background/UI Core/Light */
+  --figma___badges-surface-success-border: 121 66% 31% / 1;
+  /* ✦ Theme/Badges/Surface/success/border/UI Core/Light */
+  --figma___badges-surface-success-text: 121 66% 31% / 1;
+  /* ✦ Theme/Badges/Surface/success/text/UI Core/Light */
+  --figma___badges-surface-warning-background: 24 100% 95% / 1;
+  /* ✦ Theme/Badges/Surface/warning/background/UI Core/Light */
+  --figma___badges-surface-warning-border: 22 100% 56% / 1;
+  /* ✦ Theme/Badges/Surface/warning/border/UI Core/Light */
+  --figma___badges-surface-warning-text: 22 100% 56% / 1;
+  /* ✦ Theme/Badges/Surface/warning/text/UI Core/Light */
+  --figma___border-disabled: 235 19% 87% / 1;
+  /* ✦ Theme/Border/Disabled/UI Core/Light */
+  --figma___border-hover: 213 100% 32% / 1;
+  /* ✦ Theme/Border/Hover/UI Core/Light */
+  --figma___border-primary: 235 19% 87% / 1;
+  /* ✦ Theme/Border/Primary/UI Core/Light */
+  --figma___border-secondary: 240 41% 97% / 1;
+  /* ✦ Theme/Border/Secondary/UI Core/Light */
+  --figma___border-selected: 206 98% 42% / 1;
+  /* ✦ Theme/Border/Selected/UI Core/Light */
+  --figma___breadcrumbs-current: 235 11% 47% / 1;
+  /* ✦ Theme/Breadcrumbs/current/UI Core/Light */
+  --figma___breadcrumbs-visited: 206 98% 42% / 1;
+  /* ✦ Theme/Breadcrumbs/visited/UI Core/Light */
+  --figma___button-ghost-accent-active: 213 100% 32% / 0;
+  /* ✦ Theme/Button/Ghost/Accent/Active/UI Core/Light */
+  --figma___button-ghost-accent-active-text: 213 100% 32% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Active text/UI Core/Light */
+  --figma___button-ghost-accent-hover: 213 100% 32% / 0;
+  /* ✦ Theme/Button/Ghost/Accent/Hover/UI Core/Light */
+  --figma___button-ghost-accent-hover-text: 213 100% 32% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Hover text/UI Core/Light */
+  --figma___button-ghost-accent-text-disabled: 206 98% 42% / 0.5;
+  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/UI Core/Light */
+  --figma___button-ghost-accent-text-primary: 206 98% 42% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Text-primary/UI Core/Light */
+  --figma___button-ghost-error-active: 4 75% 75% / 0;
+  /* ✦ Theme/Button/Ghost/Error/Active/UI Core/Light */
+  --figma___button-ghost-error-active-text: 3 79% 43% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Active Text/UI Core/Light */
+  --figma___button-ghost-error-hover: 4 74% 85% / 0;
+  /* ✦ Theme/Button/Ghost/Error/Hover/UI Core/Light */
+  --figma___button-ghost-error-hover-text: 3 79% 43% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Hover text/UI Core/Light */
+  --figma___button-ghost-error-text-disabled: 4 75% 75% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Text-disabled/UI Core/Light */
+  --figma___button-ghost-error-text-primary: 4 79% 45% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Text-primary/UI Core/Light */
+  --figma___button-ghost-neutral-active: 235 19% 87% / 0;
+  /* ✦ Theme/Button/Ghost/Neutral/Active/UI Core/Light */
+  --figma___button-ghost-neutral-active-text: 240 11% 15% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Active Text/UI Core/Light */
+  --figma___button-ghost-neutral-hover: 240 41% 97% / 0;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover/UI Core/Light */
+  --figma___button-ghost-neutral-hover-text: 240 11% 15% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover text/UI Core/Light */
+  --figma___button-ghost-neutral-text-disabled: 237 14% 73% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/UI Core/Light */
+  --figma___button-ghost-neutral-text-primary: 234 11% 35% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/UI Core/Light */
+  --figma___button-ghost-success-active: 139 99% 33% / 0;
+  /* ✦ Theme/Button/Ghost/Success/Active/UI Core/Light */
+  --figma___button-ghost-success-active-text: 121 66% 31% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Active Text/UI Core/Light */
+  --figma___button-ghost-success-hover: 139 98% 37% / 0;
+  /* ✦ Theme/Button/Ghost/Success/Hover/UI Core/Light */
+  --figma___button-ghost-success-hover-text: 121 66% 31% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Hover text/UI Core/Light */
+  --figma___button-ghost-success-text-disabled: 114 55% 75% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Text-disabled/UI Core/Light */
+  --figma___button-ghost-success-text-primary: 122 58% 38% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Text-primary/UI Core/Light */
+  --figma___button-outline-accent-active: 195 100% 97% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Active/UI Core/Light */
+  --figma___button-outline-accent-default-border: 206 98% 42% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Default border/UI Core/Light */
+  --figma___button-outline-accent-disabled-border: 206 98% 42% / 0.5;
+  /* ✦ Theme/Button/Outline/Accent/Disabled Border/UI Core/Light */
+  --figma___button-outline-accent-hover: 195 100% 97% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Hover/UI Core/Light */
+  --figma___button-outline-accent-text-disabled: 206 98% 42% / 0.5;
+  /* ✦ Theme/Button/Outline/Accent/Text-disabled/UI Core/Light */
+  --figma___button-outline-accent-text-primary: 206 98% 42% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Text-primary/UI Core/Light */
+  --figma___button-outline-error-active: 5 74% 94% / 1;
+  /* ✦ Theme/Button/Outline/Error/Active/UI Core/Light */
+  --figma___button-outline-error-default-border: 4 77% 48% / 1;
+  /* ✦ Theme/Button/Outline/Error/Default - border/UI Core/Light */
+  --figma___button-outline-error-disabled-border: 4 74% 85% / 1;
+  /* ✦ Theme/Button/Outline/Error/Disabled-border/UI Core/Light */
+  --figma___button-outline-error-hover: 5 74% 94% / 1;
+  /* ✦ Theme/Button/Outline/Error/Hover/UI Core/Light */
+  --figma___button-outline-error-text-disabled: 4 82% 63% / 1;
+  /* ✦ Theme/Button/Outline/Error/Text-disabled/UI Core/Light */
+  --figma___button-outline-error-text-primary: 3 79% 43% / 1;
+  /* ✦ Theme/Button/Outline/Error/Text-primary/UI Core/Light */
+  --figma___button-outline-neutral-active: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Active/UI Core/Light */
+  --figma___button-outline-neutral-default-border: 235 19% 87% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Default - border/UI Core/Light */
+  --figma___button-outline-neutral-disabled-border: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/UI Core/Light */
+  --figma___button-outline-neutral-hover: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Hover/UI Core/Light */
+  --figma___button-outline-neutral-text-disabled: 237 14% 73% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/UI Core/Light */
+  --figma___button-outline-neutral-text-primary: 236 11% 25% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Text-primary/UI Core/Light */
+  --figma___button-outline-success-active: 112 58% 93% / 1;
+  /* ✦ Theme/Button/Outline/Success/Active/UI Core/Light */
+  --figma___button-outline-success-default-border: 122 58% 38% / 1;
+  /* ✦ Theme/Button/Outline/Success/Default-border/UI Core/Light */
+  --figma___button-outline-success-disabled-border: 113 55% 82% / 1;
+  /* ✦ Theme/Button/Outline/Success/Disabled - border/UI Core/Light */
+  --figma___button-outline-success-hover: 112 58% 93% / 1;
+  /* ✦ Theme/Button/Outline/Success/Hover/UI Core/Light */
+  --figma___button-outline-success-text-disabled: 117 54% 68% / 1;
+  /* ✦ Theme/Button/Outline/Success/Text-disabled/UI Core/Light */
+  --figma___button-outline-success-text-primary: 121 66% 31% / 1;
+  /* ✦ Theme/Button/Outline/Success/Text-primary/UI Core/Light */
+  --figma___button-soft-accent-active: 192 96% 90% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Active/UI Core/Light */
+  --figma___button-soft-accent-disabled: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Disabled/UI Core/Light */
+  --figma___button-soft-accent-hover: 192 96% 90% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Hover/UI Core/Light */
+  --figma___button-soft-accent-text-disabled: 237 14% 73% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Text-disabled/UI Core/Light */
+  --figma___button-soft-accent-text-primary: 206 98% 42% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Text-primary/UI Core/Light */
+  --figma___button-soft-accent-default: 195 100% 97% / 1;
+  /* ✦ Theme/Button/Soft/Accent/default/UI Core/Light */
+  --figma___button-soft-error-active: 5 74% 94% / 1;
+  /* ✦ Theme/Button/Soft/Error/Active/UI Core/Light */
+  --figma___button-soft-error-disabled: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Soft/Error/Disabled/UI Core/Light */
+  --figma___button-soft-error-hover: 5 74% 94% / 1;
+  /* ✦ Theme/Button/Soft/Error/Hover/UI Core/Light */
+  --figma___button-soft-error-text-disabled: 237 14% 73% / 1;
+  /* ✦ Theme/Button/Soft/Error/Text-disabled/UI Core/Light */
+  --figma___button-soft-error-text-primary: 4 79% 45% / 1;
+  /* ✦ Theme/Button/Soft/Error/Text-primary/UI Core/Light */
+  --figma___button-soft-error-default: 4 73% 96% / 1;
+  /* ✦ Theme/Button/Soft/Error/default/UI Core/Light */
+  --figma___button-soft-neutral-active: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Active/UI Core/Light */
+  --figma___button-soft-neutral-disabled: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Disabled/UI Core/Light */
+  --figma___button-soft-neutral-hover: 235 19% 87% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Hover/UI Core/Light */
+  --figma___button-soft-neutral-text-disabled: 237 14% 73% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/UI Core/Light */
+  --figma___button-soft-neutral-text-primary: 236 11% 25% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Text-primary/UI Core/Light */
+  --figma___button-soft-neutral-default: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/default/UI Core/Light */
+  --figma___button-soft-success-active: 112 56% 89% / 1;
+  /* ✦ Theme/Button/Soft/Success/Active/UI Core/Light */
+  --figma___button-soft-success-disabled: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Soft/Success/Disabled/UI Core/Light */
+  --figma___button-soft-success-hover: 112 56% 89% / 1;
+  /* ✦ Theme/Button/Soft/Success/Hover/UI Core/Light */
+  --figma___button-soft-success-text-disabled: 237 14% 73% / 1;
+  /* ✦ Theme/Button/Soft/Success/Text-disabled/UI Core/Light */
+  --figma___button-soft-success-text-primary: 122 58% 38% / 1;
+  /* ✦ Theme/Button/Soft/Success/Text-primary/UI Core/Light */
+  --figma___button-soft-success-default: 112 58% 93% / 1;
+  /* ✦ Theme/Button/Soft/Success/default/UI Core/Light */
+  --figma___button-solid-accent-active: 206 98% 42% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Active/UI Core/Light */
+  --figma___button-solid-accent-disabled: 206 98% 42% / 0.5;
+  /* ✦ Theme/Button/Solid/Accent/Disabled/UI Core/Light */
+  --figma___button-solid-accent-hover: 213 100% 32% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Hover/UI Core/Light */
+  --figma___button-solid-accent-text-disabled: 0 0% 100% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Text-disabled/UI Core/Light */
+  --figma___button-solid-accent-text-primary: 0 0% 100% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Text-primary/UI Core/Light */
+  --figma___button-solid-accent-default: 206 98% 42% / 1;
+  /* ✦ Theme/Button/Solid/Accent/default/UI Core/Light */
+  --figma___button-solid-error-active: 4 77% 48% / 1;
+  /* ✦ Theme/Button/Solid/Error/Active/UI Core/Light */
+  --figma___button-solid-error-disabled: 4 75% 75% / 1;
+  /* ✦ Theme/Button/Solid/Error/Disabled/UI Core/Light */
+  --figma___button-solid-error-hover: 3 84% 38% / 1;
+  /* ✦ Theme/Button/Solid/Error/Hover/UI Core/Light */
+  --figma___button-solid-error-text-disabled: 0 0% 100% / 1;
+  /* ✦ Theme/Button/Solid/Error/Text-disabled/UI Core/Light */
+  --figma___button-solid-error-text-primary: 0 0% 100% / 1;
+  /* ✦ Theme/Button/Solid/Error/Text-primary/UI Core/Light */
+  --figma___button-solid-error-default: 4 77% 48% / 1;
+  /* ✦ Theme/Button/Solid/Error/default/UI Core/Light */
+  --figma___button-solid-neutral-active: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Active/UI Core/Light */
+  --figma___button-solid-neutral-disabled: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Disabled/UI Core/Light */
+  --figma___button-solid-neutral-hover: 235 19% 87% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Hover/UI Core/Light */
+  --figma___button-solid-neutral-text-disabled: 237 14% 73% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/UI Core/Light */
+  --figma___button-solid-neutral-text-primary: 236 11% 25% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Text-primary/UI Core/Light */
+  --figma___button-solid-neutral-default: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/default/UI Core/Light */
+  --figma___button-solid-success-active: 122 44% 46% / 1;
+  /* ✦ Theme/Button/Solid/Success/Active/UI Core/Light */
+  --figma___button-solid-success-disabled: 117 54% 68% / 1;
+  /* ✦ Theme/Button/Solid/Success/Disabled/UI Core/Light */
+  --figma___button-solid-success-hover: 121 66% 31% / 1;
+  /* ✦ Theme/Button/Solid/Success/Hover/UI Core/Light */
+  --figma___button-solid-success-text-disabled: 0 0% 100% / 1;
+  /* ✦ Theme/Button/Solid/Success/Text-disabled/UI Core/Light */
+  --figma___button-solid-success-text-primary: 0 0% 100% / 1;
+  /* ✦ Theme/Button/Solid/Success/Text-primary/UI Core/Light */
+  --figma___button-solid-success-default: 122 44% 46% / 1;
+  /* ✦ Theme/Button/Solid/Success/default/UI Core/Light */
+  --figma___button-surface-accent-active: 192 96% 90% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Active/UI Core/Light */
+  --figma___button-surface-accent-active-border: 194 100% 82% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Active border/UI Core/Light */
+  --figma___button-surface-accent-disabled: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Disabled/UI Core/Light */
+  --figma___button-surface-accent-hover: 192 96% 90% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Hover/UI Core/Light */
+  --figma___button-surface-accent-hover-border: 194 100% 82% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Hover Border/UI Core/Light */
+  --figma___button-surface-accent-text-disabled: 206 98% 42% / 0.5;
+  /* ✦ Theme/Button/Surface/Accent/Text-disabled/UI Core/Light */
+  --figma___button-surface-accent-text-primary: 206 98% 42% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Text-primary/UI Core/Light */
+  --figma___button-surface-accent-default: 195 100% 97% / 1;
+  /* ✦ Theme/Button/Surface/Accent/default/UI Core/Light */
+  --figma___button-surface-accent-default-border: 194 100% 82% / 1;
+  /* ✦ Theme/Button/Surface/Accent/default border/UI Core/Light */
+  --figma___button-surface-error-active: 5 74% 94% / 1;
+  /* ✦ Theme/Button/Surface/Error/Active/UI Core/Light */
+  --figma___button-surface-error-active-border: 4 74% 85% / 1;
+  /* ✦ Theme/Button/Surface/Error/Active border/UI Core/Light */
+  --figma___button-surface-error-disabled: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Surface/Error/Disabled/UI Core/Light */
+  --figma___button-surface-error-hover: 5 74% 94% / 1;
+  /* ✦ Theme/Button/Surface/Error/Hover/UI Core/Light */
+  --figma___button-surface-error-hover-border: 4 74% 85% / 1;
+  /* ✦ Theme/Button/Surface/Error/Hover border/UI Core/Light */
+  --figma___button-surface-error-text-disabled: 237 14% 73% / 1;
+  /* ✦ Theme/Button/Surface/Error/Text-disabled/UI Core/Light */
+  --figma___button-surface-error-text-primary: 4 79% 45% / 1;
+  /* ✦ Theme/Button/Surface/Error/Text-primary/UI Core/Light */
+  --figma___button-surface-error-border: 4 74% 85% / 1;
+  /* ✦ Theme/Button/Surface/Error/border/UI Core/Light */
+  --figma___button-surface-error-default: 4 73% 96% / 1;
+  /* ✦ Theme/Button/Surface/Error/default/UI Core/Light */
+  --figma___button-surface-neutral-active: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Active/UI Core/Light */
+  --figma___button-surface-neutral-disabled: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Disabled/UI Core/Light */
+  --figma___button-surface-neutral-hover: 210 25% 98% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Hover/UI Core/Light */
+  --figma___button-surface-neutral-text-disabled: 237 14% 73% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/UI Core/Light */
+  --figma___button-surface-neutral-text-primary: 236 11% 25% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Text-primary/UI Core/Light */
+  --figma___button-surface-neutral-border: 235 19% 87% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/border/UI Core/Light */
+  --figma___button-surface-neutral-default: 240 41% 97% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/default/UI Core/Light */
+  --figma___button-surface-success-active: 112 56% 89% / 1;
+  /* ✦ Theme/Button/Surface/Success/Active/UI Core/Light */
+  --figma___button-surface-success-disabled: 235 19% 87% / 1;
+  /* ✦ Theme/Button/Surface/Success/Disabled/UI Core/Light */
+  --figma___button-surface-success-hover: 112 56% 89% / 1;
+  /* ✦ Theme/Button/Surface/Success/Hover/UI Core/Light */
+  --figma___button-surface-success-hover-border: 122 53% 55% / 1;
+  /* ✦ Theme/Button/Surface/Success/Hover border/UI Core/Light */
+  --figma___button-surface-success-text-disabled: 237 14% 73% / 1;
+  /* ✦ Theme/Button/Surface/Success/Text-disabled/UI Core/Light */
+  --figma___button-surface-success-text-primary: 122 58% 38% / 1;
+  /* ✦ Theme/Button/Surface/Success/Text-primary/UI Core/Light */
+  --figma___button-surface-success-active-border: 122 53% 55% / 1;
+  /* ✦ Theme/Button/Surface/Success/active border/UI Core/Light */
+  --figma___button-surface-success-default: 112 58% 93% / 1;
+  /* ✦ Theme/Button/Surface/Success/default/UI Core/Light */
+  --figma___button-surface-success-default-border: 113 55% 82% / 1;
+  /* ✦ Theme/Button/Surface/Success/default border/UI Core/Light */
+  --figma___calendar-background: 0 0% 100% / 1;
+  /* ✦ Theme/Calendar/Background/UI Core/Light */
+  --figma___calendar-selected-date-background: 206 98% 42% / 1;
+  /* ✦ Theme/Calendar/Selected Date/Background/UI Core/Light */
+  --figma___calendar-selected-date-text: 0 0% 100% / 1;
+  /* ✦ Theme/Calendar/Selected Date/Text/UI Core/Light */
+  --figma___calendar-selected-range-background: 195 100% 97% / 1;
+  /* ✦ Theme/Calendar/Selected Range/Background/UI Core/Light */
+  --figma___calendar-selected-range-text: 206 98% 42% / 1;
+  /* ✦ Theme/Calendar/Selected Range/Text/UI Core/Light */
+  --figma___checkbox-background: 0 0% 100% / 0.8;
+  /* ✦ Theme/Checkbox/Background/UI Core/Light */
+  --figma___checkbox-paper: 0 0% 100% / 0.5;
+  /* ✦ Theme/Checkbox/Paper/UI Core/Light */
+  --figma___checkbox-surface-checked-active-active: 206 98% 42% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/UI Core/Light */
+  --figma___checkbox-surface-checked-active-check: 0 0% 100% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/UI Core/Light */
+  --figma___checkbox-surface-checked-active-hover: 206 98% 42% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/UI Core/Light */
+  --figma___checkbox-surface-checked-active-default-background: 206 98% 42% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/UI Core/Light */
+  --figma___checkbox-surface-checked-disabled-check: 0 0% 100% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/UI Core/Light */
+  --figma___checkbox-surface-checked-disabled-disabled: 238 13% 62% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/UI Core/Light */
+  --figma___checkbox-surface-checked-disabled-border: 238 13% 62% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/UI Core/Light */
+  --figma___checkbox-surface-intermediate-active-active-border: 206 98% 42% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/UI Core/Light */
+  --figma___checkbox-surface-intermediate-active-check: 0 0% 100% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/UI Core/Light */
+  --figma___checkbox-surface-intermediate-active-hover-border: 206 98% 42% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/UI Core/Light */
+  --figma___checkbox-surface-intermediate-active-default-background: 206 98% 42% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/UI Core/Light */
+  --figma___checkbox-surface-intermediate-active-default-border: 206 98% 42% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/UI Core/Light */
+  --figma___checkbox-surface-intermediate-disabled-check: 0 0% 100% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/UI Core/Light */
+  --figma___checkbox-surface-intermediate-disabled-disabled: 238 13% 62% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/UI Core/Light */
+  --figma___checkbox-surface-intermediate-disabled-border: 238 13% 62% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/UI Core/Light */
+  --figma___checkbox-surface-unchecked-active-active-border: 206 98% 42% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/UI Core/Light */
+  --figma___checkbox-surface-unchecked-active-hover-border: 213 100% 32% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/UI Core/Light */
+  --figma___checkbox-surface-unchecked-active-default-background: 0 0% 100% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/UI Core/Light */
+  --figma___checkbox-surface-unchecked-active-default-border: 206 98% 42% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/UI Core/Light */
+  --figma___checkbox-surface-unchecked-disabled-disabled: 240 41% 97% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/UI Core/Light */
+  --figma___checkbox-surface-unchecked-disabled-border: 235 19% 87% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/UI Core/Light */
+  --figma___checkbox-border: 235 19% 87% / 1;
+  /* ✦ Theme/Checkbox/border/UI Core/Light */
+  --figma___default-colors-black: 0 0% 0% / 1;
+  /* ✦ Theme/Default colors/black/UI Core/Light */
+  --figma___default-colors-dark-to-white: 0 0% 0% / 1;
+  /* ✦ Theme/Default colors/dark-to-white/UI Core/Light */
+  --figma___default-colors-white: 0 0% 100% / 1;
+  /* ✦ Theme/Default colors/white/UI Core/Light */
+  --figma___default-colors-white-to-dark: 0 0% 100% / 1;
+  /* ✦ Theme/Default colors/white-to-dark/UI Core/Light */
+  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
+  /* ✦ Theme/Dropdown/Dropdown Item/Default/UI Core/Light */
+  --figma___dropdown-dropdown-item-hover: 195 100% 97% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Hover/UI Core/Light */
+  --figma___dropdown-dropdown-item-selected: 206 98% 42% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Selected/UI Core/Light */
+  --figma___dropdown-text-shortcut-text-selected: 0 0% 100% / 0.8;
+  /* ✦ Theme/Dropdown/Text/Shortcut text selected/UI Core/Light */
+  --figma___dropdown-text-text-selected: 0 0% 100% / 1;
+  /* ✦ Theme/Dropdown/Text/Text Selected/UI Core/Light */
+  --figma___dropdown-text-hover: 206 98% 42% / 1;
+  /* ✦ Theme/Dropdown/Text/hover/UI Core/Light */
+  --figma___dropdown-background: 0 0% 100% / 1;
+  /* ✦ Theme/Dropdown/background/UI Core/Light */
+  --figma___dropdown-border: 0 0% 100% / 0;
+  /* ✦ Theme/Dropdown/border/UI Core/Light */
+  --figma___dropdown-separator: 240 41% 97% / 1;
+  /* ✦ Theme/Dropdown/separator/UI Core/Light */
+  --figma___filter-active: 235 19% 87% / 1;
+  /* ✦ Theme/Filter/Active/UI Core/Light */
+  --figma___filter-default: 0 0% 100% / 1;
+  /* ✦ Theme/Filter/Default/UI Core/Light */
+  --figma___filter-hover: 235 19% 87% / 1;
+  /* ✦ Theme/Filter/Hover/UI Core/Light */
+  --figma___inline-alert-banner-customisable: 240 41% 97% / 1;
+  /* ✦ Theme/Inline Alert Banner/Customisable/UI Core/Light */
+  --figma___inline-alert-banner-error: 4 73% 96% / 1;
+  /* ✦ Theme/Inline Alert Banner/Error/UI Core/Light */
+  --figma___inline-alert-banner-info: 195 100% 97% / 1;
+  /* ✦ Theme/Inline Alert Banner/Info/UI Core/Light */
+  --figma___inline-alert-banner-reminder: 46 100% 97% / 1;
+  /* ✦ Theme/Inline Alert Banner/Reminder/UI Core/Light */
+  --figma___inline-alert-banner-success: 112 58% 93% / 1;
+  /* ✦ Theme/Inline Alert Banner/Success/UI Core/Light */
+  --figma___inline-alert-banner-warning: 27 100% 96% / 1;
+  /* ✦ Theme/Inline Alert Banner/Warning/UI Core/Light */
+  --figma___modal-background: 0 0% 100% / 1;
+  /* ✦ Theme/Modal/Background/UI Core/Light */
+  --figma___modal-paper: 0 0% 100% / 1;
+  /* ✦ Theme/Modal/Paper/UI Core/Light */
+  --figma___modal-border: 0 0% 0% / 0;
+  /* ✦ Theme/Modal/border/UI Core/Light */
+  --figma___neutral-color-gray-1: 210 25% 98% / 1;
+  /* ✦ Theme/Neutral color/Gray/1/UI Core/Light */
+  --figma___neutral-color-gray-2: 240 41% 97% / 1;
+  /* ✦ Theme/Neutral color/Gray/2/UI Core/Light */
+  --figma___neutral-color-gray-3: 235 19% 87% / 1;
+  /* ✦ Theme/Neutral color/Gray/3/UI Core/Light */
+  --figma___neutral-color-gray-4: 237 14% 73% / 1;
+  /* ✦ Theme/Neutral color/Gray/4/UI Core/Light */
+  --figma___neutral-color-gray-5: 238 13% 62% / 1;
+  /* ✦ Theme/Neutral color/Gray/5/UI Core/Light */
+  --figma___neutral-color-gray-6: 235 11% 47% / 1;
+  /* ✦ Theme/Neutral color/Gray/6/UI Core/Light */
+  --figma___neutral-color-gray-7: 234 11% 35% / 1;
+  /* ✦ Theme/Neutral color/Gray/7/UI Core/Light */
+  --figma___neutral-color-gray-8: 236 11% 25% / 1;
+  /* ✦ Theme/Neutral color/Gray/8/UI Core/Light */
+  --figma___neutral-color-gray-9: 240 11% 15% / 1;
+  /* ✦ Theme/Neutral color/Gray/9/UI Core/Light */
+  --figma___neutral-color-gray-10: 240 8% 5% / 1;
+  /* ✦ Theme/Neutral color/Gray/10/UI Core/Light */
+  --figma___neutral-color-gray-alpha-1: 210 25% 98% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/1/UI Core/Light */
+  --figma___neutral-color-gray-alpha-2: 240 41% 97% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/2/UI Core/Light */
+  --figma___neutral-color-gray-alpha-3: 235 19% 87% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/3/UI Core/Light */
+  --figma___neutral-color-gray-alpha-4: 237 14% 73% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/4/UI Core/Light */
+  --figma___neutral-color-gray-alpha-5: 238 13% 62% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/5/UI Core/Light */
+  --figma___neutral-color-gray-alpha-6: 235 11% 47% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/6/UI Core/Light */
+  --figma___neutral-color-gray-alpha-7: 234 11% 35% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/7/UI Core/Light */
+  --figma___neutral-color-gray-alpha-8: 236 11% 25% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/8/UI Core/Light */
+  --figma___neutral-color-gray-alpha-9: 240 11% 15% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/9/UI Core/Light */
+  --figma___neutral-color-gray-alpha-10: 240 8% 5% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/10/UI Core/Light */
+  --figma___other-colors-ai-violet-1: 258 100% 98% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/1/UI Core/Light */
+  --figma___other-colors-ai-violet-2: 256 70% 95% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/2/UI Core/Light */
+  --figma___other-colors-ai-violet-3: 256 68% 89% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/3/UI Core/Light */
+  --figma___other-colors-ai-violet-4: 256 69% 84% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/4/UI Core/Light */
+  --figma___other-colors-ai-violet-5: 256 68% 78% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/5/UI Core/Light */
+  --figma___other-colors-ai-violet-6: 256 68% 73% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/6/UI Core/Light */
+  --figma___other-colors-ai-violet-7: 256 68% 62% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/7/UI Core/Light */
+  --figma___other-colors-ai-violet-8: 256 68% 56% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/8/UI Core/Light */
+  --figma___other-colors-ai-violet-9: 256 68% 51% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/9/UI Core/Light */
+  --figma___other-colors-ai-violet-10: 256 60% 46% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/10/UI Core/Light */
+  --figma___other-colors-ai-violet-alpha-1: 258 100% 98% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/1/UI Core/Light */
+  --figma___other-colors-ai-violet-alpha-2: 256 70% 95% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/2/UI Core/Light */
+  --figma___other-colors-ai-violet-alpha-3: 256 68% 89% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/3/UI Core/Light */
+  --figma___other-colors-ai-violet-alpha-4: 256 69% 84% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/4/UI Core/Light */
+  --figma___other-colors-ai-violet-alpha-5: 256 68% 78% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/5/UI Core/Light */
+  --figma___other-colors-ai-violet-alpha-6: 256 68% 73% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/6/UI Core/Light */
+  --figma___other-colors-ai-violet-alpha-7: 256 68% 62% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/7/UI Core/Light */
+  --figma___other-colors-ai-violet-alpha-8: 256 68% 56% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/8/UI Core/Light */
+  --figma___other-colors-ai-violet-alpha-9: 256 68% 51% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/9/UI Core/Light */
+  --figma___other-colors-ai-violet-alpha-10: 256 60% 46% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/10/UI Core/Light */
+  --figma___other-colors-blue-1: 240 100% 95% / 1;
+  /* ✦ Theme/Other Colors/Blue/1/UI Core/Light */
+  --figma___other-colors-blue-2: 241 100% 90% / 1;
+  /* ✦ Theme/Other Colors/Blue/2/UI Core/Light */
+  --figma___other-colors-blue-3: 241 100% 84% / 1;
+  /* ✦ Theme/Other Colors/Blue/3/UI Core/Light */
+  --figma___other-colors-blue-4: 241 100% 80% / 1;
+  /* ✦ Theme/Other Colors/Blue/4/UI Core/Light */
+  --figma___other-colors-blue-5: 240 100% 76% / 1;
+  /* ✦ Theme/Other Colors/Blue/5/UI Core/Light */
+  --figma___other-colors-blue-6: 241 82% 66% / 1;
+  /* ✦ Theme/Other Colors/Blue/6/UI Core/Light */
+  --figma___other-colors-blue-7: 241 90% 64% / 1;
+  /* ✦ Theme/Other Colors/Blue/7/UI Core/Light */
+  --figma___other-colors-blue-8: 241 69% 57% / 1;
+  /* ✦ Theme/Other Colors/Blue/8/UI Core/Light */
+  --figma___other-colors-blue-9: 240 51% 46% / 1;
+  /* ✦ Theme/Other Colors/Blue/9/UI Core/Light */
+  --figma___other-colors-blue-10: 241 54% 38% / 1;
+  /* ✦ Theme/Other Colors/Blue/10/UI Core/Light */
+  --figma___other-colors-blue-alpha-1: 195 100% 97% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/1/UI Core/Light */
+  --figma___other-colors-blue-alpha-2: 192 96% 90% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/2/UI Core/Light */
+  --figma___other-colors-blue-alpha-3: 194 100% 82% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/3/UI Core/Light */
+  --figma___other-colors-blue-alpha-4: 195 91% 60% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/4/UI Core/Light */
+  --figma___other-colors-blue-alpha-5: 194 100% 45% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/5/UI Core/Light */
+  --figma___other-colors-blue-alpha-6: 202 100% 45% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/6/UI Core/Light */
+  --figma___other-colors-blue-alpha-7: 206 98% 42% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/7/UI Core/Light */
+  --figma___other-colors-blue-alpha-8: 213 100% 32% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/8/UI Core/Light */
+  --figma___other-colors-blue-alpha-9: 213 82% 22% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/9/UI Core/Light */
+  --figma___other-colors-blue-alpha-10: 212 72% 10% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/10/UI Core/Light */
+  --figma___other-colors-indigo-1: 240 33% 99% / 1;
+  /* ✦ Theme/Other Colors/Indigo/1/UI Core/Light */
+  --figma___other-colors-indigo-2: 223 100% 99% / 1;
+  /* ✦ Theme/Other Colors/Indigo/2/UI Core/Light */
+  --figma___other-colors-indigo-3: 224 100% 97% / 1;
+  /* ✦ Theme/Other Colors/Indigo/3/UI Core/Light */
+  --figma___other-colors-indigo-4: 222 92% 95% / 1;
+  /* ✦ Theme/Other Colors/Indigo/4/UI Core/Light */
+  --figma___other-colors-indigo-5: 225 85% 92% / 1;
+  /* ✦ Theme/Other Colors/Indigo/5/UI Core/Light */
+  --figma___other-colors-indigo-6: 224 81% 88% / 1;
+  /* ✦ Theme/Other Colors/Indigo/6/UI Core/Light */
+  --figma___other-colors-indigo-7: 226 70% 55% / 1;
+  /* ✦ Theme/Other Colors/Indigo/7/UI Core/Light */
+  --figma___other-colors-indigo-8: 226 59% 51% / 1;
+  /* ✦ Theme/Other Colors/Indigo/8/UI Core/Light */
+  --figma___other-colors-indigo-9: 226 55% 45% / 1;
+  /* ✦ Theme/Other Colors/Indigo/9/UI Core/Light */
+  --figma___other-colors-indigo-10: 226 63% 17% / 1;
+  /* ✦ Theme/Other Colors/Indigo/10/UI Core/Light */
+  --figma___other-colors-indigo-alpha-1: 240 93% 26% / 0.01;
+  /* ✦ Theme/Other Colors/Indigo Alpha/1/UI Core/Light */
+  --figma___other-colors-indigo-alpha-2: 223 100% 51% / 0.03;
+  /* ✦ Theme/Other Colors/Indigo Alpha/2/UI Core/Light */
+  --figma___other-colors-indigo-alpha-3: 224 100% 50% / 0.06;
+  /* ✦ Theme/Other Colors/Indigo Alpha/3/UI Core/Light */
+  --figma___other-colors-indigo-alpha-4: 222 98% 48% / 0.1;
+  /* ✦ Theme/Other Colors/Indigo Alpha/4/UI Core/Light */
+  --figma___other-colors-indigo-alpha-5: 225 98% 46% / 0.15;
+  /* ✦ Theme/Other Colors/Indigo Alpha/5/UI Core/Light */
+  --figma___other-colors-indigo-alpha-6: 224 99% 45% / 0.22;
+  /* ✦ Theme/Other Colors/Indigo Alpha/6/UI Core/Light */
+  --figma___other-colors-indigo-alpha-7: 226 100% 41% / 0.76;
+  /* ✦ Theme/Other Colors/Indigo Alpha/7/UI Core/Light */
+  --figma___other-colors-indigo-alpha-8: 226 100% 37% / 0.77;
+  /* ✦ Theme/Other Colors/Indigo Alpha/8/UI Core/Light */
+  --figma___other-colors-indigo-alpha-9: 225 100% 14% / 0.88;
+  /* ✦ Theme/Other Colors/Indigo Alpha/9/UI Core/Light */
+  --figma___other-colors-indigo-alpha-10: 225 100% 14% / 0.88;
+  /* ✦ Theme/Other Colors/Indigo Alpha/10/UI Core/Light */
+  --figma___other-colors-mint-1: 168 71% 99% / 1;
+  /* ✦ Theme/Other Colors/Mint/1/UI Core/Light */
+  --figma___other-colors-mint-2: 164 88% 97% / 1;
+  /* ✦ Theme/Other Colors/Mint/2/UI Core/Light */
+  --figma___other-colors-mint-3: 164 79% 93% / 1;
+  /* ✦ Theme/Other Colors/Mint/3/UI Core/Light */
+  --figma___other-colors-mint-4: 165 73% 88% / 1;
+  /* ✦ Theme/Other Colors/Mint/4/UI Core/Light */
+  --figma___other-colors-mint-5: 166 60% 83% / 1;
+  /* ✦ Theme/Other Colors/Mint/5/UI Core/Light */
+  --figma___other-colors-mint-6: 166 50% 77% / 1;
+  /* ✦ Theme/Other Colors/Mint/6/UI Core/Light */
+  --figma___other-colors-mint-7: 167 70% 72% / 1;
+  /* ✦ Theme/Other Colors/Mint/7/UI Core/Light */
+  --figma___other-colors-mint-8: 167 62% 69% / 1;
+  /* ✦ Theme/Other Colors/Mint/8/UI Core/Light */
+  --figma___other-colors-mint-9: 172 50% 31% / 1;
+  /* ✦ Theme/Other Colors/Mint/9/UI Core/Light */
+  --figma___other-colors-mint-10: 171 51% 17% / 1;
+  /* ✦ Theme/Other Colors/Mint/10/UI Core/Light */
+  --figma___other-colors-mint-alpha-1: 168 95% 43% / 0.02;
+  /* ✦ Theme/Other Colors/Mint Alpha/1/UI Core/Light */
+  --figma___other-colors-mint-alpha-2: 164 99% 47% / 0.06;
+  /* ✦ Theme/Other Colors/Mint Alpha/2/UI Core/Light */
+  --figma___other-colors-mint-alpha-3: 164 99% 44% / 0.13;
+  /* ✦ Theme/Other Colors/Mint Alpha/3/UI Core/Light */
+  --figma___other-colors-mint-alpha-4: 165 100% 42% / 0.2;
+  /* ✦ Theme/Other Colors/Mint Alpha/4/UI Core/Light */
+  --figma___other-colors-mint-alpha-5: 166 100% 38% / 0.27;
+  /* ✦ Theme/Other Colors/Mint Alpha/5/UI Core/Light */
+  --figma___other-colors-mint-alpha-6: 166 99% 33% / 0.35;
+  /* ✦ Theme/Other Colors/Mint Alpha/6/UI Core/Light */
+  --figma___other-colors-mint-alpha-7: 167 100% 41% / 0.47;
+  /* ✦ Theme/Other Colors/Mint Alpha/7/UI Core/Light */
+  --figma___other-colors-mint-alpha-8: 167 100% 38% / 0.5;
+  /* ✦ Theme/Other Colors/Mint Alpha/8/UI Core/Light */
+  --figma___other-colors-mint-alpha-9: 172 100% 18% / 0.85;
+  /* ✦ Theme/Other Colors/Mint Alpha/9/UI Core/Light */
+  --figma___other-colors-mint-alpha-10: 171 100% 10% / 0.91;
+  /* ✦ Theme/Other Colors/Mint Alpha/10/UI Core/Light */
+  --figma___other-colors-orange-1: 27 100% 96% / 1;
+  /* ✦ Theme/Other Colors/Orange/1/UI Core/Light */
+  --figma___other-colors-orange-2: 24 100% 95% / 1;
+  /* ✦ Theme/Other Colors/Orange/2/UI Core/Light */
+  --figma___other-colors-orange-3: 25 100% 87% / 1;
+  /* ✦ Theme/Other Colors/Orange/3/UI Core/Light */
+  --figma___other-colors-orange-4: 25 100% 79% / 1;
+  /* ✦ Theme/Other Colors/Orange/4/UI Core/Light */
+  --figma___other-colors-orange-5: 25 100% 71% / 1;
+  /* ✦ Theme/Other Colors/Orange/5/UI Core/Light */
+  --figma___other-colors-orange-6: 25 100% 58% / 1;
+  /* ✦ Theme/Other Colors/Orange/6/UI Core/Light */
+  --figma___other-colors-orange-7: 24 100% 57% / 1;
+  /* ✦ Theme/Other Colors/Orange/7/UI Core/Light */
+  --figma___other-colors-orange-8: 22 100% 56% / 1;
+  /* ✦ Theme/Other Colors/Orange/8/UI Core/Light */
+  --figma___other-colors-orange-9: 20 100% 55% / 1;
+  /* ✦ Theme/Other Colors/Orange/9/UI Core/Light */
+  --figma___other-colors-orange-10: 17 100% 53% / 1;
+  /* ✦ Theme/Other Colors/Orange/10/UI Core/Light */
+  --figma___other-colors-orange-alpha-1: 27 100% 96% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/1/UI Core/Light */
+  --figma___other-colors-orange-alpha-2: 24 100% 95% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/2/UI Core/Light */
+  --figma___other-colors-orange-alpha-3: 25 100% 87% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/3/UI Core/Light */
+  --figma___other-colors-orange-alpha-4: 25 100% 79% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/4/UI Core/Light */
+  --figma___other-colors-orange-alpha-5: 25 100% 71% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/5/UI Core/Light */
+  --figma___other-colors-orange-alpha-6: 25 100% 58% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/6/UI Core/Light */
+  --figma___other-colors-orange-alpha-7: 24 100% 57% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/7/UI Core/Light */
+  --figma___other-colors-orange-alpha-8: 22 100% 56% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/8/UI Core/Light */
+  --figma___other-colors-orange-alpha-9: 20 100% 55% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/9/UI Core/Light */
+  --figma___other-colors-orange-alpha-10: 17 100% 53% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/10/UI Core/Light */
+  --figma___other-colors-yellow-1: 46 100% 97% / 1;
+  /* ✦ Theme/Other Colors/Yellow/1/UI Core/Light */
+  --figma___other-colors-yellow-2: 45 100% 95% / 1;
+  /* ✦ Theme/Other Colors/Yellow/2/UI Core/Light */
+  --figma___other-colors-yellow-3: 47 97% 88% / 1;
+  /* ✦ Theme/Other Colors/Yellow/3/UI Core/Light */
+  --figma___other-colors-yellow-4: 46 98% 81% / 1;
+  /* ✦ Theme/Other Colors/Yellow/4/UI Core/Light */
+  --figma___other-colors-yellow-5: 46 99% 73% / 1;
+  /* ✦ Theme/Other Colors/Yellow/5/UI Core/Light */
+  --figma___other-colors-yellow-6: 46 98% 61% / 1;
+  /* ✦ Theme/Other Colors/Yellow/6/UI Core/Light */
+  --figma___other-colors-yellow-7: 45 98% 60% / 1;
+  /* ✦ Theme/Other Colors/Yellow/7/UI Core/Light */
+  --figma___other-colors-yellow-8: 41 100% 55% / 1;
+  /* ✦ Theme/Other Colors/Yellow/8/UI Core/Light */
+  --figma___other-colors-yellow-9: 41 100% 50% / 1;
+  /* ✦ Theme/Other Colors/Yellow/9/UI Core/Light */
+  --figma___other-colors-yellow-10: 41 98% 45% / 1;
+  /* ✦ Theme/Other Colors/Yellow/10/UI Core/Light */
+  --figma___other-colors-yellow-alpha-1: 46 100% 97% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/1/UI Core/Light */
+  --figma___other-colors-yellow-alpha-2: 45 100% 95% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/2/UI Core/Light */
+  --figma___other-colors-yellow-alpha-3: 47 97% 88% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/3/UI Core/Light */
+  --figma___other-colors-yellow-alpha-4: 46 98% 81% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/4/UI Core/Light */
+  --figma___other-colors-yellow-alpha-5: 46 99% 73% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/5/UI Core/Light */
+  --figma___other-colors-yellow-alpha-6: 46 98% 61% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/6/UI Core/Light */
+  --figma___other-colors-yellow-alpha-7: 45 98% 60% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/7/UI Core/Light */
+  --figma___other-colors-yellow-alpha-8: 41 100% 55% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/8/UI Core/Light */
+  --figma___other-colors-yellow-alpha-9: 41 100% 50% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/9/UI Core/Light */
+  --figma___other-colors-yellow-alpha-10: 41 98% 45% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/10/UI Core/Light */
+  --figma___overlays-black-alpha-1: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/1/UI Core/Light */
+  --figma___overlays-black-alpha-2: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/2/UI Core/Light */
+  --figma___overlays-black-alpha-3: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/3/UI Core/Light */
+  --figma___overlays-black-alpha-4: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/4/UI Core/Light */
+  --figma___overlays-black-alpha-5: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/5/UI Core/Light */
+  --figma___overlays-black-alpha-6: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/6/UI Core/Light */
+  --figma___overlays-black-alpha-7: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/7/UI Core/Light */
+  --figma___overlays-black-alpha-8: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/8/UI Core/Light */
+  --figma___overlays-black-alpha-9: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/9/UI Core/Light */
+  --figma___overlays-black-alpha-10: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/10/UI Core/Light */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/1/UI Core/Light */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/2/UI Core/Light */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/3/UI Core/Light */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/4/UI Core/Light */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/5/UI Core/Light */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/6/UI Core/Light */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/7/UI Core/Light */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/8/UI Core/Light */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/9/UI Core/Light */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/10/UI Core/Light */
+  --figma___pagination-active-background: 202 100% 45% / 1;
+  /* ✦ Theme/Pagination/Active/Background/UI Core/Light */
+  --figma___pagination-active-border: 202 100% 45% / 0;
+  /* ✦ Theme/Pagination/Active/Border/UI Core/Light */
+  --figma___pagination-active-text: 0 0% 100% / 1;
+  /* ✦ Theme/Pagination/Active/Text/UI Core/Light */
+  --figma___pagination-background: 206 98% 42% / 0.21;
+  /* ✦ Theme/Pagination/Background/UI Core/Light */
+  --figma___pagination-default-background: 0 0% 100% / 1;
+  /* ✦ Theme/Pagination/Default/Background/UI Core/Light */
+  --figma___pagination-default-border: 0 0% 89% / 0;
+  /* ✦ Theme/Pagination/Default/Border/UI Core/Light */
+  --figma___pagination-default-text: 235 11% 47% / 1;
+  /* ✦ Theme/Pagination/Default/Text/UI Core/Light */
+  --figma___pagination-hover-background: 0 0% 100% / 1;
+  /* ✦ Theme/Pagination/Hover/Background/UI Core/Light */
+  --figma___pagination-hover-border: 206 98% 42% / 0;
+  /* ✦ Theme/Pagination/Hover/Border/UI Core/Light */
+  --figma___pagination-hover-text: 240 8% 5% / 1;
+  /* ✦ Theme/Pagination/Hover/Text/UI Core/Light */
+  --figma___pagination-pagination-shadow-1: 237 21% 20% / 0.04;
+  /* ✦ Theme/Pagination/Pagination shadow/1/UI Core/Light */
+  --figma___pagination-pagination-shadow-2: 236 8% 41% / 0.16;
+  /* ✦ Theme/Pagination/Pagination shadow/2/UI Core/Light */
+  --figma___primary-color-primary-accent-1: 195 100% 97% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/1/UI Core/Light */
+  --figma___primary-color-primary-accent-2: 192 96% 90% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/2/UI Core/Light */
+  --figma___primary-color-primary-accent-3: 194 100% 82% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/3/UI Core/Light */
+  --figma___primary-color-primary-accent-4: 195 91% 60% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/4/UI Core/Light */
+  --figma___primary-color-primary-accent-5: 194 100% 45% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/5/UI Core/Light */
+  --figma___primary-color-primary-accent-6: 202 100% 45% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/6/UI Core/Light */
+  --figma___primary-color-primary-accent-7: 206 98% 42% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/7/UI Core/Light */
+  --figma___primary-color-primary-accent-8: 213 100% 32% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/8/UI Core/Light */
+  --figma___primary-color-primary-accent-9: 213 82% 22% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/9/UI Core/Light */
+  --figma___primary-color-primary-accent-10: 212 72% 10% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/10/UI Core/Light */
+  --figma___primary-color-primary-alpha-1: 195 100% 97% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/1/UI Core/Light */
+  --figma___primary-color-primary-alpha-2: 192 96% 90% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/2/UI Core/Light */
+  --figma___primary-color-primary-alpha-3: 194 100% 82% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/3/UI Core/Light */
+  --figma___primary-color-primary-alpha-4: 195 91% 60% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/4/UI Core/Light */
+  --figma___primary-color-primary-alpha-5: 194 100% 45% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/5/UI Core/Light */
+  --figma___primary-color-primary-alpha-6: 202 100% 45% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/6/UI Core/Light */
+  --figma___primary-color-primary-alpha-7: 206 98% 42% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/7/UI Core/Light */
+  --figma___primary-color-primary-alpha-8: 213 100% 32% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/8/UI Core/Light */
+  --figma___primary-color-primary-alpha-9: 213 82% 22% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/9/UI Core/Light */
+  --figma___primary-color-primary-alpha-10: 212 72% 10% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/10/UI Core/Light */
+  --figma___radio-button-background: 0 0% 100% / 0.8;
+  /* ✦ Theme/Radio button/Background/UI Core/Light */
+  --figma___radio-button-checked-active-active-border: 206 98% 42% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active Border/UI Core/Light */
+  --figma___radio-button-checked-active-active-background: 206 98% 42% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active background/UI Core/Light */
+  --figma___radio-button-checked-active-dot: 0 0% 100% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Dot/UI Core/Light */
+  --figma___radio-button-checked-active-hover-background: 213 100% 32% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover background/UI Core/Light */
+  --figma___radio-button-checked-active-hover-border: 213 100% 32% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover border/UI Core/Light */
+  --figma___radio-button-checked-active-default-background: 206 98% 42% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default background/UI Core/Light */
+  --figma___radio-button-checked-active-default-border: 206 98% 42% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default border/UI Core/Light */
+  --figma___radio-button-checked-disabled-dot: 0 0% 100% / 1;
+  /* ✦ Theme/Radio button/Checked/Disabled/Dot/UI Core/Light */
+  --figma___radio-button-checked-disabled-background: 240 41% 97% / 1;
+  /* ✦ Theme/Radio button/Checked/Disabled/background/UI Core/Light */
+  --figma___radio-button-checked-disabled-border: 235 19% 87% / 1;
+  /* ✦ Theme/Radio button/Checked/Disabled/border/UI Core/Light */
+  --figma___radio-button-paper: 0 0% 100% / 0.5;
+  /* ✦ Theme/Radio button/Paper/UI Core/Light */
+  --figma___radio-button-unchecked-active-active-border: 206 98% 42% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/Active border/UI Core/Light */
+  --figma___radio-button-unchecked-active-hover-border: 213 100% 32% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/UI Core/Light */
+  --figma___radio-button-unchecked-active-default-background: 0 0% 100% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/default background/UI Core/Light */
+  --figma___radio-button-unchecked-active-default-border: 206 98% 42% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/default border/UI Core/Light */
+  --figma___radio-button-unchecked-disabled-background: 240 41% 97% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/background/UI Core/Light */
+  --figma___radio-button-unchecked-disabled-border: 235 19% 87% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/border/UI Core/Light */
+  --figma___radio-button-border: 235 19% 87% / 1;
+  /* ✦ Theme/Radio button/border/UI Core/Light */
+  --figma___secondary-crimson-crimson-1: 330 100% 98% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 1/UI Core/Light */
+  --figma___secondary-crimson-crimson-10: 331 83% 43% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 10/UI Core/Light */
+  --figma___secondary-crimson-crimson-2: 328 100% 97% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 2/UI Core/Light */
+  --figma___secondary-crimson-crimson-3: 332 100% 90% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 3/UI Core/Light */
+  --figma___secondary-crimson-crimson-4: 331 100% 84% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 4/UI Core/Light */
+  --figma___secondary-crimson-crimson-5: 332 100% 77% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 5/UI Core/Light */
+  --figma___secondary-crimson-crimson-6: 331 100% 64% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 6/UI Core/Light */
+  --figma___secondary-crimson-crimson-7: 331 91% 59% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 7/UI Core/Light */
+  --figma___secondary-crimson-crimson-8: 331 85% 55% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 8/UI Core/Light */
+  --figma___secondary-crimson-crimson-9: 331 75% 49% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 9/UI Core/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-1: 330 100% 98% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/UI Core/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-10: 331 75% 49% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/UI Core/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-11: 331 83% 43% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/UI Core/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-2: 328 100% 97% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/UI Core/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-3: 332 100% 90% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/UI Core/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-4: 331 100% 84% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/UI Core/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-5: 332 100% 77% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/UI Core/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-6: 331 100% 64% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/UI Core/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-8: 331 91% 59% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/UI Core/Light */
+  --figma___secondary-crimson-alpha-crimson-alpha-9: 331 85% 55% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/UI Core/Light */
+  --figma___secondary-lime-1: 87 67% 94% / 1;
+  /* ✦ Theme/Secondary/Lime/1/UI Core/Light */
+  --figma___secondary-lime-2: 89 67% 92% / 1;
+  /* ✦ Theme/Secondary/Lime/2/UI Core/Light */
+  --figma___secondary-lime-3: 88 50% 76% / 1;
+  /* ✦ Theme/Secondary/Lime/3/UI Core/Light */
+  --figma___secondary-lime-4: 88 60% 65% / 1;
+  /* ✦ Theme/Secondary/Lime/4/UI Core/Light */
+  --figma___secondary-lime-5: 88 50% 60% / 1;
+  /* ✦ Theme/Secondary/Lime/5/UI Core/Light */
+  --figma___secondary-lime-6: 79 100% 36% / 1;
+  /* ✦ Theme/Secondary/Lime/6/UI Core/Light */
+  --figma___secondary-lime-7: 88 54% 45% / 1;
+  /* ✦ Theme/Secondary/Lime/7/UI Core/Light */
+  --figma___secondary-lime-8: 92 48% 42% / 1;
+  /* ✦ Theme/Secondary/Lime/8/UI Core/Light */
+  --figma___secondary-lime-9: 95 49% 36% / 1;
+  /* ✦ Theme/Secondary/Lime/9/UI Core/Light */
+  --figma___secondary-lime-10: 103 40% 34% / 1;
+  /* ✦ Theme/Secondary/Lime/10/UI Core/Light */
+  --figma___secondary-lime-alpha-1: 87 67% 94% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/1/UI Core/Light */
+  --figma___secondary-lime-alpha-2: 89 67% 92% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/2/UI Core/Light */
+  --figma___secondary-lime-alpha-3: 88 50% 76% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/3/UI Core/Light */
+  --figma___secondary-lime-alpha-4: 88 60% 65% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/4/UI Core/Light */
+  --figma___secondary-lime-alpha-5: 88 50% 60% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/5/UI Core/Light */
+  --figma___secondary-lime-alpha-6: 79 100% 36% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/6/UI Core/Light */
+  --figma___secondary-lime-alpha-7: 88 54% 45% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/7/UI Core/Light */
+  --figma___secondary-lime-alpha-8: 92 48% 42% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/8/UI Core/Light */
+  --figma___secondary-lime-alpha-9: 95 49% 36% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/9/UI Core/Light */
+  --figma___secondary-lime-alpha-10: 103 40% 34% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/10/UI Core/Light */
+  --figma___secondary-purple-1: 262 100% 94% / 1;
+  /* ✦ Theme/Secondary/Purple/1/UI Core/Light */
+  --figma___secondary-purple-2: 262 100% 91% / 1;
+  /* ✦ Theme/Secondary/Purple/2/UI Core/Light */
+  --figma___secondary-purple-3: 262 100% 85% / 1;
+  /* ✦ Theme/Secondary/Purple/3/UI Core/Light */
+  --figma___secondary-purple-4: 262 100% 81% / 1;
+  /* ✦ Theme/Secondary/Purple/4/UI Core/Light */
+  --figma___secondary-purple-5: 262 95% 75% / 1;
+  /* ✦ Theme/Secondary/Purple/5/UI Core/Light */
+  --figma___secondary-purple-6: 261 60% 56% / 1;
+  /* ✦ Theme/Secondary/Purple/6/UI Core/Light */
+  --figma___secondary-purple-7: 262 55% 49% / 1;
+  /* ✦ Theme/Secondary/Purple/7/UI Core/Light */
+  --figma___secondary-purple-8: 262 60% 42% / 1;
+  /* ✦ Theme/Secondary/Purple/8/UI Core/Light */
+  --figma___secondary-purple-9: 262 57% 36% / 1;
+  /* ✦ Theme/Secondary/Purple/9/UI Core/Light */
+  --figma___secondary-purple-10: 270 86% 30% / 1;
+  /* ✦ Theme/Secondary/Purple/10/UI Core/Light */
+  --figma___secondary-purple-alpha-1: 262 100% 94% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/1/UI Core/Light */
+  --figma___secondary-purple-alpha-2: 262 100% 91% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/2/UI Core/Light */
+  --figma___secondary-purple-alpha-3: 262 100% 85% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/3/UI Core/Light */
+  --figma___secondary-purple-alpha-4: 262 100% 81% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/4/UI Core/Light */
+  --figma___secondary-purple-alpha-5: 262 95% 75% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/5/UI Core/Light */
+  --figma___secondary-purple-alpha-6: 261 60% 56% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/6/UI Core/Light */
+  --figma___secondary-purple-alpha-7: 262 55% 49% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/7/UI Core/Light */
+  --figma___secondary-purple-alpha-8: 262 60% 42% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/8/UI Core/Light */
+  --figma___secondary-purple-alpha-9: 262 57% 36% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/9/UI Core/Light */
+  --figma___secondary-purple-alpha-10: 270 86% 30% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/10/UI Core/Light */
+  --figma___secondary-teal-1: 183 96% 91% / 1;
+  /* ✦ Theme/Secondary/Teal/1/UI Core/Light */
+  --figma___secondary-teal-2: 183 97% 87% / 1;
+  /* ✦ Theme/Secondary/Teal/2/UI Core/Light */
+  --figma___secondary-teal-3: 182 74% 81% / 1;
+  /* ✦ Theme/Secondary/Teal/3/UI Core/Light */
+  --figma___secondary-teal-4: 184 71% 68% / 1;
+  /* ✦ Theme/Secondary/Teal/4/UI Core/Light */
+  --figma___secondary-teal-5: 184 70% 58% / 1;
+  /* ✦ Theme/Secondary/Teal/5/UI Core/Light */
+  --figma___secondary-teal-6: 184 90% 44% / 1;
+  /* ✦ Theme/Secondary/Teal/6/UI Core/Light */
+  --figma___secondary-teal-7: 184 97% 41% / 1;
+  /* ✦ Theme/Secondary/Teal/7/UI Core/Light */
+  --figma___secondary-teal-8: 184 94% 39% / 1;
+  /* ✦ Theme/Secondary/Teal/8/UI Core/Light */
+  --figma___secondary-teal-9: 184 95% 37% / 1;
+  /* ✦ Theme/Secondary/Teal/9/UI Core/Light */
+  --figma___secondary-teal-10: 184 92% 35% / 1;
+  /* ✦ Theme/Secondary/Teal/10/UI Core/Light */
+  --figma___secondary-teal-alpha-1: 183 96% 91% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/1/UI Core/Light */
+  --figma___secondary-teal-alpha-2: 183 97% 87% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/2/UI Core/Light */
+  --figma___secondary-teal-alpha-3: 182 74% 81% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/3/UI Core/Light */
+  --figma___secondary-teal-alpha-4: 184 71% 68% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/4/UI Core/Light */
+  --figma___secondary-teal-alpha-5: 184 70% 58% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/5/UI Core/Light */
+  --figma___secondary-teal-alpha-6: 184 90% 44% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/6/UI Core/Light */
+  --figma___secondary-teal-alpha-7: 184 97% 41% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/7/UI Core/Light */
+  --figma___secondary-teal-alpha-8: 184 94% 39% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/8/UI Core/Light */
+  --figma___secondary-teal-alpha-9: 184 95% 37% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/9/UI Core/Light */
+  --figma___secondary-teal-alpha-10: 184 92% 35% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/10/UI Core/Light */
+  --figma___shadow-shadow-button-1: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow - button/1/UI Core/Light */
+  --figma___shadow-shadow-button-2: 0 0% 100% / 0.31;
+  /* ✦ Theme/Shadow/Shadow - button/2/UI Core/Light */
+  --figma___shadow-shadow-button-3: 0 0% 100% / 0.46;
+  /* ✦ Theme/Shadow/Shadow - button/3/UI Core/Light */
+  --figma___shadow-shadow-button-4: 0 0% 100% / 0;
+  /* ✦ Theme/Shadow/Shadow - button/4/UI Core/Light */
+  --figma___shadow-shadow-1-1: 237 21% 20% / 0.08;
+  /* ✦ Theme/Shadow/Shadow 1/1/UI Core/Light */
+  --figma___shadow-shadow-2-1: 237 21% 20% / 0.04;
+  /* ✦ Theme/Shadow/Shadow 2/1/UI Core/Light */
+  --figma___shadow-shadow-2-2: 236 8% 41% / 0.16;
+  /* ✦ Theme/Shadow/Shadow 2/2/UI Core/Light */
+  --figma___shadow-shadow-2-3: 240 100% 12% / 0;
+  /* ✦ Theme/Shadow/Shadow 2/3/UI Core/Light */
+  --figma___shadow-shadow-3-1: 237 21% 20% / 0.04;
+  /* ✦ Theme/Shadow/Shadow 3/1/UI Core/Light */
+  --figma___shadow-shadow-3-2: 236 8% 41% / 0.16;
+  /* ✦ Theme/Shadow/Shadow 3/2/UI Core/Light */
+  --figma___shadow-shadow-3-3: 240 100% 12% / 0;
+  /* ✦ Theme/Shadow/Shadow 3/3/UI Core/Light */
+  --figma___shadow-shadow-4-1: 237 21% 20% / 0.04;
+  /* ✦ Theme/Shadow/Shadow 4/1/UI Core/Light */
+  --figma___shadow-shadow-4-2: 236 8% 41% / 0.16;
+  /* ✦ Theme/Shadow/Shadow 4/2/UI Core/Light */
+  --figma___shadow-shadow-5-1: 237 21% 20% / 0.04;
+  /* ✦ Theme/Shadow/Shadow 5/1/UI Core/Light */
+  --figma___shadow-shadow-5-2: 236 8% 41% / 0.16;
+  /* ✦ Theme/Shadow/Shadow 5/2/UI Core/Light */
+  --figma___shadow-shadow-6-1: 237 21% 20% / 0.04;
+  /* ✦ Theme/Shadow/Shadow 6/1/UI Core/Light */
+  --figma___shadow-shadow-6-2: 236 8% 41% / 0.16;
+  /* ✦ Theme/Shadow/Shadow 6/2/UI Core/Light */
+  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
+  /* ✦ Theme/Shadow/Shadow-button-active/1/UI Core/Light */
+  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
+  /* ✦ Theme/Shadow/Shadow-button-active/2/UI Core/Light */
+  --figma___shadow-shadow-button-active-3: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow-button-active/3/UI Core/Light */
+  --figma___shadow-shadow-button-active-4: 0 0% 0% / 0.08;
+  /* ✦ Theme/Shadow/Shadow-button-active/4/UI Core/Light */
+  --figma___side-nav-container-nav-background: 212 72% 10% / 1;
+  /* ✦ Theme/Side nav/Container/Nav-background/UI Core/Light */
+  --figma___side-nav-container-nav-border: 220 6% 90% / 0;
+  /* ✦ Theme/Side nav/Container/Nav-border/UI Core/Light */
+  --figma___side-nav-module-logo-text: 0 0% 100% / 1;
+  /* ✦ Theme/Side nav/Module Logo Text/UI Core/Light */
+  --figma___side-nav-nav-item-default-icon: 238 13% 62% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Default/Icon/UI Core/Light */
+  --figma___side-nav-nav-item-default-text: 237 14% 73% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Default/Text/UI Core/Light */
+  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
+  /* ✦ Theme/Side nav/Nav-item/Default/default/UI Core/Light */
+  --figma___side-nav-nav-item-hover-background: 215 46% 20% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Background/UI Core/Light */
+  --figma___side-nav-nav-item-hover-icon: 238 13% 62% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/UI Core/Light */
+  --figma___side-nav-nav-item-hover-text: 237 14% 73% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Text/UI Core/Light */
+  --figma___side-nav-nav-item-selected-background: 215 46% 20% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Background/UI Core/Light */
+  --figma___side-nav-nav-item-selected-icon: 195 91% 60% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/UI Core/Light */
+  --figma___side-nav-nav-item-selected-text: 195 91% 60% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Text/UI Core/Light */
+  --figma___side-nav-profile-role: 235 11% 47% / 1;
+  /* ✦ Theme/Side nav/Profile/Role/UI Core/Light */
+  --figma___side-nav-profile-text: 238 13% 62% / 1;
+  /* ✦ Theme/Side nav/Profile/Text/UI Core/Light */
+  --figma___side-nav-scope-selector-default-border: 234 11% 35% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Border/UI Core/Light */
+  --figma___side-nav-scope-selector-default-main-text-icon: 0 0% 100% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/UI Core/Light */
+  --figma___side-nav-scope-selector-default-scope-name: 238 13% 62% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/UI Core/Light */
+  --figma___side-nav-scope-selector-default-default: 0 0% 0% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/default/UI Core/Light */
+  --figma___side-nav-scope-selector-hover-border: 206 98% 42% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/UI Core/Light */
+  --figma___side-nav-scope-selector-hover-main-text-icon: 0 0% 100% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/UI Core/Light */
+  --figma___side-nav-scope-selector-hover-scope-name: 238 13% 62% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/UI Core/Light */
+  --figma___side-nav-scope-selector-hover-default: 0 0% 0% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/default/UI Core/Light */
+  --figma___side-nav-scope-selector-selected-border: 206 98% 42% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/UI Core/Light */
+  --figma___side-nav-scope-selector-selected-main-text-icon: 0 0% 100% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/UI Core/Light */
+  --figma___side-nav-scope-selector-selected-scope-name: 238 13% 62% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/UI Core/Light */
+  --figma___side-nav-scope-selector-selected-background: 0 0% 0% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/background/UI Core/Light */
+  --figma___side-nav-separator: 236 11% 25% / 1;
+  /* ✦ Theme/Side nav/Separator/UI Core/Light */
+  --figma___status-colors-error-1: 4 73% 96% / 1;
+  /* ✦ Theme/Status colors/Error/1/UI Core/Light */
+  --figma___status-colors-error-2: 5 74% 94% / 1;
+  /* ✦ Theme/Status colors/Error/2/UI Core/Light */
+  --figma___status-colors-error-3: 4 74% 85% / 1;
+  /* ✦ Theme/Status colors/Error/3/UI Core/Light */
+  --figma___status-colors-error-4: 4 75% 75% / 1;
+  /* ✦ Theme/Status colors/Error/4/UI Core/Light */
+  --figma___status-colors-error-5: 4 82% 63% / 1;
+  /* ✦ Theme/Status colors/Error/5/UI Core/Light */
+  --figma___status-colors-error-6: 4 78% 52% / 1;
+  /* ✦ Theme/Status colors/Error/6/UI Core/Light */
+  --figma___status-colors-error-7: 4 77% 48% / 1;
+  /* ✦ Theme/Status colors/Error/7/UI Core/Light */
+  --figma___status-colors-error-8: 4 79% 45% / 1;
+  /* ✦ Theme/Status colors/Error/8/UI Core/Light */
+  --figma___status-colors-error-9: 3 79% 43% / 1;
+  /* ✦ Theme/Status colors/Error/9/UI Core/Light */
+  --figma___status-colors-error-10: 3 84% 38% / 1;
+  /* ✦ Theme/Status colors/Error/10/UI Core/Light */
+  --figma___status-colors-error-alpha-1: 4 73% 96% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/1/UI Core/Light */
+  --figma___status-colors-error-alpha-2: 5 74% 94% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/2/UI Core/Light */
+  --figma___status-colors-error-alpha-3: 4 74% 85% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/3/UI Core/Light */
+  --figma___status-colors-error-alpha-4: 4 75% 75% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/4/UI Core/Light */
+  --figma___status-colors-error-alpha-5: 4 82% 63% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/5/UI Core/Light */
+  --figma___status-colors-error-alpha-6: 4 78% 52% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/6/UI Core/Light */
+  --figma___status-colors-error-alpha-7: 4 77% 48% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/7/UI Core/Light */
+  --figma___status-colors-error-alpha-8: 4 79% 45% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/8/UI Core/Light */
+  --figma___status-colors-error-alpha-9: 3 79% 43% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/9/UI Core/Light */
+  --figma___status-colors-error-alpha-10: 3 84% 38% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/10/UI Core/Light */
+  --figma___status-colors-info-1: 240 100% 95% / 1;
+  /* ✦ Theme/Status colors/Info/1/UI Core/Light */
+  --figma___status-colors-info-2: 241 100% 90% / 1;
+  /* ✦ Theme/Status colors/Info/2/UI Core/Light */
+  --figma___status-colors-info-3: 241 100% 84% / 1;
+  /* ✦ Theme/Status colors/Info/3/UI Core/Light */
+  --figma___status-colors-info-4: 241 100% 80% / 1;
+  /* ✦ Theme/Status colors/Info/4/UI Core/Light */
+  --figma___status-colors-info-5: 240 100% 76% / 1;
+  /* ✦ Theme/Status colors/Info/5/UI Core/Light */
+  --figma___status-colors-info-6: 241 82% 66% / 1;
+  /* ✦ Theme/Status colors/Info/6/UI Core/Light */
+  --figma___status-colors-info-7: 241 90% 64% / 1;
+  /* ✦ Theme/Status colors/Info/7/UI Core/Light */
+  --figma___status-colors-info-8: 241 69% 57% / 1;
+  /* ✦ Theme/Status colors/Info/8/UI Core/Light */
+  --figma___status-colors-info-9: 240 51% 46% / 1;
+  /* ✦ Theme/Status colors/Info/9/UI Core/Light */
+  --figma___status-colors-info-10: 241 54% 38% / 1;
+  /* ✦ Theme/Status colors/Info/10/UI Core/Light */
+  --figma___status-colors-info-alpha-1: 240 100% 95% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/1/UI Core/Light */
+  --figma___status-colors-info-alpha-2: 241 100% 90% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/2/UI Core/Light */
+  --figma___status-colors-info-alpha-3: 241 100% 84% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/3/UI Core/Light */
+  --figma___status-colors-info-alpha-4: 241 100% 80% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/4/UI Core/Light */
+  --figma___status-colors-info-alpha-5: 240 100% 76% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/5/UI Core/Light */
+  --figma___status-colors-info-alpha-6: 241 82% 66% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/6/UI Core/Light */
+  --figma___status-colors-info-alpha-7: 241 90% 64% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/7/UI Core/Light */
+  --figma___status-colors-info-alpha-8: 241 69% 57% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/8/UI Core/Light */
+  --figma___status-colors-info-alpha-9: 240 51% 46% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/9/UI Core/Light */
+  --figma___status-colors-info-alpha-10: 241 54% 38% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/10/UI Core/Light */
+  --figma___status-colors-success-1: 112 58% 93% / 1;
+  /* ✦ Theme/Status colors/Success/1/UI Core/Light */
+  --figma___status-colors-success-2: 112 56% 89% / 1;
+  /* ✦ Theme/Status colors/Success/2/UI Core/Light */
+  --figma___status-colors-success-3: 113 55% 82% / 1;
+  /* ✦ Theme/Status colors/Success/3/UI Core/Light */
+  --figma___status-colors-success-4: 114 55% 75% / 1;
+  /* ✦ Theme/Status colors/Success/4/UI Core/Light */
+  --figma___status-colors-success-5: 117 54% 68% / 1;
+  /* ✦ Theme/Status colors/Success/5/UI Core/Light */
+  --figma___status-colors-success-6: 122 53% 55% / 1;
+  /* ✦ Theme/Status colors/Success/6/UI Core/Light */
+  --figma___status-colors-success-7: 122 44% 46% / 1;
+  /* ✦ Theme/Status colors/Success/7/UI Core/Light */
+  --figma___status-colors-success-8: 122 58% 38% / 1;
+  /* ✦ Theme/Status colors/Success/8/UI Core/Light */
+  --figma___status-colors-success-9: 121 66% 31% / 1;
+  /* ✦ Theme/Status colors/Success/9/UI Core/Light */
+  --figma___status-colors-success-10: 121 51% 24% / 1;
+  /* ✦ Theme/Status colors/Success/10/UI Core/Light */
+  --figma___status-colors-success-alpha-1: 140 95% 39% / 0.02;
+  /* ✦ Theme/Status colors/Success Alpha/1/UI Core/Light */
+  --figma___status-colors-success-alpha-2: 139 98% 37% / 0.09;
+  /* ✦ Theme/Status colors/Success Alpha/2/UI Core/Light */
+  --figma___status-colors-success-alpha-3: 139 98% 37% / 0.09;
+  /* ✦ Theme/Status colors/Success Alpha/3/UI Core/Light */
+  --figma___status-colors-success-alpha-4: 139 99% 33% / 0.13;
+  /* ✦ Theme/Status colors/Success Alpha/4/UI Core/Light */
+  --figma___status-colors-success-alpha-5: 141 100% 30% / 0.2;
+  /* ✦ Theme/Status colors/Success Alpha/5/UI Core/Light */
+  --figma___status-colors-success-alpha-6: 142 99% 29% / 0.29;
+  /* ✦ Theme/Status colors/Success Alpha/6/UI Core/Light */
+  --figma___status-colors-success-alpha-7: 151 100% 29% / 0.64;
+  /* ✦ Theme/Status colors/Success Alpha/7/UI Core/Light */
+  --figma___status-colors-success-alpha-8: 151 100% 28% / 0.81;
+  /* ✦ Theme/Status colors/Success Alpha/8/UI Core/Light */
+  --figma___status-colors-success-alpha-9: 153 100% 21% / 0.91;
+  /* ✦ Theme/Status colors/Success Alpha/9/UI Core/Light */
+  --figma___status-colors-success-alpha-10: 155 100% 7% / 0.9;
+  /* ✦ Theme/Status colors/Success Alpha/10/UI Core/Light */
+  --figma___status-colors-warning-1: 27 100% 96% / 1;
+  /* ✦ Theme/Status colors/Warning/1/UI Core/Light */
+  --figma___status-colors-warning-2: 24 100% 95% / 1;
+  /* ✦ Theme/Status colors/Warning/2/UI Core/Light */
+  --figma___status-colors-warning-3: 25 100% 87% / 1;
+  /* ✦ Theme/Status colors/Warning/3/UI Core/Light */
+  --figma___status-colors-warning-4: 25 100% 79% / 1;
+  /* ✦ Theme/Status colors/Warning/4/UI Core/Light */
+  --figma___status-colors-warning-5: 25 100% 71% / 1;
+  /* ✦ Theme/Status colors/Warning/5/UI Core/Light */
+  --figma___status-colors-warning-6: 25 100% 58% / 1;
+  /* ✦ Theme/Status colors/Warning/6/UI Core/Light */
+  --figma___status-colors-warning-7: 24 100% 57% / 1;
+  /* ✦ Theme/Status colors/Warning/7/UI Core/Light */
+  --figma___status-colors-warning-8: 22 100% 56% / 1;
+  /* ✦ Theme/Status colors/Warning/8/UI Core/Light */
+  --figma___status-colors-warning-9: 20 100% 55% / 1;
+  /* ✦ Theme/Status colors/Warning/9/UI Core/Light */
+  --figma___status-colors-warning-10: 17 100% 53% / 1;
+  /* ✦ Theme/Status colors/Warning/10/UI Core/Light */
+  --figma___status-colors-warning-alpha-1: 27 100% 96% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/1/UI Core/Light */
+  --figma___status-colors-warning-alpha-2: 24 100% 95% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/2/UI Core/Light */
+  --figma___status-colors-warning-alpha-3: 25 100% 87% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/3/UI Core/Light */
+  --figma___status-colors-warning-alpha-4: 25 100% 79% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/4/UI Core/Light */
+  --figma___status-colors-warning-alpha-5: 25 100% 71% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/5/UI Core/Light */
+  --figma___status-colors-warning-alpha-6: 25 100% 58% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/6/UI Core/Light */
+  --figma___status-colors-warning-alpha-7: 24 100% 57% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/7/UI Core/Light */
+  --figma___status-colors-warning-alpha-8: 22 100% 56% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/8/UI Core/Light */
+  --figma___status-colors-warning-alpha-9: 20 100% 55% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/9/UI Core/Light */
+  --figma___status-colors-warning-alpha-10: 17 100% 53% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/10/UI Core/Light */
+  --figma___switch-background: 0 0% 100% / 0.8;
+  /* ✦ Theme/Switch/Background/UI Core/Light */
+  --figma___switch-checked-active-thumb-thumb-background: 0 0% 100% / 1;
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/UI Core/Light */
+  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/UI Core/Light */
+  --figma___switch-checked-active-background: 206 98% 42% / 1;
+  /* ✦ Theme/Switch/Checked/Active/background/UI Core/Light */
+  --figma___switch-checked-active-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Checked/Active/border/UI Core/Light */
+  --figma___switch-checked-default-thumb-thumb-background: 0 0% 100% / 1;
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/UI Core/Light */
+  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/UI Core/Light */
+  --figma___switch-checked-default-default-background: 206 98% 42% / 1;
+  /* ✦ Theme/Switch/Checked/Default/default background/UI Core/Light */
+  --figma___switch-checked-default-default-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Checked/Default/default border/UI Core/Light */
+  --figma___switch-checked-disabled-thumb-thumb-background: 0 0% 100% / 1;
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/UI Core/Light */
+  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/UI Core/Light */
+  --figma___switch-checked-disabled-background: 206 98% 42% / 0.5;
+  /* ✦ Theme/Switch/Checked/Disabled/background/UI Core/Light */
+  --figma___switch-checked-disabled-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/border/UI Core/Light */
+  --figma___switch-checked-hover-thumb-thumb-background: 0 0% 100% / 1;
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/UI Core/Light */
+  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/UI Core/Light */
+  --figma___switch-checked-hover-background: 213 100% 32% / 1;
+  /* ✦ Theme/Switch/Checked/Hover/background/UI Core/Light */
+  --figma___switch-checked-hover-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/border/UI Core/Light */
+  --figma___switch-paper: 0 0% 100% / 0.5;
+  /* ✦ Theme/Switch/Paper/UI Core/Light */
+  --figma___switch-unchecked-active-thumb-thumb-background: 0 0% 100% / 1;
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/UI Core/Light */
+  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/UI Core/Light */
+  --figma___switch-unchecked-active-background: 235 19% 87% / 1;
+  /* ✦ Theme/Switch/Unchecked/Active/background/UI Core/Light */
+  --figma___switch-unchecked-active-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Unchecked/Active/border/UI Core/Light */
+  --figma___switch-unchecked-default-thumb-thumb-background: 0 0% 100% / 1;
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/UI Core/Light */
+  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/UI Core/Light */
+  --figma___switch-unchecked-default-default-background: 235 19% 87% / 1;
+  /* ✦ Theme/Switch/Unchecked/Default/default background/UI Core/Light */
+  --figma___switch-unchecked-default-default-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Unchecked/Default/default border/UI Core/Light */
+  --figma___switch-unchecked-disabled-thumb-thumb-background: 0 0% 100% / 1;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/UI Core/Light */
+  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/UI Core/Light */
+  --figma___switch-unchecked-disabled-background: 240 41% 97% / 1;
+  /* ✦ Theme/Switch/Unchecked/Disabled/background/UI Core/Light */
+  --figma___switch-unchecked-disabled-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Unchecked/Disabled/border/UI Core/Light */
+  --figma___switch-unchecked-hover-thumb-thumb-background: 0 0% 100% / 1;
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/UI Core/Light */
+  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/UI Core/Light */
+  --figma___switch-unchecked-hover-background: 237 14% 73% / 1;
+  /* ✦ Theme/Switch/Unchecked/Hover/background/UI Core/Light */
+  --figma___switch-unchecked-hover-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Unchecked/Hover/border/UI Core/Light */
+  --figma___switch-border: 235 19% 87% / 1;
+  /* ✦ Theme/Switch/border/UI Core/Light */
+  --figma___tabs-number-active-background: 206 98% 42% / 1;
+  /* ✦ Theme/Tabs/Number/Active/Background/UI Core/Light */
+  --figma___tabs-number-active-text: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Number/Active/text/UI Core/Light */
+  --figma___tabs-number-default-hover-background: 240 41% 97% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/Background/UI Core/Light */
+  --figma___tabs-number-default-hover-text: 235 11% 47% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/text/UI Core/Light */
+  --figma___tabs-pills-active-active: 195 100% 97% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Active/UI Core/Light */
+  --figma___tabs-pills-active-text: 213 100% 32% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Text/UI Core/Light */
+  --figma___tabs-pills-active-border-grad-1: 0 0% 100% / 0;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 1/UI Core/Light */
+  --figma___tabs-pills-active-border-grad-2: 0 0% 100% / 0;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 2/UI Core/Light */
+  --figma___tabs-pills-backgrounds: 235 19% 87% / 1;
+  /* ✦ Theme/Tabs/Pills/Backgrounds/UI Core/Light */
+  --figma___tabs-pills-default-background: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Pills/Default/Background/UI Core/Light */
+  --figma___tabs-pills-default-text: 236 11% 25% / 1;
+  /* ✦ Theme/Tabs/Pills/Default/Text/UI Core/Light */
+  --figma___tabs-pills-hover-background: 195 100% 97% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Background/UI Core/Light */
+  --figma___tabs-pills-hover-text: 236 11% 25% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Text/UI Core/Light */
+  --figma___tabs-pills-number-active-background: 206 98% 42% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/Background/UI Core/Light */
+  --figma___tabs-pills-number-active-text: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/text/UI Core/Light */
+  --figma___tabs-pills-border-grad-1: 235 19% 87% / 1;
+  /* ✦ Theme/Tabs/Pills/border grad 1/UI Core/Light */
+  --figma___tabs-pills-border-grad-2: 235 19% 87% / 1;
+  /* ✦ Theme/Tabs/Pills/border grad 2/UI Core/Light */
+  --figma___tabs-primary-active-text: 240 8% 5% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Text/UI Core/Light */
+  --figma___tabs-primary-active-underline: 206 98% 42% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Underline/UI Core/Light */
+  --figma___tabs-primary-border: 206 98% 42% / 1;
+  /* ✦ Theme/Tabs/Primary/Border/UI Core/Light */
+  --figma___tabs-primary-default-background: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Primary/Default/Background/UI Core/Light */
+  --figma___tabs-primary-default-text: 236 11% 25% / 1;
+  /* ✦ Theme/Tabs/Primary/Default/Text/UI Core/Light */
+  --figma___tabs-primary-hover-background: 0 0% 100% / 0;
+  /* ✦ Theme/Tabs/Primary/Hover/Background/UI Core/Light */
+  --figma___tabs-primary-hover-text: 206 98% 42% / 1;
+  /* ✦ Theme/Tabs/Primary/Hover/Text/UI Core/Light */
+  --figma___tabs-primary-pills-pills: 213 82% 22% / 1;
+  /* ✦ Theme/Tabs/Primary/Pills/Pills/UI Core/Light */
+  --figma___text-disabled: 237 14% 73% / 1;
+  /* ✦ Theme/Text/Disabled/UI Core/Light */
+  --figma___text-links: 206 98% 42% / 1;
+  /* ✦ Theme/Text/Links/UI Core/Light */
+  --figma___text-secondary: 236 11% 25% / 1;
+  /* ✦ Theme/Text/Secondary/UI Core/Light */
+  --figma___text-tertiary: 235 11% 47% / 1;
+  /* ✦ Theme/Text/Tertiary/UI Core/Light */
+  --figma___text-primary: 240 8% 5% / 1;
+  /* ✦ Theme/Text/primary/UI Core/Light */
+  --figma___textfield-assistive-text-primary: 235 11% 47% / 1;
+  /* ✦ Theme/Textfield/Assistive Text/Primary/UI Core/Light */
+  --figma___textfield-background: 0 0% 100% / 1;
+  /* ✦ Theme/Textfield/Background/UI Core/Light */
+  --figma___textfield-input-field-background: 0 0% 100% / 1;
+  /* ✦ Theme/Textfield/Input Field/Background/UI Core/Light */
+  --figma___textfield-input-field-default: 235 19% 87% / 1;
+  /* ✦ Theme/Textfield/Input Field/Default/UI Core/Light */
+  --figma___textfield-input-field-error: 4 77% 48% / 1;
+  /* ✦ Theme/Textfield/Input Field/Error/UI Core/Light */
+  --figma___textfield-input-field-hover: 206 98% 42% / 1;
+  /* ✦ Theme/Textfield/Input Field/Hover/UI Core/Light */
+  --figma___textfield-label-info-icon: 206 98% 42% / 1;
+  /* ✦ Theme/Textfield/Label/Info Icon/UI Core/Light */
+  --figma___textfield-label-link: 206 98% 42% / 1;
+  /* ✦ Theme/Textfield/Label/Link/UI Core/Light */
+  --figma___textfield-label-main: 236 11% 25% / 1;
+  /* ✦ Theme/Textfield/Label/Main/UI Core/Light */
+  --figma___textfield-label-optional: 235 11% 47% / 1;
+  /* ✦ Theme/Textfield/Label/Optional/UI Core/Light */
+  --figma___textfield-pin-soft-background: 240 41% 97% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/Background/UI Core/Light */
+  --figma___textfield-pin-soft-border: 235 19% 87% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/border/UI Core/Light */
+  --figma___textfield-pin-soft-pin: 206 98% 42% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/pin/UI Core/Light */
+  --figma___textfield-pin-surface-background: 240 41% 97% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/Background/UI Core/Light */
+  --figma___textfield-pin-surface-border: 235 19% 87% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/border/UI Core/Light */
+  --figma___textfield-pin-surface-pin: 206 98% 42% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/pin/UI Core/Light */
+  --figma___tooltip-background: 215 46% 20% / 1;
+  /* ✦ Theme/Tooltip/Background/UI Core/Light */
+  --figma___tooltip-body-text: 0 0% 100% / 1;
+  /* ✦ Theme/Tooltip/Body Text/UI Core/Light */
+  --figma___tooltip-dismissable-icon: 234 11% 35% / 1;
+  /* ✦ Theme/Tooltip/Dismissable icon/UI Core/Light */
+  --figma___tooltip-tooltip-title: 0 0% 100% / 1;
+  /* ✦ Theme/Tooltip/Tooltip Title/UI Core/Light */
+}
+
+/* Color variables - dark mode */
+.ui-core-dark {
+  --figma___background-backdrop: 212 72% 10% / 0.75;
+  /* ✦ Theme/Background/Backdrop/UI Core/Dark */
+  --figma___background-cards-and-rows-default: 0 0% 0% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Default/UI Core/Dark */
+  --figma___background-cards-and-rows-hover: 240 4% 10% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Hover/UI Core/Dark */
+  --figma___background-cards-and-rows-primary-blue-selected: 206 100% 50% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Primary-blue-selected/UI Core/Dark */
+  --figma___background-cards-and-rows-selected: 240 4% 10% / 1;
+  /* ✦ Theme/Background/Cards and Rows/Selected/UI Core/Dark */
+  --figma___background-header-page-header: 0 0% 0% / 1;
+  /* ✦ Theme/Background/Header/Page Header/UI Core/Dark */
+  --figma___background-header-table-header: 0 0% 0% / 1;
+  /* ✦ Theme/Background/Header/Table Header/UI Core/Dark */
+  --figma___background-paper: 240 4% 10% / 1;
+  /* ✦ Theme/Background/Paper/UI Core/Dark */
+  --figma___background-primary: 240 4% 10% / 1;
+  /* ✦ Theme/Background/Primary/UI Core/Dark */
+  --figma___background-solid: 0 0% 0% / 1;
+  /* ✦ Theme/Background/Solid/UI Core/Dark */
+  --figma___badges-soft-amber-background: 54 100% 17% / 1;
+  /* ✦ Theme/Badges/Soft/Amber/background/UI Core/Dark */
+  --figma___badges-soft-amber-text: 210 25% 98% / 1;
+  /* ✦ Theme/Badges/Soft/Amber/text/UI Core/Dark */
+  --figma___badges-soft-blue-background: 215 46% 20% / 1;
+  /* ✦ Theme/Badges/Soft/Blue/background/UI Core/Dark */
+  --figma___badges-soft-blue-text: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Soft/Blue/text/UI Core/Dark */
+  --figma___badges-soft-bronze-background: 30 69% 18% / 1;
+  /* ✦ Theme/Badges/Soft/Bronze/background/UI Core/Dark */
+  --figma___badges-soft-bronze-text: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Soft/Bronze/text/UI Core/Dark */
+  --figma___badges-soft-brown-background: 32 67% 12% / 1;
+  /* ✦ Theme/Badges/Soft/Brown/background/UI Core/Dark */
+  --figma___badges-soft-brown-text: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Soft/Brown/text/UI Core/Dark */
+  --figma___badges-soft-crimson-background: 330 100% 25% / 1;
+  /* ✦ Theme/Badges/Soft/Crimson/background/UI Core/Dark */
+  --figma___badges-soft-crimson-text: 326 77% 77% / 1;
+  /* ✦ Theme/Badges/Soft/Crimson/text/UI Core/Dark */
+  --figma___badges-soft-cyan-background: 180 100% 20% / 1;
+  /* ✦ Theme/Badges/Soft/Cyan/background/UI Core/Dark */
+  --figma___badges-soft-cyan-text: 180 77% 77% / 1;
+  /* ✦ Theme/Badges/Soft/Cyan/text/UI Core/Dark */
+  --figma___badges-soft-gold-background: 30 69% 18% / 1;
+  /* ✦ Theme/Badges/Soft/Gold/background/UI Core/Dark */
+  --figma___badges-soft-gold-text: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Soft/Gold/text/UI Core/Dark */
+  --figma___badges-soft-grass-background: 122 64% 11% / 1;
+  /* ✦ Theme/Badges/Soft/Grass/background/UI Core/Dark */
+  --figma___badges-soft-grass-text: 118 49% 70% / 1;
+  /* ✦ Theme/Badges/Soft/Grass/text/UI Core/Dark */
+  --figma___badges-soft-green-background: 127 73% 15% / 1;
+  /* ✦ Theme/Badges/Soft/Green/background/UI Core/Dark */
+  --figma___badges-soft-green-text: 124 36% 52% / 1;
+  /* ✦ Theme/Badges/Soft/Green/text/UI Core/Dark */
+  --figma___badges-soft-indigo-background: 241 52% 28% / 1;
+  /* ✦ Theme/Badges/Soft/Indigo/background/UI Core/Dark */
+  --figma___badges-soft-indigo-text: 239 48% 52% / 1;
+  /* ✦ Theme/Badges/Soft/Indigo/text/UI Core/Dark */
+  --figma___badges-soft-iris-background: 254 74% 37% / 1;
+  /* ✦ Theme/Badges/Soft/Iris/background/UI Core/Dark */
+  --figma___badges-soft-iris-text: 251 80% 74% / 1;
+  /* ✦ Theme/Badges/Soft/Iris/text/UI Core/Dark */
+  --figma___badges-soft-jade-background: 127 73% 15% / 1;
+  /* ✦ Theme/Badges/Soft/Jade/background/UI Core/Dark */
+  --figma___badges-soft-jade-text: 118 49% 70% / 1;
+  /* ✦ Theme/Badges/Soft/Jade/text/UI Core/Dark */
+  --figma___badges-soft-lime-background: 84 100% 25% / 1;
+  /* ✦ Theme/Badges/Soft/Lime/background/UI Core/Dark */
+  --figma___badges-soft-lime-text: 120 34% 85% / 1;
+  /* ✦ Theme/Badges/Soft/Lime/text/UI Core/Dark */
+  --figma___badges-soft-mint-background: 127 73% 15% / 1;
+  /* ✦ Theme/Badges/Soft/Mint/background/UI Core/Dark */
+  --figma___badges-soft-mint-text: 118 49% 70% / 1;
+  /* ✦ Theme/Badges/Soft/Mint/text/UI Core/Dark */
+  --figma___badges-soft-orange-background: 30 69% 18% / 1;
+  /* ✦ Theme/Badges/Soft/Orange/background/UI Core/Dark */
+  --figma___badges-soft-orange-text: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Soft/Orange/text/UI Core/Dark */
+  --figma___badges-soft-pink-background: 330 100% 25% / 1;
+  /* ✦ Theme/Badges/Soft/Pink/background/UI Core/Dark */
+  --figma___badges-soft-pink-text: 326 77% 77% / 1;
+  /* ✦ Theme/Badges/Soft/Pink/text/UI Core/Dark */
+  --figma___badges-soft-plum-background: 264 100% 20% / 1;
+  /* ✦ Theme/Badges/Soft/Plum/background/UI Core/Dark */
+  --figma___badges-soft-plum-text: 264 67% 52% / 1;
+  /* ✦ Theme/Badges/Soft/Plum/text/UI Core/Dark */
+  --figma___badges-soft-purple-background: 264 100% 25% / 1;
+  /* ✦ Theme/Badges/Soft/Purple/background/UI Core/Dark */
+  --figma___badges-soft-purple-text: 264 67% 52% / 1;
+  /* ✦ Theme/Badges/Soft/Purple/text/UI Core/Dark */
+  --figma___badges-soft-red-background: 0 67% 12% / 1;
+  /* ✦ Theme/Badges/Soft/Red/background/UI Core/Dark */
+  --figma___badges-soft-red-text: 0 68% 42% / 1;
+  /* ✦ Theme/Badges/Soft/Red/text/UI Core/Dark */
+  --figma___badges-soft-ruby-background: 0 67% 12% / 1;
+  /* ✦ Theme/Badges/Soft/Ruby/background/UI Core/Dark */
+  --figma___badges-soft-ruby-text: 0 68% 42% / 1;
+  /* ✦ Theme/Badges/Soft/Ruby/text/UI Core/Dark */
+  --figma___badges-soft-sky-background: 214 58% 16% / 1;
+  /* ✦ Theme/Badges/Soft/Sky/background/UI Core/Dark */
+  --figma___badges-soft-sky-text: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Soft/Sky/text/UI Core/Dark */
+  --figma___badges-soft-teal-background: 180 100% 20% / 1;
+  /* ✦ Theme/Badges/Soft/Teal/background/UI Core/Dark */
+  --figma___badges-soft-teal-text: 180 77% 77% / 1;
+  /* ✦ Theme/Badges/Soft/Teal/text/UI Core/Dark */
+  --figma___badges-soft-violet-background: 256 82% 30% / 1;
+  /* ✦ Theme/Badges/Soft/Violet/background/UI Core/Dark */
+  --figma___badges-soft-violet-text: 251 80% 74% / 1;
+  /* ✦ Theme/Badges/Soft/Violet/text/UI Core/Dark */
+  --figma___badges-soft-yellow-background: 54 100% 17% / 1;
+  /* ✦ Theme/Badges/Soft/Yellow/background/UI Core/Dark */
+  --figma___badges-soft-yellow-text: 47 89% 89% / 1;
+  /* ✦ Theme/Badges/Soft/Yellow/text/UI Core/Dark */
+  --figma___badges-soft-accent-background: 216 50% 12% / 1;
+  /* ✦ Theme/Badges/Soft/accent/background/UI Core/Dark */
+  --figma___badges-soft-accent-text: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Soft/accent/text/UI Core/Dark */
+  --figma___badges-soft-error-background: 0 67% 12% / 1;
+  /* ✦ Theme/Badges/Soft/error/background/UI Core/Dark */
+  --figma___badges-soft-error-text: 0 100% 70% / 1;
+  /* ✦ Theme/Badges/Soft/error/text/UI Core/Dark */
+  --figma___badges-soft-info-background: 216 50% 12% / 1;
+  /* ✦ Theme/Badges/Soft/info/background/UI Core/Dark */
+  --figma___badges-soft-info-text: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Soft/info/text/UI Core/Dark */
+  --figma___badges-soft-success-background: 122 64% 11% / 1;
+  /* ✦ Theme/Badges/Soft/success/background/UI Core/Dark */
+  --figma___badges-soft-success-text: 117 62% 79% / 1;
+  /* ✦ Theme/Badges/Soft/success/text/UI Core/Dark */
+  --figma___badges-soft-warning-background: 30 69% 18% / 1;
+  /* ✦ Theme/Badges/Soft/warning/background/UI Core/Dark */
+  --figma___badges-soft-warning-text: 19 79% 54% / 1;
+  /* ✦ Theme/Badges/Soft/warning/text/UI Core/Dark */
+  --figma___badges-solid-amber-background: 54 92% 69% / 1;
+  /* ✦ Theme/Badges/Solid/Amber/background/UI Core/Dark */
+  --figma___badges-solid-amber-text: 210 25% 98% / 1;
+  /* ✦ Theme/Badges/Solid/Amber/text/UI Core/Dark */
+  --figma___badges-solid-blue-background: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Solid/Blue/background/UI Core/Dark */
+  --figma___badges-solid-blue-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Blue/text/UI Core/Dark */
+  --figma___badges-solid-bronze-background: 19 79% 54% / 1;
+  /* ✦ Theme/Badges/Solid/Bronze/background/UI Core/Dark */
+  --figma___badges-solid-bronze-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Bronze/text/UI Core/Dark */
+  --figma___badges-solid-brown-background: 19 79% 54% / 1;
+  /* ✦ Theme/Badges/Solid/Brown/background/UI Core/Dark */
+  --figma___badges-solid-brown-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Brown/text/UI Core/Dark */
+  --figma___badges-solid-crimson-background: 326 77% 77% / 1;
+  /* ✦ Theme/Badges/Solid/Crimson/background/UI Core/Dark */
+  --figma___badges-solid-crimson-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Crimson/text/UI Core/Dark */
+  --figma___badges-solid-cyan-background: 180 60% 50% / 1;
+  /* ✦ Theme/Badges/Solid/Cyan/background/UI Core/Dark */
+  --figma___badges-solid-cyan-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Cyan/text/UI Core/Dark */
+  --figma___badges-solid-gold-background: 19 79% 54% / 1;
+  /* ✦ Theme/Badges/Solid/Gold/background/UI Core/Dark */
+  --figma___badges-solid-gold-text: 0 0% 82% / 1;
+  /* ✦ Theme/Badges/Solid/Gold/text/UI Core/Dark */
+  --figma___badges-solid-grass-background: 118 49% 70% / 1;
+  /* ✦ Theme/Badges/Solid/Grass/background/UI Core/Dark */
+  --figma___badges-solid-grass-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Grass/text/UI Core/Dark */
+  --figma___badges-solid-green-background: 117 62% 79% / 1;
+  /* ✦ Theme/Badges/Solid/Green/background/UI Core/Dark */
+  --figma___badges-solid-green-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Green/text/UI Core/Dark */
+  --figma___badges-solid-indigo-background: 239 48% 52% / 1;
+  /* ✦ Theme/Badges/Solid/Indigo/background/UI Core/Dark */
+  --figma___badges-solid-indigo-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Indigo/text/UI Core/Dark */
+  --figma___badges-solid-iris-background: 251 80% 74% / 1;
+  /* ✦ Theme/Badges/Solid/Iris/background/UI Core/Dark */
+  --figma___badges-solid-iris-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Iris/text/UI Core/Dark */
+  --figma___badges-solid-jade-background: 121 42% 62% / 1;
+  /* ✦ Theme/Badges/Solid/Jade/background/UI Core/Dark */
+  --figma___badges-solid-jade-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Jade/text/UI Core/Dark */
+  --figma___badges-solid-lime-background: 120 34% 85% / 1;
+  /* ✦ Theme/Badges/Solid/Lime/background/UI Core/Dark */
+  --figma___badges-solid-lime-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Lime/text/UI Core/Dark */
+  --figma___badges-solid-mint-background: 121 42% 62% / 1;
+  /* ✦ Theme/Badges/Solid/Mint/background/UI Core/Dark */
+  --figma___badges-solid-mint-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Mint/text/UI Core/Dark */
+  --figma___badges-solid-orange-background: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Solid/Orange/background/UI Core/Dark */
+  --figma___badges-solid-orange-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Orange/text/UI Core/Dark */
+  --figma___badges-solid-pink-background: 326 77% 77% / 1;
+  /* ✦ Theme/Badges/Solid/Pink/background/UI Core/Dark */
+  --figma___badges-solid-pink-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Pink/text/UI Core/Dark */
+  --figma___badges-solid-plum-background: 264 67% 52% / 1;
+  /* ✦ Theme/Badges/Solid/Plum/background/UI Core/Dark */
+  --figma___badges-solid-plum-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Plum/text/UI Core/Dark */
+  --figma___badges-solid-purple-background: 264 67% 52% / 1;
+  /* ✦ Theme/Badges/Solid/Purple/background/UI Core/Dark */
+  --figma___badges-solid-purple-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Purple/text/UI Core/Dark */
+  --figma___badges-solid-red-background: 0 68% 42% / 1;
+  /* ✦ Theme/Badges/Solid/Red/background/UI Core/Dark */
+  --figma___badges-solid-red-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Red/text/UI Core/Dark */
+  --figma___badges-solid-ruby-background: 0 68% 42% / 1;
+  /* ✦ Theme/Badges/Solid/Ruby/background/UI Core/Dark */
+  --figma___badges-solid-ruby-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Ruby/text/UI Core/Dark */
+  --figma___badges-solid-sky-background: 214 58% 16% / 1;
+  /* ✦ Theme/Badges/Solid/Sky/background/UI Core/Dark */
+  --figma___badges-solid-sky-text: 210 25% 98% / 1;
+  /* ✦ Theme/Badges/Solid/Sky/text/UI Core/Dark */
+  --figma___badges-solid-success-background: 117 62% 79% / 1;
+  /* ✦ Theme/Badges/Solid/Success/background/UI Core/Dark */
+  --figma___badges-solid-success-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Success/text/UI Core/Dark */
+  --figma___badges-solid-teal-background: 180 60% 50% / 1;
+  /* ✦ Theme/Badges/Solid/Teal/background/UI Core/Dark */
+  --figma___badges-solid-teal-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Teal/text/UI Core/Dark */
+  --figma___badges-solid-violet-background: 251 80% 74% / 1;
+  /* ✦ Theme/Badges/Solid/Violet/background/UI Core/Dark */
+  --figma___badges-solid-violet-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/Violet/text/UI Core/Dark */
+  --figma___badges-solid-yellow-background: 55 92% 58% / 1;
+  /* ✦ Theme/Badges/Solid/Yellow/background/UI Core/Dark */
+  --figma___badges-solid-yellow-text: 210 25% 98% / 1;
+  /* ✦ Theme/Badges/Solid/Yellow/text/UI Core/Dark */
+  --figma___badges-solid-accent-background: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Solid/accent/background/UI Core/Dark */
+  --figma___badges-solid-accent-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/accent/text/UI Core/Dark */
+  --figma___badges-solid-info-background: 240 59% 59% / 1;
+  /* ✦ Theme/Badges/Solid/info/background/UI Core/Dark */
+  --figma___badges-solid-info-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/info/text/UI Core/Dark */
+  --figma___badges-solid-warning-background: 19 67% 48% / 1;
+  /* ✦ Theme/Badges/Solid/warning/background/UI Core/Dark */
+  --figma___badges-solid-warning-text: 0 0% 0% / 1;
+  /* ✦ Theme/Badges/Solid/warning/text/UI Core/Dark */
+  --figma___badges-surface-amber-background: 54 100% 17% / 1;
+  /* ✦ Theme/Badges/Surface/Amber/background/UI Core/Dark */
+  --figma___badges-surface-amber-border: 210 25% 98% / 1;
+  /* ✦ Theme/Badges/Surface/Amber/border/UI Core/Dark */
+  --figma___badges-surface-amber-text: 210 25% 98% / 1;
+  /* ✦ Theme/Badges/Surface/Amber/text/UI Core/Dark */
+  --figma___badges-surface-blue-background: 215 46% 20% / 1;
+  /* ✦ Theme/Badges/Surface/Blue/background/UI Core/Dark */
+  --figma___badges-surface-blue-border: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Surface/Blue/border/UI Core/Dark */
+  --figma___badges-surface-blue-text: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Surface/Blue/text/UI Core/Dark */
+  --figma___badges-surface-bronze-background: 30 69% 18% / 1;
+  /* ✦ Theme/Badges/Surface/Bronze/background/UI Core/Dark */
+  --figma___badges-surface-bronze-border: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Bronze/border/UI Core/Dark */
+  --figma___badges-surface-bronze-text: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Bronze/text/UI Core/Dark */
+  --figma___badges-surface-brown-background: 32 67% 12% / 1;
+  /* ✦ Theme/Badges/Surface/Brown/background/UI Core/Dark */
+  --figma___badges-surface-brown-border: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Brown/border/UI Core/Dark */
+  --figma___badges-surface-brown-text: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Brown/text/UI Core/Dark */
+  --figma___badges-surface-crimson-border: 326 77% 77% / 1;
+  /* ✦ Theme/Badges/Surface/Crimson/Border/UI Core/Dark */
+  --figma___badges-surface-crimson-background: 330 100% 25% / 1;
+  /* ✦ Theme/Badges/Surface/Crimson/background/UI Core/Dark */
+  --figma___badges-surface-crimson-text: 326 77% 77% / 1;
+  /* ✦ Theme/Badges/Surface/Crimson/text/UI Core/Dark */
+  --figma___badges-surface-cyan-border: 180 77% 77% / 1;
+  /* ✦ Theme/Badges/Surface/Cyan/Border/UI Core/Dark */
+  --figma___badges-surface-cyan-background: 180 100% 20% / 1;
+  /* ✦ Theme/Badges/Surface/Cyan/background/UI Core/Dark */
+  --figma___badges-surface-cyan-text: 180 77% 77% / 1;
+  /* ✦ Theme/Badges/Surface/Cyan/text/UI Core/Dark */
+  --figma___badges-surface-gold-border: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Gold/Border/UI Core/Dark */
+  --figma___badges-surface-gold-background: 30 69% 18% / 1;
+  /* ✦ Theme/Badges/Surface/Gold/background/UI Core/Dark */
+  --figma___badges-surface-gold-text: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Gold/text/UI Core/Dark */
+  --figma___badges-surface-grass-border: 118 49% 70% / 1;
+  /* ✦ Theme/Badges/Surface/Grass/Border/UI Core/Dark */
+  --figma___badges-surface-grass-background: 122 64% 11% / 1;
+  /* ✦ Theme/Badges/Surface/Grass/background/UI Core/Dark */
+  --figma___badges-surface-grass-text: 118 49% 70% / 1;
+  /* ✦ Theme/Badges/Surface/Grass/text/UI Core/Dark */
+  --figma___badges-surface-green-background: 127 73% 15% / 1;
+  /* ✦ Theme/Badges/Surface/Green/background/UI Core/Dark */
+  --figma___badges-surface-green-border: 124 36% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Green/border/UI Core/Dark */
+  --figma___badges-surface-green-text: 124 36% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Green/text/UI Core/Dark */
+  --figma___badges-surface-indigo-background: 241 52% 28% / 1;
+  /* ✦ Theme/Badges/Surface/Indigo/background/UI Core/Dark */
+  --figma___badges-surface-indigo-border: 239 48% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Indigo/border/UI Core/Dark */
+  --figma___badges-surface-indigo-text: 239 48% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Indigo/text/UI Core/Dark */
+  --figma___badges-surface-iris-border: 251 80% 74% / 1;
+  /* ✦ Theme/Badges/Surface/Iris/Border/UI Core/Dark */
+  --figma___badges-surface-iris-background: 254 74% 37% / 1;
+  /* ✦ Theme/Badges/Surface/Iris/background/UI Core/Dark */
+  --figma___badges-surface-iris-text: 251 80% 74% / 1;
+  /* ✦ Theme/Badges/Surface/Iris/text/UI Core/Dark */
+  --figma___badges-surface-jade-border: 118 49% 70% / 1;
+  /* ✦ Theme/Badges/Surface/Jade/Border/UI Core/Dark */
+  --figma___badges-surface-jade-background: 127 73% 15% / 1;
+  /* ✦ Theme/Badges/Surface/Jade/background/UI Core/Dark */
+  --figma___badges-surface-jade-text: 118 49% 70% / 1;
+  /* ✦ Theme/Badges/Surface/Jade/text/UI Core/Dark */
+  --figma___badges-surface-lime-border: 120 34% 85% / 1;
+  /* ✦ Theme/Badges/Surface/Lime/Border/UI Core/Dark */
+  --figma___badges-surface-lime-background: 84 100% 25% / 1;
+  /* ✦ Theme/Badges/Surface/Lime/background/UI Core/Dark */
+  --figma___badges-surface-lime-text: 120 34% 85% / 1;
+  /* ✦ Theme/Badges/Surface/Lime/text/UI Core/Dark */
+  --figma___badges-surface-mint-background: 127 73% 15% / 1;
+  /* ✦ Theme/Badges/Surface/Mint/background/UI Core/Dark */
+  --figma___badges-surface-mint-border: 118 49% 70% / 1;
+  /* ✦ Theme/Badges/Surface/Mint/border/UI Core/Dark */
+  --figma___badges-surface-mint-text: 118 49% 70% / 1;
+  /* ✦ Theme/Badges/Surface/Mint/text/UI Core/Dark */
+  --figma___badges-surface-orange-background: 30 69% 18% / 1;
+  /* ✦ Theme/Badges/Surface/Orange/background/UI Core/Dark */
+  --figma___badges-surface-orange-border: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Orange/border/UI Core/Dark */
+  --figma___badges-surface-orange-text: 18 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Orange/text/UI Core/Dark */
+  --figma___badges-surface-pink-background: 330 100% 25% / 1;
+  /* ✦ Theme/Badges/Surface/Pink/background/UI Core/Dark */
+  --figma___badges-surface-pink-border: 326 77% 77% / 1;
+  /* ✦ Theme/Badges/Surface/Pink/border/UI Core/Dark */
+  --figma___badges-surface-pink-text: 326 77% 77% / 1;
+  /* ✦ Theme/Badges/Surface/Pink/text/UI Core/Dark */
+  --figma___badges-surface-plum-background: 264 100% 20% / 1;
+  /* ✦ Theme/Badges/Surface/Plum/background/UI Core/Dark */
+  --figma___badges-surface-plum-border: 264 67% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Plum/border/UI Core/Dark */
+  --figma___badges-surface-plum-text: 264 67% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Plum/text/UI Core/Dark */
+  --figma___badges-surface-purple-background: 264 100% 25% / 1;
+  /* ✦ Theme/Badges/Surface/Purple/background/UI Core/Dark */
+  --figma___badges-surface-purple-border: 264 67% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Purple/border/UI Core/Dark */
+  --figma___badges-surface-purple-text: 264 67% 52% / 1;
+  /* ✦ Theme/Badges/Surface/Purple/text/UI Core/Dark */
+  --figma___badges-surface-red-background: 0 67% 12% / 1;
+  /* ✦ Theme/Badges/Surface/Red/background/UI Core/Dark */
+  --figma___badges-surface-red-border: 0 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Red/border/UI Core/Dark */
+  --figma___badges-surface-red-text: 0 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Red/text/UI Core/Dark */
+  --figma___badges-surface-ruby-background: 0 67% 12% / 1;
+  /* ✦ Theme/Badges/Surface/Ruby/background/UI Core/Dark */
+  --figma___badges-surface-ruby-border: 0 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Ruby/border/UI Core/Dark */
+  --figma___badges-surface-ruby-text: 0 68% 42% / 1;
+  /* ✦ Theme/Badges/Surface/Ruby/text/UI Core/Dark */
+  --figma___badges-surface-sky-background: 214 58% 16% / 1;
+  /* ✦ Theme/Badges/Surface/Sky/background/UI Core/Dark */
+  --figma___badges-surface-sky-border: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Surface/Sky/border/UI Core/Dark */
+  --figma___badges-surface-sky-text: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Surface/Sky/text/UI Core/Dark */
+  --figma___badges-surface-teal-background: 180 100% 20% / 1;
+  /* ✦ Theme/Badges/Surface/Teal/background/UI Core/Dark */
+  --figma___badges-surface-teal-border: 180 77% 77% / 1;
+  /* ✦ Theme/Badges/Surface/Teal/border/UI Core/Dark */
+  --figma___badges-surface-teal-text: 180 77% 77% / 1;
+  /* ✦ Theme/Badges/Surface/Teal/text/UI Core/Dark */
+  --figma___badges-surface-violet-background: 256 82% 30% / 1;
+  /* ✦ Theme/Badges/Surface/Violet/background/UI Core/Dark */
+  --figma___badges-surface-violet-border: 251 80% 74% / 1;
+  /* ✦ Theme/Badges/Surface/Violet/border/UI Core/Dark */
+  --figma___badges-surface-violet-text: 251 80% 74% / 1;
+  /* ✦ Theme/Badges/Surface/Violet/text/UI Core/Dark */
+  --figma___badges-surface-yellow-background: 54 100% 17% / 1;
+  /* ✦ Theme/Badges/Surface/Yellow/background/UI Core/Dark */
+  --figma___badges-surface-yellow-border: 47 89% 89% / 1;
+  /* ✦ Theme/Badges/Surface/Yellow/border/UI Core/Dark */
+  --figma___badges-surface-yellow-text: 47 89% 89% / 1;
+  /* ✦ Theme/Badges/Surface/Yellow/text/UI Core/Dark */
+  --figma___badges-surface-accent-background: 215 46% 20% / 1;
+  /* ✦ Theme/Badges/Surface/accent/background/UI Core/Dark */
+  --figma___badges-surface-accent-border: 206 100% 62% / 1;
+  /* ✦ Theme/Badges/Surface/accent/border/UI Core/Dark */
+  --figma___badges-surface-accent-text: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Surface/accent/text/UI Core/Dark */
+  --figma___badges-surface-error-background: 0 67% 12% / 1;
+  /* ✦ Theme/Badges/Surface/error/background/UI Core/Dark */
+  --figma___badges-surface-error-border: 0 100% 70% / 1;
+  /* ✦ Theme/Badges/Surface/error/border/UI Core/Dark */
+  --figma___badges-surface-error-text: 0 100% 70% / 1;
+  /* ✦ Theme/Badges/Surface/error/text/UI Core/Dark */
+  --figma___badges-surface-info-background: 216 50% 12% / 1;
+  /* ✦ Theme/Badges/Surface/info/background/UI Core/Dark */
+  --figma___badges-surface-info-border: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Surface/info/border/UI Core/Dark */
+  --figma___badges-surface-info-text: 206 100% 50% / 1;
+  /* ✦ Theme/Badges/Surface/info/text/UI Core/Dark */
+  --figma___badges-surface-success-background: 122 64% 11% / 1;
+  /* ✦ Theme/Badges/Surface/success/background/UI Core/Dark */
+  --figma___badges-surface-success-border: 117 62% 79% / 1;
+  /* ✦ Theme/Badges/Surface/success/border/UI Core/Dark */
+  --figma___badges-surface-success-text: 117 62% 79% / 1;
+  /* ✦ Theme/Badges/Surface/success/text/UI Core/Dark */
+  --figma___badges-surface-warning-background: 30 69% 18% / 1;
+  /* ✦ Theme/Badges/Surface/warning/background/UI Core/Dark */
+  --figma___badges-surface-warning-border: 19 79% 54% / 1;
+  /* ✦ Theme/Badges/Surface/warning/border/UI Core/Dark */
+  --figma___badges-surface-warning-text: 19 79% 54% / 1;
+  /* ✦ Theme/Badges/Surface/warning/text/UI Core/Dark */
+  --figma___border-disabled: 0 0% 16% / 1;
+  /* ✦ Theme/Border/Disabled/UI Core/Dark */
+  --figma___border-hover: 206 100% 62% / 1;
+  /* ✦ Theme/Border/Hover/UI Core/Dark */
+  --figma___border-primary: 0 0% 16% / 1;
+  /* ✦ Theme/Border/Primary/UI Core/Dark */
+  --figma___border-secondary: 0 0% 11% / 1;
+  /* ✦ Theme/Border/Secondary/UI Core/Dark */
+  --figma___border-selected: 206 100% 50% / 1;
+  /* ✦ Theme/Border/Selected/UI Core/Dark */
+  --figma___breadcrumbs-current: 0 0% 35% / 1;
+  /* ✦ Theme/Breadcrumbs/current/UI Core/Dark */
+  --figma___breadcrumbs-visited: 206 100% 50% / 1;
+  /* ✦ Theme/Breadcrumbs/visited/UI Core/Dark */
+  --figma___button-ghost-accent-active: 213 100% 32% / 0;
+  /* ✦ Theme/Button/Ghost/Accent/Active/UI Core/Dark */
+  --figma___button-ghost-accent-active-text: 206 100% 62% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Active text/UI Core/Dark */
+  --figma___button-ghost-accent-hover: 213 100% 32% / 0;
+  /* ✦ Theme/Button/Ghost/Accent/Hover/UI Core/Dark */
+  --figma___button-ghost-accent-hover-text: 206 100% 62% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Hover text/UI Core/Dark */
+  --figma___button-ghost-accent-text-disabled: 206 98% 42% / 0.5;
+  /* ✦ Theme/Button/Ghost/Accent/Text-disabled/UI Core/Dark */
+  --figma___button-ghost-accent-text-primary: 206 100% 50% / 1;
+  /* ✦ Theme/Button/Ghost/Accent/Text-primary/UI Core/Dark */
+  --figma___button-ghost-error-active: 4 75% 75% / 0;
+  /* ✦ Theme/Button/Ghost/Error/Active/UI Core/Dark */
+  --figma___button-ghost-error-active-text: 0 100% 62% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Active Text/UI Core/Dark */
+  --figma___button-ghost-error-hover: 4 74% 85% / 0;
+  /* ✦ Theme/Button/Ghost/Error/Hover/UI Core/Dark */
+  --figma___button-ghost-error-hover-text: 0 100% 62% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Hover text/UI Core/Dark */
+  --figma___button-ghost-error-text-disabled: 0 68% 30% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Text-disabled/UI Core/Dark */
+  --figma___button-ghost-error-text-primary: 0 78% 55% / 1;
+  /* ✦ Theme/Button/Ghost/Error/Text-primary/UI Core/Dark */
+  --figma___button-ghost-neutral-active: 235 19% 87% / 0;
+  /* ✦ Theme/Button/Ghost/Neutral/Active/UI Core/Dark */
+  --figma___button-ghost-neutral-active-text: 0 0% 69% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Active Text/UI Core/Dark */
+  --figma___button-ghost-neutral-hover: 240 41% 97% / 0;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover/UI Core/Dark */
+  --figma___button-ghost-neutral-hover-text: 0 0% 69% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Hover text/UI Core/Dark */
+  --figma___button-ghost-neutral-text-disabled: 0 0% 23% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-disabled/UI Core/Dark */
+  --figma___button-ghost-neutral-text-primary: 0 0% 42% / 1;
+  /* ✦ Theme/Button/Ghost/Neutral/Text-primary/UI Core/Dark */
+  --figma___button-ghost-success-active: 139 99% 33% / 0;
+  /* ✦ Theme/Button/Ghost/Success/Active/UI Core/Dark */
+  --figma___button-ghost-success-active-text: 117 62% 79% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Active Text/UI Core/Dark */
+  --figma___button-ghost-success-hover: 139 98% 37% / 0;
+  /* ✦ Theme/Button/Ghost/Success/Hover/UI Core/Dark */
+  --figma___button-ghost-success-hover-text: 117 62% 79% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Hover text/UI Core/Dark */
+  --figma___button-ghost-success-text-disabled: 122 55% 32% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Text-disabled/UI Core/Dark */
+  --figma___button-ghost-success-text-primary: 118 49% 70% / 1;
+  /* ✦ Theme/Button/Ghost/Success/Text-primary/UI Core/Dark */
+  --figma___button-outline-accent-active: 215 46% 20% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Active/UI Core/Dark */
+  --figma___button-outline-accent-default-border: 206 100% 50% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Default border/UI Core/Dark */
+  --figma___button-outline-accent-disabled-border: 206 98% 42% / 0.5;
+  /* ✦ Theme/Button/Outline/Accent/Disabled Border/UI Core/Dark */
+  --figma___button-outline-accent-hover: 215 46% 20% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Hover/UI Core/Dark */
+  --figma___button-outline-accent-text-disabled: 206 98% 42% / 0.5;
+  /* ✦ Theme/Button/Outline/Accent/Text-disabled/UI Core/Dark */
+  --figma___button-outline-accent-text-primary: 206 100% 50% / 1;
+  /* ✦ Theme/Button/Outline/Accent/Text-primary/UI Core/Dark */
+  --figma___button-outline-error-active: 0 67% 18% / 1;
+  /* ✦ Theme/Button/Outline/Error/Active/UI Core/Dark */
+  --figma___button-outline-error-default-border: 0 67% 48% / 1;
+  /* ✦ Theme/Button/Outline/Error/Default - border/UI Core/Dark */
+  --figma___button-outline-error-disabled-border: 0 67% 24% / 1;
+  /* ✦ Theme/Button/Outline/Error/Disabled-border/UI Core/Dark */
+  --figma___button-outline-error-hover: 0 67% 18% / 1;
+  /* ✦ Theme/Button/Outline/Error/Hover/UI Core/Dark */
+  --figma___button-outline-error-text-disabled: 0 68% 36% / 1;
+  /* ✦ Theme/Button/Outline/Error/Text-disabled/UI Core/Dark */
+  --figma___button-outline-error-text-primary: 0 100% 62% / 1;
+  /* ✦ Theme/Button/Outline/Error/Text-primary/UI Core/Dark */
+  --figma___button-outline-neutral-active: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Active/UI Core/Dark */
+  --figma___button-outline-neutral-default-border: 0 0% 16% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Default - border/UI Core/Dark */
+  --figma___button-outline-neutral-disabled-border: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Disabled - border/UI Core/Dark */
+  --figma___button-outline-neutral-hover: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Hover/UI Core/Dark */
+  --figma___button-outline-neutral-text-disabled: 0 0% 23% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Text-disabled/UI Core/Dark */
+  --figma___button-outline-neutral-text-primary: 0 0% 54% / 1;
+  /* ✦ Theme/Button/Outline/Neutral/Text-primary/UI Core/Dark */
+  --figma___button-outline-success-active: 122 64% 11% / 1;
+  /* ✦ Theme/Button/Outline/Success/Active/UI Core/Dark */
+  --figma___button-outline-success-default-border: 118 49% 70% / 1;
+  /* ✦ Theme/Button/Outline/Success/Default-border/UI Core/Dark */
+  --figma___button-outline-success-disabled-border: 123 67% 24% / 1;
+  /* ✦ Theme/Button/Outline/Success/Disabled - border/UI Core/Dark */
+  --figma___button-outline-success-hover: 122 64% 11% / 1;
+  /* ✦ Theme/Button/Outline/Success/Hover/UI Core/Dark */
+  --figma___button-outline-success-text-disabled: 122 50% 36% / 1;
+  /* ✦ Theme/Button/Outline/Success/Text-disabled/UI Core/Dark */
+  --figma___button-outline-success-text-primary: 117 62% 79% / 1;
+  /* ✦ Theme/Button/Outline/Success/Text-primary/UI Core/Dark */
+  --figma___button-soft-accent-active: 216 50% 12% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Active/UI Core/Dark */
+  --figma___button-soft-accent-disabled: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Disabled/UI Core/Dark */
+  --figma___button-soft-accent-hover: 216 50% 12% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Hover/UI Core/Dark */
+  --figma___button-soft-accent-text-disabled: 0 0% 23% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Text-disabled/UI Core/Dark */
+  --figma___button-soft-accent-text-primary: 206 100% 50% / 1;
+  /* ✦ Theme/Button/Soft/Accent/Text-primary/UI Core/Dark */
+  --figma___button-soft-accent-default: 215 46% 20% / 1;
+  /* ✦ Theme/Button/Soft/Accent/default/UI Core/Dark */
+  --figma___button-soft-error-active: 0 67% 18% / 1;
+  /* ✦ Theme/Button/Soft/Error/Active/UI Core/Dark */
+  --figma___button-soft-error-disabled: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Soft/Error/Disabled/UI Core/Dark */
+  --figma___button-soft-error-hover: 0 67% 18% / 1;
+  /* ✦ Theme/Button/Soft/Error/Hover/UI Core/Dark */
+  --figma___button-soft-error-text-disabled: 0 0% 23% / 1;
+  /* ✦ Theme/Button/Soft/Error/Text-disabled/UI Core/Dark */
+  --figma___button-soft-error-text-primary: 0 78% 55% / 1;
+  /* ✦ Theme/Button/Soft/Error/Text-primary/UI Core/Dark */
+  --figma___button-soft-error-default: 0 67% 12% / 1;
+  /* ✦ Theme/Button/Soft/Error/default/UI Core/Dark */
+  --figma___button-soft-neutral-active: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Active/UI Core/Dark */
+  --figma___button-soft-neutral-disabled: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Disabled/UI Core/Dark */
+  --figma___button-soft-neutral-hover: 0 0% 16% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Hover/UI Core/Dark */
+  --figma___button-soft-neutral-text-disabled: 0 0% 23% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Text-disabled/UI Core/Dark */
+  --figma___button-soft-neutral-text-primary: 0 0% 54% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/Text-primary/UI Core/Dark */
+  --figma___button-soft-neutral-default: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Soft/Neutral/default/UI Core/Dark */
+  --figma___button-soft-success-active: 127 73% 15% / 1;
+  /* ✦ Theme/Button/Soft/Success/Active/UI Core/Dark */
+  --figma___button-soft-success-disabled: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Soft/Success/Disabled/UI Core/Dark */
+  --figma___button-soft-success-hover: 127 73% 15% / 1;
+  /* ✦ Theme/Button/Soft/Success/Hover/UI Core/Dark */
+  --figma___button-soft-success-text-disabled: 0 0% 23% / 1;
+  /* ✦ Theme/Button/Soft/Success/Text-disabled/UI Core/Dark */
+  --figma___button-soft-success-text-primary: 118 49% 70% / 1;
+  /* ✦ Theme/Button/Soft/Success/Text-primary/UI Core/Dark */
+  --figma___button-soft-success-default: 122 64% 11% / 1;
+  /* ✦ Theme/Button/Soft/Success/default/UI Core/Dark */
+  --figma___button-solid-accent-active: 206 100% 50% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Active/UI Core/Dark */
+  --figma___button-solid-accent-disabled: 206 98% 42% / 0.5;
+  /* ✦ Theme/Button/Solid/Accent/Disabled/UI Core/Dark */
+  --figma___button-solid-accent-hover: 206 100% 62% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Hover/UI Core/Dark */
+  --figma___button-solid-accent-text-disabled: 0 0% 0% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Text-disabled/UI Core/Dark */
+  --figma___button-solid-accent-text-primary: 0 0% 100% / 1;
+  /* ✦ Theme/Button/Solid/Accent/Text-primary/UI Core/Dark */
+  --figma___button-solid-accent-default: 206 100% 50% / 1;
+  /* ✦ Theme/Button/Solid/Accent/default/UI Core/Dark */
+  --figma___button-solid-error-active: 0 67% 48% / 1;
+  /* ✦ Theme/Button/Solid/Error/Active/UI Core/Dark */
+  --figma___button-solid-error-disabled: 0 68% 30% / 1;
+  /* ✦ Theme/Button/Solid/Error/Disabled/UI Core/Dark */
+  --figma___button-solid-error-hover: 0 100% 70% / 1;
+  /* ✦ Theme/Button/Solid/Error/Hover/UI Core/Dark */
+  --figma___button-solid-error-text-disabled: 0 0% 0% / 1;
+  /* ✦ Theme/Button/Solid/Error/Text-disabled/UI Core/Dark */
+  --figma___button-solid-error-text-primary: 0 0% 100% / 1;
+  /* ✦ Theme/Button/Solid/Error/Text-primary/UI Core/Dark */
+  --figma___button-solid-error-default: 0 67% 48% / 1;
+  /* ✦ Theme/Button/Solid/Error/default/UI Core/Dark */
+  --figma___button-solid-neutral-active: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Active/UI Core/Dark */
+  --figma___button-solid-neutral-disabled: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Disabled/UI Core/Dark */
+  --figma___button-solid-neutral-hover: 0 0% 16% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Hover/UI Core/Dark */
+  --figma___button-solid-neutral-text-disabled: 0 0% 23% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Text-disabled/UI Core/Dark */
+  --figma___button-solid-neutral-text-primary: 0 0% 54% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/Text-primary/UI Core/Dark */
+  --figma___button-solid-neutral-default: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Solid/Neutral/default/UI Core/Dark */
+  --figma___button-solid-success-active: 121 42% 62% / 1;
+  /* ✦ Theme/Button/Solid/Success/Active/UI Core/Dark */
+  --figma___button-solid-success-disabled: 122 50% 36% / 1;
+  /* ✦ Theme/Button/Solid/Success/Disabled/UI Core/Dark */
+  --figma___button-solid-success-hover: 117 62% 79% / 1;
+  /* ✦ Theme/Button/Solid/Success/Hover/UI Core/Dark */
+  --figma___button-solid-success-text-disabled: 0 0% 0% / 1;
+  /* ✦ Theme/Button/Solid/Success/Text-disabled/UI Core/Dark */
+  --figma___button-solid-success-text-primary: 0 0% 100% / 1;
+  /* ✦ Theme/Button/Solid/Success/Text-primary/UI Core/Dark */
+  --figma___button-solid-success-default: 121 42% 62% / 1;
+  /* ✦ Theme/Button/Solid/Success/default/UI Core/Dark */
+  --figma___button-surface-accent-active: 216 50% 12% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Active/UI Core/Dark */
+  --figma___button-surface-accent-active-border: 214 58% 16% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Active border/UI Core/Dark */
+  --figma___button-surface-accent-disabled: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Disabled/UI Core/Dark */
+  --figma___button-surface-accent-hover: 216 50% 12% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Hover/UI Core/Dark */
+  --figma___button-surface-accent-hover-border: 214 58% 16% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Hover Border/UI Core/Dark */
+  --figma___button-surface-accent-text-disabled: 206 98% 42% / 0.5;
+  /* ✦ Theme/Button/Surface/Accent/Text-disabled/UI Core/Dark */
+  --figma___button-surface-accent-text-primary: 206 100% 50% / 1;
+  /* ✦ Theme/Button/Surface/Accent/Text-primary/UI Core/Dark */
+  --figma___button-surface-accent-default: 215 46% 20% / 1;
+  /* ✦ Theme/Button/Surface/Accent/default/UI Core/Dark */
+  --figma___button-surface-accent-default-border: 214 58% 16% / 1;
+  /* ✦ Theme/Button/Surface/Accent/default border/UI Core/Dark */
+  --figma___button-surface-error-active: 0 67% 18% / 1;
+  /* ✦ Theme/Button/Surface/Error/Active/UI Core/Dark */
+  --figma___button-surface-error-active-border: 0 67% 24% / 1;
+  /* ✦ Theme/Button/Surface/Error/Active border/UI Core/Dark */
+  --figma___button-surface-error-disabled: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Surface/Error/Disabled/UI Core/Dark */
+  --figma___button-surface-error-hover: 0 67% 18% / 1;
+  /* ✦ Theme/Button/Surface/Error/Hover/UI Core/Dark */
+  --figma___button-surface-error-hover-border: 0 67% 24% / 1;
+  /* ✦ Theme/Button/Surface/Error/Hover border/UI Core/Dark */
+  --figma___button-surface-error-text-disabled: 0 0% 23% / 1;
+  /* ✦ Theme/Button/Surface/Error/Text-disabled/UI Core/Dark */
+  --figma___button-surface-error-text-primary: 0 78% 55% / 1;
+  /* ✦ Theme/Button/Surface/Error/Text-primary/UI Core/Dark */
+  --figma___button-surface-error-border: 0 67% 24% / 1;
+  /* ✦ Theme/Button/Surface/Error/border/UI Core/Dark */
+  --figma___button-surface-error-default: 0 67% 12% / 1;
+  /* ✦ Theme/Button/Surface/Error/default/UI Core/Dark */
+  --figma___button-surface-neutral-active: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Active/UI Core/Dark */
+  --figma___button-surface-neutral-disabled: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Disabled/UI Core/Dark */
+  --figma___button-surface-neutral-hover: 0 0% 7% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Hover/UI Core/Dark */
+  --figma___button-surface-neutral-text-disabled: 0 0% 23% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Text-disabled/UI Core/Dark */
+  --figma___button-surface-neutral-text-primary: 0 0% 54% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/Text-primary/UI Core/Dark */
+  --figma___button-surface-neutral-border: 0 0% 16% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/border/UI Core/Dark */
+  --figma___button-surface-neutral-default: 0 0% 11% / 1;
+  /* ✦ Theme/Button/Surface/Neutral/default/UI Core/Dark */
+  --figma___button-surface-success-active: 127 73% 15% / 1;
+  /* ✦ Theme/Button/Surface/Success/Active/UI Core/Dark */
+  --figma___button-surface-success-disabled: 0 0% 16% / 1;
+  /* ✦ Theme/Button/Surface/Success/Disabled/UI Core/Dark */
+  --figma___button-surface-success-hover: 127 73% 15% / 1;
+  /* ✦ Theme/Button/Surface/Success/Hover/UI Core/Dark */
+  --figma___button-surface-success-hover-border: 124 36% 52% / 1;
+  /* ✦ Theme/Button/Surface/Success/Hover border/UI Core/Dark */
+  --figma___button-surface-success-text-disabled: 0 0% 23% / 1;
+  /* ✦ Theme/Button/Surface/Success/Text-disabled/UI Core/Dark */
+  --figma___button-surface-success-text-primary: 118 49% 70% / 1;
+  /* ✦ Theme/Button/Surface/Success/Text-primary/UI Core/Dark */
+  --figma___button-surface-success-active-border: 124 36% 52% / 1;
+  /* ✦ Theme/Button/Surface/Success/active border/UI Core/Dark */
+  --figma___button-surface-success-default: 122 64% 11% / 1;
+  /* ✦ Theme/Button/Surface/Success/default/UI Core/Dark */
+  --figma___button-surface-success-default-border: 123 67% 24% / 1;
+  /* ✦ Theme/Button/Surface/Success/default border/UI Core/Dark */
+  --figma___calendar-background: 0 0% 0% / 1;
+  /* ✦ Theme/Calendar/Background/UI Core/Dark */
+  --figma___calendar-selected-date-background: 206 100% 50% / 1;
+  /* ✦ Theme/Calendar/Selected Date/Background/UI Core/Dark */
+  --figma___calendar-selected-date-text: 0 0% 0% / 1;
+  /* ✦ Theme/Calendar/Selected Date/Text/UI Core/Dark */
+  --figma___calendar-selected-range-background: 215 46% 20% / 1;
+  /* ✦ Theme/Calendar/Selected Range/Background/UI Core/Dark */
+  --figma___calendar-selected-range-text: 206 100% 50% / 1;
+  /* ✦ Theme/Calendar/Selected Range/Text/UI Core/Dark */
+  --figma___checkbox-background: 236 19% 14% / 0.5;
+  /* ✦ Theme/Checkbox/Background/UI Core/Dark */
+  --figma___checkbox-paper: 0 0% 100% / 0.03;
+  /* ✦ Theme/Checkbox/Paper/UI Core/Dark */
+  --figma___checkbox-surface-checked-active-active: 206 100% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Active/UI Core/Dark */
+  --figma___checkbox-surface-checked-active-check: 0 0% 0% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Check/UI Core/Dark */
+  --figma___checkbox-surface-checked-active-hover: 206 100% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/Hover/UI Core/Dark */
+  --figma___checkbox-surface-checked-active-default-background: 206 100% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Active/default background/UI Core/Dark */
+  --figma___checkbox-surface-checked-disabled-check: 0 0% 0% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Check/UI Core/Dark */
+  --figma___checkbox-surface-checked-disabled-disabled: 0 0% 29% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/Disabled/UI Core/Dark */
+  --figma___checkbox-surface-checked-disabled-border: 0 0% 29% / 1;
+  /* ✦ Theme/Checkbox/Surface/Checked/Disabled/border/UI Core/Dark */
+  --figma___checkbox-surface-intermediate-active-active-border: 206 100% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Active border/UI Core/Dark */
+  --figma___checkbox-surface-intermediate-active-check: 0 0% 0% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Check/UI Core/Dark */
+  --figma___checkbox-surface-intermediate-active-hover-border: 206 100% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/Hover border/UI Core/Dark */
+  --figma___checkbox-surface-intermediate-active-default-background: 206 100% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default background/UI Core/Dark */
+  --figma___checkbox-surface-intermediate-active-default-border: 206 100% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Active/default border/UI Core/Dark */
+  --figma___checkbox-surface-intermediate-disabled-check: 0 0% 0% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Check/UI Core/Dark */
+  --figma___checkbox-surface-intermediate-disabled-disabled: 0 0% 29% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/Disabled/UI Core/Dark */
+  --figma___checkbox-surface-intermediate-disabled-border: 0 0% 29% / 1;
+  /* ✦ Theme/Checkbox/Surface/Intermediate/Disabled/border/UI Core/Dark */
+  --figma___checkbox-surface-unchecked-active-active-border: 206 100% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Active border/UI Core/Dark */
+  --figma___checkbox-surface-unchecked-active-hover-border: 206 100% 62% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/Hover border/UI Core/Dark */
+  --figma___checkbox-surface-unchecked-active-default-background: 0 0% 0% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default background/UI Core/Dark */
+  --figma___checkbox-surface-unchecked-active-default-border: 206 100% 50% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Active/default border/UI Core/Dark */
+  --figma___checkbox-surface-unchecked-disabled-disabled: 0 0% 11% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/Disabled/UI Core/Dark */
+  --figma___checkbox-surface-unchecked-disabled-border: 0 0% 16% / 1;
+  /* ✦ Theme/Checkbox/Surface/Unchecked/Disabled/border/UI Core/Dark */
+  --figma___checkbox-border: 0 0% 16% / 1;
+  /* ✦ Theme/Checkbox/border/UI Core/Dark */
+  --figma___default-colors-black: 210 25% 98% / 1;
+  /* ✦ Theme/Default colors/black/UI Core/Dark */
+  --figma___default-colors-dark-to-white: 210 25% 98% / 1;
+  /* ✦ Theme/Default colors/dark-to-white/UI Core/Dark */
+  --figma___default-colors-white: 0 0% 0% / 1;
+  /* ✦ Theme/Default colors/white/UI Core/Dark */
+  --figma___default-colors-white-to-dark: 0 0% 0% / 1;
+  /* ✦ Theme/Default colors/white-to-dark/UI Core/Dark */
+  --figma___dropdown-dropdown-item-default: 0 0% 100% / 0;
+  /* ✦ Theme/Dropdown/Dropdown Item/Default/UI Core/Dark */
+  --figma___dropdown-dropdown-item-hover: 215 46% 20% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Hover/UI Core/Dark */
+  --figma___dropdown-dropdown-item-selected: 206 100% 50% / 1;
+  /* ✦ Theme/Dropdown/Dropdown Item/Selected/UI Core/Dark */
+  --figma___dropdown-text-shortcut-text-selected: 0 0% 100% / 0.8;
+  /* ✦ Theme/Dropdown/Text/Shortcut text selected/UI Core/Dark */
+  --figma___dropdown-text-text-selected: 0 0% 100% / 1;
+  /* ✦ Theme/Dropdown/Text/Text Selected/UI Core/Dark */
+  --figma___dropdown-text-hover: 206 100% 50% / 1;
+  /* ✦ Theme/Dropdown/Text/hover/UI Core/Dark */
+  --figma___dropdown-background: 0 0% 0% / 1;
+  /* ✦ Theme/Dropdown/background/UI Core/Dark */
+  --figma___dropdown-border: 0 0% 100% / 0;
+  /* ✦ Theme/Dropdown/border/UI Core/Dark */
+  --figma___dropdown-separator: 0 0% 11% / 1;
+  /* ✦ Theme/Dropdown/separator/UI Core/Dark */
+  --figma___filter-active: 0 0% 16% / 1;
+  /* ✦ Theme/Filter/Active/UI Core/Dark */
+  --figma___filter-default: 0 0% 0% / 1;
+  /* ✦ Theme/Filter/Default/UI Core/Dark */
+  --figma___filter-hover: 0 0% 16% / 1;
+  /* ✦ Theme/Filter/Hover/UI Core/Dark */
+  --figma___inline-alert-banner-customisable: 0 0% 11% / 1;
+  /* ✦ Theme/Inline Alert Banner/Customisable/UI Core/Dark */
+  --figma___inline-alert-banner-error: 0 67% 12% / 1;
+  /* ✦ Theme/Inline Alert Banner/Error/UI Core/Dark */
+  --figma___inline-alert-banner-info: 215 46% 20% / 1;
+  /* ✦ Theme/Inline Alert Banner/Info/UI Core/Dark */
+  --figma___inline-alert-banner-reminder: 54 100% 8% / 1;
+  /* ✦ Theme/Inline Alert Banner/Reminder/UI Core/Dark */
+  --figma___inline-alert-banner-success: 122 64% 11% / 1;
+  /* ✦ Theme/Inline Alert Banner/Success/UI Core/Dark */
+  --figma___inline-alert-banner-warning: 32 67% 12% / 1;
+  /* ✦ Theme/Inline Alert Banner/Warning/UI Core/Dark */
+  --figma___modal-background: 0 0% 0% / 1;
+  /* ✦ Theme/Modal/Background/UI Core/Dark */
+  --figma___modal-paper: 0 0% 0% / 1;
+  /* ✦ Theme/Modal/Paper/UI Core/Dark */
+  --figma___modal-border: 0 0% 0% / 0;
+  /* ✦ Theme/Modal/border/UI Core/Dark */
+  --figma___neutral-color-gray-1: 0 0% 7% / 1;
+  /* ✦ Theme/Neutral color/Gray/1/UI Core/Dark */
+  --figma___neutral-color-gray-2: 0 0% 11% / 1;
+  /* ✦ Theme/Neutral color/Gray/2/UI Core/Dark */
+  --figma___neutral-color-gray-3: 0 0% 16% / 1;
+  /* ✦ Theme/Neutral color/Gray/3/UI Core/Dark */
+  --figma___neutral-color-gray-4: 0 0% 23% / 1;
+  /* ✦ Theme/Neutral color/Gray/4/UI Core/Dark */
+  --figma___neutral-color-gray-5: 0 0% 29% / 1;
+  /* ✦ Theme/Neutral color/Gray/5/UI Core/Dark */
+  --figma___neutral-color-gray-6: 0 0% 35% / 1;
+  /* ✦ Theme/Neutral color/Gray/6/UI Core/Dark */
+  --figma___neutral-color-gray-7: 0 0% 42% / 1;
+  /* ✦ Theme/Neutral color/Gray/7/UI Core/Dark */
+  --figma___neutral-color-gray-8: 0 0% 54% / 1;
+  /* ✦ Theme/Neutral color/Gray/8/UI Core/Dark */
+  --figma___neutral-color-gray-9: 0 0% 69% / 1;
+  /* ✦ Theme/Neutral color/Gray/9/UI Core/Dark */
+  --figma___neutral-color-gray-10: 0 0% 82% / 1;
+  /* ✦ Theme/Neutral color/Gray/10/UI Core/Dark */
+  --figma___neutral-color-gray-alpha-1: 0 0% 7% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/1/UI Core/Dark */
+  --figma___neutral-color-gray-alpha-2: 0 0% 11% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/2/UI Core/Dark */
+  --figma___neutral-color-gray-alpha-3: 0 0% 16% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/3/UI Core/Dark */
+  --figma___neutral-color-gray-alpha-4: 0 0% 23% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/4/UI Core/Dark */
+  --figma___neutral-color-gray-alpha-5: 0 0% 29% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/5/UI Core/Dark */
+  --figma___neutral-color-gray-alpha-6: 0 0% 35% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/6/UI Core/Dark */
+  --figma___neutral-color-gray-alpha-7: 0 0% 42% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/7/UI Core/Dark */
+  --figma___neutral-color-gray-alpha-8: 0 0% 54% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/8/UI Core/Dark */
+  --figma___neutral-color-gray-alpha-9: 0 0% 69% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/9/UI Core/Dark */
+  --figma___neutral-color-gray-alpha-10: 0 0% 82% / 1;
+  /* ✦ Theme/Neutral color/Gray Alpha/10/UI Core/Dark */
+  --figma___other-colors-ai-violet-1: 256 82% 30% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/1/UI Core/Dark */
+  --figma___other-colors-ai-violet-2: 254 74% 37% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/2/UI Core/Dark */
+  --figma___other-colors-ai-violet-3: 254 68% 42% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/3/UI Core/Dark */
+  --figma___other-colors-ai-violet-4: 254 64% 48% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/4/UI Core/Dark */
+  --figma___other-colors-ai-violet-5: 252 70% 59% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/5/UI Core/Dark */
+  --figma___other-colors-ai-violet-6: 251 73% 64% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/6/UI Core/Dark */
+  --figma___other-colors-ai-violet-7: 252 76% 69% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/7/UI Core/Dark */
+  --figma___other-colors-ai-violet-8: 251 80% 74% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/8/UI Core/Dark */
+  --figma___other-colors-ai-violet-9: 252 85% 79% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/9/UI Core/Dark */
+  --figma___other-colors-ai-violet-10: 253 100% 84% / 1;
+  /* ✦ Theme/Other Colors/AI Violet/10/UI Core/Dark */
+  --figma___other-colors-ai-violet-alpha-1: 256 82% 30% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/1/UI Core/Dark */
+  --figma___other-colors-ai-violet-alpha-2: 254 74% 37% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/2/UI Core/Dark */
+  --figma___other-colors-ai-violet-alpha-3: 254 68% 42% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/3/UI Core/Dark */
+  --figma___other-colors-ai-violet-alpha-4: 254 64% 48% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/4/UI Core/Dark */
+  --figma___other-colors-ai-violet-alpha-5: 252 70% 59% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/5/UI Core/Dark */
+  --figma___other-colors-ai-violet-alpha-6: 251 73% 64% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/6/UI Core/Dark */
+  --figma___other-colors-ai-violet-alpha-7: 252 76% 69% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/7/UI Core/Dark */
+  --figma___other-colors-ai-violet-alpha-8: 251 80% 74% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/8/UI Core/Dark */
+  --figma___other-colors-ai-violet-alpha-9: 252 85% 79% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/9/UI Core/Dark */
+  --figma___other-colors-ai-violet-alpha-10: 253 100% 84% / 1;
+  /* ✦ Theme/Other Colors/AI Violet Alpha/10/UI Core/Dark */
+  --figma___other-colors-blue-1: 241 53% 23% / 1;
+  /* ✦ Theme/Other Colors/Blue/1/UI Core/Dark */
+  --figma___other-colors-blue-2: 241 52% 28% / 1;
+  /* ✦ Theme/Other Colors/Blue/2/UI Core/Dark */
+  --figma___other-colors-blue-3: 241 51% 33% / 1;
+  /* ✦ Theme/Other Colors/Blue/3/UI Core/Dark */
+  --figma___other-colors-blue-4: 241 49% 39% / 1;
+  /* ✦ Theme/Other Colors/Blue/4/UI Core/Dark */
+  --figma___other-colors-blue-5: 241 48% 44% / 1;
+  /* ✦ Theme/Other Colors/Blue/5/UI Core/Dark */
+  --figma___other-colors-blue-6: 239 48% 52% / 1;
+  /* ✦ Theme/Other Colors/Blue/6/UI Core/Dark */
+  --figma___other-colors-blue-7: 240 59% 59% / 1;
+  /* ✦ Theme/Other Colors/Blue/7/UI Core/Dark */
+  --figma___other-colors-blue-8: 240 74% 67% / 1;
+  /* ✦ Theme/Other Colors/Blue/8/UI Core/Dark */
+  --figma___other-colors-blue-9: 240 100% 77% / 1;
+  /* ✦ Theme/Other Colors/Blue/9/UI Core/Dark */
+  --figma___other-colors-blue-10: 240 100% 83% / 1;
+  /* ✦ Theme/Other Colors/Blue/10/UI Core/Dark */
+  --figma___other-colors-blue-alpha-1: 215 46% 20% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/1/UI Core/Dark */
+  --figma___other-colors-blue-alpha-2: 216 50% 12% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/2/UI Core/Dark */
+  --figma___other-colors-blue-alpha-3: 214 58% 16% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/3/UI Core/Dark */
+  --figma___other-colors-blue-alpha-4: 213 67% 21% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/4/UI Core/Dark */
+  --figma___other-colors-blue-alpha-5: 194 100% 45% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/5/UI Core/Dark */
+  --figma___other-colors-blue-alpha-6: 212 72% 25% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/6/UI Core/Dark */
+  --figma___other-colors-blue-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/7/UI Core/Dark */
+  --figma___other-colors-blue-alpha-8: 206 100% 62% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/8/UI Core/Dark */
+  --figma___other-colors-blue-alpha-9: 205 100% 71% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/9/UI Core/Dark */
+  --figma___other-colors-blue-alpha-10: 212 72% 10% / 1;
+  /* ✦ Theme/Other Colors/Blue Alpha/10/UI Core/Dark */
+  --figma___other-colors-indigo-1: 226 25% 10% / 1;
+  /* ✦ Theme/Other Colors/Indigo/1/UI Core/Dark */
+  --figma___other-colors-indigo-2: 230 36% 13% / 1;
+  /* ✦ Theme/Other Colors/Indigo/2/UI Core/Dark */
+  --figma___other-colors-indigo-3: 228 43% 18% / 1;
+  /* ✦ Theme/Other Colors/Indigo/3/UI Core/Dark */
+  --figma___other-colors-indigo-4: 228 45% 21% / 1;
+  /* ✦ Theme/Other Colors/Indigo/4/UI Core/Dark */
+  --figma___other-colors-indigo-5: 227 48% 24% / 1;
+  /* ✦ Theme/Other Colors/Indigo/5/UI Core/Dark */
+  --figma___other-colors-indigo-6: 225 51% 29% / 1;
+  /* ✦ Theme/Other Colors/Indigo/6/UI Core/Dark */
+  --figma___other-colors-indigo-7: 226 70% 55% / 1;
+  /* ✦ Theme/Other Colors/Indigo/7/UI Core/Dark */
+  --figma___other-colors-indigo-8: 230 74% 63% / 1;
+  /* ✦ Theme/Other Colors/Indigo/8/UI Core/Dark */
+  --figma___other-colors-indigo-9: 235 100% 80% / 1;
+  /* ✦ Theme/Other Colors/Indigo/9/UI Core/Dark */
+  --figma___other-colors-indigo-10: 236 94% 93% / 1;
+  /* ✦ Theme/Other Colors/Indigo/10/UI Core/Dark */
+  --figma___other-colors-indigo-alpha-1: 240 100% 49% / 0.04;
+  /* ✦ Theme/Other Colors/Indigo Alpha/1/UI Core/Dark */
+  --figma___other-colors-indigo-alpha-2: 232 100% 50% / 0.09;
+  /* ✦ Theme/Other Colors/Indigo Alpha/2/UI Core/Dark */
+  --figma___other-colors-indigo-alpha-3: 228 100% 57% / 0.18;
+  /* ✦ Theme/Other Colors/Indigo Alpha/3/UI Core/Dark */
+  --figma___other-colors-indigo-alpha-4: 228 99% 59% / 0.24;
+  /* ✦ Theme/Other Colors/Indigo Alpha/4/UI Core/Dark */
+  --figma___other-colors-indigo-alpha-5: 227 99% 60% / 0.29;
+  /* ✦ Theme/Other Colors/Indigo Alpha/5/UI Core/Dark */
+  --figma___other-colors-indigo-alpha-6: 225 100% 61% / 0.37;
+  /* ✦ Theme/Other Colors/Indigo Alpha/6/UI Core/Dark */
+  --figma___other-colors-indigo-alpha-7: 226 100% 63% / 0.85;
+  /* ✦ Theme/Other Colors/Indigo Alpha/7/UI Core/Dark */
+  --figma___other-colors-indigo-alpha-8: 230 100% 70% / 0.9;
+  /* ✦ Theme/Other Colors/Indigo Alpha/8/UI Core/Dark */
+  --figma___other-colors-indigo-alpha-9: 236 100% 94% / 1;
+  /* ✦ Theme/Other Colors/Indigo Alpha/9/UI Core/Dark */
+  --figma___other-colors-indigo-alpha-10: 236 100% 94% / 1;
+  /* ✦ Theme/Other Colors/Indigo Alpha/10/UI Core/Dark */
+  --figma___other-colors-mint-1: 173 52% 6% / 1;
+  /* ✦ Theme/Other Colors/Mint/1/UI Core/Dark */
+  --figma___other-colors-mint-2: 174 51% 8% / 1;
+  /* ✦ Theme/Other Colors/Mint/2/UI Core/Dark */
+  --figma___other-colors-mint-3: 176 52% 11% / 1;
+  /* ✦ Theme/Other Colors/Mint/3/UI Core/Dark */
+  --figma___other-colors-mint-4: 173 56% 13% / 1;
+  /* ✦ Theme/Other Colors/Mint/4/UI Core/Dark */
+  --figma___other-colors-mint-5: 173 57% 15% / 1;
+  /* ✦ Theme/Other Colors/Mint/5/UI Core/Dark */
+  --figma___other-colors-mint-6: 173 58% 18% / 1;
+  /* ✦ Theme/Other Colors/Mint/6/UI Core/Dark */
+  --figma___other-colors-mint-7: 167 70% 72% / 1;
+  /* ✦ Theme/Other Colors/Mint/7/UI Core/Dark */
+  --figma___other-colors-mint-8: 163 80% 77% / 1;
+  /* ✦ Theme/Other Colors/Mint/8/UI Core/Dark */
+  --figma___other-colors-mint-9: 167 70% 58% / 1;
+  /* ✦ Theme/Other Colors/Mint/9/UI Core/Dark */
+  --figma___other-colors-mint-10: 156 71% 86% / 1;
+  /* ✦ Theme/Other Colors/Mint/10/UI Core/Dark */
+  --figma___other-colors-mint-alpha-1: 120 100% 44% / 0;
+  /* ✦ Theme/Other Colors/Mint Alpha/1/UI Core/Dark */
+  --figma___other-colors-mint-alpha-2: 165 100% 49% / 0.03;
+  /* ✦ Theme/Other Colors/Mint Alpha/2/UI Core/Dark */
+  --figma___other-colors-mint-alpha-3: 174 100% 50% / 0.07;
+  /* ✦ Theme/Other Colors/Mint Alpha/3/UI Core/Dark */
+  --figma___other-colors-mint-alpha-4: 172 100% 50% / 0.11;
+  /* ✦ Theme/Other Colors/Mint Alpha/4/UI Core/Dark */
+  --figma___other-colors-mint-alpha-5: 172 100% 50% / 0.15;
+  /* ✦ Theme/Other Colors/Mint Alpha/5/UI Core/Dark */
+  --figma___other-colors-mint-alpha-6: 173 100% 50% / 0.21;
+  /* ✦ Theme/Other Colors/Mint Alpha/6/UI Core/Dark */
+  --figma___other-colors-mint-alpha-7: 167 100% 78% / 0.91;
+  /* ✦ Theme/Other Colors/Mint Alpha/7/UI Core/Dark */
+  --figma___other-colors-mint-alpha-8: 163 100% 81% / 0.95;
+  /* ✦ Theme/Other Colors/Mint Alpha/8/UI Core/Dark */
+  --figma___other-colors-mint-alpha-9: 167 100% 66% / 0.86;
+  /* ✦ Theme/Other Colors/Mint Alpha/9/UI Core/Dark */
+  --figma___other-colors-mint-alpha-10: 155 100% 90% / 0.96;
+  /* ✦ Theme/Other Colors/Mint Alpha/10/UI Core/Dark */
+  --figma___other-colors-orange-1: 32 67% 12% / 1;
+  /* ✦ Theme/Other Colors/Orange/1/UI Core/Dark */
+  --figma___other-colors-orange-2: 30 69% 18% / 1;
+  /* ✦ Theme/Other Colors/Orange/2/UI Core/Dark */
+  --figma___other-colors-orange-3: 27 69% 24% / 1;
+  /* ✦ Theme/Other Colors/Orange/3/UI Core/Dark */
+  --figma___other-colors-orange-4: 26 68% 30% / 1;
+  /* ✦ Theme/Other Colors/Orange/4/UI Core/Dark */
+  --figma___other-colors-orange-5: 17 68% 36% / 1;
+  /* ✦ Theme/Other Colors/Orange/5/UI Core/Dark */
+  --figma___other-colors-orange-6: 18 68% 42% / 1;
+  /* ✦ Theme/Other Colors/Orange/6/UI Core/Dark */
+  --figma___other-colors-orange-7: 19 67% 48% / 1;
+  /* ✦ Theme/Other Colors/Orange/7/UI Core/Dark */
+  --figma___other-colors-orange-8: 19 79% 54% / 1;
+  /* ✦ Theme/Other Colors/Orange/8/UI Core/Dark */
+  --figma___other-colors-orange-9: 19 100% 60% / 1;
+  /* ✦ Theme/Other Colors/Orange/9/UI Core/Dark */
+  --figma___other-colors-orange-10: 19 100% 64% / 1;
+  /* ✦ Theme/Other Colors/Orange/10/UI Core/Dark */
+  --figma___other-colors-orange-alpha-1: 32 67% 12% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/1/UI Core/Dark */
+  --figma___other-colors-orange-alpha-2: 30 69% 18% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/2/UI Core/Dark */
+  --figma___other-colors-orange-alpha-3: 27 69% 24% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/3/UI Core/Dark */
+  --figma___other-colors-orange-alpha-4: 26 68% 30% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/4/UI Core/Dark */
+  --figma___other-colors-orange-alpha-5: 17 68% 36% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/5/UI Core/Dark */
+  --figma___other-colors-orange-alpha-6: 18 68% 42% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/6/UI Core/Dark */
+  --figma___other-colors-orange-alpha-7: 19 67% 48% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/7/UI Core/Dark */
+  --figma___other-colors-orange-alpha-8: 19 79% 54% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/8/UI Core/Dark */
+  --figma___other-colors-orange-alpha-9: 19 100% 60% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/9/UI Core/Dark */
+  --figma___other-colors-orange-alpha-10: 19 100% 64% / 1;
+  /* ✦ Theme/Other Colors/Orange Alpha/10/UI Core/Dark */
+  --figma___other-colors-yellow-1: 54 100% 8% / 1;
+  /* ✦ Theme/Other Colors/Yellow/1/UI Core/Dark */
+  --figma___other-colors-yellow-2: 54 100% 17% / 1;
+  /* ✦ Theme/Other Colors/Yellow/2/UI Core/Dark */
+  --figma___other-colors-yellow-3: 54 100% 25% / 1;
+  /* ✦ Theme/Other Colors/Yellow/3/UI Core/Dark */
+  --figma___other-colors-yellow-4: 54 100% 33% / 1;
+  /* ✦ Theme/Other Colors/Yellow/4/UI Core/Dark */
+  --figma___other-colors-yellow-5: 54 100% 41% / 1;
+  /* ✦ Theme/Other Colors/Yellow/5/UI Core/Dark */
+  --figma___other-colors-yellow-6: 55 100% 48% / 1;
+  /* ✦ Theme/Other Colors/Yellow/6/UI Core/Dark */
+  --figma___other-colors-yellow-7: 55 92% 58% / 1;
+  /* ✦ Theme/Other Colors/Yellow/7/UI Core/Dark */
+  --figma___other-colors-yellow-8: 54 92% 69% / 1;
+  /* ✦ Theme/Other Colors/Yellow/8/UI Core/Dark */
+  --figma___other-colors-yellow-9: 53 91% 79% / 1;
+  /* ✦ Theme/Other Colors/Yellow/9/UI Core/Dark */
+  --figma___other-colors-yellow-10: 47 89% 89% / 1;
+  /* ✦ Theme/Other Colors/Yellow/10/UI Core/Dark */
+  --figma___other-colors-yellow-alpha-1: 54 100% 8% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/1/UI Core/Dark */
+  --figma___other-colors-yellow-alpha-2: 54 100% 17% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/2/UI Core/Dark */
+  --figma___other-colors-yellow-alpha-3: 54 100% 25% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/3/UI Core/Dark */
+  --figma___other-colors-yellow-alpha-4: 54 100% 33% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/4/UI Core/Dark */
+  --figma___other-colors-yellow-alpha-5: 54 100% 41% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/5/UI Core/Dark */
+  --figma___other-colors-yellow-alpha-6: 55 100% 48% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/6/UI Core/Dark */
+  --figma___other-colors-yellow-alpha-7: 55 92% 58% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/7/UI Core/Dark */
+  --figma___other-colors-yellow-alpha-8: 54 92% 69% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/8/UI Core/Dark */
+  --figma___other-colors-yellow-alpha-9: 53 91% 79% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/9/UI Core/Dark */
+  --figma___other-colors-yellow-alpha-10: 47 89% 89% / 1;
+  /* ✦ Theme/Other Colors/Yellow Alpha/10/UI Core/Dark */
+  --figma___overlays-black-alpha-1: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/1/UI Core/Dark */
+  --figma___overlays-black-alpha-2: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/2/UI Core/Dark */
+  --figma___overlays-black-alpha-3: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/3/UI Core/Dark */
+  --figma___overlays-black-alpha-4: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/4/UI Core/Dark */
+  --figma___overlays-black-alpha-5: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/5/UI Core/Dark */
+  --figma___overlays-black-alpha-6: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/6/UI Core/Dark */
+  --figma___overlays-black-alpha-7: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/7/UI Core/Dark */
+  --figma___overlays-black-alpha-8: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/8/UI Core/Dark */
+  --figma___overlays-black-alpha-9: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/9/UI Core/Dark */
+  --figma___overlays-black-alpha-10: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/Black Alpha/10/UI Core/Dark */
+  --figma___overlays-white-alpha-1: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/1/UI Core/Dark */
+  --figma___overlays-white-alpha-2: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/2/UI Core/Dark */
+  --figma___overlays-white-alpha-3: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/3/UI Core/Dark */
+  --figma___overlays-white-alpha-4: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/4/UI Core/Dark */
+  --figma___overlays-white-alpha-5: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/5/UI Core/Dark */
+  --figma___overlays-white-alpha-6: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/6/UI Core/Dark */
+  --figma___overlays-white-alpha-7: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/7/UI Core/Dark */
+  --figma___overlays-white-alpha-8: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/8/UI Core/Dark */
+  --figma___overlays-white-alpha-9: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/9/UI Core/Dark */
+  --figma___overlays-white-alpha-10: 0 0% 100% / 1;
+  /* ✦ Theme/Overlays/White Alpha/10/UI Core/Dark */
+  --figma___pagination-active-background: 212 72% 25% / 1;
+  /* ✦ Theme/Pagination/Active/Background/UI Core/Dark */
+  --figma___pagination-active-border: 202 100% 45% / 0;
+  /* ✦ Theme/Pagination/Active/Border/UI Core/Dark */
+  --figma___pagination-active-text: 0 0% 0% / 1;
+  /* ✦ Theme/Pagination/Active/Text/UI Core/Dark */
+  --figma___pagination-background: 206 98% 42% / 0.21;
+  /* ✦ Theme/Pagination/Background/UI Core/Dark */
+  --figma___pagination-default-background: 0 0% 0% / 1;
+  /* ✦ Theme/Pagination/Default/Background/UI Core/Dark */
+  --figma___pagination-default-border: 0 0% 89% / 0;
+  /* ✦ Theme/Pagination/Default/Border/UI Core/Dark */
+  --figma___pagination-default-text: 0 0% 35% / 1;
+  /* ✦ Theme/Pagination/Default/Text/UI Core/Dark */
+  --figma___pagination-hover-background: 0 0% 0% / 1;
+  /* ✦ Theme/Pagination/Hover/Background/UI Core/Dark */
+  --figma___pagination-hover-border: 206 98% 42% / 0;
+  /* ✦ Theme/Pagination/Hover/Border/UI Core/Dark */
+  --figma___pagination-hover-text: 0 0% 82% / 1;
+  /* ✦ Theme/Pagination/Hover/Text/UI Core/Dark */
+  --figma___pagination-pagination-shadow-1: 237 21% 20% / 0.04;
+  /* ✦ Theme/Pagination/Pagination shadow/1/UI Core/Dark */
+  --figma___pagination-pagination-shadow-2: 236 8% 41% / 0.16;
+  /* ✦ Theme/Pagination/Pagination shadow/2/UI Core/Dark */
+  --figma___primary-color-primary-accent-1: 215 46% 20% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/1/UI Core/Dark */
+  --figma___primary-color-primary-accent-2: 216 50% 12% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/2/UI Core/Dark */
+  --figma___primary-color-primary-accent-3: 214 58% 16% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/3/UI Core/Dark */
+  --figma___primary-color-primary-accent-4: 213 67% 21% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/4/UI Core/Dark */
+  --figma___primary-color-primary-accent-5: 194 100% 45% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/5/UI Core/Dark */
+  --figma___primary-color-primary-accent-6: 212 72% 25% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/6/UI Core/Dark */
+  --figma___primary-color-primary-accent-7: 206 100% 50% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/7/UI Core/Dark */
+  --figma___primary-color-primary-accent-8: 206 100% 62% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/8/UI Core/Dark */
+  --figma___primary-color-primary-accent-9: 205 100% 71% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/9/UI Core/Dark */
+  --figma___primary-color-primary-accent-10: 212 72% 10% / 1;
+  /* ✦ Theme/Primary Color/Primary Accent/10/UI Core/Dark */
+  --figma___primary-color-primary-alpha-1: 215 46% 20% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/1/UI Core/Dark */
+  --figma___primary-color-primary-alpha-2: 216 50% 12% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/2/UI Core/Dark */
+  --figma___primary-color-primary-alpha-3: 214 58% 16% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/3/UI Core/Dark */
+  --figma___primary-color-primary-alpha-4: 213 67% 21% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/4/UI Core/Dark */
+  --figma___primary-color-primary-alpha-5: 194 100% 45% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/5/UI Core/Dark */
+  --figma___primary-color-primary-alpha-6: 212 72% 25% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/6/UI Core/Dark */
+  --figma___primary-color-primary-alpha-7: 206 100% 50% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/7/UI Core/Dark */
+  --figma___primary-color-primary-alpha-8: 206 100% 62% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/8/UI Core/Dark */
+  --figma___primary-color-primary-alpha-9: 205 100% 71% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/9/UI Core/Dark */
+  --figma___primary-color-primary-alpha-10: 212 72% 10% / 1;
+  /* ✦ Theme/Primary Color/Primary Alpha/10/UI Core/Dark */
+  --figma___radio-button-background: 236 19% 14% / 0.5;
+  /* ✦ Theme/Radio button/Background/UI Core/Dark */
+  --figma___radio-button-checked-active-active-border: 206 100% 50% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active Border/UI Core/Dark */
+  --figma___radio-button-checked-active-active-background: 206 100% 50% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Active background/UI Core/Dark */
+  --figma___radio-button-checked-active-dot: 0 0% 0% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Dot/UI Core/Dark */
+  --figma___radio-button-checked-active-hover-background: 206 100% 62% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover background/UI Core/Dark */
+  --figma___radio-button-checked-active-hover-border: 206 100% 62% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/Hover border/UI Core/Dark */
+  --figma___radio-button-checked-active-default-background: 206 100% 50% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default background/UI Core/Dark */
+  --figma___radio-button-checked-active-default-border: 206 100% 50% / 1;
+  /* ✦ Theme/Radio button/Checked/Active/default border/UI Core/Dark */
+  --figma___radio-button-checked-disabled-dot: 0 0% 0% / 1;
+  /* ✦ Theme/Radio button/Checked/Disabled/Dot/UI Core/Dark */
+  --figma___radio-button-checked-disabled-background: 0 0% 11% / 1;
+  /* ✦ Theme/Radio button/Checked/Disabled/background/UI Core/Dark */
+  --figma___radio-button-checked-disabled-border: 0 0% 16% / 1;
+  /* ✦ Theme/Radio button/Checked/Disabled/border/UI Core/Dark */
+  --figma___radio-button-paper: 0 0% 100% / 0.03;
+  /* ✦ Theme/Radio button/Paper/UI Core/Dark */
+  --figma___radio-button-unchecked-active-active-border: 206 100% 50% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/Active border/UI Core/Dark */
+  --figma___radio-button-unchecked-active-hover-border: 206 100% 62% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/Hover border/UI Core/Dark */
+  --figma___radio-button-unchecked-active-default-background: 0 0% 0% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/default background/UI Core/Dark */
+  --figma___radio-button-unchecked-active-default-border: 206 100% 50% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Active/default border/UI Core/Dark */
+  --figma___radio-button-unchecked-disabled-background: 0 0% 11% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/background/UI Core/Dark */
+  --figma___radio-button-unchecked-disabled-border: 0 0% 16% / 1;
+  /* ✦ Theme/Radio button/Unchecked/Disabled/border/UI Core/Dark */
+  --figma___radio-button-border: 0 0% 16% / 1;
+  /* ✦ Theme/Radio button/border/UI Core/Dark */
+  --figma___secondary-crimson-crimson-1: 330 100% 20% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 1/UI Core/Dark */
+  --figma___secondary-crimson-crimson-10: 327 79% 95% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 10/UI Core/Dark */
+  --figma___secondary-crimson-crimson-2: 330 100% 25% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 2/UI Core/Dark */
+  --figma___secondary-crimson-crimson-3: 330 100% 30% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 3/UI Core/Dark */
+  --figma___secondary-crimson-crimson-4: 330 100% 35% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 4/UI Core/Dark */
+  --figma___secondary-crimson-crimson-5: 330 100% 40% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 5/UI Core/Dark */
+  --figma___secondary-crimson-crimson-6: 332 67% 52% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 6/UI Core/Dark */
+  --figma___secondary-crimson-crimson-7: 335 66% 64% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 7/UI Core/Dark */
+  --figma___secondary-crimson-crimson-8: 326 77% 77% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 8/UI Core/Dark */
+  --figma___secondary-crimson-crimson-9: 331 67% 88% / 1;
+  /* ✦ Theme/Secondary/Crimson/Crimson 9/UI Core/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-1: 330 100% 20% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 1/UI Core/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-10: 331 67% 88% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 10/UI Core/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-11: 327 79% 95% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 11/UI Core/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-2: 330 100% 25% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 2/UI Core/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-3: 330 100% 30% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 3/UI Core/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-4: 330 100% 35% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 4/UI Core/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-5: 330 100% 40% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 5/UI Core/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-6: 332 67% 52% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 6/UI Core/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-8: 335 66% 64% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 8/UI Core/Dark */
+  --figma___secondary-crimson-alpha-crimson-alpha-9: 326 77% 77% / 1;
+  /* ✦ Theme/Secondary/Crimson Alpha/Crimson Alpha 9/UI Core/Dark */
+  --figma___secondary-lime-1: 84 100% 20% / 1;
+  /* ✦ Theme/Secondary/Lime/1/UI Core/Dark */
+  --figma___secondary-lime-2: 84 100% 25% / 1;
+  /* ✦ Theme/Secondary/Lime/2/UI Core/Dark */
+  --figma___secondary-lime-3: 83 100% 30% / 1;
+  /* ✦ Theme/Secondary/Lime/3/UI Core/Dark */
+  --figma___secondary-lime-4: 83 100% 35% / 1;
+  /* ✦ Theme/Secondary/Lime/4/UI Core/Dark */
+  --figma___secondary-lime-5: 82 100% 40% / 1;
+  /* ✦ Theme/Secondary/Lime/5/UI Core/Dark */
+  --figma___secondary-lime-6: 95 66% 64% / 1;
+  /* ✦ Theme/Secondary/Lime/6/UI Core/Dark */
+  --figma___secondary-lime-7: 100 61% 75% / 1;
+  /* ✦ Theme/Secondary/Lime/7/UI Core/Dark */
+  --figma___secondary-lime-8: 120 34% 85% / 1;
+  /* ✦ Theme/Secondary/Lime/8/UI Core/Dark */
+  --figma___secondary-lime-9: 120 33% 92% / 1;
+  /* ✦ Theme/Secondary/Lime/9/UI Core/Dark */
+  --figma___secondary-lime-10: 120 53% 97% / 1;
+  /* ✦ Theme/Secondary/Lime/10/UI Core/Dark */
+  --figma___secondary-lime-alpha-1: 84 100% 20% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/1/UI Core/Dark */
+  --figma___secondary-lime-alpha-2: 84 100% 25% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/2/UI Core/Dark */
+  --figma___secondary-lime-alpha-3: 83 100% 30% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/3/UI Core/Dark */
+  --figma___secondary-lime-alpha-4: 83 100% 35% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/4/UI Core/Dark */
+  --figma___secondary-lime-alpha-5: 82 100% 40% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/5/UI Core/Dark */
+  --figma___secondary-lime-alpha-6: 95 66% 64% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/6/UI Core/Dark */
+  --figma___secondary-lime-alpha-7: 100 61% 75% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/7/UI Core/Dark */
+  --figma___secondary-lime-alpha-8: 120 34% 85% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/8/UI Core/Dark */
+  --figma___secondary-lime-alpha-9: 120 33% 92% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/9/UI Core/Dark */
+  --figma___secondary-lime-alpha-10: 120 53% 97% / 1;
+  /* ✦ Theme/Secondary/Lime Alpha/10/UI Core/Dark */
+  --figma___secondary-purple-1: 264 100% 20% / 1;
+  /* ✦ Theme/Secondary/Purple/1/UI Core/Dark */
+  --figma___secondary-purple-2: 264 100% 25% / 1;
+  /* ✦ Theme/Secondary/Purple/2/UI Core/Dark */
+  --figma___secondary-purple-3: 264 100% 30% / 1;
+  /* ✦ Theme/Secondary/Purple/3/UI Core/Dark */
+  --figma___secondary-purple-4: 264 100% 35% / 1;
+  /* ✦ Theme/Secondary/Purple/4/UI Core/Dark */
+  --figma___secondary-purple-5: 264 100% 40% / 1;
+  /* ✦ Theme/Secondary/Purple/5/UI Core/Dark */
+  --figma___secondary-purple-6: 264 67% 52% / 1;
+  /* ✦ Theme/Secondary/Purple/6/UI Core/Dark */
+  --figma___secondary-purple-7: 265 66% 64% / 1;
+  /* ✦ Theme/Secondary/Purple/7/UI Core/Dark */
+  --figma___secondary-purple-8: 258 77% 77% / 1;
+  /* ✦ Theme/Secondary/Purple/8/UI Core/Dark */
+  --figma___secondary-purple-9: 253 85% 89% / 1;
+  /* ✦ Theme/Secondary/Purple/9/UI Core/Dark */
+  --figma___secondary-purple-10: 273 79% 95% / 1;
+  /* ✦ Theme/Secondary/Purple/10/UI Core/Dark */
+  --figma___secondary-purple-alpha-1: 264 100% 20% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/1/UI Core/Dark */
+  --figma___secondary-purple-alpha-2: 264 100% 25% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/2/UI Core/Dark */
+  --figma___secondary-purple-alpha-3: 264 100% 30% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/3/UI Core/Dark */
+  --figma___secondary-purple-alpha-4: 264 100% 35% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/4/UI Core/Dark */
+  --figma___secondary-purple-alpha-5: 264 100% 40% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/5/UI Core/Dark */
+  --figma___secondary-purple-alpha-6: 264 67% 52% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/6/UI Core/Dark */
+  --figma___secondary-purple-alpha-7: 265 66% 64% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/7/UI Core/Dark */
+  --figma___secondary-purple-alpha-8: 258 77% 77% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/8/UI Core/Dark */
+  --figma___secondary-purple-alpha-9: 253 85% 89% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/9/UI Core/Dark */
+  --figma___secondary-purple-alpha-10: 273 79% 95% / 1;
+  /* ✦ Theme/Secondary/Purple Alpha/10/UI Core/Dark */
+  --figma___secondary-teal-1: 180 100% 15% / 1;
+  /* ✦ Theme/Secondary/Teal/1/UI Core/Dark */
+  --figma___secondary-teal-2: 180 100% 20% / 1;
+  /* ✦ Theme/Secondary/Teal/2/UI Core/Dark */
+  --figma___secondary-teal-3: 180 100% 25% / 1;
+  /* ✦ Theme/Secondary/Teal/3/UI Core/Dark */
+  --figma___secondary-teal-4: 180 100% 30% / 1;
+  /* ✦ Theme/Secondary/Teal/4/UI Core/Dark */
+  --figma___secondary-teal-5: 180 100% 35% / 1;
+  /* ✦ Theme/Secondary/Teal/5/UI Core/Dark */
+  --figma___secondary-teal-6: 180 60% 50% / 1;
+  /* ✦ Theme/Secondary/Teal/6/UI Core/Dark */
+  --figma___secondary-teal-7: 180 66% 64% / 1;
+  /* ✦ Theme/Secondary/Teal/7/UI Core/Dark */
+  --figma___secondary-teal-8: 180 77% 77% / 1;
+  /* ✦ Theme/Secondary/Teal/8/UI Core/Dark */
+  --figma___secondary-teal-9: 180 85% 89% / 1;
+  /* ✦ Theme/Secondary/Teal/9/UI Core/Dark */
+  --figma___secondary-teal-10: 180 85% 95% / 1;
+  /* ✦ Theme/Secondary/Teal/10/UI Core/Dark */
+  --figma___secondary-teal-alpha-1: 180 100% 15% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/1/UI Core/Dark */
+  --figma___secondary-teal-alpha-2: 180 100% 20% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/2/UI Core/Dark */
+  --figma___secondary-teal-alpha-3: 180 100% 25% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/3/UI Core/Dark */
+  --figma___secondary-teal-alpha-4: 180 100% 30% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/4/UI Core/Dark */
+  --figma___secondary-teal-alpha-5: 180 100% 35% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/5/UI Core/Dark */
+  --figma___secondary-teal-alpha-6: 180 60% 50% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/6/UI Core/Dark */
+  --figma___secondary-teal-alpha-7: 180 66% 64% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/7/UI Core/Dark */
+  --figma___secondary-teal-alpha-8: 180 77% 77% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/8/UI Core/Dark */
+  --figma___secondary-teal-alpha-9: 180 85% 89% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/9/UI Core/Dark */
+  --figma___secondary-teal-alpha-10: 180 85% 95% / 1;
+  /* ✦ Theme/Secondary/Teal Alpha/10/UI Core/Dark */
+  --figma___shadow-shadow-button-1: 0 0% 0% / 0.5;
+  /* ✦ Theme/Shadow/Shadow - button/1/UI Core/Dark */
+  --figma___shadow-shadow-button-2: 0 0% 100% / 0.31;
+  /* ✦ Theme/Shadow/Shadow - button/2/UI Core/Dark */
+  --figma___shadow-shadow-button-3: 0 0% 100% / 0.31;
+  /* ✦ Theme/Shadow/Shadow - button/3/UI Core/Dark */
+  --figma___shadow-shadow-button-4: 0 0% 0% / 0.11;
+  /* ✦ Theme/Shadow/Shadow - button/4/UI Core/Dark */
+  --figma___shadow-shadow-1-1: 0 0% 0% / 0.13;
+  /* ✦ Theme/Shadow/Shadow 1/1/UI Core/Dark */
+  --figma___shadow-shadow-2-1: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 2/1/UI Core/Dark */
+  --figma___shadow-shadow-2-2: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 2/2/UI Core/Dark */
+  --figma___shadow-shadow-2-3: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 2/3/UI Core/Dark */
+  --figma___shadow-shadow-3-1: 0 0% 0% / 0.45;
+  /* ✦ Theme/Shadow/Shadow 3/1/UI Core/Dark */
+  --figma___shadow-shadow-3-2: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow 3/2/UI Core/Dark */
+  --figma___shadow-shadow-3-3: 0 0% 0% / 0.11;
+  /* ✦ Theme/Shadow/Shadow 3/3/UI Core/Dark */
+  --figma___shadow-shadow-4-1: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow 4/1/UI Core/Dark */
+  --figma___shadow-shadow-4-2: 0 0% 0% / 0.17;
+  /* ✦ Theme/Shadow/Shadow 4/2/UI Core/Dark */
+  --figma___shadow-shadow-5-1: 0 0% 0% / 0.5;
+  /* ✦ Theme/Shadow/Shadow 5/1/UI Core/Dark */
+  --figma___shadow-shadow-5-2: 0 0% 0% / 0.27;
+  /* ✦ Theme/Shadow/Shadow 5/2/UI Core/Dark */
+  --figma___shadow-shadow-6-1: 0 0% 0% / 0.88;
+  /* ✦ Theme/Shadow/Shadow 6/1/UI Core/Dark */
+  --figma___shadow-shadow-6-2: 0 0% 0% / 0.61;
+  /* ✦ Theme/Shadow/Shadow 6/2/UI Core/Dark */
+  --figma___shadow-shadow-button-active-1: 0 0% 100% / 0.17;
+  /* ✦ Theme/Shadow/Shadow-button-active/1/UI Core/Dark */
+  --figma___shadow-shadow-button-active-2: 0 0% 100% / 0.07;
+  /* ✦ Theme/Shadow/Shadow-button-active/2/UI Core/Dark */
+  --figma___shadow-shadow-button-active-3: 0 0% 100% / 0.27;
+  /* ✦ Theme/Shadow/Shadow-button-active/3/UI Core/Dark */
+  --figma___shadow-shadow-button-active-4: 0 0% 100% / 0.11;
+  /* ✦ Theme/Shadow/Shadow-button-active/4/UI Core/Dark */
+  --figma___side-nav-container-nav-background: 212 72% 10% / 1;
+  /* ✦ Theme/Side nav/Container/Nav-background/UI Core/Dark */
+  --figma___side-nav-container-nav-border: 220 6% 90% / 0;
+  /* ✦ Theme/Side nav/Container/Nav-border/UI Core/Dark */
+  --figma___side-nav-module-logo-text: 0 0% 100% / 1;
+  /* ✦ Theme/Side nav/Module Logo Text/UI Core/Dark */
+  --figma___side-nav-nav-item-default-icon: 0 0% 29% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Default/Icon/UI Core/Dark */
+  --figma___side-nav-nav-item-default-text: 0 0% 23% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Default/Text/UI Core/Dark */
+  --figma___side-nav-nav-item-default-default: 0 0% 100% / 0;
+  /* ✦ Theme/Side nav/Nav-item/Default/default/UI Core/Dark */
+  --figma___side-nav-nav-item-hover-background: 195 100% 97% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Background/UI Core/Dark */
+  --figma___side-nav-nav-item-hover-icon: 0 0% 29% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Icon/UI Core/Dark */
+  --figma___side-nav-nav-item-hover-text: 0 0% 23% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Hover/Text/UI Core/Dark */
+  --figma___side-nav-nav-item-selected-background: 215 46% 20% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Background/UI Core/Dark */
+  --figma___side-nav-nav-item-selected-icon: 213 67% 21% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Icon/UI Core/Dark */
+  --figma___side-nav-nav-item-selected-text: 213 67% 21% / 1;
+  /* ✦ Theme/Side nav/Nav-item/Selected/Text/UI Core/Dark */
+  --figma___side-nav-profile-role: 0 0% 35% / 1;
+  /* ✦ Theme/Side nav/Profile/Role/UI Core/Dark */
+  --figma___side-nav-profile-text: 0 0% 29% / 1;
+  /* ✦ Theme/Side nav/Profile/Text/UI Core/Dark */
+  --figma___side-nav-scope-selector-default-border: 0 0% 42% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Border/UI Core/Dark */
+  --figma___side-nav-scope-selector-default-main-text-icon: 0 0% 0% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Main Text & Icon/UI Core/Dark */
+  --figma___side-nav-scope-selector-default-scope-name: 0 0% 29% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/Scope Name/UI Core/Dark */
+  --figma___side-nav-scope-selector-default-default: 0 0% 0% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Default/default/UI Core/Dark */
+  --figma___side-nav-scope-selector-hover-border: 206 100% 50% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Border/UI Core/Dark */
+  --figma___side-nav-scope-selector-hover-main-text-icon: 0 0% 0% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Main Text & Icon/UI Core/Dark */
+  --figma___side-nav-scope-selector-hover-scope-name: 0 0% 29% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/Scope Name/UI Core/Dark */
+  --figma___side-nav-scope-selector-hover-default: 0 0% 0% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Hover/default/UI Core/Dark */
+  --figma___side-nav-scope-selector-selected-border: 206 100% 50% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Border/UI Core/Dark */
+  --figma___side-nav-scope-selector-selected-main-text-icon: 0 0% 0% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Main Text & Icon/UI Core/Dark */
+  --figma___side-nav-scope-selector-selected-scope-name: 0 0% 29% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/Scope Name/UI Core/Dark */
+  --figma___side-nav-scope-selector-selected-background: 0 0% 0% / 1;
+  /* ✦ Theme/Side nav/Scope Selector/Selected/background/UI Core/Dark */
+  --figma___side-nav-separator: 0 0% 54% / 1;
+  /* ✦ Theme/Side nav/Separator/UI Core/Dark */
+  --figma___status-colors-error-1: 0 67% 12% / 1;
+  /* ✦ Theme/Status colors/Error/1/UI Core/Dark */
+  --figma___status-colors-error-2: 0 67% 18% / 1;
+  /* ✦ Theme/Status colors/Error/2/UI Core/Dark */
+  --figma___status-colors-error-3: 0 67% 24% / 1;
+  /* ✦ Theme/Status colors/Error/3/UI Core/Dark */
+  --figma___status-colors-error-4: 0 68% 30% / 1;
+  /* ✦ Theme/Status colors/Error/4/UI Core/Dark */
+  --figma___status-colors-error-5: 0 68% 36% / 1;
+  /* ✦ Theme/Status colors/Error/5/UI Core/Dark */
+  --figma___status-colors-error-6: 0 68% 42% / 1;
+  /* ✦ Theme/Status colors/Error/6/UI Core/Dark */
+  --figma___status-colors-error-7: 0 67% 48% / 1;
+  /* ✦ Theme/Status colors/Error/7/UI Core/Dark */
+  --figma___status-colors-error-8: 0 78% 55% / 1;
+  /* ✦ Theme/Status colors/Error/8/UI Core/Dark */
+  --figma___status-colors-error-9: 0 100% 62% / 1;
+  /* ✦ Theme/Status colors/Error/9/UI Core/Dark */
+  --figma___status-colors-error-10: 0 100% 70% / 1;
+  /* ✦ Theme/Status colors/Error/10/UI Core/Dark */
+  --figma___status-colors-error-alpha-1: 0 67% 12% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/1/UI Core/Dark */
+  --figma___status-colors-error-alpha-2: 0 67% 18% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/2/UI Core/Dark */
+  --figma___status-colors-error-alpha-3: 0 67% 24% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/3/UI Core/Dark */
+  --figma___status-colors-error-alpha-4: 0 68% 30% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/4/UI Core/Dark */
+  --figma___status-colors-error-alpha-5: 0 68% 36% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/5/UI Core/Dark */
+  --figma___status-colors-error-alpha-6: 0 68% 42% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/6/UI Core/Dark */
+  --figma___status-colors-error-alpha-7: 0 67% 48% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/7/UI Core/Dark */
+  --figma___status-colors-error-alpha-8: 0 78% 55% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/8/UI Core/Dark */
+  --figma___status-colors-error-alpha-9: 0 100% 62% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/9/UI Core/Dark */
+  --figma___status-colors-error-alpha-10: 0 100% 70% / 1;
+  /* ✦ Theme/Status colors/Error Alpha/10/UI Core/Dark */
+  --figma___status-colors-info-1: 241 53% 23% / 1;
+  /* ✦ Theme/Status colors/Info/1/UI Core/Dark */
+  --figma___status-colors-info-2: 241 52% 28% / 1;
+  /* ✦ Theme/Status colors/Info/2/UI Core/Dark */
+  --figma___status-colors-info-3: 241 51% 33% / 1;
+  /* ✦ Theme/Status colors/Info/3/UI Core/Dark */
+  --figma___status-colors-info-4: 241 49% 39% / 1;
+  /* ✦ Theme/Status colors/Info/4/UI Core/Dark */
+  --figma___status-colors-info-5: 241 48% 44% / 1;
+  /* ✦ Theme/Status colors/Info/5/UI Core/Dark */
+  --figma___status-colors-info-6: 239 48% 52% / 1;
+  /* ✦ Theme/Status colors/Info/6/UI Core/Dark */
+  --figma___status-colors-info-7: 240 59% 59% / 1;
+  /* ✦ Theme/Status colors/Info/7/UI Core/Dark */
+  --figma___status-colors-info-8: 240 74% 67% / 1;
+  /* ✦ Theme/Status colors/Info/8/UI Core/Dark */
+  --figma___status-colors-info-9: 240 100% 77% / 1;
+  /* ✦ Theme/Status colors/Info/9/UI Core/Dark */
+  --figma___status-colors-info-10: 240 100% 83% / 1;
+  /* ✦ Theme/Status colors/Info/10/UI Core/Dark */
+  --figma___status-colors-info-alpha-1: 241 53% 23% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/1/UI Core/Dark */
+  --figma___status-colors-info-alpha-2: 241 52% 28% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/2/UI Core/Dark */
+  --figma___status-colors-info-alpha-3: 241 51% 33% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/3/UI Core/Dark */
+  --figma___status-colors-info-alpha-4: 241 49% 39% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/4/UI Core/Dark */
+  --figma___status-colors-info-alpha-5: 241 48% 44% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/5/UI Core/Dark */
+  --figma___status-colors-info-alpha-6: 239 48% 52% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/6/UI Core/Dark */
+  --figma___status-colors-info-alpha-7: 240 59% 59% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/7/UI Core/Dark */
+  --figma___status-colors-info-alpha-8: 240 74% 67% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/8/UI Core/Dark */
+  --figma___status-colors-info-alpha-9: 240 100% 77% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/9/UI Core/Dark */
+  --figma___status-colors-info-alpha-10: 240 100% 83% / 1;
+  /* ✦ Theme/Status colors/Info Alpha/10/UI Core/Dark */
+  --figma___status-colors-success-1: 122 64% 11% / 1;
+  /* ✦ Theme/Status colors/Success/1/UI Core/Dark */
+  --figma___status-colors-success-2: 127 73% 15% / 1;
+  /* ✦ Theme/Status colors/Success/2/UI Core/Dark */
+  --figma___status-colors-success-3: 123 67% 24% / 1;
+  /* ✦ Theme/Status colors/Success/3/UI Core/Dark */
+  --figma___status-colors-success-4: 122 55% 32% / 1;
+  /* ✦ Theme/Status colors/Success/4/UI Core/Dark */
+  --figma___status-colors-success-5: 122 50% 36% / 1;
+  /* ✦ Theme/Status colors/Success/5/UI Core/Dark */
+  --figma___status-colors-success-6: 124 36% 52% / 1;
+  /* ✦ Theme/Status colors/Success/6/UI Core/Dark */
+  --figma___status-colors-success-7: 121 42% 62% / 1;
+  /* ✦ Theme/Status colors/Success/7/UI Core/Dark */
+  --figma___status-colors-success-8: 118 49% 70% / 1;
+  /* ✦ Theme/Status colors/Success/8/UI Core/Dark */
+  --figma___status-colors-success-9: 117 62% 79% / 1;
+  /* ✦ Theme/Status colors/Success/9/UI Core/Dark */
+  --figma___status-colors-success-10: 119 66% 85% / 1;
+  /* ✦ Theme/Status colors/Success/10/UI Core/Dark */
+  --figma___status-colors-success-alpha-1: 120 100% 44% / 0;
+  /* ✦ Theme/Status colors/Success Alpha/1/UI Core/Dark */
+  --figma___status-colors-success-alpha-2: 120 100% 49% / 0.02;
+  /* ✦ Theme/Status colors/Success Alpha/2/UI Core/Dark */
+  --figma___status-colors-success-alpha-3: 149 100% 49% / 0.07;
+  /* ✦ Theme/Status colors/Success Alpha/3/UI Core/Dark */
+  --figma___status-colors-success-alpha-4: 154 100% 50% / 0.11;
+  /* ✦ Theme/Status colors/Success Alpha/4/UI Core/Dark */
+  --figma___status-colors-success-alpha-5: 153 99% 53% / 0.15;
+  /* ✦ Theme/Status colors/Success Alpha/5/UI Core/Dark */
+  --figma___status-colors-success-alpha-6: 155 99% 55% / 0.2;
+  /* ✦ Theme/Status colors/Success Alpha/6/UI Core/Dark */
+  --figma___status-colors-success-alpha-7: 151 100% 63% / 0.5;
+  /* ✦ Theme/Status colors/Success Alpha/7/UI Core/Dark */
+  --figma___status-colors-success-alpha-8: 151 100% 62% / 0.61;
+  /* ✦ Theme/Status colors/Success Alpha/8/UI Core/Dark */
+  --figma___status-colors-success-alpha-9: 151 100% 64% / 0.82;
+  /* ✦ Theme/Status colors/Success Alpha/9/UI Core/Dark */
+  --figma___status-colors-success-alpha-10: 144 100% 87% / 0.94;
+  /* ✦ Theme/Status colors/Success Alpha/10/UI Core/Dark */
+  --figma___status-colors-warning-1: 32 67% 12% / 1;
+  /* ✦ Theme/Status colors/Warning/1/UI Core/Dark */
+  --figma___status-colors-warning-2: 30 69% 18% / 1;
+  /* ✦ Theme/Status colors/Warning/2/UI Core/Dark */
+  --figma___status-colors-warning-3: 27 69% 24% / 1;
+  /* ✦ Theme/Status colors/Warning/3/UI Core/Dark */
+  --figma___status-colors-warning-4: 26 68% 30% / 1;
+  /* ✦ Theme/Status colors/Warning/4/UI Core/Dark */
+  --figma___status-colors-warning-5: 17 68% 36% / 1;
+  /* ✦ Theme/Status colors/Warning/5/UI Core/Dark */
+  --figma___status-colors-warning-6: 18 68% 42% / 1;
+  /* ✦ Theme/Status colors/Warning/6/UI Core/Dark */
+  --figma___status-colors-warning-7: 19 67% 48% / 1;
+  /* ✦ Theme/Status colors/Warning/7/UI Core/Dark */
+  --figma___status-colors-warning-8: 19 79% 54% / 1;
+  /* ✦ Theme/Status colors/Warning/8/UI Core/Dark */
+  --figma___status-colors-warning-9: 19 100% 60% / 1;
+  /* ✦ Theme/Status colors/Warning/9/UI Core/Dark */
+  --figma___status-colors-warning-10: 19 100% 64% / 1;
+  /* ✦ Theme/Status colors/Warning/10/UI Core/Dark */
+  --figma___status-colors-warning-alpha-1: 32 67% 12% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/1/UI Core/Dark */
+  --figma___status-colors-warning-alpha-2: 30 69% 18% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/2/UI Core/Dark */
+  --figma___status-colors-warning-alpha-3: 27 69% 24% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/3/UI Core/Dark */
+  --figma___status-colors-warning-alpha-4: 26 68% 30% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/4/UI Core/Dark */
+  --figma___status-colors-warning-alpha-5: 17 68% 36% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/5/UI Core/Dark */
+  --figma___status-colors-warning-alpha-6: 18 68% 42% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/6/UI Core/Dark */
+  --figma___status-colors-warning-alpha-7: 19 67% 48% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/7/UI Core/Dark */
+  --figma___status-colors-warning-alpha-8: 19 79% 54% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/8/UI Core/Dark */
+  --figma___status-colors-warning-alpha-9: 19 100% 60% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/9/UI Core/Dark */
+  --figma___status-colors-warning-alpha-10: 19 100% 64% / 1;
+  /* ✦ Theme/Status colors/Warning Alpha/10/UI Core/Dark */
+  --figma___switch-background: 236 19% 14% / 0.5;
+  /* ✦ Theme/Switch/Background/UI Core/Dark */
+  --figma___switch-checked-active-thumb-thumb-background: 0 0% 0% / 1;
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Background/UI Core/Dark */
+  --figma___switch-checked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Active/Thumb/Thumb Border/UI Core/Dark */
+  --figma___switch-checked-active-background: 206 100% 50% / 1;
+  /* ✦ Theme/Switch/Checked/Active/background/UI Core/Dark */
+  --figma___switch-checked-active-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Checked/Active/border/UI Core/Dark */
+  --figma___switch-checked-default-thumb-thumb-background: 0 0% 0% / 1;
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Background/UI Core/Dark */
+  --figma___switch-checked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Default/Thumb/Thumb Border/UI Core/Dark */
+  --figma___switch-checked-default-default-background: 206 100% 50% / 1;
+  /* ✦ Theme/Switch/Checked/Default/default background/UI Core/Dark */
+  --figma___switch-checked-default-default-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Checked/Default/default border/UI Core/Dark */
+  --figma___switch-checked-disabled-thumb-thumb-background: 0 0% 0% / 1;
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Background/UI Core/Dark */
+  --figma___switch-checked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/Thumb/Thumb Border/UI Core/Dark */
+  --figma___switch-checked-disabled-background: 206 98% 42% / 0.5;
+  /* ✦ Theme/Switch/Checked/Disabled/background/UI Core/Dark */
+  --figma___switch-checked-disabled-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Checked/Disabled/border/UI Core/Dark */
+  --figma___switch-checked-hover-thumb-thumb-background: 0 0% 0% / 1;
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Background/UI Core/Dark */
+  --figma___switch-checked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/Thumb/Thumb Border/UI Core/Dark */
+  --figma___switch-checked-hover-background: 206 100% 62% / 1;
+  /* ✦ Theme/Switch/Checked/Hover/background/UI Core/Dark */
+  --figma___switch-checked-hover-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Checked/Hover/border/UI Core/Dark */
+  --figma___switch-paper: 0 0% 100% / 0.03;
+  /* ✦ Theme/Switch/Paper/UI Core/Dark */
+  --figma___switch-unchecked-active-thumb-thumb-background: 0 0% 0% / 1;
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Background/UI Core/Dark */
+  --figma___switch-unchecked-active-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Active/Thumb/Thumb Border/UI Core/Dark */
+  --figma___switch-unchecked-active-background: 0 0% 16% / 1;
+  /* ✦ Theme/Switch/Unchecked/Active/background/UI Core/Dark */
+  --figma___switch-unchecked-active-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Unchecked/Active/border/UI Core/Dark */
+  --figma___switch-unchecked-default-thumb-thumb-background: 0 0% 0% / 1;
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Background/UI Core/Dark */
+  --figma___switch-unchecked-default-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Default/Thumb/Thumb Border/UI Core/Dark */
+  --figma___switch-unchecked-default-default-background: 0 0% 16% / 1;
+  /* ✦ Theme/Switch/Unchecked/Default/default background/UI Core/Dark */
+  --figma___switch-unchecked-default-default-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Unchecked/Default/default border/UI Core/Dark */
+  --figma___switch-unchecked-disabled-thumb-thumb-background: 0 0% 0% / 1;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Background/UI Core/Dark */
+  --figma___switch-unchecked-disabled-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Disabled/Thumb/Thumb Border/UI Core/Dark */
+  --figma___switch-unchecked-disabled-background: 0 0% 11% / 1;
+  /* ✦ Theme/Switch/Unchecked/Disabled/background/UI Core/Dark */
+  --figma___switch-unchecked-disabled-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Unchecked/Disabled/border/UI Core/Dark */
+  --figma___switch-unchecked-hover-thumb-thumb-background: 0 0% 0% / 1;
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Background/UI Core/Dark */
+  --figma___switch-unchecked-hover-thumb-thumb-border: 0 0% 100% / 0;
+  /* ✦ Theme/Switch/Unchecked/Hover/Thumb/Thumb Border/UI Core/Dark */
+  --figma___switch-unchecked-hover-background: 0 0% 23% / 1;
+  /* ✦ Theme/Switch/Unchecked/Hover/background/UI Core/Dark */
+  --figma___switch-unchecked-hover-border: 0 0% 0% / 0;
+  /* ✦ Theme/Switch/Unchecked/Hover/border/UI Core/Dark */
+  --figma___switch-border: 0 0% 16% / 1;
+  /* ✦ Theme/Switch/border/UI Core/Dark */
+  --figma___tabs-number-active-background: 206 100% 50% / 1;
+  /* ✦ Theme/Tabs/Number/Active/Background/UI Core/Dark */
+  --figma___tabs-number-active-text: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Number/Active/text/UI Core/Dark */
+  --figma___tabs-number-default-hover-background: 0 0% 11% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/Background/UI Core/Dark */
+  --figma___tabs-number-default-hover-text: 0 0% 35% / 1;
+  /* ✦ Theme/Tabs/Number/Default & Hover/text/UI Core/Dark */
+  --figma___tabs-pills-active-active: 215 46% 20% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Active/UI Core/Dark */
+  --figma___tabs-pills-active-text: 206 100% 62% / 1;
+  /* ✦ Theme/Tabs/Pills/Active/Text/UI Core/Dark */
+  --figma___tabs-pills-active-border-grad-1: 0 0% 100% / 0;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 1/UI Core/Dark */
+  --figma___tabs-pills-active-border-grad-2: 0 0% 100% / 0;
+  /* ✦ Theme/Tabs/Pills/Active/border grad 2/UI Core/Dark */
+  --figma___tabs-pills-backgrounds: 0 0% 16% / 1;
+  /* ✦ Theme/Tabs/Pills/Backgrounds/UI Core/Dark */
+  --figma___tabs-pills-default-background: 0 0% 0% / 1;
+  /* ✦ Theme/Tabs/Pills/Default/Background/UI Core/Dark */
+  --figma___tabs-pills-default-text: 0 0% 54% / 1;
+  /* ✦ Theme/Tabs/Pills/Default/Text/UI Core/Dark */
+  --figma___tabs-pills-hover-background: 215 46% 20% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Background/UI Core/Dark */
+  --figma___tabs-pills-hover-text: 0 0% 54% / 1;
+  /* ✦ Theme/Tabs/Pills/Hover/Text/UI Core/Dark */
+  --figma___tabs-pills-number-active-background: 206 100% 50% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/Background/UI Core/Dark */
+  --figma___tabs-pills-number-active-text: 0 0% 100% / 1;
+  /* ✦ Theme/Tabs/Pills/Number/Active/text/UI Core/Dark */
+  --figma___tabs-pills-border-grad-1: 0 0% 16% / 1;
+  /* ✦ Theme/Tabs/Pills/border grad 1/UI Core/Dark */
+  --figma___tabs-pills-border-grad-2: 0 0% 16% / 1;
+  /* ✦ Theme/Tabs/Pills/border grad 2/UI Core/Dark */
+  --figma___tabs-primary-active-text: 0 0% 82% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Text/UI Core/Dark */
+  --figma___tabs-primary-active-underline: 206 100% 50% / 1;
+  /* ✦ Theme/Tabs/Primary/Active/Underline/UI Core/Dark */
+  --figma___tabs-primary-border: 206 100% 50% / 1;
+  /* ✦ Theme/Tabs/Primary/Border/UI Core/Dark */
+  --figma___tabs-primary-default-background: 0 0% 0% / 1;
+  /* ✦ Theme/Tabs/Primary/Default/Background/UI Core/Dark */
+  --figma___tabs-primary-default-text: 0 0% 54% / 1;
+  /* ✦ Theme/Tabs/Primary/Default/Text/UI Core/Dark */
+  --figma___tabs-primary-hover-background: 0 0% 100% / 0;
+  /* ✦ Theme/Tabs/Primary/Hover/Background/UI Core/Dark */
+  --figma___tabs-primary-hover-text: 206 100% 50% / 1;
+  /* ✦ Theme/Tabs/Primary/Hover/Text/UI Core/Dark */
+  --figma___tabs-primary-pills-pills: 205 100% 71% / 1;
+  /* ✦ Theme/Tabs/Primary/Pills/Pills/UI Core/Dark */
+  --figma___text-disabled: 0 0% 23% / 1;
+  /* ✦ Theme/Text/Disabled/UI Core/Dark */
+  --figma___text-links: 206 100% 50% / 1;
+  /* ✦ Theme/Text/Links/UI Core/Dark */
+  --figma___text-secondary: 0 0% 54% / 1;
+  /* ✦ Theme/Text/Secondary/UI Core/Dark */
+  --figma___text-tertiary: 0 0% 35% / 1;
+  /* ✦ Theme/Text/Tertiary/UI Core/Dark */
+  --figma___text-primary: 0 0% 82% / 1;
+  /* ✦ Theme/Text/primary/UI Core/Dark */
+  --figma___textfield-assistive-text-primary: 0 0% 35% / 1;
+  /* ✦ Theme/Textfield/Assistive Text/Primary/UI Core/Dark */
+  --figma___textfield-background: 0 0% 0% / 0.5;
+  /* ✦ Theme/Textfield/Background/UI Core/Dark */
+  --figma___textfield-input-field-background: 0 0% 0% / 1;
+  /* ✦ Theme/Textfield/Input Field/Background/UI Core/Dark */
+  --figma___textfield-input-field-default: 0 0% 16% / 1;
+  /* ✦ Theme/Textfield/Input Field/Default/UI Core/Dark */
+  --figma___textfield-input-field-error: 0 67% 48% / 1;
+  /* ✦ Theme/Textfield/Input Field/Error/UI Core/Dark */
+  --figma___textfield-input-field-hover: 206 100% 50% / 1;
+  /* ✦ Theme/Textfield/Input Field/Hover/UI Core/Dark */
+  --figma___textfield-label-info-icon: 206 100% 50% / 1;
+  /* ✦ Theme/Textfield/Label/Info Icon/UI Core/Dark */
+  --figma___textfield-label-link: 206 100% 50% / 1;
+  /* ✦ Theme/Textfield/Label/Link/UI Core/Dark */
+  --figma___textfield-label-main: 0 0% 54% / 1;
+  /* ✦ Theme/Textfield/Label/Main/UI Core/Dark */
+  --figma___textfield-label-optional: 0 0% 35% / 1;
+  /* ✦ Theme/Textfield/Label/Optional/UI Core/Dark */
+  --figma___textfield-pin-soft-background: 0 0% 11% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/Background/UI Core/Dark */
+  --figma___textfield-pin-soft-border: 0 0% 16% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/border/UI Core/Dark */
+  --figma___textfield-pin-soft-pin: 206 100% 50% / 1;
+  /* ✦ Theme/Textfield/Pin/Soft/pin/UI Core/Dark */
+  --figma___textfield-pin-surface-background: 0 0% 11% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/Background/UI Core/Dark */
+  --figma___textfield-pin-surface-border: 0 0% 16% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/border/UI Core/Dark */
+  --figma___textfield-pin-surface-pin: 206 100% 50% / 1;
+  /* ✦ Theme/Textfield/Pin/Surface/pin/UI Core/Dark */
+  --figma___tooltip-background: 195 100% 97% / 1;
+  /* ✦ Theme/Tooltip/Background/UI Core/Dark */
+  --figma___tooltip-body-text: 0 0% 0% / 1;
+  /* ✦ Theme/Tooltip/Body Text/UI Core/Dark */
+  --figma___tooltip-dismissable-icon: 0 0% 42% / 1;
+  /* ✦ Theme/Tooltip/Dismissable icon/UI Core/Dark */
+  --figma___tooltip-tooltip-title: 0 0% 0% / 1;
+  /* ✦ Theme/Tooltip/Tooltip Title/UI Core/Dark */
+}

--- a/packages/canary/tailwind.config.js
+++ b/packages/canary/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 import figmaColors from "./src/style-tokens/colors"
 import figmaDimensions from "./src/style-tokens/dimensions"
+import figmaFontSizes from "./src/style-tokens/fonts"
 
 // eslint-disable-next-line no-undef
 module.exports = {
@@ -95,6 +96,7 @@ module.exports = {
         DEFAULT: '1px'
       },
       fontSize: {
+        ...figmaFontSizes,
         tiny: '12px',
         xs: '13px'
       },

--- a/packages/canary/tailwind.config.js
+++ b/packages/canary/tailwind.config.js
@@ -1,4 +1,7 @@
 /** @type {import('tailwindcss').Config} */
+import figmaColors from "./src/style-tokens/colors"
+import figmaDimensions from "./src/style-tokens/dimensions"
+
 // eslint-disable-next-line no-undef
 module.exports = {
   darkMode: ['class'],
@@ -16,7 +19,11 @@ module.exports = {
       fontFamily: {
         sans: ['Inter', 'sans-serif']
       },
+      spacing: {
+        ...figmaDimensions
+      },
       colors: {
+        ...figmaColors,
         border: 'hsl(var(--border))',
         'border-background': 'hsl(var(--border-background))',
         input: 'hsl(var(--input))',
@@ -81,7 +88,8 @@ module.exports = {
         }
       },
       borderRadius: {
-        DEFAULT: 'var(--radius)'
+        DEFAULT: 'var(--radius)',
+        ...figmaDimensions
       },
       border: {
         DEFAULT: '1px'


### PR DESCRIPTION
# Summary
- This PR includes the CSS files (for Harness Open Source, Harness Theme, and UI Core theme) and tailwind files (color, dimensions) which is exported from Figma

# TL;DR
- Implementation is only exporting semantic and component tokens from Figma into CSS and tailwind files.
- These same semantic and component tokens are used by the designers in the Figma UI
- Adding these tokens directly to Tailwind ensures that the developers can easily reference the tokens from Figma and use them in tailwind. What they see in Figma is what they can use in code.

# Background
## Starting from Figma...
- Our Figma tokens are organized as such: A core collection and its theme collections.
- The theme collections contains base tokens for that specific theme. At this point since there are 3 themes, there are 3 collections. The tokens in this theme have two modes: Light, Dark. The variables within this collection is not used by the designers directly in Figma. Instead, these are only used as reference by the core collection.
- The core collection contains both semantic and component tokens for the 3 themes. The tokens here reference the base tokens from the respective theme collections meaning that the tokens in the core collection has access to to Light/Dark values in the theme collections. The designers will be using these tokens in their Figma UIs.
- In summary, think of the core collection as an interface that allows the designers access to semantic and component tokens that can be used irregardless of theme. 

> Core collection in Figma with colors for different themes
<img width="1257" alt="Screenshot 2024-08-21 at 1 12 43 PM" src="https://github.com/user-attachments/assets/b7449eb5-27e0-4d52-9662-e924a9846a20">


> Theme collection in Figma with light/dark values 
<img width="854" alt="Screenshot 2024-08-21 at 1 13 38 PM" src="https://github.com/user-attachments/assets/58a2a429-e785-410a-b81a-08e14be434f2">

## Through the token pipeline...
- Given the explanation above, we only need to export the Figma tokens from the core collection (remember the interface?). Meaning the exported tokens that will be built to CSS and Tailwind inlcudes semantic and component tokens but not base tokens.
- With this method, we can ensure that for the different themes in the generated CSS files, they all have the same set of CSS variables. Same goes for Tailwind. This provides confidence for the developers that they can use the semantic and component level tokens within their code irregardless of the theme

## To Tailwind file in this codebase
- Previously we discussed that we will be following shadcn method of theming. Meaning we have a CSS file that contains the mapping between the semantic and component level tokens to the CSS variables. 
- However, given that we are only exporting semantic and component level tokens, this CSS file that includes the shadcn mapping is not generated. 
- With that same reason, we can actually add the semantic and component level tokens (color and dimensions) to tailwind directly, which is then picked up by the Tailwind intellisense. With this method, the developer has that confidence that what they see in Figma is what they can use in Tailwind. Ensuring design consistency
- On a side note, we added a prefix to the tailwind tokens from Figma, so that the likelihood of the tokens from Figma clashing with tokens used directly in Tailwind is mitigated

# Tailwind intellisense
> What devs see in Figma is what they can use in Tailwind
<img width="1728" alt="Screenshot 2024-08-21 at 1 05 31 AM" src="https://github.com/user-attachments/assets/290b04ac-554b-4548-846c-ef330e45572f">

