### PR TITLE
Loading status for the header

### DIFF
--- a/apps/gitness/src/components/Header.tsx
+++ b/apps/gitness/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { Topbar, Text } from '@harnessio/canary'
-import { TopBarWidget } from '@harnessio/playground'
+import { TopBarWidget, TopBarWidgetLoading } from '@harnessio/playground'
 import { useMembershipSpacesQuery, TypesSpace } from '@harnessio/code-service-client'
 
 export default function Header() {
@@ -9,15 +9,7 @@ export default function Header() {
   })
   //prevent rendering the page until the projects are loaded
   if (isLoading) {
-    return (
-      <Topbar.Root>
-        <Topbar.Left>
-          <Text size={2} weight="medium" className="text-primary">
-            Loading Your Projects...
-          </Text>
-        </Topbar.Left>
-      </Topbar.Root>
-    )
+    return <TopBarWidgetLoading isLoading={isLoading} />
   }
 
   const projectsItem: TypesSpace[] =

--- a/packages/playground/src/components/layout/top-bar-loading.tsx
+++ b/packages/playground/src/components/layout/top-bar-loading.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Refresh } from '@harnessio/icons-noir'
+import { Topbar, Text } from '@harnessio/canary'
+
+interface WidgetLoadingProps {
+  isLoading: boolean
+}
+
+export const TopBarWidgetLoading: React.FC<WidgetLoadingProps> = ({ isLoading }) => {
+  console.log(isLoading)
+  return (
+    <Topbar.Root>
+      <Topbar.Left>
+        <div className="flex gap-2 flex-row items-center justify-center">
+          <Text size={6} className="flex bg-muted rounded-full p-1.5 gap-4 align-middle ">
+            <Refresh className="animate-spin" />
+          </Text>
+          <Text size={2} weight="medium" className="flex text-primary-muted flex-grow align-middle">
+            Loading Your Projects...
+          </Text>
+        </div>
+      </Topbar.Left>
+    </Topbar.Root>
+  )
+}

--- a/packages/playground/src/components/layout/top-bar-loading.tsx
+++ b/packages/playground/src/components/layout/top-bar-loading.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import { Refresh } from '@harnessio/icons-noir'
 import { Topbar, Text } from '@harnessio/canary'
-
 interface WidgetLoadingProps {
   isLoading: boolean
 }
 
 export const TopBarWidgetLoading: React.FC<WidgetLoadingProps> = ({ isLoading }) => {
-  console.log(isLoading)
+  if (!isLoading) {
+    return null
+  }
+
   return (
     <Topbar.Root>
       <Topbar.Left>

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -2,6 +2,7 @@ export * from './components/theme-provider'
 
 export * from './components/pipeline-list'
 export * from './components/layout/top-bar-widget'
+export * from './components/layout/top-bar-loading'
 export * from './layouts/PaddingListLayout'
 export * from './layouts/Floating1ColumnLayout'
 export * from './components/loaders/skeleton-list'

--- a/packages/playground/src/pages/create-pipeline-page.tsx
+++ b/packages/playground/src/pages/create-pipeline-page.tsx
@@ -11,7 +11,7 @@ import {
   Input,
   AIPrompt
 } from '@harnessio/canary'
-import Floating1ColumnLayout from '../layouts/Floating1ColumnLayout'
+import { Floating1ColumnLayout } from '../layouts/Floating1ColumnLayout'
 import { Link } from 'react-router-dom'
 
 const SectionList = ({ children }: { children: React.ReactNode }) => (


### PR DESCRIPTION
- migrate elements for the loading status from gitness to playground
- make the design aligned with dropdown in UX for the component consistency 
- only rendering data in the playground and still left the logic in the gitness
- loading status
<img width="1728" alt="Screenshot 2024-09-12 at 4 05 52 PM" src="https://github.com/user-attachments/assets/5996baa7-1e29-4151-86de-c1836165252f">
- loaded status
<img width="1728" alt="Screenshot 2024-09-12 at 4 12 50 PM" src="https://github.com/user-attachments/assets/350b9ee3-6ef5-4861-b20d-ed4abd2f59f3">

