### PR TITLE
Execution output log page

### DIFF
--- a/packages/playground/src/components/execution/key-value-table.tsx
+++ b/packages/playground/src/components/execution/key-value-table.tsx
@@ -42,13 +42,13 @@ export const KeyValueTable: React.FC<KeyValueTableProps> = ({
     return listItems.map((item, index: number) => {
       if (typeof item.value === 'string') {
         return (
-          <ul className="border-b flex flex-row align-middle" key={index} style={{ paddingLeft: `${level / 2}rem` }}>
-            <li className="pr-2.5 py-2.5 w-1/2 text-studio-7" style={{ paddingLeft: `${level * 1 + 1}rem` }}>
+          <ul className="border-b flex flex-row align-middle" key={index}>
+            <li className="pr-2.5 py-2.5 w-1/2 text-studio-7" style={{ paddingLeft: `${level + 1}rem` }}>
               <Text size={2} weight="normal">
                 {item.name}
               </Text>
             </li>
-            <li className="pr-2.5 py-2.5 w-1/2 text-studio-7">
+            <li className="pl-2 pr-2.5 py-2.5 w-1/2 text-studio-7">
               <Text size={2} weight="normal">
                 {item.value}
               </Text>
@@ -63,7 +63,7 @@ export const KeyValueTable: React.FC<KeyValueTableProps> = ({
                 className="w-full pt-2 pb-2 pr-4 flex gap-1"
                 leftChevron
                 style={{
-                  paddingLeft: `${level * 1 + 1}rem`
+                  paddingLeft: `${level + 1}rem`
                 }}>
                 <Text size={2} weight="normal" className={specTitleStyle}>
                   {item.name}

--- a/packages/playground/src/components/execution/key-value-table.tsx
+++ b/packages/playground/src/components/execution/key-value-table.tsx
@@ -48,7 +48,7 @@ export const KeyValueTable: React.FC<KeyValueTableProps> = ({
                 {item.name}
               </Text>
             </li>
-            <li className="pl-2 pr-2.5 py-2.5 w-1/2 text-studio-7">
+            <li className="pl-1.5 pr-2.5 py-2.5 w-1/2 text-studio-7">
               <Text size={2} weight="normal">
                 {item.value}
               </Text>
@@ -60,7 +60,7 @@ export const KeyValueTable: React.FC<KeyValueTableProps> = ({
           <Accordion type="single" key={index} className="border-0" defaultValue={item.name} collapsible>
             <AccordionItem value={item.name} className="border-0">
               <AccordionTrigger
-                className="w-full pt-2 pb-2 pr-4 flex gap-1"
+                className="w-full py-2.5 pr-4 flex gap-1"
                 leftChevron
                 style={{
                   paddingLeft: `${level + 1}rem`
@@ -85,12 +85,12 @@ export const KeyValueTable: React.FC<KeyValueTableProps> = ({
       if (typeof item.value === 'string') {
         return (
           <TableRow key={index} className="border-b">
-            <TableCell className="pt-2.5 pl-4 w-1/2">
+            <TableCell className="py-2.5 pl-5 w-1/2">
               <Text size={2} weight="normal" className="text-studio-7">
                 {item.name}
               </Text>
             </TableCell>
-            <TableCell className="pt-2.5 w-1/2">
+            <TableCell className="py-2.5 w-1/2">
               <Text size={2} weight="normal" className="text-studio-7">
                 {item.value}
               </Text>
@@ -104,7 +104,7 @@ export const KeyValueTable: React.FC<KeyValueTableProps> = ({
               <Accordion type="single" collapsible defaultValue={item.name}>
                 <AccordionItem value={item.name} className="border-0">
                   <AccordionTrigger
-                    className="w-full pt-2 pb-2 pl-4 flex pr-4 gap-1 data-[state=open]:border-b-0 data-[state=closed]:border-b"
+                    className="w-full py-2.5 pl-4 flex pr-4 gap-1 data-[state=open]:border-b-0 data-[state=closed]:border-b"
                     leftChevron>
                     <Text size={2} weight="normal" className={specTitleStyle}>
                       {item.name}
@@ -122,24 +122,22 @@ export const KeyValueTable: React.FC<KeyValueTableProps> = ({
   }
 
   return (
-    <div className="overflow-x-auto pt-4">
-      <Table className={className}>
-        <TableHeader>
-          <TableRow>
-            <TableHead>
-              <Text size={2} weight="semibold" className="text-primary">
-                {tableTitleName}
-              </Text>
-            </TableHead>
-            <TableHead>
-              <Text size={2} weight="semibold" className="text-primary">
-                {tableTitleVal}
-              </Text>
-            </TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>{Array.isArray(tableSpec) && renderTableRows(tableSpec)}</TableBody>
-      </Table>
-    </div>
+    <Table className={className}>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="py-3">
+            <Text size={2} weight="semibold" className="text-primary">
+              {tableTitleName}
+            </Text>
+          </TableHead>
+          <TableHead className="py-3">
+            <Text size={2} weight="semibold" className="text-primary">
+              {tableTitleVal}
+            </Text>
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>{Array.isArray(tableSpec) && renderTableRows(tableSpec)}</TableBody>
+    </Table>
   )
 }

--- a/packages/playground/src/components/execution/step-execution.tsx
+++ b/packages/playground/src/components/execution/step-execution.tsx
@@ -11,6 +11,8 @@ import { KeyValueTable } from './key-value-table'
 export interface StepProps {
   input: []
   inputTitle: { name: string; value: string }
+  output: []
+  outputTitle: { name: string; value: string }
   name: string
   status: ExecutionState
   started?: number
@@ -49,7 +51,7 @@ const StepExecutionToolbar: React.FC = () => {
 
 export const StepExecution: React.FC<StageExecutionProps> = ({ step, stepIndex }) => {
   const inputTable = step.input
-  const { name, value } = step.inputTitle
+  const outputTable = step.output
   return (
     <Layout.Vertical>
       <Layout.Horizontal className="flex justify-between items-center">
@@ -76,7 +78,21 @@ export const StepExecution: React.FC<StageExecutionProps> = ({ step, stepIndex }
           <TabsContent value={StepExecutionTab.INPUT}>
             {/*here is the execution details of input table */}
             <ScrollArea className="h-[calc(100vh-23rem)] border-t pt-4">
-              <KeyValueTable tableSpec={inputTable} tableTitleName={name} tableTitleVal={value} />
+              <KeyValueTable
+                tableSpec={inputTable}
+                tableTitleName={step.inputTitle.name}
+                tableTitleVal={step.inputTitle.value}
+              />
+            </ScrollArea>
+          </TabsContent>
+          <TabsContent value={StepExecutionTab.OUTPUT}>
+            {/*here is the execution details of input table */}
+            <ScrollArea className="h-[calc(100vh-23rem)] border-t pt-4">
+              <KeyValueTable
+                tableSpec={outputTable}
+                tableTitleName={step.outputTitle.name}
+                tableTitleVal={step.outputTitle.value}
+              />
             </ScrollArea>
           </TabsContent>
         </Layout.Vertical>

--- a/packages/playground/src/components/execution/step-execution.tsx
+++ b/packages/playground/src/components/execution/step-execution.tsx
@@ -79,6 +79,7 @@ export const StepExecution: React.FC<StageExecutionProps> = ({ step, stepIndex }
             {/*here is the execution details of input table */}
             <ScrollArea className="h-[calc(100vh-23rem)] border-t pt-4">
               <KeyValueTable
+                className="pt-2"
                 tableSpec={inputTable}
                 tableTitleName={step.inputTitle.name}
                 tableTitleVal={step.inputTitle.value}
@@ -89,6 +90,7 @@ export const StepExecution: React.FC<StageExecutionProps> = ({ step, stepIndex }
             {/*here is the execution details of output table */}
             <ScrollArea className="h-[calc(100vh-23rem)] border-t pt-4">
               <KeyValueTable
+                className="pt-2"
                 tableSpec={outputTable}
                 tableTitleName={step.outputTitle.name}
                 tableTitleVal={step.outputTitle.value}

--- a/packages/playground/src/components/execution/step-execution.tsx
+++ b/packages/playground/src/components/execution/step-execution.tsx
@@ -86,7 +86,7 @@ export const StepExecution: React.FC<StageExecutionProps> = ({ step, stepIndex }
             </ScrollArea>
           </TabsContent>
           <TabsContent value={StepExecutionTab.OUTPUT}>
-            {/*here is the execution details of input table */}
+            {/*here is the execution details of output table */}
             <ScrollArea className="h-[calc(100vh-23rem)] border-t pt-4">
               <KeyValueTable
                 tableSpec={outputTable}

--- a/packages/playground/src/pages/mocks/execution/mockExecution.ts
+++ b/packages/playground/src/pages/mocks/execution/mockExecution.ts
@@ -165,107 +165,107 @@ export const data = {
           ],
           output: [
             {
-              name: '21212',
-              value: 'Input Value'
+              name: '12345',
+              value: 'Output Value'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
             },
             {
               name: 'spec',
               value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
                 {
                   name: 'instance selection',
                   value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
+                    { name: 'type', value: 'Fixed' },
+                    { name: 'type', value: 'Fixed' }
                   ]
                 },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
+                { name: 'spec', value: { name: 'percentage', value: '10' } },
+                { name: 'skipDryRun', value: 'true' },
+                { name: 'delegate selectors', value: 'value2' }
               ]
             }
           ]
@@ -396,107 +396,107 @@ export const data = {
           ],
           output: [
             {
-              name: '21212',
-              value: 'Input Value'
+              name: '12345',
+              value: 'Output Value'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
             },
             {
               name: 'spec',
               value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
                 {
                   name: 'instance selection',
                   value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
+                    { name: 'type', value: 'Fixed' },
+                    { name: 'type', value: 'Fixed' }
                   ]
                 },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
+                { name: 'spec', value: { name: 'percentage', value: '10' } },
+                { name: 'skipDryRun', value: 'true' },
+                { name: 'delegate selectors', value: 'value2' }
               ]
             }
           ]
@@ -873,107 +873,107 @@ export const data = {
           ],
           output: [
             {
-              name: '21212',
-              value: 'Input Value'
+              name: '12345',
+              value: 'Output Value'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
             },
             {
               name: 'spec',
               value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
                 {
                   name: 'instance selection',
                   value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
+                    { name: 'type', value: 'Fixed' },
+                    { name: 'type', value: 'Fixed' }
                   ]
                 },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
+                { name: 'spec', value: { name: 'percentage', value: '10' } },
+                { name: 'skipDryRun', value: 'true' },
+                { name: 'delegate selectors', value: 'value2' }
               ]
             }
           ]
@@ -1104,107 +1104,107 @@ export const data = {
           ],
           output: [
             {
-              name: '21212',
-              value: 'Input Value'
+              name: '12345',
+              value: 'Output Value'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
             },
             {
               name: 'spec',
               value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
                 {
                   name: 'instance selection',
                   value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
+                    { name: 'type', value: 'Fixed' },
+                    { name: 'type', value: 'Fixed' }
                   ]
                 },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
+                { name: 'spec', value: { name: 'percentage', value: '10' } },
+                { name: 'skipDryRun', value: 'true' },
+                { name: 'delegate selectors', value: 'value2' }
               ]
             }
           ]
@@ -1335,107 +1335,107 @@ export const data = {
           ],
           output: [
             {
-              name: '21212',
-              value: 'Input Value'
+              name: '12345',
+              value: 'Output Value'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'identifier',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'name',
-              value: 'canaryDeployment'
+              value: 'blueGreenDeployment'
             },
             {
               name: 'timeout',
-              value: '10m'
+              value: '15m'
             },
             {
               name: 'type',
-              value: 'K8sCanaryDeploy'
+              value: 'K8sBlueGreenDeploy'
             },
             {
               name: 'type',
-              value: 'percentage'
+              value: 'rolling'
             },
             {
               name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
             },
             {
               name: 'spec',
               value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
                 {
                   name: 'instance selection',
                   value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
+                    { name: 'type', value: 'Fixed' },
+                    { name: 'type', value: 'Fixed' }
                   ]
                 },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
+                { name: 'spec', value: { name: 'percentage', value: '10' } },
+                { name: 'skipDryRun', value: 'true' },
+                { name: 'delegate selectors', value: 'value2' }
               ]
             }
           ]

--- a/packages/playground/src/pages/mocks/execution/mockExecution.ts
+++ b/packages/playground/src/pages/mocks/execution/mockExecution.ts
@@ -53,6 +53,10 @@ export const data = {
             name: 'Input Name',
             value: 'Input Value'
           },
+          outputTitle: {
+            name: 'Output Name',
+            value: 'Output Value'
+          },
           input: [
             {
               name: '21212',
@@ -159,7 +163,112 @@ export const data = {
               ]
             }
           ],
-          outout: []
+          output: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: { name: 'percentage', value: '5' } },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ]
         },
         {
           number: 2,
@@ -175,127 +284,9 @@ export const data = {
             name: 'Input Name',
             value: 'Input Value'
           },
-          input: [
-            {
-              name: '21212',
-              value: 'Input Value'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-            },
-            {
-              name: 'spec',
-              value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-                {
-                  name: 'instance selection',
-                  value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
-                  ]
-                },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
-              ]
-            }
-          ],
-          outout: []
-        },
-        {
-          number: 3,
-          name: 'Checkmarx',
-          status: ExecutionState.SUCCESS,
-          exit_code: 0,
-          started: 1722296944000,
-          stopped: 1722296949000,
-          depends_on: ['clone'],
-          image: 'docker.io/library/alpine:latest',
-          detached: false,
-          inputTitle: {
-            name: 'Input Name',
-            value: 'Input Value'
+          outputTitle: {
+            name: 'Output Name',
+            value: 'Output Value'
           },
           input: [
             {
@@ -403,7 +394,343 @@ export const data = {
               ]
             }
           ],
-          outout: []
+          output: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: { name: 'percentage', value: '5' } },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ]
+        },
+        {
+          number: 3,
+          name: 'Checkmarx',
+          status: ExecutionState.SUCCESS,
+          exit_code: 0,
+          started: 1722296944000,
+          stopped: 1722296949000,
+          depends_on: ['clone'],
+          image: 'docker.io/library/alpine:latest',
+          detached: false,
+          inputTitle: {
+            name: 'Input Name',
+            value: 'Input Value'
+          },
+          outputTitle: {
+            name: 'Output Name',
+            value: 'Output Value'
+          },
+          input: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: { name: 'percentage', value: '5' } },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ],
+          output: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: { name: 'percentage', value: '5' } },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -434,6 +761,10 @@ export const data = {
             name: 'Input Name',
             value: 'Input Value'
           },
+          outputTitle: {
+            name: 'Output Name',
+            value: 'Output Value'
+          },
           input: [
             {
               name: '21212',
@@ -522,9 +853,130 @@ export const data = {
             {
               name: 'spec',
               value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: { name: 'percentage', value: '5' } },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
             }
           ],
-          output: []
+          output: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: { name: 'percentage', value: '5' } },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ]
         },
         {
           number: 2,
@@ -540,111 +992,9 @@ export const data = {
             name: 'Input Name',
             value: 'Input Value'
           },
-          input: [
-            {
-              name: '21212',
-              value: 'Input Value'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-            }
-          ],
-          output: []
-        },
-        {
-          number: 3,
-          name: 'Canary Deployment',
-          status: ExecutionState.SKIPPED,
-          exit_code: 0,
-          started: 1722296944000,
-          stopped: 1722296944000,
-          depends_on: ['clone'],
-          image: 'docker.io/library/alpine:latest',
-          detached: false,
-          inputTitle: {
-            name: 'Input Name',
-            value: 'Input Value'
+          outputTitle: {
+            name: 'Output Name',
+            value: 'Output Value'
           },
           input: [
             {
@@ -734,9 +1084,361 @@ export const data = {
             {
               name: 'spec',
               value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: { name: 'percentage', value: '5' } },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
             }
           ],
-          output: []
+          output: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: { name: 'percentage', value: '5' } },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ]
+        },
+        {
+          number: 3,
+          name: 'Canary Deployment',
+          status: ExecutionState.SKIPPED,
+          exit_code: 0,
+          started: 1722296944000,
+          stopped: 1722296944000,
+          depends_on: ['clone'],
+          image: 'docker.io/library/alpine:latest',
+          detached: false,
+          inputTitle: {
+            name: 'Input Name',
+            value: 'Input Value'
+          },
+          outputTitle: {
+            name: 'Output Name',
+            value: 'Output Value'
+          },
+          input: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: { name: 'percentage', value: '5' } },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ],
+          output: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: { name: 'percentage', value: '5' } },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
- added output data for execution output page
- removed unnecessary wrapper <div>
- fixed the parent padding that caused the padding of children moving right
- aligned the same children in the same level of the padding(called padding h*ll)
- added keyValueTable in the execution output page
<img width="714" alt="Screenshot 2024-09-04 at 2 14 54 PM" src="https://github.com/user-attachments/assets/2e5ab2cd-a990-4d1f-9cfd-6a98104834b6">
<img width="908" alt="Screenshot 2024-09-04 at 3 46 39 PM" src="https://github.com/user-attachments/assets/79e1fd22-80cd-4943-ab69-41715a39e1a6">
<img width="1723" alt="Screenshot 2024-09-04 at 4 07 45 PM" src="https://github.com/user-attachments/assets/42f0da3e-5391-4971-a681-45a55e86fc32">
