### PR TITLE
Adding sandbox layout to repo list page

### DIFF
--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
-import { ThemeProvider, RootLayout } from '@harnessio/playground'
+import { ThemeProvider, RootLayout, SandboxRoot } from '@harnessio/playground'
 import { TooltipProvider } from '@harnessio/canary'
 import { queryClient } from './framework/queryClient'
 import PipelineListPage from './pages/pipeline-list'
@@ -25,12 +25,15 @@ import { ReposBranchesListPage } from './pages/repo/repo-branch-list'
 import PullRequestDataProvider from './pages/pull-request/context/pull-request-data-provider'
 import PullRequestConversationPage from './pages/pull-request/pull-request-conversation-page'
 import { RepoFiles } from './pages/repo/repo-files'
+import { SandboxRepoHeader } from './pages/repo-sandbox/repo-sandbox-header'
+import ReposSandboxListPage from './pages/repo-sandbox/repo-sandbox-list'
 
 export default function App() {
   const router = createBrowserRouter([
     {
       path: '/',
       element: <RootLayout />,
+
       children: [
         { index: true, element: <LandingPage /> },
         {
@@ -168,6 +171,26 @@ export default function App() {
     {
       path: '/signin',
       element: <SignInPage />
+    },
+    {
+      path: '/sandbox',
+      element: <SandboxRoot />,
+      children: [
+        {
+          path: 'spaces',
+          element: <SandboxRepoHeader />,
+          children: [
+            {
+              path: ':spaceId/repos',
+              element: <ReposSandboxListPage />
+            },
+            {
+              path: ':spaceId/repos/create',
+              element: <CreateRepo />
+            }
+          ]
+        }
+      ]
     }
   ])
 

--- a/apps/gitness/src/pages/repo-sandbox/repo-sandbox-header.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-sandbox-header.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { Outlet } from 'react-router-dom'
+import { SandboxLayout } from '@harnessio/playground'
+import { Topbar, Text } from '@harnessio/canary'
+import { TopBarWidget, Project } from '@harnessio/playground'
+import { useNavigate } from 'react-router-dom'
+import { TypesMembershipSpace } from '@harnessio/code-service-client'
+import { useAppContext } from '../../framework/context/AppContext'
+import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
+
+const SandboxRepoHeader: React.FC = () => {
+  const navigate = useNavigate()
+  const space = useGetSpaceURLParam()
+  const { spaces } = useAppContext()
+
+  const projectsItem =
+    spaces?.map((space: TypesMembershipSpace) => ({
+      id: space?.space?.id,
+      name: space?.space?.path
+    })) || []
+
+  if (projectsItem.length === 0) {
+    return (
+      <SandboxLayout.Header>
+        <Topbar.Root>
+          <Topbar.Left>
+            <Text size={2} weight="medium" className="text-primary">
+              Please create a new project
+            </Text>
+          </Topbar.Left>
+        </Topbar.Root>
+      </SandboxLayout.Header>
+    )
+  }
+
+  return (
+    <>
+      <SandboxLayout.Header>
+        <TopBarWidget
+          projects={projectsItem}
+          onSelectProject={(selectedProject: Project) => {
+            if (selectedProject?.name) {
+              navigate(`/sandbox/spaces/${selectedProject.name}/repos`)
+            }
+          }}
+          preselectedProject={projectsItem.find(item => item.name === space)}
+        />
+      </SandboxLayout.Header>
+      <Outlet />
+    </>
+  )
+}
+
+export { SandboxRepoHeader }

--- a/apps/gitness/src/pages/repo-sandbox/repo-sandbox-list.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-sandbox-list.tsx
@@ -18,7 +18,6 @@ import { SkeletonList, RepoList, SandboxLayout } from '@harnessio/playground'
 import { Link, useNavigate } from 'react-router-dom'
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
 import { usePagination } from '../../framework/hooks/usePagination'
-// import Header from '../../components/Header'
 import { timeAgoFromEpochTime } from '../pipeline-edit/utils/time-utils'
 
 const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' }, { name: 'Filter option 3' }]

--- a/apps/gitness/src/pages/repo-sandbox/repo-sandbox-list.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-sandbox-list.tsx
@@ -1,0 +1,149 @@
+import {
+  Button,
+  ListActions,
+  ListPagination,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  SearchBox,
+  Spacer,
+  Text
+} from '@harnessio/canary'
+import { useState } from 'react'
+import { useListReposQuery, RepoRepositoryOutput } from '@harnessio/code-service-client'
+import { SkeletonList, RepoList, SandboxLayout } from '@harnessio/playground'
+import { Link, useNavigate } from 'react-router-dom'
+import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
+import { usePagination } from '../../framework/hooks/usePagination'
+// import Header from '../../components/Header'
+import { timeAgoFromEpochTime } from '../pipeline-edit/utils/time-utils'
+
+const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' }, { name: 'Filter option 3' }]
+const sortOptions = [{ name: 'Sort option 1' }, { name: 'Sort option 2' }, { name: 'Sort option 3' }]
+const viewOptions = [{ name: 'View option 1' }, { name: 'View option 2' }]
+
+const LinkComponent = ({ to, children }: { to: string; children: React.ReactNode }) => <Link to={to}>{children}</Link>
+
+export default function ReposSandboxListPage() {
+  // hardcoded
+  const totalPages = 10
+  const navigate = useNavigate()
+  const space = useGetSpaceURLParam()
+  const [loadState, _] = useState('float')
+
+  const { isFetching, data } = useListReposQuery({ queryParams: {}, space_ref: `${space}/+` })
+  const { currentPage, previousPage, nextPage, handleClick } = usePagination(1, totalPages)
+
+  const renderListContent = () => {
+    if (isFetching) {
+      return <SkeletonList />
+    }
+    return (
+      data && (
+        <RepoList
+          LinkComponent={LinkComponent}
+          repos={data?.map((repo: RepoRepositoryOutput) => {
+            return {
+              id: repo.id,
+              name: repo.identifier,
+              description: repo.description,
+              private: !repo.is_public,
+              stars: 0,
+              forks: repo.num_forks,
+              pulls: repo.num_pulls,
+              timestamp: repo.updated && timeAgoFromEpochTime(repo.updated)
+            }
+          })}
+        />
+      )
+    )
+  }
+
+  return (
+    <>
+      {loadState.includes('sub') && (
+        <SandboxLayout.LeftSubPanel hasHeader>
+          <SandboxLayout.Content>
+            <Text as="p" size={2} className="text-primary/70">
+              SubMenu
+            </Text>
+            <Text as="p" size={2} className="text-primary/70">
+              2,000 pixels tall
+            </Text>
+            <div className="h-[2000px]" />
+            <Text as="p" size={2} className="text-primary/70">
+              End of SubMenu
+            </Text>
+          </SandboxLayout.Content>
+        </SandboxLayout.LeftSubPanel>
+      )}
+      <SandboxLayout.Main
+        hasHeader
+        hasLeftPanel
+        hasLeftSubPanel={loadState.includes('sub')}
+        fullWidth={loadState.includes('full')}>
+        <SandboxLayout.Content>
+          <Spacer size={10} />
+          <Text size={5} weight={'medium'}>
+            Repositories
+          </Text>
+          <Spacer size={6} />
+          <ListActions.Root>
+            <ListActions.Left>
+              <SearchBox.Root placeholder="Search repositories" />
+            </ListActions.Left>
+            <ListActions.Right>
+              <ListActions.Dropdown title="Filter" items={filterOptions} />
+              <ListActions.Dropdown title="Sort" items={sortOptions} />
+              <ListActions.Dropdown title="View" items={viewOptions} />
+              <Button variant="default" onClick={() => navigate(`/sandbox/spaces/${space}/repos/create`)}>
+                Create Repo
+              </Button>
+            </ListActions.Right>
+          </ListActions.Root>
+          <Spacer size={5} />
+          {renderListContent()}
+          <Spacer size={8} />
+          {(data?.length ?? 0) > 0 && (
+            <ListPagination.Root>
+              <Pagination>
+                <PaginationContent>
+                  <PaginationItem>
+                    <PaginationPrevious
+                      size="sm"
+                      href="#"
+                      onClick={() => currentPage > 1 && previousPage()}
+                      disabled={currentPage === 1}
+                    />
+                  </PaginationItem>
+                  {Array.from({ length: totalPages }, (_, index) => (
+                    <PaginationItem key={index}>
+                      <PaginationLink
+                        isActive={currentPage === index + 1}
+                        size="sm_icon"
+                        href="#"
+                        onClick={() => handleClick(index + 1)}>
+                        {index + 1}
+                      </PaginationLink>
+                    </PaginationItem>
+                  ))}
+                  <PaginationItem>
+                    <PaginationNext
+                      size="sm"
+                      href="#"
+                      onClick={() => currentPage < totalPages && nextPage()}
+                      disabled={currentPage === totalPages}
+                    />
+                  </PaginationItem>
+                </PaginationContent>
+              </Pagination>
+            </ListPagination.Root>
+          )}
+        </SandboxLayout.Content>
+      </SandboxLayout.Main>
+    </>
+  )
+}

--- a/apps/gitness/src/pages/repo/repo-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-list.tsx
@@ -76,7 +76,7 @@ export default function ReposListPage() {
             <ListActions.Dropdown title="Filter" items={filterOptions} />
             <ListActions.Dropdown title="Sort" items={sortOptions} />
             <ListActions.Dropdown title="View" items={viewOptions} />
-            <Button variant="default" onClick={() => navigate(`/${space}/repos/create`)}>
+            <Button variant="default" onClick={() => navigate(`/sandbox/spaces/${space}/repos/create`)}>
               Create Repo
             </Button>
           </ListActions.Right>

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -83,6 +83,5 @@ export * as FormFieldSet from './components/form-field-set'
 export * as SandboxLayout from './layouts/SandboxLayout'
 export * from './pages/sandbox-repo-create-page'
 export * from './layouts/SandboxRoot'
-export * from './layouts/SandboxRepo'
 
 export * from './configs/canary-outlets'

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -82,5 +82,7 @@ export * as FormFieldSet from './components/form-field-set'
 // SANDBOX LAYOUTS
 export * as SandboxLayout from './layouts/SandboxLayout'
 export * from './pages/sandbox-repo-create-page'
+export * from './layouts/SandboxRoot'
+export * from './layouts/SandboxRepo'
 
 export * from './configs/canary-outlets'


### PR DESCRIPTION
- Introduces `sandbox` layout and routing to Gitness. 
- Temporarily duplicates files and routes to ensure stability during the transition.
- All pages using Sandbox layouts will be added under the `sandbox` route in `App.tsx`. The aim is to migrate all pages to sandbox layout asap. 
- This PR applies `sandbox` layout to `repo-list-page`. After review by @joetaylor-harness, we can roll out the layout to other pages.
- The focus of this PR is to ensure proper implementation of the sandbox layout.






