### PR TITLE
Playground: new layout sandbox to avoid conflicts/blocks

### DIFF
--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -27,6 +27,10 @@ import RepoExecutionListPage from './pages/repo-execution-list-page'
 import RepoWebhooksListPage from './pages/repo-webhooks-page'
 import { CreatePipelinePage } from './pages/create-pipeline-page'
 import { SandboxRoot } from './layouts/SandboxRoot'
+import { SandboxRepo } from './layouts/SandboxRepo'
+import { SandboxRepoListPage } from './pages/sandbox-repo-list-page'
+import { SandboxRepoSummaryPage } from './pages/sandbox-repo-summary-page'
+import { SandboxRepoSinglePage } from './pages/sandbox-repo-single-page'
 
 const router = createBrowserRouter([
   // TEMPORARY LAYOUT SANDBOX
@@ -36,7 +40,23 @@ const router = createBrowserRouter([
     children: [
       {
         path: 'repos',
-        element: <div>Sandbox repos</div>
+        element: <SandboxRepo />, // Contains the breadcrumbs header
+        children: [
+          {
+            index: true,
+            element: <SandboxRepoListPage />
+          },
+          {
+            path: ':repoId',
+            element: <SandboxRepoSinglePage />, // Contains the nav tabs header AND inherits the breadcrumbs header
+            children: [
+              {
+                path: 'summary',
+                element: <SandboxRepoSummaryPage />
+              }
+            ]
+          }
+        ]
       },
       {
         path: 'landing',

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -26,8 +26,24 @@ import RepoPipelineListPage from './pages/repo-pipeline-list-page'
 import RepoExecutionListPage from './pages/repo-execution-list-page'
 import RepoWebhooksListPage from './pages/repo-webhooks-page'
 import { CreatePipelinePage } from './pages/create-pipeline-page'
+import { SandboxRoot } from './layouts/SandboxRoot'
 
 const router = createBrowserRouter([
+  // TEMPORARY LAYOUT SANDBOX
+  {
+    path: '/sandbox',
+    element: <SandboxRoot />,
+    children: [
+      {
+        path: 'repos',
+        element: <div>Sandbox repos</div>
+      },
+      {
+        path: 'landing',
+        element: <div>Sandbox landing</div>
+      }
+    ]
+  },
   {
     path: '/',
     element: <RootLayout />,
@@ -145,22 +161,6 @@ const router = createBrowserRouter([
             path: 'create',
             element: <CreatePipelinePage />
           }
-          // {
-          //   path: ':pipelineId',
-          //   element: <PipelineDetailsPage />,
-          //   children: [
-          //     {
-          //       path: 'executions',
-          //       element: <RepoExecutionListPage />,
-          //       children: [
-          //         {
-          //           path: ':executionId',
-          //           element: <ExecutionDetailsPage />
-          //         }
-          //       ]
-          //     }
-          //   ]
-          // }
         ]
       },
       // EXECUTIONS (OUTSIDE REPOS)

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -56,3 +56,6 @@ export * from './utils/utils'
 
 export * as ShaBadge from './components/sha-badge'
 export * as FileViewGauge from './components/file-view-gauge'
+
+// SANDBOX LAYOUTS
+export * as SandboxLayout from './layouts/SandboxLayout'

--- a/packages/playground/src/layouts/RootLayout.tsx
+++ b/packages/playground/src/layouts/RootLayout.tsx
@@ -92,6 +92,15 @@ export const RootLayout: React.FC = () => {
                   </NavLink>
                 ))}
               </Navbar.AccordionGroup>
+              {/* Sandboxed new layout examples */}
+              <Navbar.AccordionGroup title="Layout sandbox">
+                <NavLink to="/sandbox/repos">
+                  <Navbar.Item text="Repositories" icon={<Icon name="repositories" size={12} />} />
+                </NavLink>
+                <NavLink to="/sandbox/landing">
+                  <Navbar.Item text="Landing" icon={<Icon name="harness" size={12} />} />
+                </NavLink>
+              </Navbar.AccordionGroup>
             </Navbar.Content>
             <Navbar.Footer>
               <NavbarUser.Root />

--- a/packages/playground/src/layouts/SandboxLayout.tsx
+++ b/packages/playground/src/layouts/SandboxLayout.tsx
@@ -1,18 +1,15 @@
 import { cn } from '@harnessio/canary'
 import React from 'react'
 
-const Root: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+function Root({ children }: { children: React.ReactNode }) {
   return <div className="h-screen">{children}</div>
 }
 
-function Sidebar({ children, nested, className }: { children: React.ReactNode; nested?: boolean; className?: string }) {
+function LeftPanel({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
     <div
       className={cn(
         'fixed left-0 top-0 bottom-0 z-50 w-[220px] border-r border-border-background overflow-y-auto',
-        {
-          'left-[220px] top-[100px]': nested
-        },
         className
       )}>
       {children}
@@ -20,38 +17,80 @@ function Sidebar({ children, nested, className }: { children: React.ReactNode; n
   )
 }
 
-function Main({ children }: { children: React.ReactNode }) {
-  return <div className="h-full pl-[220px]">{children}</div>
-}
+function LeftSubPanel({
+  children,
+  hasHeader,
+  hasSubHeader,
+  className
+}: {
+  children: React.ReactNode
+  hasHeader?: boolean
+  hasSubHeader?: boolean
+  className?: string
+}) {
+  const paddingTopClass =
+    hasHeader && hasSubHeader ? 'top-[100px]' : hasHeader ? 'top-[55px]' : hasSubHeader ? 'top-[45px]' : ''
 
-function Header({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
     <div
       className={cn(
-        'h-[100px] fixed top-0 left-[220px] right-0 border-b border-border-background z-50 bg-background',
+        'fixed left-[220px] top-0 bottom-0 z-50 w-[220px] border-r border-border-background overflow-y-auto',
+        paddingTopClass,
         className
       )}>
       {children}
     </div>
+  )
+}
+
+function Header({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('h-auto fixed top-0 left-[220px] right-0 z-50 bg-background', className)}>{children}</div>
+}
+
+function SubHeader({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={cn('h-auto fixed top-[55px] left-[220px] right-0 z-40 bg-background', className)}>{children}</div>
   )
 }
 
 function Content({
   children,
   fullWidth,
-  className
+  className,
+  hasHeader,
+  hasSubHeader,
+  hasLeftPanel,
+  hasLeftSubPanel
 }: {
   children: React.ReactNode
   fullWidth?: boolean
   className?: string
+  hasHeader?: boolean
+  hasSubHeader?: boolean
+  hasLeftPanel?: boolean
+  hasLeftSubPanel?: boolean
 }) {
-  if (fullWidth) return <div className={cn('min-h-full pt-[100px] w-full px-8 pb-24', className)}>{children}</div>
+  const paddingTopClass =
+    hasHeader && hasSubHeader ? 'pt-[100px]' : hasHeader ? 'pt-[55px]' : hasSubHeader ? 'pt-[45px]' : ''
+
+  const paddingLeftClass =
+    hasLeftPanel && hasLeftSubPanel ? 'pl-[440px]' : hasLeftPanel || hasLeftSubPanel ? 'pl-[220px]' : ''
+
+  if (fullWidth) {
+    return (
+      <div className={cn('min-h-full', paddingLeftClass)}>
+        <div className={cn('min-h-full w-full px-8 pb-16', paddingTopClass, className)}>{children}</div>
+      </div>
+    )
+  }
 
   return (
-    <div className="flex min-h-full pt-[100px]">
-      <div className={cn('mx-auto max-w-[1200px] w-full', className)}>{children}</div>
+    <div className={cn('min-h-full', paddingLeftClass)}>
+      <div className={cn('min-h-full mx-auto max-w-[1200px] w-full px-8 pb-16', paddingTopClass, className)}>
+        {children}
+      </div>
     </div>
   )
 }
 
-export { Root, Sidebar, Main, Header, Content }
+export { Root, LeftPanel, LeftSubPanel, Header, SubHeader, Content }

--- a/packages/playground/src/layouts/SandboxLayout.tsx
+++ b/packages/playground/src/layouts/SandboxLayout.tsx
@@ -1,7 +1,57 @@
+import { cn } from '@harnessio/canary'
 import React from 'react'
 
 const Root: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  return <>{children}</>
+  return <div className="h-screen">{children}</div>
 }
 
-export { Root }
+function Sidebar({ children, nested, className }: { children: React.ReactNode; nested?: boolean; className?: string }) {
+  return (
+    <div
+      className={cn(
+        'fixed left-0 top-0 bottom-0 z-50 w-[220px] border-r border-border-background overflow-y-auto',
+        {
+          'left-[220px] top-[100px]': nested
+        },
+        className
+      )}>
+      {children}
+    </div>
+  )
+}
+
+function Main({ children }: { children: React.ReactNode }) {
+  return <div className="h-full pl-[220px]">{children}</div>
+}
+
+function Header({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div
+      className={cn(
+        'h-[100px] fixed top-0 left-[220px] right-0 border-b border-border-background z-50 bg-background',
+        className
+      )}>
+      {children}
+    </div>
+  )
+}
+
+function Content({
+  children,
+  fullWidth,
+  className
+}: {
+  children: React.ReactNode
+  fullWidth?: boolean
+  className?: string
+}) {
+  if (fullWidth) return <div className={cn('min-h-full pt-[100px] w-full px-8 pb-24', className)}>{children}</div>
+
+  return (
+    <div className="flex min-h-full pt-[100px]">
+      <div className={cn('mx-auto max-w-[1200px] w-full', className)}>{children}</div>
+    </div>
+  )
+}
+
+export { Root, Sidebar, Main, Header, Content }

--- a/packages/playground/src/layouts/SandboxLayout.tsx
+++ b/packages/playground/src/layouts/SandboxLayout.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Root: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return <>{children}</>
+}
+
+export { Root }

--- a/packages/playground/src/layouts/SandboxRepo.tsx
+++ b/packages/playground/src/layouts/SandboxRepo.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { noop } from 'lodash-es'
+import { Outlet } from 'react-router-dom'
+import { TopBarWidget } from '../components/layout/top-bar-widget'
+import { mockProjects } from '../data/mockProjects'
+import { SandboxLayout } from '..'
+
+const SandboxRepo: React.FC = () => {
+  return (
+    <>
+      <SandboxLayout.Header>
+        <TopBarWidget projects={mockProjects} onSelectProject={noop} />
+      </SandboxLayout.Header>
+      <Outlet />
+    </>
+  )
+}
+
+export { SandboxRepo }

--- a/packages/playground/src/layouts/SandboxRoot.tsx
+++ b/packages/playground/src/layouts/SandboxRoot.tsx
@@ -1,11 +1,109 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { SandboxLayout } from '../index'
-import { Outlet } from 'react-router-dom'
+import { Link, NavLink, Outlet } from 'react-router-dom'
+import { Icon, Navbar, NavbarProjectChooser, NavbarUser } from '@harnessio/canary'
 
 export const SandboxRoot: React.FC = () => {
+  const [showMore, setShowMore] = useState<boolean>(false)
+
+  const primaryMenuItems = [
+    {
+      text: 'Repositories',
+      icon: <Icon name="repositories" size={12} />,
+      to: '/repos'
+    },
+    {
+      text: 'Pipelines',
+      icon: <Icon name="pipelines" size={12} />,
+      to: '/pipelines'
+    },
+    {
+      text: 'Executions',
+      icon: <Icon name="executions" size={12} />,
+      to: '/executions'
+    },
+    {
+      text: 'Featured Flags',
+      icon: <Icon name="featured-flags" size={12} />,
+      to: '/feature-flags'
+    }
+  ]
+
+  const pinnedMenuItems = [
+    {
+      text: 'Chaos Engineering',
+      icon: <Icon name="chaos-engineering" size={12} />,
+      to: '/chaos-engineering'
+    },
+    {
+      text: 'Environment',
+      icon: <Icon name="environment" size={12} />,
+      to: 'environment'
+    },
+    {
+      text: 'Secrets',
+      icon: <Icon name="secrets" size={12} />,
+      to: 'secrets'
+    },
+    {
+      text: 'Connectors',
+      icon: <Icon name="connectors" size={12} />,
+      to: 'connectors'
+    }
+  ]
+
+  function handleMore() {
+    setShowMore(!showMore)
+  }
   return (
     <SandboxLayout.Root>
-      <Outlet />
+      <SandboxLayout.Sidebar>
+        <Navbar.Root className="max-md:hidden fixed top-0 left-0 bottom-0 z-50">
+          <Navbar.Header>
+            <NavbarProjectChooser.Root
+              avatarLink={
+                <Link to="/">
+                  <Icon name="harness" size={20} className="text-primary" />
+                </Link>
+              }
+            />
+          </Navbar.Header>
+          <Navbar.Content>
+            <Navbar.Group>
+              {primaryMenuItems.map((item, idx) => (
+                <NavLink key={idx} to={item.to || ''}>
+                  {({ isActive }) => <Navbar.Item key={idx} text={item.text} icon={item.icon} active={isActive} />}
+                </NavLink>
+              ))}
+              <div onClick={() => (!showMore ? handleMore() : null)}>
+                <Navbar.Item text="More" icon={<Icon name="ellipsis" size={12} />} />
+              </div>
+            </Navbar.Group>
+            <Navbar.AccordionGroup title="Pinned">
+              {pinnedMenuItems.map((item, idx) => (
+                <NavLink key={idx} to={item.to || ''}>
+                  {({ isActive }) => <Navbar.Item key={idx} text={item.text} icon={item.icon} active={isActive} />}
+                </NavLink>
+              ))}
+            </Navbar.AccordionGroup>
+            {/* Sandboxed new layout examples */}
+            <Navbar.AccordionGroup title="Layout sandbox">
+              <NavLink to="/sandbox/repos">
+                <Navbar.Item text="Repositories" icon={<Icon name="repositories" size={12} />} />
+              </NavLink>
+              <NavLink to="/sandbox/landing">
+                <Navbar.Item text="Landing" icon={<Icon name="harness" size={12} />} />
+              </NavLink>
+            </Navbar.AccordionGroup>
+          </Navbar.Content>
+          <Navbar.Footer>
+            <NavbarUser.Root />
+          </Navbar.Footer>
+        </Navbar.Root>
+      </SandboxLayout.Sidebar>
+      <SandboxLayout.Main>
+        <Outlet />
+      </SandboxLayout.Main>
     </SandboxLayout.Root>
   )
 }

--- a/packages/playground/src/layouts/SandboxRoot.tsx
+++ b/packages/playground/src/layouts/SandboxRoot.tsx
@@ -57,7 +57,7 @@ export const SandboxRoot: React.FC = () => {
   }
   return (
     <SandboxLayout.Root>
-      <SandboxLayout.Sidebar>
+      <SandboxLayout.LeftPanel>
         <Navbar.Root className="max-md:hidden fixed top-0 left-0 bottom-0 z-50">
           <Navbar.Header>
             <NavbarProjectChooser.Root
@@ -89,10 +89,13 @@ export const SandboxRoot: React.FC = () => {
             {/* Sandboxed new layout examples */}
             <Navbar.AccordionGroup title="Layout sandbox">
               <NavLink to="/sandbox/repos">
-                <Navbar.Item text="Repositories" icon={<Icon name="repositories" size={12} />} />
+                <Navbar.Item text="Repo List" icon={<Icon name="repositories" size={12} />} />
               </NavLink>
-              <NavLink to="/sandbox/landing">
-                <Navbar.Item text="Landing" icon={<Icon name="harness" size={12} />} />
+              <NavLink to="/sandbox/repos/drone/summary">
+                <Navbar.Item
+                  text="Repo&nbsp;&nbsp;/&nbsp;&nbsp;Summary"
+                  icon={<Icon name="repositories" size={12} />}
+                />
               </NavLink>
             </Navbar.AccordionGroup>
           </Navbar.Content>
@@ -100,10 +103,8 @@ export const SandboxRoot: React.FC = () => {
             <NavbarUser.Root />
           </Navbar.Footer>
         </Navbar.Root>
-      </SandboxLayout.Sidebar>
-      <SandboxLayout.Main>
-        <Outlet />
-      </SandboxLayout.Main>
+      </SandboxLayout.LeftPanel>
+      <Outlet />
     </SandboxLayout.Root>
   )
 }

--- a/packages/playground/src/layouts/SandboxRoot.tsx
+++ b/packages/playground/src/layouts/SandboxRoot.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { SandboxLayout } from '../index'
+import { Outlet } from 'react-router-dom'
+
+export const SandboxRoot: React.FC = () => {
+  return (
+    <SandboxLayout.Root>
+      <Outlet />
+    </SandboxLayout.Root>
+  )
+}

--- a/packages/playground/src/pages/sandbox-repo-list-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-list-page.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react'
+import { RepoList } from '../components/repo-list'
+import {
+  Text,
+  Spacer,
+  ListActions,
+  ListPagination,
+  Button,
+  SearchBox,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationLink,
+  PaginationEllipsis,
+  PaginationNext
+} from '@harnessio/canary'
+import { Link } from 'react-router-dom'
+import { mockRepos } from '../data/mockReposData'
+import { SandboxLayout } from '../index'
+import { PlaygroundSandboxLayoutSettings } from '../settings/sandbox-settings'
+
+const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' }, { name: 'Filter option 3' }]
+const sortOptions = [{ name: 'Sort option 1' }, { name: 'Sort option 2' }, { name: 'Sort option 3' }]
+
+function SandboxRepoListPage() {
+  const [loadState, setLoadState] = useState('float')
+
+  const LinkComponent = ({ to, children }: { to: string; children: React.ReactNode }) => (
+    <Link to={`/repos/${to}`}>{children}</Link>
+  )
+
+  return (
+    <>
+      {loadState.includes('sub') && (
+        <SandboxLayout.LeftSubPanel hasHeader>
+          <div className="px-8 py-5">
+            <Text as="p" size={2} className="text-primary/70">
+              SubMenu
+            </Text>
+            <Text as="p" size={2} className="text-primary/70">
+              2,000 pixels tall
+            </Text>
+            <div className="h-[2000px]" />
+            <Text as="p" size={2} className="text-primary/70">
+              End of SubMenu
+            </Text>
+          </div>
+        </SandboxLayout.LeftSubPanel>
+      )}
+      <SandboxLayout.Content
+        hasHeader
+        hasLeftPanel
+        hasLeftSubPanel={loadState.includes('sub')}
+        fullWidth={loadState.includes('full')}>
+        <Spacer size={16} />
+        <Text size={5} weight={'medium'}>
+          Repositories
+        </Text>
+        <Spacer size={6} />
+        <ListActions.Root>
+          <ListActions.Left>
+            <SearchBox.Root placeholder="Search repositories" />
+          </ListActions.Left>
+          <ListActions.Right>
+            <ListActions.Dropdown title="Filter" items={filterOptions} />
+            <ListActions.Dropdown title="Sort" items={sortOptions} />
+            <Button variant="default">Create repository</Button>
+          </ListActions.Right>
+        </ListActions.Root>
+        <Spacer size={5} />
+        <RepoList repos={mockRepos} LinkComponent={LinkComponent} /> <Spacer size={8} />
+        {loadState === 'data-loaded' && (
+          <ListPagination.Root>
+            <Pagination>
+              <PaginationContent>
+                <PaginationItem>
+                  <PaginationPrevious size="sm" href="#" />
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationLink isActive size="sm_icon" href="#">
+                    1
+                  </PaginationLink>
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationLink size="sm_icon" href="#">
+                    2
+                  </PaginationLink>
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationLink size="sm_icon" href="#">
+                    <PaginationEllipsis />
+                  </PaginationLink>
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationLink size="sm_icon" href="#">
+                    4
+                  </PaginationLink>
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationLink size="sm_icon" href="#">
+                    5
+                  </PaginationLink>
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationNext size="sm" href="#" />
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          </ListPagination.Root>
+        )}
+        <PlaygroundSandboxLayoutSettings loadState={loadState} setLoadState={setLoadState} />
+      </SandboxLayout.Content>
+    </>
+  )
+}
+
+export { SandboxRepoListPage }

--- a/packages/playground/src/pages/sandbox-repo-single-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-single-page.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Tabs, TabsList, TabsTrigger } from '@harnessio/canary'
+import { SandboxLayout } from '..'
+import { NavLink, Outlet } from 'react-router-dom'
+
+function SandboxRepoSinglePage() {
+  return (
+    <>
+      <SandboxLayout.SubHeader>
+        <Tabs variant="navigation" defaultValue="summary">
+          <TabsList>
+            <NavLink to={`summary`}>
+              <TabsTrigger value="/summary">Summary</TabsTrigger>
+            </NavLink>
+            <NavLink to={`pipelines`}>
+              <TabsTrigger value="pipelines">Pipelines</TabsTrigger>
+            </NavLink>
+            <NavLink to={`commits`}>
+              <TabsTrigger value="commits">Commits</TabsTrigger>
+            </NavLink>
+            <NavLink to={`pull-requests`}>
+              <TabsTrigger value="pull-requests">Pull Requests</TabsTrigger>
+            </NavLink>
+            <NavLink to={`webhooks`}>
+              <TabsTrigger value="webhooks">Webhooks</TabsTrigger>
+            </NavLink>
+            <NavLink to={`branches`}>
+              <TabsTrigger value="branches">Branches</TabsTrigger>
+            </NavLink>
+          </TabsList>
+        </Tabs>
+      </SandboxLayout.SubHeader>
+      <Outlet />
+    </>
+  )
+}
+
+export { SandboxRepoSinglePage }

--- a/packages/playground/src/pages/sandbox-repo-summary-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-summary-page.tsx
@@ -1,0 +1,173 @@
+import React, { useState } from 'react'
+import { pick } from 'lodash-es'
+import {
+  Spacer,
+  ListActions,
+  Button,
+  SearchBox,
+  Text,
+  Icon,
+  ButtonGroup,
+  StackedList,
+  IconProps
+} from '@harnessio/canary'
+import { Summary } from '../components/repo-summary'
+import { RepoSummaryPanel } from '../components/repo-summary-panel'
+import { BranchSelector } from '../components/branch-chooser'
+import { FullWidth2ColumnLayout } from '../layouts/FullWidth2ColumnLayout'
+import { mockFiles } from '../data/mockSummaryFiiles'
+import { SandboxLayout } from '..'
+import { PlaygroundSandboxLayoutSettings } from '../settings/sandbox-settings'
+
+const mockSummaryDetails: { id: string; name: string; count: number; iconName: IconProps['name'] }[] = [
+  {
+    id: '0',
+    name: 'Commits',
+    count: 594,
+    iconName: 'tube-sign'
+  },
+  {
+    id: '1',
+    name: 'Branches',
+    count: 27,
+    iconName: 'branch'
+  },
+  {
+    id: '2',
+    name: 'Tags',
+    count: 69,
+    iconName: 'tag'
+  },
+  {
+    id: '3',
+    name: 'Open pull requests',
+    count: 0,
+    iconName: 'open-pr'
+  }
+]
+
+const mockBranchList = [
+  {
+    name: 'main'
+  },
+  {
+    name: 'new-feature'
+  },
+  {
+    name: 'test-wip'
+  },
+  {
+    name: 'display-db'
+  }
+]
+
+function SandboxRepoSummaryPage() {
+  const [loadState, setLoadState] = useState('float')
+
+  return (
+    <>
+      {loadState.includes('sub') && (
+        <SandboxLayout.LeftSubPanel hasHeader hasSubHeader>
+          <div className="px-8 py-5">
+            <Text as="p" size={2} className="text-primary/70">
+              SubMenu
+            </Text>
+            <Text as="p" size={2} className="text-primary/70">
+              2,000 pixels tall
+            </Text>
+            <div className="h-[2000px]" />
+            <Text as="p" size={2} className="text-primary/70">
+              End of SubMenu
+            </Text>
+          </div>
+        </SandboxLayout.LeftSubPanel>
+      )}
+      <SandboxLayout.Content
+        fullWidth={loadState.includes('full')}
+        hasLeftPanel
+        hasLeftSubPanel={loadState.includes('sub')}
+        hasHeader
+        hasSubHeader>
+        <FullWidth2ColumnLayout
+          leftColumn={
+            <>
+              <Spacer size={6} />
+              <ListActions.Root>
+                <ListActions.Left>
+                  <ButtonGroup.Root>
+                    <BranchSelector name={'main'} branchList={mockBranchList} />
+                    <SearchBox.Root placeholder="Search" />
+                  </ButtonGroup.Root>
+                </ListActions.Left>
+                <ListActions.Right>
+                  <ButtonGroup.Root>
+                    <Button variant="outline">
+                      Add file&nbsp;&nbsp;
+                      <Icon name="chevron-down" size={11} className="chevron-down" />
+                    </Button>
+                    <Button variant="default">Clone repository</Button>
+                  </ButtonGroup.Root>
+                </ListActions.Right>
+              </ListActions.Root>
+              <Spacer size={5} />
+              <Summary
+                files={mockFiles}
+                latestFile={pick(mockFiles[0], ['user', 'lastCommitMessage', 'timestamp', 'sha'])}
+              />
+              <Spacer size={12} />
+              <StackedList.Root>
+                <StackedList.Item isHeader disableHover>
+                  <StackedList.Field title={<Text color="tertiaryBackground">README.md</Text>} />
+                </StackedList.Item>
+                <StackedList.Item disableHover>
+                  {/* Dummy WYSIWYG content */}
+                  <div className="flex flex-col gap-4 px-3 py-2">
+                    <Text size={5} weight="medium">
+                      Pixel Point — Web Design and Development
+                    </Text>
+                    <Text size={3}>Table of Contents</Text>
+                    <ul className="flex flex-col gap-1">
+                      <li>
+                        <Text weight="normal" className="text-primary/80">
+                          - Welcome
+                        </Text>
+                      </li>
+                      <li>
+                        <Text weight="normal" className="text-primary/80">
+                          - Getting started
+                        </Text>
+                      </li>
+                      <li>
+                        <Text weight="normal" className="text-primary/80">
+                          - Usage
+                        </Text>
+                      </li>
+                    </ul>
+                    <Text size={3} weight="medium">
+                      Welcome
+                    </Text>
+                    <Text className="text-primary/80">
+                      Below you will find some basic information about how to work with this project. If you've spotted
+                      a bug, a copywriting mistake or just want to suggest some better solution, please, refer to the
+                      contribution section.
+                    </Text>
+                    <Text className="text-primary/80">
+                      Hello there! This repo is a home to Pixel Point, a web agency that designs and develops
+                      world-class marketing websites. We made this codebase available to open source community so
+                      everyone can get something useful out of our expertise, be it for project structure, code patterns
+                      or plugins.
+                    </Text>
+                  </div>
+                </StackedList.Item>
+              </StackedList.Root>
+            </>
+          }
+          rightColumn={<RepoSummaryPanel title="Summary" timestamp={'May 6, 2024'} details={mockSummaryDetails} />}
+        />
+      </SandboxLayout.Content>
+      <PlaygroundSandboxLayoutSettings loadState={loadState} setLoadState={setLoadState} />
+    </>
+  )
+}
+
+export { SandboxRepoSummaryPage }

--- a/packages/playground/src/settings/sandbox-settings.tsx
+++ b/packages/playground/src/settings/sandbox-settings.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import PlaygroundSettingsMenu from './menu'
+
+interface SettingsProps {
+  loadState: string
+  setLoadState: (state: string) => void
+}
+
+export const PlaygroundSandboxLayoutSettings = ({ loadState, setLoadState }: SettingsProps) => {
+  const settingsOptions = [
+    { key: 'float', label: 'Floating content' },
+    { key: 'full', label: 'Full width content' },
+    { key: 'float-sub', label: 'Floating + nested panel' },
+    { key: 'full-sub', label: 'Full width + nested panel' }
+  ]
+
+  return (
+    <PlaygroundSettingsMenu
+      title="Sandbox layout settings"
+      options={settingsOptions}
+      loadState={loadState}
+      setLoadState={setLoadState}
+    />
+  )
+}


### PR DESCRIPTION
To de-risk getting the layout right, factoring in the need to allow body overflow scroll and nested menu columns (such as Repositories > Code), I've temporarily added a layout sandbox. This will stop new layout changes from breaking existing views. Accessed via a navbar accordion group:

<img width="219" alt="image" src="https://github.com/user-attachments/assets/78ceeaf5-0dba-4686-9e0a-52f937c00930">
