### PR TITLE
Integrating refactored pagination into playground

### DIFF
--- a/apps/gitness/src/framework/hooks/usePagination.ts
+++ b/apps/gitness/src/framework/hooks/usePagination.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-export const usePagination = (initialPage: number = 1, totalPages: number) => {
+export const usePagination = (initialPage: number = 1, totalPages: number = 1) => {
   const [currentPage, setCurrentPage] = useState<number>(initialPage)
 
   const handleClick = (page: number) => {

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -8,6 +8,7 @@ import {
   PaginationItem,
   PaginationLink,
   PaginationNext,
+  PaginationEllipsis,
   PaginationPrevious,
   SearchBox,
   Spacer,
@@ -17,12 +18,105 @@ import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
 import { usePagination } from '../../framework/hooks/usePagination'
 
 import { useListBranchesQuery, TypesBranch } from '@harnessio/code-service-client'
+
 import { timeAgo } from '../pipeline-edit/utils/time-utils'
 
 const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' }, { name: 'Filter option 3' }]
 const sortOptions = [{ name: 'Sort option 1' }, { name: 'Sort option 2' }, { name: 'Sort option 3' }]
 
 export function ReposBranchesListPage() {
+  const PaginationComponent = ({ totalPages, previousPage, nextPage, handleClick }) => {
+    const generatePaginationItems = () => {
+      const paginationItems = []
+      const siblings = 2 // Number of adjacent pages before and after the current page
+
+      // Always show first page
+      paginationItems.push(
+        <PaginationItem key={1}>
+          <PaginationLink size="sm_icon" href="#" onClick={() => handleClick(1)} isActive={currentPage === 1}>
+            1
+          </PaginationLink>
+        </PaginationItem>
+      )
+
+      if (currentPage > 2 + siblings) {
+        paginationItems.push(
+          <PaginationItem key="start-ellipsis">
+            <PaginationEllipsis /> {/* Render ellipsis without a link */}
+          </PaginationItem>
+        ) // Ellipses before the current page
+      }
+
+      // Pages around the current page
+      for (let i = Math.max(2, currentPage - siblings); i <= Math.min(totalPages - 1, currentPage + siblings); i++) {
+        paginationItems.push(
+          <PaginationItem key={i}>
+            <PaginationLink isActive={currentPage === i} size="sm_icon" href="#" onClick={() => handleClick(i)}>
+              {i}
+            </PaginationLink>
+          </PaginationItem>
+        )
+      }
+
+      // if (currentPage < totalPages - siblings - 1) {
+      //   paginationItems.push(<span key="end-ellipsis">...</span>)
+      // }
+
+      if (currentPage < totalPages - siblings - 1) {
+        paginationItems.push(
+          <PaginationItem key="end-ellipsis">
+            <PaginationEllipsis />
+          </PaginationItem>
+        )
+      }
+
+      paginationItems.push(
+        <PaginationItem key={totalPages}>
+          <PaginationLink
+            size="sm_icon"
+            href="#"
+            onClick={() => handleClick(totalPages)}
+            isActive={currentPage === totalPages}>
+            {totalPages}
+          </PaginationLink>
+        </PaginationItem>
+      )
+
+      return paginationItems
+    }
+
+    return (
+      <ListPagination.Root>
+        <Pagination>
+          <PaginationContent>
+            {/* Previous Button */}
+            <PaginationItem>
+              <PaginationPrevious
+                size="sm"
+                href="#"
+                onClick={() => currentPage > 1 && previousPage()}
+                disabled={currentPage === 1}
+              />
+            </PaginationItem>
+
+            {/* Pagination Items */}
+            {...generatePaginationItems()}
+
+            {/* Next Button */}
+            <PaginationItem>
+              <PaginationNext
+                size="sm"
+                href="#"
+                onClick={() => currentPage < totalPages && nextPage()}
+                disabled={currentPage === totalPages}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </ListPagination.Root>
+    )
+  }
+
   // lack of data: total branches
   // hardcoded
   const totalPages = 10
@@ -38,6 +132,9 @@ export function ReposBranchesListPage() {
 
   //lack of data : avatarUrl: string, checking status , behindAhead{behind: num, ahead:num}, pullRequest{sha: string, branch number : 145}
   //TODO: fetching behindAhead data
+
+  console.log(brancheslistData)
+
   const renderContent = () => {
     if (isLoading) {
       return <SkeletonList />
@@ -114,7 +211,7 @@ export function ReposBranchesListPage() {
       <Spacer size={5} />
       {renderContent()}
       <Spacer size={8} />
-      {(brancheslistData?.length ?? 0) > 0 && (
+      {/* {(brancheslistData?.length ?? 0) > 0 && (
         <ListPagination.Root>
           <Pagination>
             <PaginationContent>
@@ -126,11 +223,6 @@ export function ReposBranchesListPage() {
                   disabled={currentPage === 1}
                 />
               </PaginationItem>
-              {/* <PaginationItem>
-              <PaginationLink size="sm_icon" href="#">
-                <PaginationEllipsis />
-              </PaginationLink>
-            </PaginationItem> */}
               {Array.from({ length: totalPages }, (_, index) => (
                 <PaginationItem key={index}>
                   <PaginationLink
@@ -153,7 +245,8 @@ export function ReposBranchesListPage() {
             </PaginationContent>
           </Pagination>
         </ListPagination.Root>
-      )}
+      )} */}
+      <PaginationComponent totalPages={7} previousPage={previousPage} nextPage={nextPage} handleClick={handleClick} />
     </PaddingListLayout>
   )
 }

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -40,8 +40,6 @@ export function ReposBranchesListPage() {
   //lack of data : avatarUrl: string, checking status , behindAhead{behind: num, ahead:num}, pullRequest{sha: string, branch number : 145}
   //TODO: fetching behindAhead data
 
-  console.log(brancheslistData)
-
   const renderContent = () => {
     if (isLoading) {
       return <SkeletonList />

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -8,7 +8,6 @@ import {
   PaginationItem,
   PaginationLink,
   PaginationNext,
-  PaginationEllipsis,
   PaginationPrevious,
   SearchBox,
   Spacer,
@@ -25,98 +24,6 @@ const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' },
 const sortOptions = [{ name: 'Sort option 1' }, { name: 'Sort option 2' }, { name: 'Sort option 3' }]
 
 export function ReposBranchesListPage() {
-  const PaginationComponent = ({ totalPages, previousPage, nextPage, handleClick }) => {
-    const generatePaginationItems = () => {
-      const paginationItems = []
-      const siblings = 2 // Number of adjacent pages before and after the current page
-
-      // Always show first page
-      paginationItems.push(
-        <PaginationItem key={1}>
-          <PaginationLink size="sm_icon" href="#" onClick={() => handleClick(1)} isActive={currentPage === 1}>
-            1
-          </PaginationLink>
-        </PaginationItem>
-      )
-
-      if (currentPage > 2 + siblings) {
-        paginationItems.push(
-          <PaginationItem key="start-ellipsis">
-            <PaginationEllipsis /> {/* Render ellipsis without a link */}
-          </PaginationItem>
-        ) // Ellipses before the current page
-      }
-
-      // Pages around the current page
-      for (let i = Math.max(2, currentPage - siblings); i <= Math.min(totalPages - 1, currentPage + siblings); i++) {
-        paginationItems.push(
-          <PaginationItem key={i}>
-            <PaginationLink isActive={currentPage === i} size="sm_icon" href="#" onClick={() => handleClick(i)}>
-              {i}
-            </PaginationLink>
-          </PaginationItem>
-        )
-      }
-
-      // if (currentPage < totalPages - siblings - 1) {
-      //   paginationItems.push(<span key="end-ellipsis">...</span>)
-      // }
-
-      if (currentPage < totalPages - siblings - 1) {
-        paginationItems.push(
-          <PaginationItem key="end-ellipsis">
-            <PaginationEllipsis />
-          </PaginationItem>
-        )
-      }
-
-      paginationItems.push(
-        <PaginationItem key={totalPages}>
-          <PaginationLink
-            size="sm_icon"
-            href="#"
-            onClick={() => handleClick(totalPages)}
-            isActive={currentPage === totalPages}>
-            {totalPages}
-          </PaginationLink>
-        </PaginationItem>
-      )
-
-      return paginationItems
-    }
-
-    return (
-      <ListPagination.Root>
-        <Pagination>
-          <PaginationContent>
-            {/* Previous Button */}
-            <PaginationItem>
-              <PaginationPrevious
-                size="sm"
-                href="#"
-                onClick={() => currentPage > 1 && previousPage()}
-                disabled={currentPage === 1}
-              />
-            </PaginationItem>
-
-            {/* Pagination Items */}
-            {...generatePaginationItems()}
-
-            {/* Next Button */}
-            <PaginationItem>
-              <PaginationNext
-                size="sm"
-                href="#"
-                onClick={() => currentPage < totalPages && nextPage()}
-                disabled={currentPage === totalPages}
-              />
-            </PaginationItem>
-          </PaginationContent>
-        </Pagination>
-      </ListPagination.Root>
-    )
-  }
-
   // lack of data: total branches
   // hardcoded
   const totalPages = 10
@@ -211,7 +118,7 @@ export function ReposBranchesListPage() {
       <Spacer size={5} />
       {renderContent()}
       <Spacer size={8} />
-      {/* {(brancheslistData?.length ?? 0) > 0 && (
+      {(brancheslistData?.length ?? 0) > 0 && (
         <ListPagination.Root>
           <Pagination>
             <PaginationContent>
@@ -245,8 +152,7 @@ export function ReposBranchesListPage() {
             </PaginationContent>
           </Pagination>
         </ListPagination.Root>
-      )} */}
-      <PaginationComponent totalPages={7} previousPage={previousPage} nextPage={nextPage} handleClick={handleClick} />
+      )}
     </PaddingListLayout>
   )
 }

--- a/apps/gitness/src/pages/repo/repo-commits.tsx
+++ b/apps/gitness/src/pages/repo/repo-commits.tsx
@@ -54,6 +54,7 @@ export default function RepoCommitsPage() {
   //   if (!commitData || !commitData.total_commits) return 0
   //   return Math.ceil(commitData.total_commits / 10)
   // }, [commitData])
+  // console.log(repository)
 
   useEffect(() => {
     if (repository) {

--- a/apps/gitness/src/pages/repo/repo-commits.tsx
+++ b/apps/gitness/src/pages/repo/repo-commits.tsx
@@ -54,7 +54,6 @@ export default function RepoCommitsPage() {
   //   if (!commitData || !commitData.total_commits) return 0
   //   return Math.ceil(commitData.total_commits / 10)
   // }, [commitData])
-  // console.log(repository)
 
   useEffect(() => {
     if (repository) {

--- a/packages/playground/src/components/pagination.tsx
+++ b/packages/playground/src/components/pagination.tsx
@@ -1,0 +1,114 @@
+import React from 'react'
+
+import {
+  ListPagination,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationEllipsis,
+  PaginationPrevious
+} from '@harnessio/canary'
+
+interface PaginationComponentProps {
+  totalPages: number
+  currentPage: number
+  previousPage: () => void
+  nextPage: () => void
+  handleClick: (totalPages: number) => void
+}
+
+export const PaginationComponent: React.FC<PaginationComponentProps> = ({
+  totalPages,
+  currentPage,
+  previousPage,
+  nextPage,
+  handleClick
+}) => {
+  const generatePaginationItems = () => {
+    const paginationItems: React.ReactElement[] = []
+    const siblings = 2 // Number of adjacent pages before and after the current page
+
+    // Always show first page
+    paginationItems.push(
+      <PaginationItem>
+        <PaginationLink size="sm_icon" href="#" onClick={() => handleClick(1)} isActive={currentPage === 1}>
+          1
+        </PaginationLink>
+      </PaginationItem>
+    )
+
+    if (currentPage > 2 + siblings) {
+      paginationItems.push(
+        <PaginationItem key="start-ellipsis">
+          <PaginationEllipsis />
+        </PaginationItem>
+      )
+    }
+
+    // Pages around the current page
+    for (let i = Math.max(2, currentPage - siblings); i <= Math.min(totalPages - 1, currentPage + siblings); i++) {
+      paginationItems.push(
+        <PaginationItem key={i}>
+          <PaginationLink isActive={currentPage === i} size="sm_icon" href="#" onClick={() => handleClick(i)}>
+            {i}
+          </PaginationLink>
+        </PaginationItem>
+      )
+    }
+
+    if (currentPage < totalPages - siblings - 1) {
+      paginationItems.push(
+        <PaginationItem key="end-ellipsis">
+          <PaginationEllipsis />
+        </PaginationItem>
+      )
+    }
+    // Always show last page
+    paginationItems.push(
+      <PaginationItem key={totalPages}>
+        <PaginationLink
+          size="sm_icon"
+          href="#"
+          onClick={() => handleClick(totalPages)}
+          isActive={currentPage === totalPages}>
+          {totalPages}
+        </PaginationLink>
+      </PaginationItem>
+    )
+
+    return paginationItems
+  }
+
+  return (
+    <ListPagination.Root>
+      <Pagination>
+        <PaginationContent>
+          {/* Previous Button */}
+          <PaginationItem>
+            <PaginationPrevious
+              size="sm"
+              href="#"
+              onClick={() => currentPage > 1 && previousPage()}
+              disabled={currentPage === 1}
+            />
+          </PaginationItem>
+
+          {/* Pagination Items */}
+          {...generatePaginationItems()}
+
+          {/* Next Button */}
+          <PaginationItem>
+            <PaginationNext
+              size="sm"
+              href="#"
+              onClick={() => currentPage < totalPages && nextPage()}
+              disabled={currentPage === totalPages}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </ListPagination.Root>
+  )
+}

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -58,6 +58,7 @@ export * from './components/form-inputs/common/InputError'
 export * from './components/form-inputs/common/InputLabel'
 export * from './components/form-inputs/common/InputWrapper'
 export * from './components/webhook-list'
+export * from './components/pagination'
 
 export * from './pages/signin-page'
 export * from './pages/create-project-page'

--- a/packages/playground/src/pages/branches-list-page.tsx
+++ b/packages/playground/src/pages/branches-list-page.tsx
@@ -3,21 +3,8 @@ import { BranchesList } from '../components/branches-list'
 import { SkeletonList } from '../components/loaders/skeleton-list'
 import { NoData } from '../components/no-data'
 import { PaddingListLayout } from '../layouts/PaddingListLayout'
-import {
-  Button,
-  ListActions,
-  ListPagination,
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-  SearchBox,
-  Spacer,
-  Text
-} from '@harnessio/canary'
+import { Button, ListActions, SearchBox, Spacer, Text } from '@harnessio/canary'
+import { PaginationComponent } from '../components/pagination'
 import PlaygroundBranchesSettings from '../settings/branches-settings'
 import { mockBranchData } from '../data/mockBranchData'
 
@@ -76,45 +63,15 @@ export default function BranchesListPage() {
       {renderContent()}
       <Spacer size={8} />
       {loadState === 'data-loaded' && (
-        <ListPagination.Root>
-          <Pagination>
-            <PaginationContent>
-              <PaginationItem>
-                <PaginationPrevious size="sm" href="#" />
-              </PaginationItem>
-              <PaginationItem>
-                <PaginationLink isActive size="sm_icon" href="#">
-                  1
-                </PaginationLink>
-              </PaginationItem>
-              <PaginationItem>
-                <PaginationLink size="sm_icon" href="#">
-                  2
-                </PaginationLink>
-              </PaginationItem>
-
-              <PaginationItem>
-                <PaginationLink size="sm_icon" href="#">
-                  <PaginationEllipsis />
-                </PaginationLink>
-              </PaginationItem>
-              <PaginationItem>
-                <PaginationLink size="sm_icon" href="#">
-                  4
-                </PaginationLink>
-              </PaginationItem>
-              <PaginationItem>
-                <PaginationLink size="sm_icon" href="#">
-                  5
-                </PaginationLink>
-              </PaginationItem>
-              <PaginationItem>
-                <PaginationNext size="sm" href="#" />
-              </PaginationItem>
-            </PaginationContent>
-          </Pagination>
-        </ListPagination.Root>
+        <PaginationComponent
+          totalPages={10}
+          currentPage={5}
+          nextPage={() => {}}
+          previousPage={() => {}}
+          handleClick={() => {}}
+        />
       )}
+
       <PlaygroundBranchesSettings loadState={loadState} setLoadState={setLoadState} />
     </PaddingListLayout>
   )

--- a/packages/playground/src/pages/commits-list-page.tsx
+++ b/packages/playground/src/pages/commits-list-page.tsx
@@ -4,19 +4,9 @@ import { SkeletonList } from '../components/loaders/skeleton-list'
 import { NoData } from '../components/no-data'
 import PlaygroundCommitsSettings from '../settings/commits-settings'
 import { PaddingListLayout } from '../layouts/PaddingListLayout'
-import {
-  ListActions,
-  ListPagination,
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-  Spacer,
-  Text
-} from '@harnessio/canary'
+import { PaginationComponent } from '../components/pagination'
+
+import { ListActions, Spacer, Text } from '@harnessio/canary'
 import { BranchSelector } from '../components/branch-chooser'
 import { mockRepos } from '../data/mockReposData'
 import { Link } from 'react-router-dom'
@@ -87,44 +77,13 @@ export default function CommitsListPage() {
       {renderContent()}
       <Spacer size={8} />
       {loadState === 'data-loaded' && (
-        <ListPagination.Root>
-          <Pagination>
-            <PaginationContent>
-              <PaginationItem>
-                <PaginationPrevious size="sm" href="#" />
-              </PaginationItem>
-              <PaginationItem>
-                <PaginationLink isActive size="sm_icon" href="#">
-                  1
-                </PaginationLink>
-              </PaginationItem>
-              <PaginationItem>
-                <PaginationLink size="sm_icon" href="#">
-                  2
-                </PaginationLink>
-              </PaginationItem>
-
-              <PaginationItem>
-                <PaginationLink size="sm_icon" href="#">
-                  <PaginationEllipsis />
-                </PaginationLink>
-              </PaginationItem>
-              <PaginationItem>
-                <PaginationLink size="sm_icon" href="#">
-                  4
-                </PaginationLink>
-              </PaginationItem>
-              <PaginationItem>
-                <PaginationLink size="sm_icon" href="#">
-                  5
-                </PaginationLink>
-              </PaginationItem>
-              <PaginationItem>
-                <PaginationNext size="sm" href="#" />
-              </PaginationItem>
-            </PaginationContent>
-          </Pagination>
-        </ListPagination.Root>
+        <PaginationComponent
+          totalPages={10}
+          currentPage={5}
+          nextPage={() => {}}
+          previousPage={() => {}}
+          handleClick={() => {}}
+        />
       )}
       <PlaygroundCommitsSettings loadState={loadState} setLoadState={setLoadState} />
     </PaddingListLayout>

--- a/packages/playground/src/pages/execution-list-page.tsx
+++ b/packages/playground/src/pages/execution-list-page.tsx
@@ -1,21 +1,10 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { noop } from 'lodash-es'
-import {
-  Text,
-  Spacer,
-  ListActions,
-  ListPagination,
-  SearchBox,
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationPrevious,
-  PaginationLink,
-  PaginationEllipsis,
-  PaginationNext
-} from '@harnessio/canary'
+import { Text, Spacer, ListActions, SearchBox } from '@harnessio/canary'
 import { type Execution, ExecutionList } from '../components/execution-list'
+import { PaginationComponent } from '../components/pagination'
+
 import { PaddingListLayout } from '../layouts/PaddingListLayout'
 import { SkeletonList } from '../components/loaders/skeleton-list'
 import { NoSearchResults } from '../components/no-search-results'
@@ -158,41 +147,13 @@ function ExecutionListPage() {
         {renderListContent()}
         <Spacer size={8} />
         {loadState == 'data-loaded' && (
-          <ListPagination.Root>
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious size="sm" href="#" />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink isActive size="sm_icon" href="#">
-                    1
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    2
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationEllipsis />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    4
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    5
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationNext size="sm" href="#" />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          </ListPagination.Root>
+          <PaginationComponent
+            totalPages={10}
+            currentPage={5}
+            nextPage={() => {}}
+            previousPage={() => {}}
+            handleClick={() => {}}
+          />
         )}
       </PaddingListLayout>
       <PlaygroundListSettings loadState={loadState} setLoadState={setLoadState} />

--- a/packages/playground/src/pages/pipeline-list-page.tsx
+++ b/packages/playground/src/pages/pipeline-list-page.tsx
@@ -1,20 +1,8 @@
 import React, { useState } from 'react'
-import {
-  Text,
-  Spacer,
-  ListActions,
-  ListPagination,
-  Button,
-  SearchBox,
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationPrevious,
-  PaginationLink,
-  PaginationEllipsis,
-  PaginationNext
-} from '@harnessio/canary'
+import { Text, Spacer, ListActions, Button, SearchBox } from '@harnessio/canary'
 import { PipelineList } from '../components/pipeline-list'
+import { PaginationComponent } from '../components/pagination'
+
 import { PaddingListLayout } from '../layouts/PaddingListLayout'
 import { SkeletonList } from '../components/loaders/skeleton-list'
 import { NoSearchResults } from '../components/no-search-results'
@@ -92,41 +80,13 @@ function PipelineListPage() {
         {renderListContent()}
         <Spacer size={8} />
         {loadState == 'data-loaded' && (
-          <ListPagination.Root>
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious size="sm" href="#" />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink isActive size="sm_icon" href="#">
-                    1
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    2
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationEllipsis />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    4
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    5
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationNext size="sm" href="#" />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          </ListPagination.Root>
+          <PaginationComponent
+            totalPages={10}
+            currentPage={5}
+            nextPage={() => {}}
+            previousPage={() => {}}
+            handleClick={() => {}}
+          />
         )}
       </PaddingListLayout>
       <PlaygroundListSettings loadState={loadState} setLoadState={setLoadState} />

--- a/packages/playground/src/pages/pull-request-list-page.tsx
+++ b/packages/playground/src/pages/pull-request-list-page.tsx
@@ -1,22 +1,10 @@
 import React, { useState } from 'react'
-import {
-  Spacer,
-  ListActions,
-  ListPagination,
-  SearchBox,
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationPrevious,
-  PaginationLink,
-  PaginationEllipsis,
-  PaginationNext,
-  Button,
-  Text
-} from '@harnessio/canary'
+import { Spacer, ListActions, SearchBox, Button, Text } from '@harnessio/canary'
 import { Link } from 'react-router-dom'
 import { PaddingListLayout } from '../layouts/PaddingListLayout'
 import { PullRequestList } from '../components/pull-request/pull-request-list'
+import { PaginationComponent } from '../components/pagination'
+
 import { SkeletonList } from '../components/loaders/skeleton-list'
 import { NoSearchResults } from '../components/no-search-results'
 import { NoData } from '../components/no-data'
@@ -242,41 +230,13 @@ function PullRequestListPage() {
         {renderListContent()}
         <Spacer size={8} />
         {loadState == 'data-loaded' && (
-          <ListPagination.Root>
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious size="sm" href="#" />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink isActive size="sm_icon" href="#">
-                    1
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    2
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationEllipsis />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    4
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    5
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationNext size="sm" href="#" />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          </ListPagination.Root>
+          <PaginationComponent
+            totalPages={10}
+            currentPage={5}
+            nextPage={() => {}}
+            previousPage={() => {}}
+            handleClick={() => {}}
+          />
         )}
       </PaddingListLayout>
       <PlaygroundListSettings loadState={loadState} setLoadState={setLoadState} />

--- a/packages/playground/src/pages/repo-execution-list-page.tsx
+++ b/packages/playground/src/pages/repo-execution-list-page.tsx
@@ -1,20 +1,8 @@
 import React, { useState } from 'react'
-import {
-  Spacer,
-  ListActions,
-  ListPagination,
-  SearchBox,
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationPrevious,
-  PaginationLink,
-  PaginationEllipsis,
-  PaginationNext,
-  Button,
-  Text
-} from '@harnessio/canary'
+import { Spacer, ListActions, SearchBox, Button, Text } from '@harnessio/canary'
 import { ExecutionList } from '../components/execution-list'
+import { PaginationComponent } from '../components/pagination'
+
 import { Link } from 'react-router-dom'
 import { PaddingListLayout } from '../layouts/PaddingListLayout'
 import { SkeletonList } from '../components/loaders/skeleton-list'
@@ -162,41 +150,13 @@ function RepoExecutionListPage() {
         {renderListContent()}
         <Spacer size={8} />
         {loadState == 'data-loaded' && (
-          <ListPagination.Root>
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious size="sm" href="#" />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink isActive size="sm_icon" href="#">
-                    1
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    2
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationEllipsis />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    4
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    5
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationNext size="sm" href="#" />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          </ListPagination.Root>
+          <PaginationComponent
+            totalPages={10}
+            currentPage={5}
+            nextPage={() => {}}
+            previousPage={() => {}}
+            handleClick={() => {}}
+          />
         )}
       </PaddingListLayout>
       <PlaygroundListSettings loadState={loadState} setLoadState={setLoadState} />

--- a/packages/playground/src/pages/repo-list-page.tsx
+++ b/packages/playground/src/pages/repo-list-page.tsx
@@ -1,21 +1,9 @@
 import React, { useState } from 'react'
 import { noop } from 'lodash-es'
 import { RepoList } from '../components/repo-list'
-import {
-  Text,
-  Spacer,
-  ListActions,
-  ListPagination,
-  Button,
-  SearchBox,
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationPrevious,
-  PaginationLink,
-  PaginationEllipsis,
-  PaginationNext
-} from '@harnessio/canary'
+import { PaginationComponent } from '../components/pagination'
+
+import { Text, Spacer, ListActions, Button, SearchBox } from '@harnessio/canary'
 import { PaddingListLayout } from '../layouts/PaddingListLayout'
 import { SkeletonList } from '../components/loaders/skeleton-list'
 import { NoData } from '../components/no-data'
@@ -97,41 +85,13 @@ function RepoListPage() {
         {renderListContent()}
         <Spacer size={8} />
         {loadState === 'data-loaded' && (
-          <ListPagination.Root>
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious size="sm" href="#" />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink isActive size="sm_icon" href="#">
-                    1
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    2
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationEllipsis />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    4
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    5
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationNext size="sm" href="#" />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          </ListPagination.Root>
+          <PaginationComponent
+            totalPages={10}
+            currentPage={5}
+            nextPage={() => {}}
+            previousPage={() => {}}
+            handleClick={() => {}}
+          />
         )}
       </PaddingListLayout>
       <PlaygroundListSettings loadState={loadState} setLoadState={setLoadState} />

--- a/packages/playground/src/pages/repo-pipeline-list-page.tsx
+++ b/packages/playground/src/pages/repo-pipeline-list-page.tsx
@@ -1,23 +1,11 @@
 import React, { useState } from 'react'
-import {
-  Spacer,
-  ListActions,
-  ListPagination,
-  Button,
-  SearchBox,
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationPrevious,
-  PaginationLink,
-  PaginationEllipsis,
-  PaginationNext,
-  Text
-} from '@harnessio/canary'
+import { Spacer, ListActions, Button, SearchBox, Text } from '@harnessio/canary'
 import { PipelineList } from '../components/pipeline-list'
 import { PaddingListLayout } from '../layouts/PaddingListLayout'
 import { NoData } from '../components/no-data'
 import { NoSearchResults } from '../components/no-search-results'
+import { PaginationComponent } from '../components/pagination'
+
 import { SkeletonList } from '../components/loaders/skeleton-list'
 import { PlaygroundListSettings } from '../settings/list-settings'
 import { mockPipelines } from '../data/mockPipelinesData'
@@ -94,41 +82,13 @@ function RepoPipelineListPage() {
         {renderListContent()}
         <Spacer size={8} />
         {loadState == 'data-loaded' && (
-          <ListPagination.Root>
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious size="sm" href="#" />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink isActive size="sm_icon" href="#">
-                    1
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    2
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationEllipsis />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    4
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    5
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationNext size="sm" href="#" />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          </ListPagination.Root>
+          <PaginationComponent
+            totalPages={10}
+            currentPage={5}
+            nextPage={() => {}}
+            previousPage={() => {}}
+            handleClick={() => {}}
+          />
         )}
       </PaddingListLayout>
       <PlaygroundListSettings loadState={loadState} setLoadState={setLoadState} />

--- a/packages/playground/src/pages/repo-webhooks-page.tsx
+++ b/packages/playground/src/pages/repo-webhooks-page.tsx
@@ -1,23 +1,10 @@
 import React, { useState } from 'react'
-import {
-  Spacer,
-  ListActions,
-  ListPagination,
-  Button,
-  SearchBox,
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationPrevious,
-  PaginationLink,
-  PaginationEllipsis,
-  PaginationNext,
-  Text
-} from '@harnessio/canary'
+import { Spacer, ListActions, Button, SearchBox, Text } from '@harnessio/canary'
 import { PaddingListLayout } from '../layouts/PaddingListLayout'
 import { NoData } from '../components/no-data'
 import { NoSearchResults } from '../components/no-search-results'
 import { SkeletonList } from '../components/loaders/skeleton-list'
+import { PaginationComponent } from '../components/pagination'
 import { PlaygroundListSettings } from '../settings/list-settings'
 import { mockWebhooks } from '../data/mockWebhooksData'
 import { Link } from 'react-router-dom'
@@ -87,41 +74,13 @@ function RepoWebhooksListPage() {
         {renderListContent()}
         <Spacer size={8} />
         {loadState == 'data-loaded' && (
-          <ListPagination.Root>
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious size="sm" href="#" />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink isActive size="sm_icon" href="#">
-                    1
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    2
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationEllipsis />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    4
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    5
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationNext size="sm" href="#" />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          </ListPagination.Root>
+          <PaginationComponent
+            totalPages={10}
+            currentPage={5}
+            nextPage={() => {}}
+            previousPage={() => {}}
+            handleClick={() => {}}
+          />
         )}
       </PaddingListLayout>
       <PlaygroundListSettings loadState={loadState} setLoadState={setLoadState} />

--- a/packages/playground/src/pages/sandbox-executions-summary-page.tsx
+++ b/packages/playground/src/pages/sandbox-executions-summary-page.tsx
@@ -1,20 +1,9 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
-import {
-  Text,
-  Spacer,
-  ListActions,
-  ListPagination,
-  SearchBox,
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationPrevious,
-  PaginationLink,
-  PaginationEllipsis,
-  PaginationNext
-} from '@harnessio/canary'
+import { Text, Spacer, ListActions, SearchBox } from '@harnessio/canary'
 import { ExecutionList } from '../components/execution-list'
+import { PaginationComponent } from '../components/pagination'
+
 import { SkeletonList } from '../components/loaders/skeleton-list'
 import { NoSearchResults } from '../components/no-search-results'
 import { NoData } from '../components/no-data'
@@ -156,41 +145,13 @@ function SandboxExecutionSummaryPage() {
         {renderListContent()}
         <Spacer size={8} />
         {loadState == 'data-loaded' && (
-          <ListPagination.Root>
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious size="sm" href="#" />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink isActive size="sm_icon" href="#">
-                    1
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    2
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationEllipsis />
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    4
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationLink size="sm_icon" href="#">
-                    5
-                  </PaginationLink>
-                </PaginationItem>
-                <PaginationItem>
-                  <PaginationNext size="sm" href="#" />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          </ListPagination.Root>
+          <PaginationComponent
+            totalPages={10}
+            currentPage={5}
+            nextPage={() => {}}
+            previousPage={() => {}}
+            handleClick={() => {}}
+          />
         )}
       </SandboxLayout.Content>
       <PlaygroundListSettings loadState={loadState} setLoadState={setLoadState} />


### PR DESCRIPTION
- Pagination component refactored and added under playground/components
- Takes props such as total pages, prev page, next page etc as discussed in standup on 9/30
- Ellipsis logic added to the component
- New Pagination component added in all listing pages of playground
- Next step would be to add this component to gitness, in a subsequent PR. 
- Screen shots attached are from playground. 
<img width="1323" alt="Screenshot 2024-09-30 at 12 56 07 PM" src="https://github.com/user-attachments/assets/f6a46db1-52f8-48fa-ba3b-b26a6008103e">
<img width="1277" alt="Screenshot 2024-09-30 at 12 56 17 PM" src="https://github.com/user-attachments/assets/fe01b3fa-1940-4296-a775-034d84d50dd9">
