### PR TITLE
Fixing App navigation with project selection

### DIFF
--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -1,9 +1,7 @@
-import React from 'react'
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider, RootLayout } from '@harnessio/playground'
 import { TooltipProvider } from '@harnessio/canary'
-import { CodeServiceAPIClient } from '@harnessio/code-service-client'
 import { queryClient } from './framework/queryClient'
 import PipelineListPage from './pages/pipeline-list'
 import SignInPage from './pages/signin'
@@ -17,33 +15,7 @@ import PipelineEditPage from './pages/pipeline-edit/pipeline-edit'
 import { LandingPage } from './pages/landing-page'
 import { AppProvider } from './framework/context/AppContext'
 
-const BASE_URL_PREFIX = '/api/v1'
-
 export default function App() {
-  React.useEffect(() => {
-    new CodeServiceAPIClient({
-      urlInterceptor: (url: string) => `${BASE_URL_PREFIX}${url}`,
-      requestInterceptor: (request: Request): Request => {
-        // Retrieve the token from storage and add to headers if available
-        const token = localStorage.getItem('token')
-        if (token) {
-          const newRequest = request.clone()
-          newRequest.headers.set('Authorization', `Bearer ${token}`)
-          return newRequest
-        }
-        return request
-      },
-      responseInterceptor: (response: Response) => {
-        switch (response.status) {
-          case 401:
-            localStorage.removeItem('token')
-            window.location.href = '/signin'
-        }
-        return response
-      }
-    })
-  }, [])
-
   const router = createBrowserRouter([
     {
       path: '/',

--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -6,7 +6,7 @@ import { queryClient } from './framework/queryClient'
 import PipelineListPage from './pages/pipeline-list'
 import SignInPage from './pages/signin'
 import PullRequestListPage from './pages/pull-request-list-page'
-import ExecutionsPage from './pages/execution-list'
+import ExecutionsListPage from './pages/execution-list'
 import ReposListPage from './pages/repo-list'
 import PullRequestLayout from './layouts/PullRequestLayout'
 import PullRequestCommitsPage from './pages/pull-request-commits-page'
@@ -47,7 +47,7 @@ export default function App() {
                 },
                 {
                   path: ':pipelineId',
-                  element: <ExecutionsPage />
+                  element: <ExecutionsListPage />
                 }
               ]
             },
@@ -75,7 +75,7 @@ export default function App() {
         // Executions (OUTSIDE REPOS)
         {
           path: 'executions',
-          element: <ExecutionsPage />
+          element: <ExecutionsListPage />
         },
         {
           path: ':spaceId/:repoId',

--- a/apps/gitness/src/components/Header.tsx
+++ b/apps/gitness/src/components/Header.tsx
@@ -1,15 +1,19 @@
 import { Topbar, Text } from '@harnessio/canary'
 import { TopBarWidget } from '@harnessio/playground'
+import { useNavigate } from 'react-router-dom'
 import { TypesMembershipSpace } from '@harnessio/code-service-client'
 import { useAppContext } from '../framework/context/AppContext'
+import { useGetSpaceURLParam } from '../framework/hooks/useGetSpaceParam'
 
 export default function Header() {
-  const { spaces } = useAppContext()
+  const navigate = useNavigate()
+  const space = useGetSpaceURLParam()
+  const { spaces, setSelectedSpace } = useAppContext()
 
   const projectsItem =
     spaces.map((space: TypesMembershipSpace) => ({
       id: space?.space?.id,
-      name: space?.space?.identifier
+      name: space?.space?.path
     })) || []
 
   if (projectsItem.length === 0) {
@@ -27,5 +31,16 @@ export default function Header() {
     )
   }
 
-  return <TopBarWidget projects={projectsItem} />
+  return (
+    <TopBarWidget
+      projects={projectsItem}
+      onSelectProject={selectedProject => {
+        if (selectedProject?.name) {
+          setSelectedSpace(selectedProject.name)
+          navigate(`/${selectedProject.name}/repos`)
+        }
+      }}
+      preselectedProject={projectsItem.find(item => item.name === space)}
+    />
+  )
 }

--- a/apps/gitness/src/framework/context/AppContext.tsx
+++ b/apps/gitness/src/framework/context/AppContext.tsx
@@ -1,5 +1,10 @@
 import React, { createContext, useContext, useState, ReactNode } from 'react'
-import { TypesSpace } from '@harnessio/code-service-client'
+import {
+  CodeServiceAPIClient,
+  MembershipSpacesOkResponse,
+  TypesSpace,
+  membershipSpaces
+} from '@harnessio/code-service-client'
 
 interface AppContextType {
   selectedSpace: string
@@ -8,11 +13,48 @@ interface AppContextType {
   setSpaces: (spaces: TypesSpace[]) => void
 }
 
+const BASE_URL_PREFIX = '/api/v1'
+
 const AppContext = createContext<AppContextType | undefined>(undefined)
 
 export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [selectedSpace, setSelectedSpace] = useState<string>('')
   const [spaces, setSpaces] = useState<TypesSpace[]>([])
+
+  React.useEffect(() => {
+    new CodeServiceAPIClient({
+      urlInterceptor: (url: string) => `${BASE_URL_PREFIX}${url}`,
+      requestInterceptor: (request: Request): Request => {
+        // Retrieve the token from storage and add to headers if available
+        const token = localStorage.getItem('token')
+        if (token) {
+          const newRequest = request.clone()
+          newRequest.headers.set('Authorization', `Bearer ${token}`)
+          return newRequest
+        }
+        return request
+      },
+      responseInterceptor: (response: Response) => {
+        switch (response.status) {
+          case 401:
+            localStorage.removeItem('token')
+            window.location.href = '/signin'
+        }
+        return response
+      }
+    })
+    membershipSpaces({
+      queryParams: { page: 1, limit: 10, sort: 'identifier', order: 'asc' }
+    }).then((response: MembershipSpacesOkResponse) => {
+      // @ts-expect-error remove "@ts-expect-error" once type issue for "content" is resolved
+      const spacesList: TypesMembershipSpace[] = response?.content
+      setSpaces(spacesList)
+      const preSelectedProject = spacesList?.[0]
+      if (preSelectedProject?.space?.path) {
+        setSelectedSpace(preSelectedProject.space.path)
+      }
+    })
+  }, [])
 
   return (
     <AppContext.Provider value={{ selectedSpace, setSelectedSpace, spaces, setSpaces }}>{children}</AppContext.Provider>

--- a/apps/gitness/src/framework/hooks/useGetSpaceParam.ts
+++ b/apps/gitness/src/framework/hooks/useGetSpaceParam.ts
@@ -1,7 +1,9 @@
 import { useParams } from 'react-router-dom'
 import type { PathParams } from '../../RouteDefinitions'
+import { useAppContext } from '../context/AppContext'
 
 export function useGetSpaceURLParam(): string | undefined {
+  const { selectedSpace } = useAppContext()
   const { spaceId } = useParams<PathParams>()
-  return spaceId
+  return spaceId || selectedSpace
 }

--- a/apps/gitness/src/layouts/RepoLayout.tsx
+++ b/apps/gitness/src/layouts/RepoLayout.tsx
@@ -1,37 +1,31 @@
 import React from 'react'
 import { Tabs, TabsList, TabsTrigger } from '@harnessio/canary'
-import { NavLink, Outlet, useParams } from 'react-router-dom'
+import { NavLink, Outlet } from 'react-router-dom'
+import Header from '../components/Header'
 
 const RepoLayout: React.FC = () => {
-  const { executionId } = useParams<{ executionId: string }>()
-
   return (
     <div>
-      {/* 
-        add back once projects api is integrated
-        <TopBarWidget projects={mockProjects} />
-      */}
-      {!executionId && (
-        <Tabs variant="navigation" defaultValue="summary">
-          <TabsList>
-            <NavLink to={`summary`}>
-              <TabsTrigger value="summary">Summary</TabsTrigger>
-            </NavLink>
-            <NavLink to={`pipelines`}>
-              <TabsTrigger value="pipelines">Pipelines</TabsTrigger>
-            </NavLink>
-            <NavLink to={`commits`}>
-              <TabsTrigger value="commits">Commits</TabsTrigger>
-            </NavLink>
-            <NavLink to={`pull-requests`}>
-              <TabsTrigger value="pull-requests">Pull Requests</TabsTrigger>
-            </NavLink>
-            <NavLink to={`branches`}>
-              <TabsTrigger value="branches">Branches</TabsTrigger>
-            </NavLink>
-          </TabsList>
-        </Tabs>
-      )}
+      <Header />
+      <Tabs variant="navigation" defaultValue="summary">
+        <TabsList>
+          <NavLink to={`summary`}>
+            <TabsTrigger value="summary">Summary</TabsTrigger>
+          </NavLink>
+          <NavLink to={`pipelines`}>
+            <TabsTrigger value="pipelines">Pipelines</TabsTrigger>
+          </NavLink>
+          <NavLink to={`commits`}>
+            <TabsTrigger value="commits">Commits</TabsTrigger>
+          </NavLink>
+          <NavLink to={`pull-requests`}>
+            <TabsTrigger value="pull-requests">Pull Requests</TabsTrigger>
+          </NavLink>
+          <NavLink to={`branches`}>
+            <TabsTrigger value="branches">Branches</TabsTrigger>
+          </NavLink>
+        </TabsList>
+      </Tabs>
       <main className="min-h-[calc(100vh-100px)] box-border overflow-hidden">
         <Outlet />
       </main>

--- a/apps/gitness/src/pages/execution-list.tsx
+++ b/apps/gitness/src/pages/execution-list.tsx
@@ -22,7 +22,7 @@ const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' },
 const sortOptions = [{ name: 'Sort option 1' }, { name: 'Sort option 2' }, { name: 'Sort option 3' }]
 const viewOptions = [{ name: 'View option 1' }, { name: 'View option 2' }]
 
-export default function ExecutionsPage() {
+export default function ExecutionsListPage() {
   const repoRef = useGetRepoRef()
   const {
     data: executions,

--- a/apps/gitness/src/pages/landing-page.tsx
+++ b/apps/gitness/src/pages/landing-page.tsx
@@ -1,35 +1,11 @@
-import { useMembershipSpacesQuery, TypesMembershipSpace } from '@harnessio/code-service-client'
-import { Home } from '@harnessio/playground'
 import { useNavigate } from 'react-router-dom'
 import { useAppContext } from '../framework/context/AppContext'
 
 export const LandingPage: React.FC = () => {
   const navigate = useNavigate()
-  const { setSelectedSpace, setSpaces } = useAppContext()
-  const { data } = useMembershipSpacesQuery({
-    queryParams: { page: 1, limit: 30, sort: 'identifier', order: 'asc' }
-  })
-  let projectList = []
-  // @ts-expect-error remove "@ts-expect-error" once type issue for "content" is resolved
-  const spaces = data?.content || []
-
-  if (spaces.length > 0) {
-    setSpaces(spaces)
-    projectList = spaces.map((membership: TypesMembershipSpace) => ({
-      id: membership?.space?.id,
-      name: membership?.space?.identifier
-    }))
+  const { selectedSpace } = useAppContext()
+  if (selectedSpace) {
+    navigate(`/${selectedSpace}/repos`)
   }
-
-  return (
-    <Home
-      isAuthed
-      title="Harness"
-      projects={projectList}
-      onSelectProject={(selectedProject: string) => {
-        setSelectedSpace(selectedProject)
-        navigate(`/${selectedProject}/repos`)
-      }}
-    />
-  )
+  return null
 }

--- a/packages/canary/src/components/effects/spotlights-box.tsx
+++ b/packages/canary/src/components/effects/spotlights-box.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Icon } from '../icon'
+import { Icon, IconProps } from '../icon'
 
 interface PageProps {
   children: React.ReactNode
-  logo: React.ReactElement<SVGSVGElement>
+  logo: IconProps['name']
   logoSize?: number
   highlightTop?: string
   highlightBottom?: string

--- a/packages/canary/src/components/resource-box.tsx
+++ b/packages/canary/src/components/resource-box.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Icon } from './icon'
+import { Icon, IconProps } from './icon'
 
 function Root({ children }: { children: React.ReactNode }) {
   return (
@@ -27,7 +27,7 @@ function List({ children }: { children: React.ReactNode }) {
   return <div className="flex flex-col gap-3">{children}</div>
 }
 
-function ListItem({ children, iconName }: { children: React.ReactNode; iconName?: string }) {
+function ListItem({ children, iconName }: { children: React.ReactNode; iconName?: IconProps['name'] }) {
   return (
     <div className="grid grid-cols-[auto_1fr] gap-2">
       <div>{iconName && <Icon name={iconName} size={20} className="text-tertiary-background" />}</div>

--- a/packages/playground/src/components/home.tsx
+++ b/packages/playground/src/components/home.tsx
@@ -16,7 +16,7 @@ import {
   SpotlightsBG,
   Text
 } from '@harnessio/canary'
-import { type Project } from '../components/layout/top-bar-widget'
+import { type Project } from '../components/project-dropdown'
 
 interface HomeProps {
   title: string
@@ -75,7 +75,11 @@ export const Home: React.FC<HomeProps> = ({
                       <CommandItem
                         key={project.id}
                         value={project.name}
-                        onSelect={() => handleSelectProject(project.name)}>
+                        onSelect={() => {
+                          if (project.name) {
+                            handleSelectProject(project.name)
+                          }
+                        }}>
                         {project.name}
                       </CommandItem>
                     ))}

--- a/packages/playground/src/components/layout/top-bar-widget.tsx
+++ b/packages/playground/src/components/layout/top-bar-widget.tsx
@@ -1,75 +1,20 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { useParams } from 'react-router-dom'
 import {
   Topbar,
   Breadcrumb,
   BreadcrumbList,
   BreadcrumbItem,
-  DropdownMenu,
-  DropdownMenuTrigger,
   BreadcrumbLink,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  Icon,
-  Avatar,
-  AvatarFallback,
   BreadcrumbSeparator,
   cn
 } from '@harnessio/canary'
-import { getInitials } from '../../utils/utils'
-
-export interface Project {
-  id: number
-  name: string
-}
-
-interface WidgetProps {
-  projects: Project[]
-}
+import { ProjectDropdown, ProjectDropdownProps } from '../project-dropdown'
 
 interface BreadcrumbItemProps {
   label: string
   link?: string
   isLast: boolean
-}
-
-const ProjectDropdown: React.FC<{ isPrimary: boolean; projects: Project[] }> = ({ isPrimary, projects }) => {
-  const [selectedProject, setSelectedProject] = useState<string>(projects[0].name || 'Select a project') // For Playground only, let's display the first project always
-
-  const handleOptionChange = (project: Project) => {
-    setSelectedProject(project.name)
-  }
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger className="group flex items-center gap-2 outline-none">
-        <Avatar className="w-7 h-7">
-          <AvatarFallback>{getInitials(selectedProject, 1)}</AvatarFallback>
-        </Avatar>
-        <BreadcrumbLink
-          className={cn('font-medium', { 'text-primary': isPrimary, 'text-navbar-text-secondary': !isPrimary })}>
-          {selectedProject}
-        </BreadcrumbLink>
-        <Icon
-          name="chevron-down"
-          size={10}
-          className={cn('chevron-down', {
-            'text-primary': isPrimary,
-            'text-navbar-text-secondary group-hover:text-primary': !isPrimary
-          })}
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="mt-1.5">
-        {projects.length === 0
-          ? 'No Projects Found'
-          : projects.map(project => (
-              <DropdownMenuItem key={project.id} onClick={() => handleOptionChange(project)}>
-                {project.name}
-              </DropdownMenuItem>
-            ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  )
 }
 
 const BreadcrumbNavItem: React.FC<BreadcrumbItemProps> = ({ label, link, isLast }) => (
@@ -80,14 +25,17 @@ const BreadcrumbNavItem: React.FC<BreadcrumbItemProps> = ({ label, link, isLast 
   </BreadcrumbItem>
 )
 
-const Breadcrumbs: React.FC<{ items: BreadcrumbItemProps[]; projects: Project[] }> = ({ items, projects }) => {
+const Breadcrumbs: React.FC<{ items: BreadcrumbItemProps[] } & Omit<ProjectDropdownProps, 'isPrimary'>> = ({
+  items,
+  ...rest
+}) => {
   const level1Only = items.length === 0
 
   return (
     <Breadcrumb className="select-none">
       <BreadcrumbList>
         <BreadcrumbItem>
-          <ProjectDropdown isPrimary={level1Only} projects={projects} />
+          <ProjectDropdown isPrimary={level1Only} {...rest} />
         </BreadcrumbItem>
 
         {items.map((item, index) => (
@@ -101,7 +49,7 @@ const Breadcrumbs: React.FC<{ items: BreadcrumbItemProps[]; projects: Project[] 
   )
 }
 
-export const TopBarWidget: React.FC<WidgetProps> = ({ projects }) => {
+export const TopBarWidget: React.FC<Omit<ProjectDropdownProps, 'isPrimary'>> = props => {
   const { repoId, executionId } = useParams<{ repoId: string; executionId: string }>()
 
   const breadcrumbItems: BreadcrumbItemProps[] = [
@@ -112,7 +60,7 @@ export const TopBarWidget: React.FC<WidgetProps> = ({ projects }) => {
   return (
     <Topbar.Root>
       <Topbar.Left>
-        <Breadcrumbs items={breadcrumbItems} projects={projects} />
+        <Breadcrumbs items={breadcrumbItems} {...props} />
       </Topbar.Left>
     </Topbar.Root>
   )

--- a/packages/playground/src/components/project-dropdown.tsx
+++ b/packages/playground/src/components/project-dropdown.tsx
@@ -1,0 +1,79 @@
+import {
+  Avatar,
+  AvatarFallback,
+  BreadcrumbLink,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Icon,
+  cn
+} from '@harnessio/canary'
+import React, { useEffect } from 'react'
+import { useState } from 'react'
+import { getInitials } from '../utils/utils'
+
+export interface Project {
+  id?: number
+  name?: string
+}
+
+export interface ProjectDropdownProps {
+  projects: Project[]
+  onSelectProject: (selected: Project) => void
+  isPrimary: boolean
+  preselectedProject?: Project
+}
+
+export const ProjectDropdown: React.FC<ProjectDropdownProps> = ({
+  isPrimary,
+  projects,
+  onSelectProject,
+  preselectedProject
+}) => {
+  const [selectedProject, setSelectedProject] = useState<string>(projects[0].name || 'Select a project')
+
+  useEffect(() => {
+    if (preselectedProject?.name) {
+      setSelectedProject(preselectedProject.name)
+    }
+  }, [preselectedProject])
+
+  const handleOptionChange = (project: Project) => {
+    if (project.name) {
+      onSelectProject(project)
+      setSelectedProject(project.name)
+    }
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="group flex items-center gap-2 outline-none">
+        <Avatar className="w-7 h-7">
+          <AvatarFallback>{getInitials(selectedProject, 1)}</AvatarFallback>
+        </Avatar>
+        <BreadcrumbLink
+          className={cn('font-medium', { 'text-primary': isPrimary, 'text-navbar-text-secondary': !isPrimary })}>
+          {selectedProject}
+        </BreadcrumbLink>
+        <Icon
+          name="chevron-down"
+          size={10}
+          className={cn('chevron-down', {
+            'text-primary': isPrimary,
+            'text-navbar-text-secondary group-hover:text-primary': !isPrimary
+          })}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="mt-1.5">
+        {projects.length === 0
+          ? 'No Projects Found'
+          : projects.map(project => (
+              <DropdownMenuItem key={project.id} onClick={() => handleOptionChange(project)}>
+                {project.name}
+              </DropdownMenuItem>
+            ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/packages/playground/src/data/mockProjects.ts
+++ b/packages/playground/src/data/mockProjects.ts
@@ -1,18 +1,20 @@
-export const mockProjects = [
+import { Project } from '../components/layout/top-bar-widget'
+
+export const mockProjects: Project[] = [
   {
-    id: '0',
+    id: 0,
     name: 'Pixel Point'
   },
   {
-    id: '1',
+    id: 1,
     name: 'United Bank'
   },
   {
-    id: '2',
+    id: 2,
     name: 'Code Wizards'
   },
   {
-    id: '3',
+    id: 3,
     name: 'Electric Fish'
   }
 ]

--- a/packages/playground/src/data/mockProjects.ts
+++ b/packages/playground/src/data/mockProjects.ts
@@ -1,4 +1,4 @@
-import { Project } from '../components/layout/top-bar-widget'
+import { Project } from '../components/project-dropdown'
 
 export const mockProjects: Project[] = [
   {

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -1,7 +1,6 @@
 export * from './components/layout/container'
 export * from './components/layout/layout'
 export * from './components/layout/topbar'
-export * from './components/home'
 
 export * from './components/execution-list'
 export * from './components/pipeline-list'

--- a/packages/playground/src/layouts/PipelineLayout.tsx
+++ b/packages/playground/src/layouts/PipelineLayout.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { Outlet } from 'react-router-dom'
+import { noop } from 'lodash-es'
 import { TopBarWidget } from '../components/layout/top-bar-widget'
 import { mockProjects } from '../data/mockProjects'
 
 const PipelineLayout: React.FC = () => {
   return (
     <>
-      <TopBarWidget projects={mockProjects} />
+      <TopBarWidget projects={mockProjects} onSelectProject={noop} />
       <Outlet />
     </>
   )

--- a/packages/playground/src/layouts/RepoLayout.tsx
+++ b/packages/playground/src/layouts/RepoLayout.tsx
@@ -1,5 +1,6 @@
-import { Tabs, TabsList, TabsTrigger } from '@harnessio/canary'
 import React from 'react'
+import { noop } from 'lodash-es'
+import { Tabs, TabsList, TabsTrigger } from '@harnessio/canary'
 import { NavLink, Outlet, useParams } from 'react-router-dom'
 import { TopBarWidget } from '../components/layout/top-bar-widget'
 import { mockProjects } from '../data/mockProjects'
@@ -9,7 +10,7 @@ const RepoLayout: React.FC = () => {
 
   return (
     <>
-      <TopBarWidget projects={mockProjects} />
+      <TopBarWidget projects={mockProjects} onSelectProject={noop} />
       {!executionId && (
         <Tabs variant="navigation" defaultValue="summary">
           <TabsList>

--- a/packages/playground/src/pages/execution-list-page.tsx
+++ b/packages/playground/src/pages/execution-list-page.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { noop } from 'lodash-es'
 import {
   Text,
   Spacer,
@@ -21,7 +23,6 @@ import { NoData } from '../components/no-data'
 import PlaygroundListSettings from '../settings/list-settings'
 import { TopBarWidget } from '../components/layout/top-bar-widget'
 import { mockProjects } from '../data/mockProjects'
-import { Link } from 'react-router-dom'
 
 const mockExecutions = [
   {
@@ -143,7 +144,7 @@ function ExecutionListPage() {
 
   return (
     <>
-      <TopBarWidget projects={mockProjects} />
+      <TopBarWidget projects={mockProjects} onSelectProject={noop} />
       <PaddingListLayout>
         <Text size={5} weight={'medium'}>
           Executions

--- a/packages/playground/src/pages/repo-list-page.tsx
+++ b/packages/playground/src/pages/repo-list-page.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { noop } from 'lodash-es'
 import { RepoList } from '../components/repo-list'
 import {
   Text,
@@ -76,7 +77,7 @@ function RepoListPage() {
 
   return (
     <>
-      <TopBarWidget projects={mockProjects} />
+      <TopBarWidget projects={mockProjects} onSelectProject={noop} />
       <PaddingListLayout>
         <Text size={5} weight={'medium'}>
           Repositories


### PR DESCRIPTION
- Adding `ProjectDropdown` as a separate component.
- Moved fetching spaces logic to app context.
- Fix Repo layout to render Header (with Project Dropdown in it).
- Default routing to first space/project from space/project list.
- Fix type issues in `playground`.