### PR TITLE
Playground: fix table auto x scroll, some layout component changes, new layout comps

### DIFF
--- a/packages/canary/src/components/table.tsx
+++ b/packages/canary/src/components/table.tsx
@@ -2,11 +2,12 @@ import * as React from 'react'
 import { cn } from '@/lib/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
 
-const tableVariants = cva('', {
+const tableVariants = cva('w-full text-sm', {
   variants: {
     variant: {
-      default: 'w-full caption-bottom text-sm',
-      asStackedList: 'w-full text-sm'
+      default: 'caption-bottom ',
+      asStackedList:
+        'rounded-md border [&_th]:px-4 [&_td]:px-4 [&_td]:py-2.5 [&_td]:align-top [&_thead]:bg-primary/[0.02]'
     }
   },
   defaultVariants: {
@@ -14,21 +15,21 @@ const tableVariants = cva('', {
   }
 })
 
-export interface TableProps extends React.HTMLAttributes<HTMLTableElement>, VariantProps<typeof tableVariants> {}
+export interface TableProps extends React.HTMLAttributes<HTMLTableElement>, VariantProps<typeof tableVariants> {
+  disableXScroll?: boolean
+}
 
-const Table = React.forwardRef<HTMLTableElement, TableProps>(({ variant, className, ...props }, ref) => (
-  <div
-    className={cn(
-      'relative w-full overflow-auto',
-      {
-        'rounded-md border [&_th]:px-4 [&_td]:px-4 [&_td]:py-2.5 [&_td]:align-middle [&_thead]:bg-primary/[0.02]':
-          variant === 'asStackedList'
-      },
-      className
-    )}>
-    <table ref={ref} className={cn(tableVariants({ variant }))} {...props} />
-  </div>
-))
+const Table = React.forwardRef<HTMLTableElement, TableProps>(
+  ({ variant, disableXScroll, className, ...props }, ref) => (
+    <div className={cn('relative w-full overflow-auto', tableVariants({ variant }), className)}>
+      <table
+        ref={ref}
+        className={cn('overflow-x-auto w-full', { 'overflow-x-hidden min-w-auto': disableXScroll })}
+        {...props}
+      />
+    </div>
+  )
+)
 Table.displayName = 'Table'
 
 const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(

--- a/packages/playground/src/layouts/SandboxLayout.tsx
+++ b/packages/playground/src/layouts/SandboxLayout.tsx
@@ -104,19 +104,19 @@ function Main({
 
   if (fullWidth) {
     return (
-      <div
+      <section
         role="region"
         aria-label="Main Content"
         className={cn('h-full', paddingLeftClass, paddingTopClass, className)}>
         {children}
-      </div>
+      </section>
     )
   }
 
   return (
-    <div role="region" aria-label="Main Content" className={cn('h-full', paddingLeftClass)}>
+    <section role="region" aria-label="Main Content" className={cn('h-full', paddingLeftClass)}>
       <div className={cn('h-full mx-auto max-w-[1200px]', paddingTopClass, className)}>{children}</div>
-    </div>
+    </section>
   )
 }
 

--- a/packages/playground/src/layouts/SandboxLayout.tsx
+++ b/packages/playground/src/layouts/SandboxLayout.tsx
@@ -45,7 +45,7 @@ function LeftSubPanel({
   return (
     <section
       className={cn(
-        'fixed left-[220px] top-0 bottom-0 z-50 w-[248px] border-r border-border-background overflow-y-auto',
+        'fixed left-[220px] top-0 bottom-0 z-40 w-[248px] border-r border-border-background overflow-y-auto',
         paddingTopClass,
         className
       )}
@@ -57,7 +57,7 @@ function LeftSubPanel({
 
 function Header({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
-    <header className={cn('h-[55px] fixed top-0 left-[220px] right-0 z-50 bg-background', className)} role="banner">
+    <header className={cn('h-[55px] fixed top-0 left-[220px] right-0 z-40 bg-background', className)} role="banner">
       {children}
     </header>
   )

--- a/packages/playground/src/layouts/SandboxRoot.tsx
+++ b/packages/playground/src/layouts/SandboxRoot.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { SandboxLayout } from '../index'
 import { Link, NavLink, Outlet } from 'react-router-dom'
 import { Icon, Navbar, NavbarProjectChooser, NavbarUser } from '@harnessio/canary'
+import { MoreSubmenu } from '../components/more-submenu'
 
 export const SandboxRoot: React.FC = () => {
   const [showMore, setShowMore] = useState<boolean>(false)
@@ -58,7 +59,7 @@ export const SandboxRoot: React.FC = () => {
   return (
     <SandboxLayout.Root>
       <SandboxLayout.LeftPanel>
-        <Navbar.Root className="max-md:hidden fixed top-0 left-0 bottom-0 z-50">
+        <Navbar.Root>
           <Navbar.Header>
             <NavbarProjectChooser.Root
               avatarLink={
@@ -111,6 +112,7 @@ export const SandboxRoot: React.FC = () => {
         </Navbar.Root>
       </SandboxLayout.LeftPanel>
       <Outlet />
+      <MoreSubmenu showMore={showMore} handleMore={handleMore} />
     </SandboxLayout.Root>
   )
 }


### PR DESCRIPTION
- ShadCN `<Table />` modded to accept `disableXScroll` prop, which prevents horiz scrolling, with default now set to `overflow-x: auto`
- Table cell vertical alignment is now 'top' not 'middle':
<img width="684" alt="image" src="https://github.com/user-attachments/assets/9f96d27c-e7c2-4f00-ab01-be322f991a43">
- `More` navbar option now works for the sandbox views (temporary)
- Layout will get a new sticky component for fixing headers on scrolling panels (coming next commit)