### PR TITLE
Playground: remove compound variant and sm change from Shad Button to fix AI button conflict

### DIFF
--- a/packages/canary/src/components/button.tsx
+++ b/packages/canary/src/components/button.tsx
@@ -17,11 +17,11 @@ const buttonVariants = cva(
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
         split: 'border flex items-center gap-1.5 p-0',
-        'gradient-border': 'bg-background hover:bg-accent hover:text-accent-foreground'
+        'gradient-border': 'bg-background hover:bg-accent text-primary hover:text-accent-foreground'
       },
       size: {
         default: 'h-9 px-4 py-2',
-        sm: 'h-5 px-1 text-[12px]',
+        sm: 'h-8 px-3 py-0 text-sm font-normal',
         xs: 'h-auto py-0.5 px-1.5 text-xs font-normal',
         lg: 'h-10 px-8',
         icon: 'h-9 w-9',
@@ -47,13 +47,6 @@ const buttonVariants = cva(
         default: 'ai-button'
       }
     },
-    compoundVariants: [
-      {
-        size: 'sm',
-        borderRadius: 'full',
-        className: 'px-2'
-      }
-    ],
     defaultVariants: {
       variant: 'default',
       size: 'default',


### PR DESCRIPTION
The addition of compound variant and style tweak to 'sm' size prop for the Shad `<Button />` component caused the new AI button to misrender. 

Removed those changes from the Button component, whilst keeping in Badge.

Issue:
<img width="387" alt="image" src="https://github.com/user-attachments/assets/bb097997-91a9-48cf-9aa8-ec828b2a6115">

Fix:
<img width="387" alt="image" src="https://github.com/user-attachments/assets/b9442141-fe1b-424c-b3c4-441cc26a99cd">
