### PR TITLE
Branchlist-behind-ahead-apicall

### DIFF
--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -105,7 +105,8 @@ export function ReposBranchesListPage() {
             },
             behindAhead: {
               behind: branchBehind || 0,
-              ahead: branchAhead || 0
+              ahead: branchAhead || 0,
+              default: repoMetadata?.default_branch === branch.name
             }
           }
         })}

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -52,7 +52,7 @@ export function ReposBranchesListPage() {
         requests: brancheslistData?.map(branch => ({ from: branch.name, to: repoMetadata?.default_branch })) || []
       }
     })
-  }, [mutate, brancheslistData, repoMetadata?.default_branch]) // Include missing dependencies
+  }, [mutate, brancheslistData, repoMetadata?.default_branch])
 
   const renderContent = () => {
     if (isLoading) {

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -87,9 +87,7 @@ export function ReposBranchesListPage() {
     return (
       <BranchesList
         branches={brancheslistData?.map((branch: TypesBranch, index) => {
-          const behindAheadValue = behindAhead[index]
-          const branchAhead = behindAheadValue?.ahead
-          const branchBehind = behindAheadValue?.behind
+          const { ahead: branchAhead, behind: branchBehind } = behindAhead[index] || {}
           return {
             id: index,
             name: branch.name,

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -59,7 +59,7 @@ export function ReposBranchesListPage() {
   })
 
   useEffect(() => {
-    if (brancheslistData !== undefined) {
+    if (brancheslistData?.length !== 0 || brancheslistData !== undefined) {
       mutate({
         body: {
           requests: brancheslistData?.map(branch => ({ from: branch.name, to: repoMetadata?.default_branch })) || []

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -59,7 +59,7 @@ export function ReposBranchesListPage() {
   })
 
   useEffect(() => {
-    if (brancheslistData?.length !== 0 || brancheslistData !== undefined) {
+    if (brancheslistData?.length !== 0 && brancheslistData !== undefined) {
       mutate({
         body: {
           requests: brancheslistData?.map(branch => ({ from: branch.name, to: repoMetadata?.default_branch })) || []

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -188,7 +188,6 @@ export function ReposBranchesListPage() {
                   href="#"
                   onClick={() => currentPage < totalPages && nextPage()}
                   disabled={currentPage === totalPages}
-                  disabled={currentPage === totalPages}
                 />
               </PaginationItem>
             </PaginationContent>

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -42,7 +42,7 @@ export function ReposBranchesListPage() {
     repo_ref: repoRef
   })
 
-  const { data: branchesDivergenceData, mutate } = useCalculateCommitDivergenceMutation({
+  const { data: getBranchDivergence, mutate } = useCalculateCommitDivergenceMutation({
     repo_ref: repoRef
   })
 
@@ -77,7 +77,7 @@ export function ReposBranchesListPage() {
 
     //get the data arr from behindAhead
     const behindAhead =
-      branchesDivergenceData?.map(divergence => {
+      getBranchDivergence?.map(divergence => {
         return {
           behind: divergence.behind,
           ahead: divergence.ahead

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -54,16 +54,18 @@ export function ReposBranchesListPage() {
     }
   )
 
-  const { data: getBranchDivergence, mutate } = useCalculateCommitDivergenceMutation({
+  const { data: branchDivergence, mutate } = useCalculateCommitDivergenceMutation({
     repo_ref: repoRef
   })
 
   useEffect(() => {
-    mutate({
-      body: {
-        requests: brancheslistData?.map(branch => ({ from: branch.name, to: repoMetadata?.default_branch })) || []
-      }
-    })
+    if (brancheslistData !== undefined) {
+      mutate({
+        body: {
+          requests: brancheslistData?.map(branch => ({ from: branch.name, to: repoMetadata?.default_branch })) || []
+        }
+      })
+    }
   }, [mutate, brancheslistData, repoMetadata?.default_branch])
 
   const renderContent = (error?: ListBranchesErrorResponse) => {
@@ -97,7 +99,7 @@ export function ReposBranchesListPage() {
 
     //get the data arr from behindAhead
     const behindAhead =
-      getBranchDivergence?.map(divergence => {
+      branchDivergence?.map(divergence => {
         return {
           behind: divergence.behind,
           ahead: divergence.ahead
@@ -114,7 +116,7 @@ export function ReposBranchesListPage() {
             sha: branch.commit?.sha || '',
             timestamp: timeAgo(branch.commit?.committer?.when || ''),
             user: {
-              name: branch.commit?.committer?.identity?.name || 'Unknown User',
+              name: branch.commit?.committer?.identity?.name || '',
               avatarUrl: ''
             },
             //hardcoded

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -66,7 +66,7 @@ export function ReposBranchesListPage() {
     })
   }, [mutate, brancheslistData, repoMetadata?.default_branch])
 
-  const renderContent = (error: ListBranchesErrorResponse) => {
+  const renderContent = (error?: ListBranchesErrorResponse) => {
     if (isLoading) {
       return <SkeletonList />
     }
@@ -187,6 +187,7 @@ export function ReposBranchesListPage() {
                   size="sm"
                   href="#"
                   onClick={() => currentPage < totalPages && nextPage()}
+                  disabled={currentPage === totalPages}
                   disabled={currentPage === totalPages}
                 />
               </PaginationItem>

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -84,17 +84,19 @@ export function ReposBranchesListPage() {
         }
       }) || []
 
+    console.log(brancheslistData)
+
     return (
       <BranchesList
         branches={brancheslistData?.map((branch: TypesBranch, index) => {
           const { ahead: branchAhead, behind: branchBehind } = behindAhead[index] || {}
           return {
             id: index,
-            name: branch.name,
-            sha: branch.commit?.sha,
+            name: branch.name || '',
+            sha: branch.commit?.sha || '',
             timestamp: timeAgo(branch.commit?.committer?.when || ''),
             user: {
-              name: branch.commit?.committer?.identity?.name,
+              name: branch.commit?.committer?.identity?.name || 'Unknown User',
               avatarUrl: ''
             },
             //hardcoded

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -74,7 +74,7 @@ export function ReposBranchesListPage() {
     if (isError) {
       return (
         <div className="mt-40">
-          <NoData iconName="no-data-branches" title="Data not available" description={[`${error.message}`]} />
+          <NoData iconName="no-data-branches" title="Data not available" description={[`${error?.message}`]} />
         </div>
       )
     }

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -104,8 +104,6 @@ export function ReposBranchesListPage() {
         }
       }) || []
 
-    console.log(brancheslistData)
-
     return (
       <BranchesList
         branches={brancheslistData?.map((branch: TypesBranch, index) => {

--- a/packages/playground/src/components/branches-list.tsx
+++ b/packages/playground/src/components/branches-list.tsx
@@ -107,7 +107,7 @@ export const BranchesList = ({ branches }: PageProps) => {
                   <div className="flex gap-1.5 items-center">
                     <Icon name="open-pr" size={11} className="text-success" />
                     <Text wrap="nowrap" size={1} truncate className="text-tertiary-background">
-                      #{branch.sha}{' '}
+                      #{branch.sha}
                     </Text>
                   </div>
                 </TableCell>

--- a/packages/playground/src/components/branches-list.tsx
+++ b/packages/playground/src/components/branches-list.tsx
@@ -10,7 +10,8 @@ import {
   Text,
   Avatar,
   AvatarImage,
-  AvatarFallback
+  AvatarFallback,
+  Badge
 } from '@harnessio/canary'
 import React from 'react'
 import { getInitials } from '../utils/utils'
@@ -34,6 +35,7 @@ interface BranchProps {
   behindAhead: {
     behind?: number
     ahead?: number
+    default?: boolean
   }
 }
 
@@ -96,10 +98,20 @@ export const BranchesList = ({ branches }: PageProps) => {
                   </div>
                 </TableCell>
                 <TableCell>
-                  <div className="flex gap-1.5 items-center">
-                    <Text wrap="nowrap" truncate className="text-tertiary-background text-center flex-grow">
-                      {branch.behindAhead.behind} | {branch.behindAhead.ahead}
-                    </Text>
+                  <div className="flex gap-1.5 items-center content-center">
+                    {branch.behindAhead.default ? (
+                      <Badge
+                        variant="outline"
+                        size="xs"
+                        className="rounded-full font-normal text-xs p-2 h-5 text-tertiary-background text-center"
+                        style={{ margin: '0 auto' }}>
+                        Default
+                      </Badge>
+                    ) : (
+                      <Text wrap="nowrap" truncate className="text-tertiary-background text-center flex-grow">
+                        {branch.behindAhead.behind} | {branch.behindAhead.ahead}
+                      </Text>
+                    )}
                   </div>
                 </TableCell>
                 {/* since we don't have the data for pull request, we can temporary hide this column */}

--- a/packages/playground/src/components/branches-list.tsx
+++ b/packages/playground/src/components/branches-list.tsx
@@ -18,7 +18,7 @@ import AvatarUrl from '../../public/images/user-avatar.svg'
 import { CopyButton } from './copy-button'
 
 interface BranchProps {
-  // id: string
+  id: number
   name: string
   sha: string
   timestamp: string
@@ -27,18 +27,18 @@ interface BranchProps {
     avatarUrl?: string
   }
   checks: {
-    done: number
-    total: number
-    status: number
+    done?: number
+    total?: number
+    status?: number
   }
   behindAhead: {
-    behind: number
-    ahead: number
+    behind?: number
+    ahead?: number
   }
 }
 
 interface PageProps {
-  branches: BranchProps[]
+  branches: BranchProps[] | undefined
 }
 
 export const BranchesList = ({ branches }: PageProps) => {
@@ -49,7 +49,7 @@ export const BranchesList = ({ branches }: PageProps) => {
           <TableHead>Branch</TableHead>
           <TableHead>Updated</TableHead>
           <TableHead className="hidden">Check status</TableHead>
-          <TableHead className="text-center hidden">Behind | Ahead</TableHead>
+          <TableHead className="text-center">Behind | Ahead</TableHead>
           {/* since we don't have the data for pull request, we can temporary hide this column */}
           <TableHead className="hidden">Pull request</TableHead>
           <TableHead>
@@ -95,7 +95,7 @@ export const BranchesList = ({ branches }: PageProps) => {
                     </Text>
                   </div>
                 </TableCell>
-                <TableCell className="hidden">
+                <TableCell>
                   <div className="flex gap-1.5 items-center">
                     <Text wrap="nowrap" truncate className="text-tertiary-background text-center flex-grow">
                       {branch.behindAhead.behind} | {branch.behindAhead.ahead}

--- a/packages/playground/src/components/branches-list.tsx
+++ b/packages/playground/src/components/branches-list.tsx
@@ -40,7 +40,7 @@ interface BranchProps {
 }
 
 interface PageProps {
-  branches: BranchProps[] | undefined
+  branches: BranchProps[]
 }
 
 export const BranchesList = ({ branches }: PageProps) => {


### PR DESCRIPTION
- Solved undefined issues for getting data from useCalculateCommitDivergenceMutation
- Used the index in branch list for getting the data of useCalculateCommitDivergenceMutation, instead of splitting props in BranchList components
- Add default setting for the default branch in the first row of the branch list
<img width="1411" alt="Screenshot 2024-09-26 at 10 04 25 AM" src="https://github.com/user-attachments/assets/6c0bb685-c964-4d9f-bfec-997acd7a4d3a">
<img width="1405" alt="Screenshot 2024-09-26 at 10 04 36 AM" src="https://github.com/user-attachments/assets/469d860e-c30a-45b8-aed2-8bfb8a7e6212">
