### PR TITLE
Playground: fix incorrectly styled first or last node connector icons

### DIFF
--- a/packages/canary/src/components/node-group.tsx
+++ b/packages/canary/src/components/node-group.tsx
@@ -57,8 +57,16 @@ function Content({ children }: { children: React.ReactNode }) {
   return <div className="col-start-2 row-start-2">{children}</div>
 }
 
-function Connector({ first }: { first?: boolean }) {
-  return <div className={cn('z-10 absolute left-[12px] top-0 bottom-0 w-[1px] border-l', { 'top-3': first })} />
+function Connector({ first, last }: { first?: boolean; last?: boolean }) {
+  return (
+    <div
+      className={cn(
+        'z-10 absolute left-[12px] top-0 bottom-0 w-[1px] border-l',
+        { 'top-3': first },
+        { 'bottom-8': last }
+      )}
+    />
+  )
 }
 
 export { Root, Icon, Title, Content, Connector }

--- a/packages/playground/src/components/commits-list.tsx
+++ b/packages/playground/src/components/commits-list.tsx
@@ -111,7 +111,7 @@ export default function RepoList({ repos, LinkComponent }: PageProps) {
               ))}
             </StackedList.Root>
           </NodeGroup.Content>
-          <NodeGroup.Connector />
+          <NodeGroup.Connector last />
         </NodeGroup.Root>
       )}
     </>

--- a/packages/playground/src/components/pull-request/pull-request-commits.tsx
+++ b/packages/playground/src/components/pull-request/pull-request-commits.tsx
@@ -59,9 +59,12 @@ export const PullRequestCommits = ({ ...props }: CommitProps) => {
     [data]
   )
 
+  const entries = Object.entries(commitsGroupedByDate)
+  const totalNodes = entries.length
+
   return (
     <>
-      {Object.entries(commitsGroupedByDate).map(([date, commitData]) => (
+      {entries.map(([date, commitData], node_idx) => (
         <NodeGroup.Root>
           <NodeGroup.Icon simpleNodeIcon />
           <NodeGroup.Title>{date && <Text color="tertiaryBackground">Commits on {date}</Text>}</NodeGroup.Title>
@@ -101,7 +104,7 @@ export const PullRequestCommits = ({ ...props }: CommitProps) => {
               </StackedList.Root>
             )}
           </NodeGroup.Content>
-          <NodeGroup.Connector />
+          <NodeGroup.Connector first={node_idx === 0} last={node_idx === totalNodes - 1} />
         </NodeGroup.Root>
       ))}
     </>


### PR DESCRIPTION
`<NodeGroup.Connector />` does not handle styling of first/last icons correctly.