### PR TITLE
Proposal: Map Figma variables to canary theme

### DIFF
--- a/packages/canary/package.json
+++ b/packages/canary/package.json
@@ -107,6 +107,7 @@
     "jest": "^29.7.0",
     "lodash-es": "^4.17.21",
     "npm-run-all": "^4.1.5",
+    "postcss-import": "^16.1.0",
     "prop-types": "^15.8.1",
     "tailwindcss": "^3.4.4",
     "vite": "^5.3.1",

--- a/packages/canary/postcss.config.js
+++ b/packages/canary/postcss.config.js
@@ -1,5 +1,6 @@
 export default {
   plugins: {
+    'postcss-import': {},
     tailwindcss: {},
     autoprefixer: {},
   },

--- a/packages/canary/src/styles.css
+++ b/packages/canary/src/styles.css
@@ -1,6 +1,9 @@
+@import "./theme/theme.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
 
 @font-face {
   font-family: 'Inter';
@@ -9,8 +12,9 @@
   src: url('/fonts/InterVariable.ttf') format('truetype');
 }
 
+/*
 :root {
-  /* PP Figma shades */
+  PP Figma shades
   --black: 240 10% 3%;
   --grey-6: 240 8% 6%;
   --grey-8: 240 7% 8%;
@@ -29,7 +33,7 @@
   --grey-98: 240 6% 98%;
   --white: 0 0% 100%;
 
-  /* PP Figma secondary colors */
+  PP Figma secondary colors
   --mint: 175 60% 65%;
   --blue: 216 80% 65%;
   --orange: 35, 75%, 55%;
@@ -39,7 +43,8 @@
 }
 
 @layer themes {
-  /* TODO: replace hsl with variables for theming */
+
+  TODO: replace hsl with variables for theming
   :root {
     --background: 0 0% 100%;
     --foreground: 240 10% 3.9%;
@@ -111,6 +116,7 @@
     --ai: var(--purple);
   }
 }
+*/
 
 @layer base {
   * {

--- a/packages/canary/src/theme/theme.css
+++ b/packages/canary/src/theme/theme.css
@@ -1,0 +1,212 @@
+:root {
+  --figma___colors-default-dark-to-white: 240 13% 3% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Light */
+  --figma___colors-default-white-to-dark: 0 0% 100% / 1;
+  /* ✦ Theme/Colors/Default/White-to-dark/Harness Open Source/Light */
+  --figma___semantic-background-cards-and-rows-default: 0 0% 100% / 0;
+  /* ✦ Theme/Semantic/Background/Cards and Rows/Default/Harness Open Source/Light */
+  --figma___colors-default-dark-to-white: 240 13% 3% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Light */
+  --figma___semantic-background-cards-and-rows-default: 0 0% 100% / 0;
+  /* ✦ Theme/Semantic/Background/Cards and Rows/Default/Harness Open Source/Light */
+  --figma___colors-default-dark-to-white: 240 13% 3% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-7: 200 7% 8% / 1;
+  /* ✦ Theme/Colors/Primary/Primary Accent/7/Harness Open Source/Light */
+  --figma___colors-default-white-to-dark: 0 0% 100% / 1;
+  /* ✦ Theme/Colors/Default/White-to-dark/Harness Open Source/Light */
+  --figma___semantic-text-primary: 200 7% 8% / 1;
+  /* ✦ Theme/Semantic/Text/primary/Harness Open Source/Light */
+  --figma___colors-secondary-teal-7: 173 80% 36% / 1;
+  /* ✦ Theme/Colors/Secondary/Teal/7/Harness Open Source/Light */
+  --figma___colors-default-dark-to-white: 240 13% 3% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Light */
+  --figma___semantic-background-paper: 0 0% 98% / 1;
+  /* ✦ Theme/Semantic/Background/Paper/Harness Open Source/Light */
+  --figma___colors-secondary-teal-7: 173 80% 36% / 1;
+  /* ✦ Theme/Colors/Secondary/Teal/7/Harness Open Source/Light */
+  --figma___colors-default-dark-to-white: 240 13% 3% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Light */
+  --figma___semantic-background-backdrop: 230 100% 9% / 0.28;
+  /* ✦ Theme/Semantic/Background/Backdrop/Harness Open Source/Light */
+  --figma___colors-secondary-teal-7: 173 80% 36% / 1;
+  /* ✦ Theme/Colors/Secondary/Teal/7/Harness Open Source/Light */
+  --figma___colors-default-dark-to-white: 240 13% 3% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Light */
+  --figma___component-dropdown-dropdown-item-default: 0 0% 100% / 0;
+  /* ✦ Theme/Component/Dropdown/Dropdown Item/Default/Harness Open Source/Light */
+  --figma___colors-default-dark-to-white: 240 13% 3% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-7: 0 80% 65% / 1;
+  /* ✦ Theme/Colors/Alerts & Status/Error/7/Harness Open Source/Light */
+  --figma___colors-default-dark-to-white: 240 13% 3% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Light */
+  --figma___semantic-border-primary: 240 7% 94% / 1;
+  /* ✦ Theme/Semantic/Border/Primary/Harness Open Source/Light */
+  --figma___semantic-border-primary: 240 7% 94% / 1;
+  /* ✦ Theme/Semantic/Border/Primary/Harness Open Source/Light */
+  --figma___colors-primary-primary-accent-7: 200 7% 8% / 1;
+  /* ✦ Theme/Colors/Primary/Primary Accent/7/Harness Open Source/Light */
+  --figma___colors-alerts-status-success-7: 142 72% 29% / 1;
+  /* ✦ Theme/Colors/Alerts & Status/Success/7/Harness Open Source/Light */
+  --figma___colors-alerts-status-error-7: 0 80% 65% / 1;
+  /* ✦ Theme/Colors/Alerts & Status/Error/7/Harness Open Source/Light */
+  --figma___colors-alerts-status-warning-7: 42 100% 62% / 1;
+  /* ✦ Theme/Colors/Alerts & Status/Warning/7/Harness Open Source/Light */
+  --figma___colors-charts-ai-violet-7: 252 56% 57% / 1;
+  /* ✦ Theme/Colors/Charts/AI Violet/7/Harness Open Source/Light */
+
+  --figma___radius-1: 3px;
+  /* ✦ Theme/Radius/1/Harness Open Source/Mode 1 */
+  --figma___radius-2: 4px;
+  /* ✦ Theme/Radius/2/Harness Open Source/Mode 1 */
+  --figma___radius-3: 6px;
+  /* ✦ Theme/Radius/3/Harness Open Source/Mode 1 */
+  --figma___radius-4: 8px;
+  /* ✦ Theme/Radius/4/Harness Open Source/Mode 1 */
+  --figma___radius-full: 9999px;
+  /* ✦ Theme/Radius/full/Harness Open Source/Mode 1 */
+  --figma___space-1: 4px;
+  /* ✦ Theme/Space/1/Harness Open Source/Mode 1 */
+  --figma___space-2: 8px;
+  /* ✦ Theme/Space/2/Harness Open Source/Mode 1 */
+  --figma___space-3: 12px;
+  /* ✦ Theme/Space/3/Harness Open Source/Mode 1 */
+  --figma___space-4: 16px;
+  /* ✦ Theme/Space/4/Harness Open Source/Mode 1 */
+  --figma___space-5: 24px;
+  /* ✦ Theme/Space/5/Harness Open Source/Mode 1 */
+  --figma___space-6: 32px;
+  /* ✦ Theme/Space/6/Harness Open Source/Mode 1 */
+  --figma___space-7: 40px;
+  /* ✦ Theme/Space/7/Harness Open Source/Mode 1 */
+  --figma___space-8: 48px;
+  /* ✦ Theme/Space/8/Harness Open Source/Mode 1 */
+  --figma___space-9: 64px;
+  /* ✦ Theme/Space/9/Harness Open Source/Mode 1 */
+}
+
+.dark {
+  --figma___colors-default-dark-to-white: 0 0% 100% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Dark */
+  --figma___colors-default-white-to-dark: 240 13% 3% / 1;
+  /* ✦ Theme/Colors/Default/White-to-dark/Harness Open Source/Dark */
+  --figma___semantic-background-cards-and-rows-default: 240 5% 12% / 0;
+  /* ✦ Theme/Semantic/Background/Cards and Rows/Default/Harness Open Source/Dark */
+  --figma___colors-default-dark-to-white: 0 0% 100% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Dark */
+  --figma___semantic-background-cards-and-rows-default: 240 5% 12% / 0;
+  /* ✦ Theme/Semantic/Background/Cards and Rows/Default/Harness Open Source/Dark */
+  --figma___colors-default-dark-to-white: 0 0% 100% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-7: 0 0% 98% / 1;
+  /* ✦ Theme/Colors/Primary/Primary Accent/7/Harness Open Source/Dark */
+  --figma___colors-default-white-to-dark: 240 13% 3% / 1;
+  /* ✦ Theme/Colors/Default/White-to-dark/Harness Open Source/Dark */
+  --figma___semantic-text-primary: 0 0% 98% / 1;
+  /* ✦ Theme/Semantic/Text/primary/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-7: 173 80% 36% / 1;
+  /* ✦ Theme/Colors/Secondary/Teal/7/Harness Open Source/Dark */
+  --figma___colors-default-dark-to-white: 0 0% 100% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Dark */
+  --figma___semantic-background-paper: 210 6% 6% / 1;
+  /* ✦ Theme/Semantic/Background/Paper/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-7: 173 80% 36% / 1;
+  /* ✦ Theme/Colors/Secondary/Teal/7/Harness Open Source/Dark */
+  --figma___colors-default-dark-to-white: 0 0% 100% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Dark */
+  --figma___semantic-background-backdrop: 0 0% 0% / 0.75;
+  /* ✦ Theme/Semantic/Background/Backdrop/Harness Open Source/Dark */
+  --figma___colors-secondary-teal-7: 173 80% 36% / 1;
+  /* ✦ Theme/Colors/Secondary/Teal/7/Harness Open Source/Dark */
+  --figma___colors-default-dark-to-white: 0 0% 100% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Dark */
+  --figma___component-dropdown-dropdown-item-default: 0 0% 100% / 0;
+  /* ✦ Theme/Component/Dropdown/Dropdown Item/Default/Harness Open Source/Dark */
+  --figma___colors-default-dark-to-white: 0 0% 100% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-7: 0 80% 65% / 1;
+  /* ✦ Theme/Colors/Alerts & Status/Error/7/Harness Open Source/Dark */
+  --figma___colors-default-dark-to-white: 0 0% 100% / 1;
+  /* ✦ Theme/Colors/Default/Dark-to-white/Harness Open Source/Dark */
+  --figma___semantic-border-primary: 240 6% 10% / 1;
+  /* ✦ Theme/Semantic/Border/Primary/Harness Open Source/Dark */
+  --figma___semantic-border-primary: 240 6% 10% / 1;
+  /* ✦ Theme/Semantic/Border/Primary/Harness Open Source/Dark */
+  --figma___colors-primary-primary-accent-7: 0 0% 98% / 1;
+  /* ✦ Theme/Colors/Primary/Primary Accent/7/Harness Open Source/Dark */
+  --figma___colors-alerts-status-success-7: 142 72% 29% / 1;
+  /* ✦ Theme/Colors/Alerts & Status/Success/7/Harness Open Source/Dark */
+  --figma___colors-alerts-status-error-7: 0 80% 65% / 1;
+  /* ✦ Theme/Colors/Alerts & Status/Error/7/Harness Open Source/Dark */
+  --figma___colors-alerts-status-warning-7: 42 100% 62% / 1;
+  /* ✦ Theme/Colors/Alerts & Status/Warning/7/Harness Open Source/Dark */
+  --figma___colors-charts-ai-violet-7: 252 56% 57% / 1;
+  /* ✦ Theme/Colors/Charts/AI Violet/7/Harness Open Source/Dark */
+}
+
+@layer themes {
+  :root {
+    --background: var(--figma___colors-default-dark-to-white);
+    --foreground: var(--figma___colors-default-white-to-dark);
+    --card: var(--figma___semantic-background-cards-and-rows-default);
+    --card-foreground: var(--figma___colors-default-dark-to-white);
+    --popover: var(--figma___semantic-background-cards-and-rows-default);
+    --popover-foreground: var(--figma___colors-default-dark-to-white);
+    --primary: var(--figma___colors-primary-primary-accent-7);
+    --primary-background: var(--figma___colors-default-white-to-dark);
+    --primary-foreground: var(--figma___semantic-text-primary);
+    --secondary: var(--figma___colors-secondary-teal-7);
+    --secondary-foreground: var(--figma___colors-default-dark-to-white);
+    --secondary-background: var(--figma___semantic-background-paper);
+    --tertiary: var(--figma___colors-secondary-teal-7);
+    --tertiary-foreground: var(--figma___colors-default-dark-to-white);
+    --tertiary-background: var(--figma___semantic-background-backdrop);
+    --muted: var(--figma___colors-secondary-teal-7);
+    --muted-foreground: var(--figma___colors-default-dark-to-white);
+    --accent: var(--figma___component-dropdown-dropdown-item-default);
+    --accent-foreground: var(--figma___colors-default-dark-to-white);
+    --destructive: var(--figma___colors-alerts-status-error-7);
+    --destructive-foreground: var(--figma___colors-default-dark-to-white);
+    --border: var(--figma___semantic-border-primary);
+    --input: var(--figma___semantic-border-primary);
+    --ring: var(--figma___colors-primary-primary-accent-7);
+    --success: var(--figma___colors-alerts-status-success-7);
+    --error: var(--figma___colors-alerts-status-error-7);
+    --warning: var(--figma___colors-alerts-status-warning-7);
+    --ai: var(--figma___colors-charts-ai-violet-7);
+    --radius: var(--figma___radius-4);
+  }
+
+  .dark {
+    --background: var(--figma___colors-default-dark-to-white);
+    --foreground: var(--figma___colors-default-white-to-dark);
+    --card: var(--figma___semantic-background-cards-and-rows-default);
+    --card-foreground: var(--figma___colors-default-dark-to-white);
+    --popover: var(--figma___semantic-background-cards-and-rows-default);
+    --popover-foreground: var(--figma___colors-default-dark-to-white);
+    --primary: var(--figma___colors-primary-primary-accent-7);
+    --primary-background: var(--figma___colors-default-white-to-dark);
+    --primary-foreground: var(--figma___semantic-text-primary);
+    --secondary: var(--figma___colors-secondary-teal-7);
+    --secondary-foreground: var(--figma___colors-default-dark-to-white);
+    --secondary-background: var(--figma___semantic-background-paper);
+    --tertiary: var(--figma___colors-secondary-teal-7);
+    --tertiary-foreground: var(--figma___colors-default-dark-to-white);
+    --tertiary-background: var(--figma___semantic-background-backdrop);
+    --muted: var(--figma___colors-secondary-teal-7);
+    --muted-foreground: var(--figma___colors-default-dark-to-white);
+    --accent: var(--figma___component-dropdown-dropdown-item-default);
+    --accent-foreground: var(--figma___colors-default-dark-to-white);
+    --destructive: var(--figma___colors-alerts-status-error-7);
+    --destructive-foreground: var(--figma___colors-default-dark-to-white);
+    --border: var(--figma___semantic-border-primary);
+    --input: var(--figma___semantic-border-primary);
+    --ring: var(--figma___colors-primary-primary-accent-7);
+    --success: var(--figma___colors-alerts-status-success-7);
+    --error: var(--figma___colors-alerts-status-error-7);
+    --warning: var(--figma___colors-alerts-status-warning-7);
+    --ai: var(--figma___colors-charts-ai-violet-7);
+    --radius: var(--figma___radius-4);
+  }
+}

--- a/packages/canary/tailwind.config.js
+++ b/packages/canary/tailwind.config.js
@@ -1,4 +1,5 @@
 /** @type {import('tailwindcss').Config} */
+
 // eslint-disable-next-line no-undef
 module.exports = {
   darkMode: ['class'],
@@ -13,6 +14,13 @@ module.exports = {
       }
     },
     extend: {
+      rounded: {
+        sm: "var(--figma___radius-1)",
+        DEFAULT: "var(--figma___radius-2)",
+        md: "var(--figma___radius-3)",
+        lg: "var(--figma___radius-4)",
+        full: "var(--figma___radius-full)"
+      },
       fontFamily: {
         sans: ['Inter', 'sans-serif']
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      postcss-import:
+        specifier: ^16.1.0
+        version: 16.1.0(postcss@8.4.41)
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -7772,6 +7775,12 @@ packages:
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-import@16.1.0:
+    resolution: {integrity: sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
       postcss: ^8.0.0
 
@@ -17337,6 +17346,13 @@ snapshots:
   possible-typed-array-names@1.0.0: {}
 
   postcss-import@15.1.0(postcss@8.4.41):
+    dependencies:
+      postcss: 8.4.41
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.8
+
+  postcss-import@16.1.0(postcss@8.4.41):
     dependencies:
       postcss: 8.4.41
       postcss-value-parser: 4.2.0


### PR DESCRIPTION
**What's done**
- We are only exporting a CSS theme file (following Shadcn) and that is used within Canary
- Had to change the tailwind file slightly to handle dimension variables

**What's pending**
- Align on how we can figure out how to map the various variables in Figma to fit the Shadcn theme in Canary