### PR TITLE
Playground: file explorer – reduce nested indent and style open folders

### DIFF
--- a/packages/playground/src/components/file-explorer.tsx
+++ b/packages/playground/src/components/file-explorer.tsx
@@ -14,24 +14,31 @@ function FolderItem({ children, key, value, isActive, content, chevronClass }: I
   return (
     <AccordionItem key={key} value={value || ''} className="border-none">
       <AccordionTrigger
-        className="p-0 w-full"
+        className={cn('p-0 w-full group', 'text-tertiary-background data-[state=open]:text-primary')}
         leftChevron
         rotateChevron
         chevronClass={chevronClass || 'text-tertiary-background group-hover:text-primary'}>
         <div
-          className={cn('group w-full flex justify-start text-tertiary-background overflow-hidden', {
+          className={cn(' w-full flex justify-start overflow-hidden transition-colors duration-200', {
             'text-primary': isActive
           })}>
           <div className="flex gap-2 items-center py-1 w-full">
-            <Icon name="folder" size={12} className="min-w-[12px] group-hover:text-primary ease-in-out duration-100" />
-            <Text as="p" size={2} className="text-inherit group-hover:text-primary ease-in-out duration-100 truncate">
+            <Icon
+              name="folder"
+              size={12}
+              className="min-w-[12px] group-hover:text-primary group-data-[state=open]:text-primary ease-in-out duration-100"
+            />
+            <Text
+              as="p"
+              size={2}
+              className="text-inherit group-hover:text-primary group-data-[state=open]:text-primary ease-in-out duration-100 truncate">
               {children}
             </Text>
           </div>
         </div>
       </AccordionTrigger>
       {content && (
-        <AccordionContent className="pl-5 pb-0 flex gap-2 items-center py-1 overflow-hidden w-full">
+        <AccordionContent className="pl-1.5 pb-0 flex gap-2 items-center py-1 overflow-hidden w-full">
           {content}
         </AccordionContent>
       )}

--- a/packages/playground/src/pages/sandbox-repo-code-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-code-page.tsx
@@ -86,7 +86,7 @@ function Sidebar() {
       <SearchBox.Root width="full" placeholder="Search" />
       <FileExplorer.Root>
         {/* 2 nested levels of identical data for demo purposes */}
-        {sidebarItems.map((itm, itm_idx) =>
+        {sidebarItems.map(itm =>
           itm.type === 'file' ? (
             <Link to="#">
               <FileExplorer.FileItem key={itm.id.toString()}>{itm.name}</FileExplorer.FileItem>
@@ -95,7 +95,7 @@ function Sidebar() {
             <FileExplorer.FolderItem
               key={itm.id.toString()}
               value={itm.id.toString()}
-              isActive={itm_idx === 3}
+              // isActive={itm_idx === 3}
               content={
                 <FileExplorer.Root>
                   {sidebarItems.map(itm =>


### PR DESCRIPTION
- Reduced the nested indents
- Styled actively-open folders

<img width="261" alt="image" src="https://github.com/user-attachments/assets/ebd477b2-b07e-47dc-bc1d-f7c33ea517f9">
