### PR TITLE
Playground: fixed Sandbox Layout screens not rendering

### DIFF
--- a/packages/canary/src/components/navbar.tsx
+++ b/packages/canary/src/components/navbar.tsx
@@ -113,7 +113,7 @@ function Item({ icon, text, description, active, submenuItem, className }: ItemP
     <div className={cn('group flex gap-2.5 items-center cursor-pointer group select-none py-1.5', className)}>
       <div
         className={cn(
-          'flex z-10 items-center text-secondary-muted group-hover:text-primary ease-in-out duration-100 truncate',
+          'w-3 min-w-3 flex z-10 items-center text-secondary-muted group-hover:text-primary ease-in-out duration-100 truncate',
           { 'text-primary': active }
         )}>
         {icon}

--- a/packages/playground/src/layouts/RootLayout.tsx
+++ b/packages/playground/src/layouts/RootLayout.tsx
@@ -77,6 +77,7 @@ export const RootLayout: React.FC = () => {
   function handleMore() {
     setShowMore(!showMore)
   }
+
   function handlePinItem(item: NavbarItem) {
     setPinnedItems(prevPinnedItems => {
       const isPinned = prevPinnedItems.some(pinned => pinned.id === item.id)

--- a/packages/playground/src/layouts/SandboxRoot.tsx
+++ b/packages/playground/src/layouts/SandboxRoot.tsx
@@ -1,8 +1,17 @@
 import React, { useState } from 'react'
 import { SandboxLayout } from '../index'
 import { Link, NavLink, Outlet } from 'react-router-dom'
-import { Icon, Navbar, NavbarProjectChooser, NavbarUser } from '@harnessio/canary'
+import { Icon, IconProps, Navbar, NavbarProjectChooser, NavbarUser } from '@harnessio/canary'
 import { MoreSubmenu } from '../components/more-submenu'
+import { navbarSubmenuData } from '../data/mockNavbarSubmenuData'
+
+interface NavbarItem {
+  id: number
+  title: string
+  iconName: IconProps['name']
+  description: string
+  to?: string
+}
 
 export const SandboxRoot: React.FC = () => {
   const [showMore, setShowMore] = useState<boolean>(false)
@@ -30,32 +39,67 @@ export const SandboxRoot: React.FC = () => {
     }
   ]
 
-  const pinnedMenuItems = [
+  const initialPinnedMenuItems: NavbarItem[] = [
     {
-      text: 'Chaos Engineering',
-      icon: <Icon name="chaos-engineering" size={12} />,
+      id: 4,
+      title: 'Chaos Engineering',
+      iconName: 'chaos-engineering',
+      description: 'Manage chaos experiments',
       to: '/chaos-engineering'
     },
     {
-      text: 'Environment',
-      icon: <Icon name="environment" size={12} />,
-      to: 'environment'
+      id: 12,
+      title: 'Environment',
+      iconName: 'environment',
+      description: 'Manage your environments',
+      to: '/environment'
     },
     {
-      text: 'Secrets',
-      icon: <Icon name="secrets" size={12} />,
-      to: 'secrets'
+      id: 13,
+      title: 'Secrets',
+      iconName: 'secrets',
+      description: 'Store your secrets securely',
+      to: '/secrets'
     },
     {
-      text: 'Connectors',
-      icon: <Icon name="connectors" size={12} />,
-      to: 'connectors'
+      id: 14,
+      title: 'Connectors',
+      iconName: 'connectors',
+      description: 'Manage your connectors',
+      to: '/connectors'
     }
   ]
+
+  const [pinnedItems, setPinnedItems] = useState<NavbarItem[]>(initialPinnedMenuItems)
 
   function handleMore() {
     setShowMore(!showMore)
   }
+
+  function handlePinItem(item: NavbarItem) {
+    setPinnedItems(prevPinnedItems => {
+      const isPinned = prevPinnedItems.some(pinned => pinned.id === item.id)
+      if (isPinned) {
+        return prevPinnedItems.filter(pinned => pinned.id !== item.id)
+      } else {
+        const itemToPin = navbarSubmenuData.flatMap(group => group.items).find(i => i.id === item.id)
+        if (itemToPin) {
+          return [
+            {
+              id: itemToPin.id,
+              title: itemToPin.title,
+              iconName: itemToPin.iconName,
+              description: itemToPin.description,
+              to: itemToPin.to || ''
+            },
+            ...prevPinnedItems
+          ]
+        }
+        return prevPinnedItems
+      }
+    })
+  }
+
   return (
     <SandboxLayout.Root>
       <SandboxLayout.LeftPanel>
@@ -81,9 +125,16 @@ export const SandboxRoot: React.FC = () => {
               </div>
             </Navbar.Group>
             <Navbar.AccordionGroup title="Pinned">
-              {pinnedMenuItems.map((item, idx) => (
-                <NavLink key={idx} to={item.to || ''}>
-                  {({ isActive }) => <Navbar.Item key={idx} text={item.text} icon={item.icon} active={isActive} />}
+              {pinnedItems.map(item => (
+                <NavLink key={item.id} to={item.to || ''}>
+                  {({ isActive }) => (
+                    <Navbar.Item
+                      key={item.id}
+                      text={item.title}
+                      icon={<Icon name={item.iconName} size={12} />}
+                      active={isActive}
+                    />
+                  )}
                 </NavLink>
               ))}
             </Navbar.AccordionGroup>
@@ -112,7 +163,7 @@ export const SandboxRoot: React.FC = () => {
         </Navbar.Root>
       </SandboxLayout.LeftPanel>
       <Outlet />
-      <MoreSubmenu showMore={showMore} handleMore={handleMore} />
+      <MoreSubmenu showMore={showMore} handleMore={handleMore} onPinItem={handlePinItem} pinnedItems={pinnedItems} />
     </SandboxLayout.Root>
   )
 }


### PR DESCRIPTION
- Not sure why this broke overnight, but no Sandbox Layout screens from the navbar were loading this morning
- There were some discrepancies in `SandboxRoot` which caused the issue, although I'm not sure why this worked fine last night.
- Fixed. 