### PR TITLE
Pages responsive layout fix

### DIFF
--- a/packages/playground/src/components/execution/execution-details.tsx
+++ b/packages/playground/src/components/execution/execution-details.tsx
@@ -23,7 +23,7 @@ export const ExecutionDetails: React.FC<ExecutionProps> = (): React.ReactElement
   const stages = execution.stages
   if (!stages || !stages.length) return <Text>No stages found</Text>
   return (
-    <Layout.Horizontal>
+    <Layout.Horizontal className="px-8">
       {/* Hardcoded height added temporarily */}
       <div className="w-2/3">
         <StageExecution stage={stages[0]} />

--- a/packages/playground/src/layouts/PaddingListLayout.tsx
+++ b/packages/playground/src/layouts/PaddingListLayout.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { cn } from '@harnessio/canary'
+
+interface PaddingListLayoutProps {
+  className?: string
+}
+
+const PaddingListLayout: React.FC<PaddingListLayoutProps> = ({ className }) => {
+  return <div className={cn('p-10', className)}></div>
+}
+
+export default PaddingListLayout

--- a/packages/playground/src/layouts/PaddingListLayout.tsx
+++ b/packages/playground/src/layouts/PaddingListLayout.tsx
@@ -3,10 +3,11 @@ import { cn } from '@harnessio/canary'
 
 interface PaddingListLayoutProps {
   className?: string
+  children: React.ReactNode
 }
 
-const PaddingListLayout: React.FC<PaddingListLayoutProps> = ({ className }) => {
-  return <div className={cn('p-10', className)}></div>
+const PaddingListLayout = ({ className, children }: PaddingListLayoutProps) => {
+  return <div className={cn('pt-10 px-6 pb-16 max-w-[1200px] min-w-[770px] mx-auto', className)}>{children}</div>
 }
 
 export default PaddingListLayout

--- a/packages/playground/src/pages/execution-details-page.tsx
+++ b/packages/playground/src/pages/execution-details-page.tsx
@@ -14,9 +14,9 @@ export enum ExecutionTab {
 
 export default function ExecutionDetailsPage() {
   return (
-    <Tabs variant="underline" defaultValue={ExecutionTab.LOG} className="w-full h-full">
+    <Tabs variant="navigation" defaultValue={ExecutionTab.LOG}>
       {/* tab height */}
-      <TabsList className="h-11 flex gap-6 items-center justify-start border-solid border-b border-t px-8">
+      <TabsList>
         <TabsTrigger value={ExecutionTab.SUMMARY}>Summary</TabsTrigger>
         {/* Need to manually adjust height to make bottom border align with parent */}
         <TabsTrigger className="h-full" value={ExecutionTab.LOG}>

--- a/packages/playground/src/pages/execution-details-page.tsx
+++ b/packages/playground/src/pages/execution-details-page.tsx
@@ -16,7 +16,7 @@ export default function ExecutionDetailsPage() {
   return (
     <Tabs variant="underline" defaultValue={ExecutionTab.LOG} className="w-full h-full">
       {/* tab height */}
-      <TabsList className="h-11 flex gap-6 items-center justify-start border-solid border-b border-t">
+      <TabsList className="h-11 flex gap-6 items-center justify-start border-solid border-b border-t px-8">
         <TabsTrigger value={ExecutionTab.SUMMARY}>Summary</TabsTrigger>
         {/* Need to manually adjust height to make bottom border align with parent */}
         <TabsTrigger className="h-full" value={ExecutionTab.LOG}>

--- a/packages/playground/src/pages/execution-list-page.tsx
+++ b/packages/playground/src/pages/execution-list-page.tsx
@@ -14,6 +14,7 @@ import {
   PaginationNext
 } from '@harnessio/canary'
 import ExecutionList from '../components/execution-list'
+import PaddingListLayout from '../layouts/PaddingListLayout'
 
 const mockExecutions = [
   {
@@ -91,8 +92,8 @@ const viewOptions = [{ name: 'View option 1' }, { name: 'View option 2' }]
 
 function ExecutionListPage() {
   return (
-    // TODO: get layout componentized, this wrapper div is just for quick presentation!
-    <div className="px-16 py-16 max-w-[1200px] min-w-[770px] mx-auto">
+    //Wrapper component for padding and list layout-Jessie
+    <PaddingListLayout>
       <Text size={5} weight={'medium'}>
         Executions
       </Text>
@@ -148,7 +149,7 @@ function ExecutionListPage() {
           </PaginationContent>
         </Pagination>
       </ListPagination.Root>
-    </div>
+    </PaddingListLayout>
   )
 }
 

--- a/packages/playground/src/pages/pipeline-list-page.tsx
+++ b/packages/playground/src/pages/pipeline-list-page.tsx
@@ -15,6 +15,7 @@ import {
   PaginationNext
 } from '@harnessio/canary'
 import PipelineList from '../components/pipeline-list'
+import PaddingListLayout from '../layouts/PaddingListLayout'
 
 const mockPipelines = [
   {
@@ -98,8 +99,8 @@ const viewOptions = [{ name: 'View option 1' }, { name: 'View option 2' }]
 
 function PipelineListPage() {
   return (
-    // TODO: get layout componentized, this wrapper div is just for quick presentation!
-    <div className="px-16 py-16 max-w-[1200px] min-w-[770px] mx-auto">
+    //Wrapper component for padding and list layout-Jessie
+    <PaddingListLayout>
       <Text size={5} weight={'medium'}>
         Pipelines
       </Text>
@@ -156,7 +157,7 @@ function PipelineListPage() {
           </PaginationContent>
         </Pagination>
       </ListPagination.Root>
-    </div>
+    </PaddingListLayout>
   )
 }
 

--- a/packages/playground/src/pages/pull-request-list-page.tsx
+++ b/packages/playground/src/pages/pull-request-list-page.tsx
@@ -10,10 +10,11 @@ import {
   Icon,
   StackedList
 } from '@harnessio/canary'
+import PaddingListLayout from '../layouts/PaddingListLayout'
 
 function PullRequestListPage() {
   return (
-    <div className="w-full max-w-[860px] min-h-full mx-auto px-5 py-5 mb-16">
+    <PaddingListLayout className="max-w-[860px]">
       <StackedList.Root className="border-none">
         <div className="flex">
           <div className="grid w-full grid-flow-col grid-cols-1 auto-cols-auto items-center gap-0">
@@ -65,7 +66,7 @@ function PullRequestListPage() {
           <PullRequestList />
         </div>
       </StackedList.Root>
-    </div>
+    </PaddingListLayout>
   )
 }
 

--- a/packages/playground/src/pages/repo-execution-list-page.tsx
+++ b/packages/playground/src/pages/repo-execution-list-page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@harnessio/canary'
 import ExecutionList from '../components/execution-list'
 import { Link } from 'react-router-dom'
+import PaddingListLayout from '../layouts/PaddingListLayout'
 
 const mockExecutions = [
   {
@@ -92,8 +93,8 @@ const viewOptions = [{ name: 'View option 1' }, { name: 'View option 2' }]
 
 function RepoExecutionListPage() {
   return (
-    // TODO: get layout componentized, this wrapper div is just for quick presentation!
-    <div className="px-6 pb-16 max-w-[1200px] min-w-[770px] mx-auto">
+    //Wrapper component for padding and list layout-Jessie
+    <PaddingListLayout>
       <ListActions.Root>
         <ListActions.Left>
           <SearchBox.Root placeholder="Search" />
@@ -148,7 +149,7 @@ function RepoExecutionListPage() {
           </PaginationContent>
         </Pagination>
       </ListPagination.Root>
-    </div>
+    </PaddingListLayout>
   )
 }
 

--- a/packages/playground/src/pages/repo-pipeline-list-page.tsx
+++ b/packages/playground/src/pages/repo-pipeline-list-page.tsx
@@ -14,6 +14,7 @@ import {
   PaginationNext
 } from '@harnessio/canary'
 import PipelineList from '../components/pipeline-list'
+import PaddingListLayout from '../layouts/PaddingListLayout'
 
 const mockPipelines = [
   {
@@ -97,8 +98,8 @@ const viewOptions = [{ name: 'View option 1' }, { name: 'View option 2' }]
 
 function RepoPipelineListPage() {
   return (
-    // TODO: get layout componentized, this wrapper div is just for quick presentation!
-    <div className="px-6 pb-16 max-w-[1200px] min-w-[770px] mx-auto">
+    //Wrapper component for padding and list layout-Jessie
+    <PaddingListLayout>
       <ListActions.Root>
         <ListActions.Left>
           <SearchBox.Root placeholder="Search" />
@@ -151,7 +152,7 @@ function RepoPipelineListPage() {
           </PaginationContent>
         </Pagination>
       </ListPagination.Root>
-    </div>
+    </PaddingListLayout>
   )
 }
 


### PR DESCRIPTION
Add reusable layout wrapper for each list page 

- Create PaddingLayout Component
- Wrapping list page as below: execution-list-page, pipeline-list-page, repo-execution-list, repo-pipeline-list, pull-request-list
