### PR TITLE
Playground: 3 new screens: forgot pwd, new pwd, verify OTP

### DIFF
--- a/packages/canary/src/components/input-otp.tsx
+++ b/packages/canary/src/components/input-otp.tsx
@@ -21,31 +21,42 @@ const InputOTPGroup = React.forwardRef<React.ElementRef<'div'>, React.ComponentP
 )
 InputOTPGroup.displayName = 'InputOTPGroup'
 
-const InputOTPSlot = React.forwardRef<
-  React.ElementRef<'div'>,
-  React.ComponentPropsWithoutRef<'div'> & { index: number }
->(({ index, className, ...props }, ref) => {
-  const inputOTPContext = React.useContext(OTPInputContext)
-  const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index]
+interface InputOTPSlotProps extends React.ComponentPropsWithoutRef<'div'> {
+  index: number
+  size?: 'lg' | 'default'
+}
 
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        'relative flex h-9 w-9 items-center justify-center border-y border-r border-input text-sm shadow-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md',
-        isActive && 'z-10 ring-1 ring-ring',
-        className
-      )}
-      {...props}>
-      {char}
-      {hasFakeCaret && (
-        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <div className="h-4 w-px animate-caret-blink bg-foreground duration-1000" />
-        </div>
-      )}
-    </div>
-  )
-})
+const InputOTPSlot = React.forwardRef<HTMLDivElement, InputOTPSlotProps>(
+  ({ index, size = 'default', className, ...props }, ref) => {
+    const inputOTPContext = React.useContext(OTPInputContext)
+
+    if (!inputOTPContext?.slots?.[index]) {
+      console.error(`No slot data available for index ${index}`)
+      return null
+    }
+
+    const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index]
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'h-9 w-9 text-sm relative flex items-center justify-center border-y border-r border-input shadow-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md',
+          { 'h-12 w-10 text-xl border-l border-r border-t border-b mx-1 p-2 rounded-md': size === 'lg' },
+          isActive && 'z-10 ring-1 ring-ring',
+          className
+        )}
+        {...props}>
+        {char}
+        {hasFakeCaret && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="h-4 w-px animate-caret-blink bg-foreground duration-1000" />
+          </div>
+        )}
+      </div>
+    )
+  }
+)
 InputOTPSlot.displayName = 'InputOTPSlot'
 
 const InputOTPSeparator = React.forwardRef<React.ElementRef<'div'>, React.ComponentPropsWithoutRef<'div'>>(

--- a/packages/playground/src/pages/forgot-password-page.tsx
+++ b/packages/playground/src/pages/forgot-password-page.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { Card, CardContent, CardHeader, CardTitle, Button, Input, Label, Icon, Text, Spacer } from '@harnessio/canary'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Floating1ColumnLayout } from '../layouts/Floating1ColumnLayout'
+import { noop } from 'lodash-es'
+
+interface PageProps {
+  handleSignUp?: () => void
+  isLoading?: boolean
+}
+
+export interface DataProps {
+  email?: string
+}
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email({ message: 'Invalid email address' })
+})
+
+export function ForgotPasswordPage({ handleSignUp, isLoading }: PageProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm({
+    resolver: zodResolver(forgotPasswordSchema)
+  })
+
+  const onSubmit = () => noop
+
+  return (
+    <Floating1ColumnLayout maxWidth="md" verticalCenter>
+      <Card variant="plain" width="full">
+        <CardHeader>
+          <CardTitle className="flex flex-col place-items-center">
+            <Icon name="gitness-logo" size={104} />
+            <Text size={6} weight="medium" color="primary">
+              Forgot password?
+            </Text>
+            <Spacer size={2} />
+            <Text size={2} color="tertiaryBackground">
+              Enter your email to receive the verification code.
+            </Text>
+          </CardTitle>
+        </CardHeader>
+        <Spacer size={1} />
+        <CardContent>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <Label htmlFor="email" variant="sm">
+              Email
+            </Label>
+            <Spacer size={1} />
+            <Input id="email" type="email" {...register('email')} placeholder="email@work.com" autoFocus />
+            {errors.email && (
+              <>
+                <Spacer size={2} />
+                <Text size={1} className="text-destructive">
+                  {errors.email.message?.toString()}
+                </Text>
+              </>
+            )}
+            <Spacer size={8} />
+            <Button variant="default" borderRadius="full" type="submit" loading={isLoading} className="w-full">
+              {isLoading ? 'Sending...' : 'Send'}
+            </Button>
+          </form>
+          <Spacer size={4} />
+          <Text size={1} color="tertiaryBackground" weight="normal" align="center" className="block">
+            Don't have an account?{' '}
+            <a className="text-primary" onClick={handleSignUp}>
+              Sign up
+            </a>
+          </Text>
+        </CardContent>
+      </Card>
+    </Floating1ColumnLayout>
+  )
+}

--- a/packages/playground/src/pages/landing-page.tsx
+++ b/packages/playground/src/pages/landing-page.tsx
@@ -4,7 +4,10 @@ import { Home } from '../components/home'
 import PlaygroundLandingSettings from '../settings/landing-settings'
 import { SignInPage } from '../pages/signin-page'
 import { useNavigate } from 'react-router-dom'
-import SignUpPage from './signup-page'
+import { SignUpPage } from './signup-page'
+import { ForgotPasswordPage } from './forgot-password-page'
+import { OTPPage } from './otp-page'
+import { NewPasswordPage } from './new-password-page'
 import { mockProjects } from '../data/mockProjects'
 import { CreateProjectPage } from './create-project-page'
 
@@ -38,6 +41,12 @@ export default function LandingPage() {
         return <SignInPage handleSignUp={handleSignUp} handleSignIn={handleSignIn} />
       case 'sign-up':
         return <SignUpPage handleSignIn={handleSignIn} />
+      case 'password-forgot':
+        return <ForgotPasswordPage handleSignUp={handleSignUp} />
+      case 'password-new':
+        return <NewPasswordPage handleSignIn={handleSignIn} />
+      case 'password-otp':
+        return <OTPPage handleResend={noop} />
       default:
         return null
     }

--- a/packages/playground/src/pages/new-password-page.tsx
+++ b/packages/playground/src/pages/new-password-page.tsx
@@ -1,66 +1,40 @@
-import React, { useState } from 'react'
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  Button,
-  Input,
-  Label,
-  Icon,
-  Text,
-  Spacer,
-  Dock
-} from '@harnessio/canary'
+import React from 'react'
+import { Card, CardContent, CardHeader, CardTitle, Button, Input, Label, Icon, Text, Spacer } from '@harnessio/canary'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Floating1ColumnLayout } from '../layouts/Floating1ColumnLayout'
+import { noop } from 'lodash-es'
 
 interface PageProps {
   handleSignIn?: () => void
+  isLoading?: boolean
 }
 
-interface DataProps {
-  userId?: string
-  email?: string
+export interface DataProps {
   password?: string
   confirmPassword?: string
 }
 
-const signUpSchema = z.object({
-  userId: z.string().nonempty({ message: 'User ID cannot be blank' }),
-  email: z.string().email({ message: 'Invalid email address' }),
+const newPasswordSchema = z.object({
   password: z.string().min(6, { message: 'Password must be at least 6 characters' }),
   confirmPassword: z.string()
 })
 
-export function SignUpPage({ handleSignIn }: PageProps) {
+export function NewPasswordPage({ handleSignIn, isLoading }: PageProps) {
   const {
     register,
     handleSubmit,
     watch,
     formState: { errors }
   } = useForm({
-    resolver: zodResolver(signUpSchema)
+    resolver: zodResolver(newPasswordSchema)
   })
-  const [isLoading, setIsLoading] = useState(false)
 
-  // Watch password and confirmPassword fields
+  const onSubmit = () => noop
+
   const password = watch('password', '')
   const confirmPassword = watch('confirmPassword', '')
-
-  const onSubmit = (data: DataProps) => {
-    if (data.password !== data.confirmPassword) {
-      // Manually set error for confirmPassword
-      return
-    }
-
-    setIsLoading(true)
-    setTimeout(() => {
-      setIsLoading(false)
-    }, 2000)
-  }
 
   return (
     <Floating1ColumnLayout maxWidth="md" verticalCenter>
@@ -69,56 +43,22 @@ export function SignUpPage({ handleSignIn }: PageProps) {
           <CardTitle className="flex flex-col place-items-center">
             <Icon name="gitness-logo" size={104} />
             <Text size={6} weight="medium" color="primary">
-              Sign up to Playground
+              Create new password
             </Text>
             <Spacer size={2} />
-
-            <Text size={2} color="tertiaryBackground">
-              Let's start your journery with us today.
+            <Text size={2} color="tertiaryBackground" align="center">
+              Your new password must be different from your previously used password.
             </Text>
           </CardTitle>
         </CardHeader>
         <Spacer size={1} />
         <CardContent>
           <form onSubmit={handleSubmit(onSubmit)}>
-            <Label htmlFor="userId" variant="sm">
-              User ID
-            </Label>
-            <Spacer size={1} />
-            <Input id="userId" type="text" {...register('userId')} placeholder="Enter your user ID" autoFocus />
-            {errors.userId && (
-              <>
-                <Spacer size={2} />
-                <Text size={1} className="text-destructive">
-                  {errors.userId.message?.toString()}
-                </Text>
-              </>
-            )}
-            <Spacer size={4} />
-            <Label htmlFor="email" variant="sm">
-              Email
-            </Label>
-            <Spacer size={1} />
-            <Input id="email" type="email" {...register('email')} placeholder="email@work.com" />
-            {errors.email && (
-              <>
-                <Spacer size={2} />
-                <Text size={1} className="text-destructive">
-                  {errors.email.message?.toString()}
-                </Text>
-              </>
-            )}
-            <Spacer size={4} />
             <Label htmlFor="password" variant="sm">
-              Password
+              New password
             </Label>
             <Spacer size={1} />
-            <Input
-              id="password"
-              type="password"
-              {...register('password')}
-              placeholder="Enter the password for your account"
-            />
+            <Input id="password" type="password" {...register('password')} placeholder="Password (6+ characters)" />
             {errors.password && (
               <>
                 <Spacer size={2} />
@@ -136,7 +76,7 @@ export function SignUpPage({ handleSignIn }: PageProps) {
               id="confirmPassword"
               type="password"
               {...register('confirmPassword')}
-              placeholder="Re-enter your password"
+              placeholder="Confirm password"
               className="form-input"
             />
             {errors.confirmPassword && (
@@ -154,7 +94,7 @@ export function SignUpPage({ handleSignIn }: PageProps) {
             )}
             <Spacer size={8} />
             <Button variant="default" borderRadius="full" type="submit" loading={isLoading} className="w-full">
-              {isLoading ? 'Signing up...' : 'Sign up'}
+              {isLoading ? 'Saving...' : 'Save'}
             </Button>
           </form>
           <Spacer size={4} />
@@ -166,12 +106,6 @@ export function SignUpPage({ handleSignIn }: PageProps) {
           </Text>
         </CardContent>
       </Card>
-      <Dock.Root>
-        <Text size={1} color="tertiaryBackground">
-          By joining, you agree to <a className="text-primary">Terms of Service</a> and{' '}
-          <a className="text-primary">Privacy Policy</a>
-        </Text>
-      </Dock.Root>
     </Floating1ColumnLayout>
   )
 }

--- a/packages/playground/src/pages/otp-page.tsx
+++ b/packages/playground/src/pages/otp-page.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Button,
+  Icon,
+  Text,
+  Spacer,
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+  ButtonGroup
+} from '@harnessio/canary'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Floating1ColumnLayout } from '../layouts/Floating1ColumnLayout'
+import { noop } from 'lodash-es'
+
+interface PageProps {
+  handleResend?: () => void
+  isLoading?: boolean
+}
+
+export interface DataProps {
+  email?: string
+}
+
+const otpPasswordSchema = z.object({
+  otp: z.string().email({ message: 'Code required' })
+})
+
+export function OTPPage({ handleResend, isLoading }: PageProps) {
+  const { register, handleSubmit } = useForm({
+    resolver: zodResolver(otpPasswordSchema)
+  })
+
+  const onSubmit = () => noop
+
+  return (
+    <Floating1ColumnLayout maxWidth="md" verticalCenter>
+      <Card variant="plain" width="full">
+        <CardHeader>
+          <CardTitle className="flex flex-col place-items-center">
+            <Icon name="gitness-logo" size={104} />
+            <Text size={6} weight="medium" color="primary">
+              Verify your email
+            </Text>
+            <Spacer size={2} />
+            <Text size={2} color="tertiaryBackground" align="center">
+              Please enter the verfication code we sent to jane@smith.com
+            </Text>
+          </CardTitle>
+        </CardHeader>
+        <Spacer size={1} />
+        <CardContent>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <InputOTP maxLength={4}>
+              <InputOTPGroup id="otp" className="flex mx-auto" {...register('otp')}>
+                <InputOTPSlot index={0} size="lg" />
+                <InputOTPSlot index={1} size="lg" />
+                <InputOTPSlot index={2} size="lg" />
+                <InputOTPSlot index={3} size="lg" />
+              </InputOTPGroup>
+            </InputOTP>
+            <Spacer size={8} />
+            <ButtonGroup.Root className="flex justify-center">
+              <Button variant="default" borderRadius="full" type="submit" loading={isLoading} className="w-44">
+                {isLoading ? 'Verfiying...' : 'Verify'}
+              </Button>
+            </ButtonGroup.Root>
+          </form>
+          <Spacer size={4} />
+          <Text size={1} color="tertiaryBackground" weight="normal" align="center" className="block">
+            Didn't receive the code?{' '}
+            <a className="text-primary" onClick={handleResend}>
+              Resend
+            </a>
+          </Text>
+        </CardContent>
+      </Card>
+    </Floating1ColumnLayout>
+  )
+}

--- a/packages/playground/src/settings/landing-settings.tsx
+++ b/packages/playground/src/settings/landing-settings.tsx
@@ -12,7 +12,10 @@ const LandingSettings = ({ loadState, setLoadState }: SettingsProps) => {
     { key: 'home-unauth', label: 'Home page (unauthed)' },
     { key: 'create-workspace', label: 'Create workspace' },
     { key: 'sign-in', label: 'Sign in' },
-    { key: 'sign-up', label: 'Sign up' }
+    { key: 'sign-up', label: 'Sign up' },
+    { key: 'password-forgot', label: 'Forgot password' },
+    { key: 'password-new', label: 'New password' },
+    { key: 'password-otp', label: 'Password OTP' }
   ]
 
   return (


### PR DESCRIPTION
Added 3 housekeeping screens from Figma, accessible from `Landing` and the usual bottom right state selector:

<img width="288" alt="image" src="https://github.com/user-attachments/assets/87956277-c16d-447e-adc8-81704672c920">

Forgot password:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/51f1776d-bb9d-4b2d-a83a-c21456e55c2f">

OTP verification:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/283c78fa-9465-440a-813a-5a71cc923c13">

Create password:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/65225ffe-2757-443c-afcd-838918a6f984">
