### PR TITLE
Fix controls on Pipeline Studio

### DIFF
--- a/packages/unified-pipeline/src/components/Canvas/Canvas.tsx
+++ b/packages/unified-pipeline/src/components/Canvas/Canvas.tsx
@@ -155,7 +155,7 @@ const CanvasInternal = (props: CanvasProps) => {
         proOptions={{ hideAttribution: true }}
         /* https://github.com/xyflow/xyflow/discussions/2827 */
         nodeOrigin={[0.5, 0.5]}>
-        <Controls position="bottom-right">
+        <Controls position="bottom-right" showFitView={false} showInteractive={false}>
           {process.env.NODE_ENV !== 'production' && (
             <>
               <ControlButton

--- a/packages/unified-pipeline/src/components/Canvas/Canvas.tsx
+++ b/packages/unified-pipeline/src/components/Canvas/Canvas.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react'
-import cx from 'classnames'
 import ReactFlow, {
   Controls,
   ReactFlowProvider,
@@ -156,7 +155,7 @@ const CanvasInternal = (props: CanvasProps) => {
         proOptions={{ hideAttribution: true }}
         /* https://github.com/xyflow/xyflow/discussions/2827 */
         nodeOrigin={[0.5, 0.5]}>
-        <Controls>
+        <Controls position="bottom-right">
           {process.env.NODE_ENV !== 'production' && (
             <>
               <ControlButton


### PR DESCRIPTION
- Changes the position of Controls to Bottom right
- Hides controls other than zoom in/out.