### PR TITLE
fix: Minor fixes for Pipeline Studio

### DIFF
--- a/packages/playground/src/pages/pipeline-edit-page.tsx
+++ b/packages/playground/src/pages/pipeline-edit-page.tsx
@@ -19,7 +19,7 @@ import {
 import { type InlineAction } from '@harnessio/yaml-editor'
 import { ArrowLeft, Box, Search, Xmark } from '@harnessio/icons-noir'
 import { YamlEditor, MonacoGlobals } from '@harnessio/yaml-editor'
-import { Node, PipelineStudio, getNodesFromPipelineYaml } from '@harnessio/unified-pipeline'
+import { PipelineStudio, getNodesFromPipelineYaml } from '@harnessio/unified-pipeline'
 import { ILanguageFeaturesService } from 'monaco-editor/esm/vs/editor/common/services/languageFeatures.js'
 import { OutlineModel } from 'monaco-editor/esm/vs/editor/contrib/documentSymbols/browser/outlineModel.js'
 import { StandaloneServices } from 'monaco-editor/esm/vs/editor/standalone/browser/standaloneServices.js'
@@ -49,14 +49,7 @@ MonacoGlobals.set({
 })
 
 function GraphView() {
-  const [nodes, setNodes] = useState<Node[]>(getNodesFromPipelineYaml(pipeline))
-
-  useEffect(() => {
-    return () => {
-      setNodes([])
-    }
-  }, [])
-
+  const nodes = useMemo(() => getNodesFromPipelineYaml(pipeline), [])
   return <PipelineStudio nodes={nodes} onAddNode={noop} onDeleteNode={noop} onSelectNode={noop} />
 }
 

--- a/packages/playground/src/pages/pipeline-edit-page.tsx
+++ b/packages/playground/src/pages/pipeline-edit-page.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { stringify } from 'yaml'
 import cx from 'classnames'
 import { noop } from 'lodash-es'
@@ -19,7 +19,7 @@ import {
 import { type InlineAction } from '@harnessio/yaml-editor'
 import { ArrowLeft, Box, Search, Xmark } from '@harnessio/icons-noir'
 import { YamlEditor, MonacoGlobals } from '@harnessio/yaml-editor'
-import { PipelineStudio, getNodesFromPipelineYaml } from '@harnessio/unified-pipeline'
+import { Node, PipelineStudio, getNodesFromPipelineYaml } from '@harnessio/unified-pipeline'
 import { ILanguageFeaturesService } from 'monaco-editor/esm/vs/editor/common/services/languageFeatures.js'
 import { OutlineModel } from 'monaco-editor/esm/vs/editor/contrib/documentSymbols/browser/outlineModel.js'
 import { StandaloneServices } from 'monaco-editor/esm/vs/editor/standalone/browser/standaloneServices.js'
@@ -49,7 +49,14 @@ MonacoGlobals.set({
 })
 
 function GraphView() {
-  const nodes = useMemo(() => getNodesFromPipelineYaml(pipeline as unknown as string), [])
+  const [nodes, setNodes] = useState<Node[]>(getNodesFromPipelineYaml(pipeline))
+
+  useEffect(() => {
+    return () => {
+      setNodes([])
+    }
+  }, [])
+
   return <PipelineStudio nodes={nodes} onAddNode={noop} onDeleteNode={noop} onSelectNode={noop} />
 }
 
@@ -227,8 +234,12 @@ const StepPalettePanel = (): JSX.Element => {
 
 export default function PipelineEditPage() {
   const [view, setView] = useState<'visual' | 'yaml'>('visual')
-  const [panelOpen, setPanelOpen] = useState(true)
+  const [panelOpen, setPanelOpen] = useState(false)
   const [drawerOpen, setDrawerOpen] = useState<'palette' | 'stepform'>()
+
+  useEffect(() => {
+    setPanelOpen(view === 'yaml')
+  }, [view])
 
   const main = useMemo(() => {
     return (

--- a/packages/unified-pipeline/src/components/Canvas/Canvas.tsx
+++ b/packages/unified-pipeline/src/components/Canvas/Canvas.tsx
@@ -154,7 +154,6 @@ const CanvasInternal = (props: CanvasProps) => {
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
         proOptions={{ hideAttribution: true }}
-        minZoom={1}
         /* https://github.com/xyflow/xyflow/discussions/2827 */
         nodeOrigin={[0.5, 0.5]}>
         <Controls>

--- a/packages/unified-pipeline/src/components/Canvas/Canvas.tsx
+++ b/packages/unified-pipeline/src/components/Canvas/Canvas.tsx
@@ -26,8 +26,6 @@ import CircleOverlay, { Position } from '../../components/CircleOverlay/CircleOv
 
 import 'reactflow/dist/style.css'
 
-const ANIMATION_DURATION = 500
-
 interface CanvasLayoutProps {
   height: number
   width: number
@@ -75,12 +73,12 @@ const CanvasInternal = (props: CanvasProps) => {
     }).then(({ nodes: layoutedNodes, edges: layoutedEdges }) => {
       setNodes([...layoutedNodes, ...childNodes])
       setEdges(layoutedEdges)
-      window.requestAnimationFrame(() =>
+      window.requestAnimationFrame(() => {
         fitView({
-          duration: ANIMATION_DURATION,
-          nodes: [{ id: layoutedNodes[1].id }]
+          nodes: [{ id: layoutedNodes[1].id }],
+          maxZoom: 1
         })
-      )
+      })
     })
   }, [props.nodes, props.edges])
 
@@ -156,12 +154,7 @@ const CanvasInternal = (props: CanvasProps) => {
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
         proOptions={{ hideAttribution: true }}
-        fitView
-        onInit={instance =>
-          setTimeout(() => window.requestAnimationFrame(() => instance.fitView({ duration: ANIMATION_DURATION })), 0)
-        }
-        minZoom={0.5}
-        maxZoom={1}
+        minZoom={1}
         /* https://github.com/xyflow/xyflow/discussions/2827 */
         nodeOrigin={[0.5, 0.5]}>
         <Controls>


### PR DESCRIPTION
Minor changes for

- Hiding Problems panel for Visual view, by default.
- Disabling animation on first render of Pipeline Studio, rendering nodes by-default at 100% zoom.