### PR TITLE
Playground: updated PR header with new pr-merged icon from Pixel Point

### DIFF
--- a/packages/canary/src/components/icon.tsx
+++ b/packages/canary/src/components/icon.tsx
@@ -83,6 +83,7 @@ import SearchContent from '../icons/search-content.svg'
 import Chain from '../icons/chain.svg'
 import ShieldTick from '../icons/shield-tick.svg'
 import CloudMining from '../icons/cloud-mining.svg'
+import PRMerged from '../icons/pr-merged.svg'
 // import Fork from '../icons/fork.svg'
 
 const IconNameMap = {
@@ -169,7 +170,8 @@ const IconNameMap = {
   'search-content': SearchContent,
   chain: Chain,
   'shield-tick': ShieldTick,
-  'cloud-mining': CloudMining
+  'cloud-mining': CloudMining,
+  'pr-merged': PRMerged
   // fork: Fork
 } satisfies Record<string, React.FunctionComponent<React.SVGProps<SVGSVGElement>>>
 

--- a/packages/canary/src/icons/pr-merged.svg
+++ b/packages/canary/src/icons/pr-merged.svg
@@ -1,0 +1,14 @@
+<svg viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_9084_38911)">
+<circle cx="3" cy="3" r="2" stroke="currentColor" stroke-linecap="round"/>
+<circle cx="11" cy="7.5" r="2" stroke="currentColor" stroke-linecap="round"/>
+<circle cx="3" cy="11" r="2" stroke="currentColor" stroke-linecap="round"/>
+<path d="M3 5V9" stroke="currentColor" stroke-linecap="round"/>
+<path d="M3 5C5 7 6.5 7.5 9 7.5" stroke="currentColor" stroke-linecap="round"/>
+</g>
+<defs>
+<clipPath id="clip0_9084_38911">
+<rect width="100%" height="100%" fill="currentColor"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/playground/src/components/pull-request/pull-request-conversation-header.tsx
+++ b/packages/playground/src/components/pull-request/pull-request-conversation-header.tsx
@@ -53,7 +53,7 @@ export const PullRequestHeader: React.FC<PullRequestTitleProps> = ({
         <div className="flex space-x-2 text-tertiary-background ">
           <div className="flex gap-2.5 items-center align-middle text-center">
             <Badge disableHover borderRadius="full" theme={merged ? 'emphasis' : 'success'} className={`select-none`}>
-              <Icon name={merged ? 'merged' : 'pr-open'} size={12} />
+              <Icon name={merged ? 'pr-merged' : 'pr-open'} size={12} />
               &nbsp;{merged ? 'Merged' : 'Open'}
             </Badge>
             <div className="flex gap-2">


### PR DESCRIPTION
New icon has arrived:

<img width="146" alt="image" src="https://github.com/user-attachments/assets/a33634e7-6488-4be7-bee1-4980ed7eac23">
