### PR TITLE
chore: Fix build issues in canary and playground

### DIFF
--- a/packages/canary/src/components/stacked-list.tsx
+++ b/packages/canary/src/components/stacked-list.tsx
@@ -32,10 +32,6 @@ const listFieldVariants = cva(
   }
 )
 
-/* eslint-disable @typescript-eslint/no-empty-object-type */
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-interface ListProps extends React.ComponentProps<'div'> {}
-
 interface ListItemProps extends React.ComponentProps<'div'>, VariantProps<typeof listItemVariants> {
   thumbnail?: React.ReactNode
   actions?: React.ReactNode

--- a/packages/canary/src/components/treeview.tsx
+++ b/packages/canary/src/components/treeview.tsx
@@ -68,10 +68,6 @@ const useTree = () => {
   return context
 }
 
-/* eslint-disable @typescript-eslint/no-empty-object-type */
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-interface TreeViewComponentProps extends React.HTMLAttributes<HTMLDivElement> {}
-
 type Direction = 'rtl' | 'ltr' | undefined
 
 type TreeViewProps = {
@@ -203,10 +199,6 @@ const TreeIndicator = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEle
 )
 
 TreeIndicator.displayName = 'TreeIndicator'
-
-/* eslint-disable @typescript-eslint/no-empty-object-type */
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-interface FolderComponentProps extends React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item> {}
 
 type FolderProps = {
   expendedItems?: string[]

--- a/packages/playground/src/components/execution/execution-details.tsx
+++ b/packages/playground/src/components/execution/execution-details.tsx
@@ -14,8 +14,8 @@ import { ContactCard } from '../contact-card'
 import { ScrollArea } from '@harnessio/canary'
 
 interface ExecutionProps {
-  pipelineId: unknown
-  executionId: unknown
+  pipelineId: number
+  executionId: number
 }
 
 export const ExecutionDetails: React.FC<ExecutionProps> = (): React.ReactElement => {

--- a/packages/playground/src/components/execution/key-value-table.tsx
+++ b/packages/playground/src/components/execution/key-value-table.tsx
@@ -13,7 +13,7 @@ import {
   AccordionTrigger
 } from '@harnessio/canary'
 
-type KeyValuePair = {
+export type KeyValuePair = {
   name: string
   value: string | KeyValuePair[]
 }

--- a/packages/playground/src/components/execution/step-execution.tsx
+++ b/packages/playground/src/components/execution/step-execution.tsx
@@ -6,20 +6,18 @@ import { data } from '../../pages/mocks/execution/mockStepLogs'
 import { Layout } from '../layout/layout'
 import { ExecutionState, ExecutionStatus } from './execution-status'
 import { getDuration } from '../../utils/TimeUtils'
-import { KeyValueTable } from './key-value-table'
+import { KeyValuePair, KeyValueTable } from './key-value-table'
 
 export interface StepProps {
-  input: []
-  inputTitle: { name: string; value: string }
-  output: []
-  outputTitle: { name: string; value: string }
   name: string
   status: ExecutionState
   started?: number
   stopped?: number
+  inputs?: KeyValuePair[]
+  outputs?: KeyValuePair[]
 }
 
-interface StageExecutionProps {
+interface StepExecutionProps {
   step: StepProps
   stepIndex: number
 }
@@ -49,9 +47,9 @@ const StepExecutionToolbar: React.FC = () => {
   )
 }
 
-export const StepExecution: React.FC<StageExecutionProps> = ({ step, stepIndex }) => {
-  const inputTable = step.input
-  const outputTable = step.output
+export const StepExecution: React.FC<StepExecutionProps> = ({ step, stepIndex }) => {
+  const inputTable = step?.inputs || []
+  const outputTable = step?.outputs || []
   return (
     <Layout.Vertical>
       <Layout.Horizontal className="flex justify-between items-center">
@@ -81,8 +79,8 @@ export const StepExecution: React.FC<StageExecutionProps> = ({ step, stepIndex }
               <KeyValueTable
                 className="pt-2"
                 tableSpec={inputTable}
-                tableTitleName={step.inputTitle.name}
-                tableTitleVal={step.inputTitle.value}
+                tableTitleName={'Input Name'}
+                tableTitleVal={'Input Value'}
               />
             </ScrollArea>
           </TabsContent>
@@ -92,8 +90,8 @@ export const StepExecution: React.FC<StageExecutionProps> = ({ step, stepIndex }
               <KeyValueTable
                 className="pt-2"
                 tableSpec={outputTable}
-                tableTitleName={step.outputTitle.name}
-                tableTitleVal={step.outputTitle.value}
+                tableTitleName={'Output Name'}
+                tableTitleVal={'Output Value'}
               />
             </ScrollArea>
           </TabsContent>

--- a/packages/playground/src/components/repo-summary-panel.tsx
+++ b/packages/playground/src/components/repo-summary-panel.tsx
@@ -8,12 +8,13 @@ import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
-  DropdownMenuItem
+  DropdownMenuItem,
+  IconProps
 } from '@harnessio/canary'
 
 interface DetailsProps {
   id: string
-  iconName: 'tube-sign' | 'open-pr' | 'tag' | 'branch' | string
+  iconName: 'tube-sign' | 'open-pr' | 'tag' | 'branch' | IconProps['name']
   name: string
   count: number
 }

--- a/packages/playground/src/pages/mocks/execution/mockExecution.ts
+++ b/packages/playground/src/pages/mocks/execution/mockExecution.ts
@@ -276,219 +276,219 @@ export const data = {
           stopped: 1722296949000,
           depends_on: ['clone'],
           image: 'docker.io/library/alpine:latest',
-          detached: false
-          // inputs: [
-          //   {
-          //     name: '21212',
-          //     value: 'Input Value'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'spec',
-          //     value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-          //   },
-          //   {
-          //     name: 'spec',
-          //     value: [
-          //       { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-          //       {
-          //         name: 'instance selection',
-          //         value: [
-          //           { name: 'type', value: 'Percentage' },
-          //           { name: 'type', value: 'Percentage' }
-          //         ]
-          //       },
-          //       { name: 'spec', value: { name: 'percentage', value: '5' } },
-          //       { name: 'skipDryRun', value: 'false' },
-          //       { name: 'delegate selectors', value: 'value1' }
-          //     ]
-          //   }
-          // ],
-          // outputs: [
-          //   {
-          //     name: '12345',
-          //     value: 'Output Value'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'blueGreenDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'blueGreenDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '15m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sBlueGreenDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'rolling'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'blueGreenDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'blueGreenDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '15m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sBlueGreenDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'rolling'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'blueGreenDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'blueGreenDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '15m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sBlueGreenDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'rolling'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'blueGreenDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'blueGreenDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '15m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sBlueGreenDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'rolling'
-          //   },
-          //   {
-          //     name: 'spec',
-          //     value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
-          //   },
-          //   {
-          //     name: 'spec',
-          //     value: [
-          //       { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
-          //       {
-          //         name: 'instance selection',
-          //         value: [
-          //           { name: 'type', value: 'Fixed' },
-          //           { name: 'type', value: 'Fixed' }
-          //         ]
-          //       },
-          //       { name: 'spec', value: { name: 'percentage', value: '10' } },
-          //       { name: 'skipDryRun', value: 'true' },
-          //       { name: 'delegate selectors', value: 'value2' }
-          //     ]
-          //   }
-          // ]
+          detached: false,
+          inputs: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: [{ name: 'percentage', value: '5' }] },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ],
+          outputs: [
+            {
+              name: '12345',
+              value: 'Output Value'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: [{ name: 'type', value: 'Fixed' }] }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: [{ name: 'type', value: 'Fixed' }] },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Fixed' },
+                    { name: 'type', value: 'Fixed' }
+                  ]
+                },
+                { name: 'spec', value: [{ name: 'percentage', value: '10' }] },
+                { name: 'skipDryRun', value: 'true' },
+                { name: 'delegate selectors', value: 'value2' }
+              ]
+            }
+          ]
         },
         {
           number: 3,
@@ -499,905 +499,905 @@ export const data = {
           stopped: 1722296949000,
           depends_on: ['clone'],
           image: 'docker.io/library/alpine:latest',
-          detached: false
-          // inputs: [
-          //   {
-          //     name: '21212',
-          //     value: 'Input Value'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'spec',
-          //     value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-          //   },
-          //   {
-          //     name: 'spec',
-          //     value: [
-          //       { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-          //       {
-          //         name: 'instance selection',
-          //         value: [
-          //           { name: 'type', value: 'Percentage' },
-          //           { name: 'type', value: 'Percentage' }
-          //         ]
-          //       },
-          //       { name: 'spec', value: { name: 'percentage', value: '5' } },
-          //       { name: 'skipDryRun', value: 'false' },
-          //       { name: 'delegate selectors', value: 'value1' }
-          //     ]
-          //   }
-          // ],
-          // outputs: [
-          //   {
-          //     name: '21212',
-          //     value: 'Input Value'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'identifier',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'name',
-          //     value: 'canaryDeployment'
-          //   },
-          //   {
-          //     name: 'timeout',
-          //     value: '10m'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'K8sCanaryDeploy'
-          //   },
-          //   {
-          //     name: 'type',
-          //     value: 'percentage'
-          //   },
-          //   {
-          //     name: 'spec',
-          //     value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-          //   },
-          //   {
-          //     name: 'spec',
-          //     value: [
-          //       { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-          //       {
-          //         name: 'instance selection',
-          //         value: [
-          //           { name: 'type', value: 'Percentage' },
-          //           { name: 'type', value: 'Percentage' }
-          //         ]
-          //       },
-          //       { name: 'spec', value: { name: 'percentage', value: '5' } },
-          //       { name: 'skipDryRun', value: 'false' },
-          //       { name: 'delegate selectors', value: 'value1' }
-          //     ]
-          //   }
-          // ]
+          detached: false,
+          inputs: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: [{ name: 'percentage', value: '5' }] },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ],
+          outputs: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: [{ name: 'percentage', value: '5' }] },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      execution_id: 1,
+      repo_id: 1,
+      number: 2,
+      name: 'Deploy to Prod',
+      status: ExecutionState.FAILURE,
+      error: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
+      exit_code: 255,
+      machine: 'vardan_bansal',
+      started: 1722296944000,
+      stopped: 1722296944000,
+      on_success: true,
+      on_failure: false,
+      steps: [
+        {
+          number: 1,
+          name: 'SBOM and SLSA Validation',
+          status: ExecutionState.FAILURE,
+          exit_code: 0,
+          started: 1722296944000,
+          stopped: 1722296944000,
+          image: 'drone/git:latest',
+          detached: false,
+          inputs: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: [{ name: 'percentage', value: '5' }] },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ],
+          outputs: [
+            {
+              name: '12345',
+              value: 'Output Value'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: [{ name: 'type', value: 'Fixed' }] }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: [{ name: 'type', value: 'Fixed' }] },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Fixed' },
+                    { name: 'type', value: 'Fixed' }
+                  ]
+                },
+                { name: 'spec', value: [{ name: 'percentage', value: '10' }] },
+                { name: 'skipDryRun', value: 'true' },
+                { name: 'delegate selectors', value: 'value2' }
+              ]
+            }
+          ]
+        },
+        {
+          number: 2,
+          name: 'Risk Profile OPA - New Criticals',
+          status: ExecutionState.SKIPPED,
+          exit_code: 0,
+          started: 1722296944000,
+          stopped: 1722296944000,
+          depends_on: ['clone'],
+          image: 'docker.io/library/alpine:latest',
+          detached: false,
+          inputs: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: [{ name: 'percentage', value: '5' }] },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ],
+          outputs: [
+            {
+              name: '12345',
+              value: 'Output Value'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: [{ name: 'type', value: 'Fixed' }] }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: [{ name: 'type', value: 'Fixed' }] },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Fixed' },
+                    { name: 'type', value: 'Fixed' }
+                  ]
+                },
+                { name: 'spec', value: [{ name: 'percentage', value: '10' }] },
+                { name: 'skipDryRun', value: 'true' },
+                { name: 'delegate selectors', value: 'value2' }
+              ]
+            }
+          ]
+        },
+        {
+          number: 3,
+          name: 'Canary Deployment',
+          status: ExecutionState.SKIPPED,
+          exit_code: 0,
+          started: 1722296944000,
+          stopped: 1722296944000,
+          depends_on: ['clone'],
+          image: 'docker.io/library/alpine:latest',
+          detached: false,
+          inputs: [
+            {
+              name: '21212',
+              value: 'Input Value'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'identifier',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'name',
+              value: 'canaryDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '10m'
+            },
+            {
+              name: 'type',
+              value: 'K8sCanaryDeploy'
+            },
+            {
+              name: 'type',
+              value: 'percentage'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Percentage' },
+                    { name: 'type', value: 'Percentage' }
+                  ]
+                },
+                { name: 'spec', value: [{ name: 'percentage', value: '5' }] },
+                { name: 'skipDryRun', value: 'false' },
+                { name: 'delegate selectors', value: 'value1' }
+              ]
+            }
+          ],
+          outputs: [
+            {
+              name: '12345',
+              value: 'Output Value'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'identifier',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'name',
+              value: 'blueGreenDeployment'
+            },
+            {
+              name: 'timeout',
+              value: '15m'
+            },
+            {
+              name: 'type',
+              value: 'K8sBlueGreenDeploy'
+            },
+            {
+              name: 'type',
+              value: 'rolling'
+            },
+            {
+              name: 'spec',
+              value: [{ name: 'instance selection', value: [{ name: 'type', value: 'Fixed' }] }]
+            },
+            {
+              name: 'spec',
+              value: [
+                { name: 'instance selection', value: [{ name: 'type', value: 'Fixed' }] },
+                {
+                  name: 'instance selection',
+                  value: [
+                    { name: 'type', value: 'Fixed' },
+                    { name: 'type', value: 'Fixed' }
+                  ]
+                },
+                { name: 'spec', value: [{ name: 'percentage', value: '10' }] },
+                { name: 'skipDryRun', value: 'true' },
+                { name: 'delegate selectors', value: 'value2' }
+              ]
+            }
+          ]
         }
       ]
     }
-    // {
-    //   execution_id: 1,
-    //   repo_id: 1,
-    //   number: 2,
-    //   name: 'Deploy to Prod',
-    //   status: ExecutionState.FAILURE,
-    //   error: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
-    //   exit_code: 255,
-    //   machine: 'vardan_bansal',
-    //   started: 1722296944000,
-    //   stopped: 1722296944000,
-    //   on_success: true,
-    //   on_failure: false,
-    //   steps: [
-    //     {
-    //       number: 1,
-    //       name: 'SBOM and SLSA Validation',
-    //       status: ExecutionState.FAILURE,
-    //       exit_code: 0,
-    //       started: 1722296944000,
-    //       stopped: 1722296944000,
-    //       image: 'drone/git:latest',
-    //       detached: false,
-    //       inputs: [
-    //         {
-    //           name: '21212',
-    //           value: 'Input Value'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [
-    //             { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-    //             {
-    //               name: 'instance selection',
-    //               value: [
-    //                 { name: 'type', value: 'Percentage' },
-    //                 { name: 'type', value: 'Percentage' }
-    //               ]
-    //             },
-    //             { name: 'spec', value: { name: 'percentage', value: '5' } },
-    //             { name: 'skipDryRun', value: 'false' },
-    //             { name: 'delegate selectors', value: 'value1' }
-    //           ]
-    //         }
-    //       ],
-    //       outputs: [
-    //         {
-    //           name: '12345',
-    //           value: 'Output Value'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [
-    //             { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
-    //             {
-    //               name: 'instance selection',
-    //               value: [
-    //                 { name: 'type', value: 'Fixed' },
-    //                 { name: 'type', value: 'Fixed' }
-    //               ]
-    //             },
-    //             { name: 'spec', value: { name: 'percentage', value: '10' } },
-    //             { name: 'skipDryRun', value: 'true' },
-    //             { name: 'delegate selectors', value: 'value2' }
-    //           ]
-    //         }
-    //       ]
-    //     },
-    //     {
-    //       number: 2,
-    //       name: 'Risk Profile OPA - New Criticals',
-    //       status: ExecutionState.SKIPPED,
-    //       exit_code: 0,
-    //       started: 1722296944000,
-    //       stopped: 1722296944000,
-    //       depends_on: ['clone'],
-    //       image: 'docker.io/library/alpine:latest',
-    //       detached: false,
-    //       inputs: [
-    //         {
-    //           name: '21212',
-    //           value: 'Input Value'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [
-    //             { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-    //             {
-    //               name: 'instance selection',
-    //               value: [
-    //                 { name: 'type', value: 'Percentage' },
-    //                 { name: 'type', value: 'Percentage' }
-    //               ]
-    //             },
-    //             { name: 'spec', value: { name: 'percentage', value: '5' } },
-    //             { name: 'skipDryRun', value: 'false' },
-    //             { name: 'delegate selectors', value: 'value1' }
-    //           ]
-    //         }
-    //       ],
-    //       outputs: [
-    //         {
-    //           name: '12345',
-    //           value: 'Output Value'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [
-    //             { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
-    //             {
-    //               name: 'instance selection',
-    //               value: [
-    //                 { name: 'type', value: 'Fixed' },
-    //                 { name: 'type', value: 'Fixed' }
-    //               ]
-    //             },
-    //             { name: 'spec', value: { name: 'percentage', value: '10' } },
-    //             { name: 'skipDryRun', value: 'true' },
-    //             { name: 'delegate selectors', value: 'value2' }
-    //           ]
-    //         }
-    //       ]
-    //     },
-    //     {
-    //       number: 3,
-    //       name: 'Canary Deployment',
-    //       status: ExecutionState.SKIPPED,
-    //       exit_code: 0,
-    //       started: 1722296944000,
-    //       stopped: 1722296944000,
-    //       depends_on: ['clone'],
-    //       image: 'docker.io/library/alpine:latest',
-    //       detached: false,
-    //       inputs: [
-    //         {
-    //           name: '21212',
-    //           value: 'Input Value'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'canaryDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '10m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sCanaryDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'percentage'
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [
-    //             { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-    //             {
-    //               name: 'instance selection',
-    //               value: [
-    //                 { name: 'type', value: 'Percentage' },
-    //                 { name: 'type', value: 'Percentage' }
-    //               ]
-    //             },
-    //             { name: 'spec', value: { name: 'percentage', value: '5' } },
-    //             { name: 'skipDryRun', value: 'false' },
-    //             { name: 'delegate selectors', value: 'value1' }
-    //           ]
-    //         }
-    //       ],
-    //       outputs: [
-    //         {
-    //           name: '12345',
-    //           value: 'Output Value'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'identifier',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'name',
-    //           value: 'blueGreenDeployment'
-    //         },
-    //         {
-    //           name: 'timeout',
-    //           value: '15m'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'K8sBlueGreenDeploy'
-    //         },
-    //         {
-    //           name: 'type',
-    //           value: 'rolling'
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
-    //         },
-    //         {
-    //           name: 'spec',
-    //           value: [
-    //             { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
-    //             {
-    //               name: 'instance selection',
-    //               value: [
-    //                 { name: 'type', value: 'Fixed' },
-    //                 { name: 'type', value: 'Fixed' }
-    //               ]
-    //             },
-    //             { name: 'spec', value: { name: 'percentage', value: '10' } },
-    //             { name: 'skipDryRun', value: 'true' },
-    //             { name: 'delegate selectors', value: 'value2' }
-    //           ]
-    //         }
-    //       ]
-    //     }
-    //   ]
-    // }
   ]
 }

--- a/packages/playground/src/pages/mocks/execution/mockExecution.ts
+++ b/packages/playground/src/pages/mocks/execution/mockExecution.ts
@@ -49,15 +49,7 @@ export const data = {
           stopped: 1722296949000,
           image: 'drone/git:latest',
           detached: false,
-          inputTitle: {
-            name: 'Input Name',
-            value: 'Input Value'
-          },
-          outputTitle: {
-            name: 'Output Name',
-            value: 'Output Value'
-          },
-          input: [
+          inputs: [
             {
               name: '21212',
               value: 'Input Value'
@@ -144,12 +136,17 @@ export const data = {
             },
             {
               name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+              value: [
+                {
+                  name: 'instance selection',
+                  value: [{ name: 'type', value: 'Percentage' }]
+                }
+              ]
             },
             {
               name: 'spec',
               value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+                { name: 'instance selection', value: [{ name: 'type', value: 'Percentage' }] },
                 {
                   name: 'instance selection',
                   value: [
@@ -157,13 +154,13 @@ export const data = {
                     { name: 'type', value: 'Percentage' }
                   ]
                 },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
+                { name: 'spec', value: [{ name: 'percentage', value: '5' }] },
                 { name: 'skipDryRun', value: 'false' },
                 { name: 'delegate selectors', value: 'value1' }
               ]
             }
           ],
-          output: [
+          outputs: [
             {
               name: '12345',
               value: 'Output Value'
@@ -250,12 +247,12 @@ export const data = {
             },
             {
               name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
+              value: [{ name: 'instance selection', value: [{ name: 'type', value: 'Fixed' }] }]
             },
             {
               name: 'spec',
               value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
+                { name: 'instance selection', value: [{ name: 'type', value: 'Fixed' }] },
                 {
                   name: 'instance selection',
                   value: [
@@ -263,7 +260,7 @@ export const data = {
                     { name: 'type', value: 'Fixed' }
                   ]
                 },
-                { name: 'spec', value: { name: 'percentage', value: '10' } },
+                { name: 'spec', value: [{ name: 'percentage', value: '10' }] },
                 { name: 'skipDryRun', value: 'true' },
                 { name: 'delegate selectors', value: 'value2' }
               ]
@@ -279,227 +276,219 @@ export const data = {
           stopped: 1722296949000,
           depends_on: ['clone'],
           image: 'docker.io/library/alpine:latest',
-          detached: false,
-          inputTitle: {
-            name: 'Input Name',
-            value: 'Input Value'
-          },
-          outputTitle: {
-            name: 'Output Name',
-            value: 'Output Value'
-          },
-          input: [
-            {
-              name: '21212',
-              value: 'Input Value'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-            },
-            {
-              name: 'spec',
-              value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-                {
-                  name: 'instance selection',
-                  value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
-                  ]
-                },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
-              ]
-            }
-          ],
-          output: [
-            {
-              name: '12345',
-              value: 'Output Value'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
-            },
-            {
-              name: 'spec',
-              value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
-                {
-                  name: 'instance selection',
-                  value: [
-                    { name: 'type', value: 'Fixed' },
-                    { name: 'type', value: 'Fixed' }
-                  ]
-                },
-                { name: 'spec', value: { name: 'percentage', value: '10' } },
-                { name: 'skipDryRun', value: 'true' },
-                { name: 'delegate selectors', value: 'value2' }
-              ]
-            }
-          ]
+          detached: false
+          // inputs: [
+          //   {
+          //     name: '21212',
+          //     value: 'Input Value'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'spec',
+          //     value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+          //   },
+          //   {
+          //     name: 'spec',
+          //     value: [
+          //       { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+          //       {
+          //         name: 'instance selection',
+          //         value: [
+          //           { name: 'type', value: 'Percentage' },
+          //           { name: 'type', value: 'Percentage' }
+          //         ]
+          //       },
+          //       { name: 'spec', value: { name: 'percentage', value: '5' } },
+          //       { name: 'skipDryRun', value: 'false' },
+          //       { name: 'delegate selectors', value: 'value1' }
+          //     ]
+          //   }
+          // ],
+          // outputs: [
+          //   {
+          //     name: '12345',
+          //     value: 'Output Value'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'blueGreenDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'blueGreenDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '15m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sBlueGreenDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'rolling'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'blueGreenDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'blueGreenDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '15m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sBlueGreenDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'rolling'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'blueGreenDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'blueGreenDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '15m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sBlueGreenDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'rolling'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'blueGreenDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'blueGreenDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '15m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sBlueGreenDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'rolling'
+          //   },
+          //   {
+          //     name: 'spec',
+          //     value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
+          //   },
+          //   {
+          //     name: 'spec',
+          //     value: [
+          //       { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
+          //       {
+          //         name: 'instance selection',
+          //         value: [
+          //           { name: 'type', value: 'Fixed' },
+          //           { name: 'type', value: 'Fixed' }
+          //         ]
+          //       },
+          //       { name: 'spec', value: { name: 'percentage', value: '10' } },
+          //       { name: 'skipDryRun', value: 'true' },
+          //       { name: 'delegate selectors', value: 'value2' }
+          //     ]
+          //   }
+          // ]
         },
         {
           number: 3,
@@ -510,937 +499,905 @@ export const data = {
           stopped: 1722296949000,
           depends_on: ['clone'],
           image: 'docker.io/library/alpine:latest',
-          detached: false,
-          inputTitle: {
-            name: 'Input Name',
-            value: 'Input Value'
-          },
-          outputTitle: {
-            name: 'Output Name',
-            value: 'Output Value'
-          },
-          input: [
-            {
-              name: '21212',
-              value: 'Input Value'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-            },
-            {
-              name: 'spec',
-              value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-                {
-                  name: 'instance selection',
-                  value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
-                  ]
-                },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
-              ]
-            }
-          ],
-          output: [
-            {
-              name: '21212',
-              value: 'Input Value'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-            },
-            {
-              name: 'spec',
-              value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-                {
-                  name: 'instance selection',
-                  value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
-                  ]
-                },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      execution_id: 1,
-      repo_id: 1,
-      number: 2,
-      name: 'Deploy to Prod',
-      status: ExecutionState.FAILURE,
-      error: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
-      exit_code: 255,
-      machine: 'vardan_bansal',
-      started: 1722296944000,
-      stopped: 1722296944000,
-      on_success: true,
-      on_failure: false,
-      steps: [
-        {
-          number: 1,
-          name: 'SBOM and SLSA Validation',
-          status: ExecutionState.FAILURE,
-          exit_code: 0,
-          started: 1722296944000,
-          stopped: 1722296944000,
-          image: 'drone/git:latest',
-          detached: false,
-          inputTitle: {
-            name: 'Input Name',
-            value: 'Input Value'
-          },
-          outputTitle: {
-            name: 'Output Name',
-            value: 'Output Value'
-          },
-          input: [
-            {
-              name: '21212',
-              value: 'Input Value'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-            },
-            {
-              name: 'spec',
-              value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-                {
-                  name: 'instance selection',
-                  value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
-                  ]
-                },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
-              ]
-            }
-          ],
-          output: [
-            {
-              name: '12345',
-              value: 'Output Value'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
-            },
-            {
-              name: 'spec',
-              value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
-                {
-                  name: 'instance selection',
-                  value: [
-                    { name: 'type', value: 'Fixed' },
-                    { name: 'type', value: 'Fixed' }
-                  ]
-                },
-                { name: 'spec', value: { name: 'percentage', value: '10' } },
-                { name: 'skipDryRun', value: 'true' },
-                { name: 'delegate selectors', value: 'value2' }
-              ]
-            }
-          ]
-        },
-        {
-          number: 2,
-          name: 'Risk Profile OPA - New Criticals',
-          status: ExecutionState.SKIPPED,
-          exit_code: 0,
-          started: 1722296944000,
-          stopped: 1722296944000,
-          depends_on: ['clone'],
-          image: 'docker.io/library/alpine:latest',
-          detached: false,
-          inputTitle: {
-            name: 'Input Name',
-            value: 'Input Value'
-          },
-          outputTitle: {
-            name: 'Output Name',
-            value: 'Output Value'
-          },
-          input: [
-            {
-              name: '21212',
-              value: 'Input Value'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-            },
-            {
-              name: 'spec',
-              value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-                {
-                  name: 'instance selection',
-                  value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
-                  ]
-                },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
-              ]
-            }
-          ],
-          output: [
-            {
-              name: '12345',
-              value: 'Output Value'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
-            },
-            {
-              name: 'spec',
-              value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
-                {
-                  name: 'instance selection',
-                  value: [
-                    { name: 'type', value: 'Fixed' },
-                    { name: 'type', value: 'Fixed' }
-                  ]
-                },
-                { name: 'spec', value: { name: 'percentage', value: '10' } },
-                { name: 'skipDryRun', value: 'true' },
-                { name: 'delegate selectors', value: 'value2' }
-              ]
-            }
-          ]
-        },
-        {
-          number: 3,
-          name: 'Canary Deployment',
-          status: ExecutionState.SKIPPED,
-          exit_code: 0,
-          started: 1722296944000,
-          stopped: 1722296944000,
-          depends_on: ['clone'],
-          image: 'docker.io/library/alpine:latest',
-          detached: false,
-          inputTitle: {
-            name: 'Input Name',
-            value: 'Input Value'
-          },
-          outputTitle: {
-            name: 'Output Name',
-            value: 'Output Value'
-          },
-          input: [
-            {
-              name: '21212',
-              value: 'Input Value'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'identifier',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'name',
-              value: 'canaryDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '10m'
-            },
-            {
-              name: 'type',
-              value: 'K8sCanaryDeploy'
-            },
-            {
-              name: 'type',
-              value: 'percentage'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
-            },
-            {
-              name: 'spec',
-              value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
-                {
-                  name: 'instance selection',
-                  value: [
-                    { name: 'type', value: 'Percentage' },
-                    { name: 'type', value: 'Percentage' }
-                  ]
-                },
-                { name: 'spec', value: { name: 'percentage', value: '5' } },
-                { name: 'skipDryRun', value: 'false' },
-                { name: 'delegate selectors', value: 'value1' }
-              ]
-            }
-          ],
-          output: [
-            {
-              name: '12345',
-              value: 'Output Value'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'identifier',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'name',
-              value: 'blueGreenDeployment'
-            },
-            {
-              name: 'timeout',
-              value: '15m'
-            },
-            {
-              name: 'type',
-              value: 'K8sBlueGreenDeploy'
-            },
-            {
-              name: 'type',
-              value: 'rolling'
-            },
-            {
-              name: 'spec',
-              value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
-            },
-            {
-              name: 'spec',
-              value: [
-                { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
-                {
-                  name: 'instance selection',
-                  value: [
-                    { name: 'type', value: 'Fixed' },
-                    { name: 'type', value: 'Fixed' }
-                  ]
-                },
-                { name: 'spec', value: { name: 'percentage', value: '10' } },
-                { name: 'skipDryRun', value: 'true' },
-                { name: 'delegate selectors', value: 'value2' }
-              ]
-            }
-          ]
+          detached: false
+          // inputs: [
+          //   {
+          //     name: '21212',
+          //     value: 'Input Value'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'spec',
+          //     value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+          //   },
+          //   {
+          //     name: 'spec',
+          //     value: [
+          //       { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+          //       {
+          //         name: 'instance selection',
+          //         value: [
+          //           { name: 'type', value: 'Percentage' },
+          //           { name: 'type', value: 'Percentage' }
+          //         ]
+          //       },
+          //       { name: 'spec', value: { name: 'percentage', value: '5' } },
+          //       { name: 'skipDryRun', value: 'false' },
+          //       { name: 'delegate selectors', value: 'value1' }
+          //     ]
+          //   }
+          // ],
+          // outputs: [
+          //   {
+          //     name: '21212',
+          //     value: 'Input Value'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'identifier',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'name',
+          //     value: 'canaryDeployment'
+          //   },
+          //   {
+          //     name: 'timeout',
+          //     value: '10m'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'K8sCanaryDeploy'
+          //   },
+          //   {
+          //     name: 'type',
+          //     value: 'percentage'
+          //   },
+          //   {
+          //     name: 'spec',
+          //     value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+          //   },
+          //   {
+          //     name: 'spec',
+          //     value: [
+          //       { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+          //       {
+          //         name: 'instance selection',
+          //         value: [
+          //           { name: 'type', value: 'Percentage' },
+          //           { name: 'type', value: 'Percentage' }
+          //         ]
+          //       },
+          //       { name: 'spec', value: { name: 'percentage', value: '5' } },
+          //       { name: 'skipDryRun', value: 'false' },
+          //       { name: 'delegate selectors', value: 'value1' }
+          //     ]
+          //   }
+          // ]
         }
       ]
     }
+    // {
+    //   execution_id: 1,
+    //   repo_id: 1,
+    //   number: 2,
+    //   name: 'Deploy to Prod',
+    //   status: ExecutionState.FAILURE,
+    //   error: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
+    //   exit_code: 255,
+    //   machine: 'vardan_bansal',
+    //   started: 1722296944000,
+    //   stopped: 1722296944000,
+    //   on_success: true,
+    //   on_failure: false,
+    //   steps: [
+    //     {
+    //       number: 1,
+    //       name: 'SBOM and SLSA Validation',
+    //       status: ExecutionState.FAILURE,
+    //       exit_code: 0,
+    //       started: 1722296944000,
+    //       stopped: 1722296944000,
+    //       image: 'drone/git:latest',
+    //       detached: false,
+    //       inputs: [
+    //         {
+    //           name: '21212',
+    //           value: 'Input Value'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [
+    //             { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+    //             {
+    //               name: 'instance selection',
+    //               value: [
+    //                 { name: 'type', value: 'Percentage' },
+    //                 { name: 'type', value: 'Percentage' }
+    //               ]
+    //             },
+    //             { name: 'spec', value: { name: 'percentage', value: '5' } },
+    //             { name: 'skipDryRun', value: 'false' },
+    //             { name: 'delegate selectors', value: 'value1' }
+    //           ]
+    //         }
+    //       ],
+    //       outputs: [
+    //         {
+    //           name: '12345',
+    //           value: 'Output Value'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [
+    //             { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
+    //             {
+    //               name: 'instance selection',
+    //               value: [
+    //                 { name: 'type', value: 'Fixed' },
+    //                 { name: 'type', value: 'Fixed' }
+    //               ]
+    //             },
+    //             { name: 'spec', value: { name: 'percentage', value: '10' } },
+    //             { name: 'skipDryRun', value: 'true' },
+    //             { name: 'delegate selectors', value: 'value2' }
+    //           ]
+    //         }
+    //       ]
+    //     },
+    //     {
+    //       number: 2,
+    //       name: 'Risk Profile OPA - New Criticals',
+    //       status: ExecutionState.SKIPPED,
+    //       exit_code: 0,
+    //       started: 1722296944000,
+    //       stopped: 1722296944000,
+    //       depends_on: ['clone'],
+    //       image: 'docker.io/library/alpine:latest',
+    //       detached: false,
+    //       inputs: [
+    //         {
+    //           name: '21212',
+    //           value: 'Input Value'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [
+    //             { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+    //             {
+    //               name: 'instance selection',
+    //               value: [
+    //                 { name: 'type', value: 'Percentage' },
+    //                 { name: 'type', value: 'Percentage' }
+    //               ]
+    //             },
+    //             { name: 'spec', value: { name: 'percentage', value: '5' } },
+    //             { name: 'skipDryRun', value: 'false' },
+    //             { name: 'delegate selectors', value: 'value1' }
+    //           ]
+    //         }
+    //       ],
+    //       outputs: [
+    //         {
+    //           name: '12345',
+    //           value: 'Output Value'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [
+    //             { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
+    //             {
+    //               name: 'instance selection',
+    //               value: [
+    //                 { name: 'type', value: 'Fixed' },
+    //                 { name: 'type', value: 'Fixed' }
+    //               ]
+    //             },
+    //             { name: 'spec', value: { name: 'percentage', value: '10' } },
+    //             { name: 'skipDryRun', value: 'true' },
+    //             { name: 'delegate selectors', value: 'value2' }
+    //           ]
+    //         }
+    //       ]
+    //     },
+    //     {
+    //       number: 3,
+    //       name: 'Canary Deployment',
+    //       status: ExecutionState.SKIPPED,
+    //       exit_code: 0,
+    //       started: 1722296944000,
+    //       stopped: 1722296944000,
+    //       depends_on: ['clone'],
+    //       image: 'docker.io/library/alpine:latest',
+    //       detached: false,
+    //       inputs: [
+    //         {
+    //           name: '21212',
+    //           value: 'Input Value'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'canaryDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '10m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sCanaryDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'percentage'
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Percentage' } }]
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [
+    //             { name: 'instance selection', value: { name: 'type', value: 'Percentage' } },
+    //             {
+    //               name: 'instance selection',
+    //               value: [
+    //                 { name: 'type', value: 'Percentage' },
+    //                 { name: 'type', value: 'Percentage' }
+    //               ]
+    //             },
+    //             { name: 'spec', value: { name: 'percentage', value: '5' } },
+    //             { name: 'skipDryRun', value: 'false' },
+    //             { name: 'delegate selectors', value: 'value1' }
+    //           ]
+    //         }
+    //       ],
+    //       outputs: [
+    //         {
+    //           name: '12345',
+    //           value: 'Output Value'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'identifier',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'name',
+    //           value: 'blueGreenDeployment'
+    //         },
+    //         {
+    //           name: 'timeout',
+    //           value: '15m'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'K8sBlueGreenDeploy'
+    //         },
+    //         {
+    //           name: 'type',
+    //           value: 'rolling'
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [{ name: 'instance selection', value: { name: 'type', value: 'Fixed' } }]
+    //         },
+    //         {
+    //           name: 'spec',
+    //           value: [
+    //             { name: 'instance selection', value: { name: 'type', value: 'Fixed' } },
+    //             {
+    //               name: 'instance selection',
+    //               value: [
+    //                 { name: 'type', value: 'Fixed' },
+    //                 { name: 'type', value: 'Fixed' }
+    //               ]
+    //             },
+    //             { name: 'spec', value: { name: 'percentage', value: '10' } },
+    //             { name: 'skipDryRun', value: 'true' },
+    //             { name: 'delegate selectors', value: 'value2' }
+    //           ]
+    //         }
+    //       ]
+    //     }
+    //   ]
+    // }
   ]
 }

--- a/packages/playground/src/pages/repo-summary-page.tsx
+++ b/packages/playground/src/pages/repo-summary-page.tsx
@@ -1,5 +1,15 @@
 import React, { useState } from 'react'
-import { Spacer, ListActions, Button, SearchBox, Text, Icon, ButtonGroup, StackedList } from '@harnessio/canary'
+import {
+  Spacer,
+  ListActions,
+  Button,
+  SearchBox,
+  Text,
+  Icon,
+  ButtonGroup,
+  StackedList,
+  IconProps
+} from '@harnessio/canary'
 import { Summary } from '../components/repo-summary'
 import { NoData } from '../components/no-data'
 import { NoSearchResults } from '../components/no-search-results'
@@ -11,7 +21,7 @@ import FullWidth2ColumnLayout from '../layouts/FullWidth2ColumnLayout'
 import { mockFiles } from '../data/mockSummaryFiiles'
 import Floating1ColumnLayout from '../layouts/Floating1ColumnLayout'
 
-const mockSummaryDetails = [
+const mockSummaryDetails: { id: string; name: string; count: number; iconName: IconProps['name'] }[] = [
   {
     id: '0',
     name: 'Commits',


### PR DESCRIPTION
- Fix build issues in canary and playground during `pnpm build`.
- Adding proper types wherever missing.
- Fix types for inputs and outputs
   - Rename to `inputs` and `outputs`
   - Fix mock data
   - Fix table column header names