### PR TITLE
Minor fixes to account for API error in repo-create-page

### DIFF
--- a/apps/gitness/src/pages/repo/repo-create-page.tsx
+++ b/apps/gitness/src/pages/repo/repo-create-page.tsx
@@ -55,7 +55,13 @@ export const CreateRepo = () => {
   return (
     <>
       <Header />
-      <SandboxRepoCreatePage onFormSubmit={onSubmit} onFormCancel={onCancel} apiError={apiError} />
+      <SandboxRepoCreatePage
+        onFormSubmit={onSubmit}
+        onFormCancel={onCancel}
+        apiError={apiError}
+        isLoading={createRepositoryMutation.isLoading}
+        isSuccess={createRepositoryMutation.isSuccess}
+      />
     </>
   )
 }

--- a/packages/playground/src/pages/sandbox-repo-create-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-create-page.tsx
@@ -38,11 +38,15 @@ interface SandboxRepoCreatePageProps {
   onFormSubmit: (data: FormFields) => void
   onFormCancel: () => void
   apiError: string | null
+  isLoading: boolean
+  isSuccess: boolean
 }
 const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
   onFormSubmit,
   apiError = null,
-  onFormCancel
+  onFormCancel,
+  isLoading,
+  isSuccess
 }) => {
   const {
     register,
@@ -67,7 +71,6 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
   const gitignoreValue = watch('gitignore')
   const licenseValue = watch('license')
 
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false)
 
   const handleSelectChange = (fieldName: keyof FormFields, value: string) => {
@@ -77,24 +80,16 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
   const handleAccessChange = (value: '1' | '2') => {
     setValue('access', value, { shouldValidate: true })
   }
+
   useEffect(() => {
-    if (apiError === null) {
+    if (isSuccess === true) {
       reset()
       setIsSubmitted(true)
-
-      setTimeout(() => {
-        setIsSubmitted(false)
-      }, 2000)
     }
-  }, [apiError])
+  }, [isSuccess])
 
   const onSubmit: SubmitHandler<FormFields> = data => {
-    setIsSubmitting(true)
     onFormSubmit(data)
-
-    setTimeout(() => {
-      setIsSubmitting(false)
-    }, 2000)
   }
 
   const handleCancel = () => {
@@ -234,8 +229,8 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
                 <ButtonGroup.Root>
                   {!isSubmitted ? (
                     <>
-                      <Button type="submit" size="sm" disabled={!isValid || isSubmitting}>
-                        {!isSubmitting ? 'Create repository' : 'Creating repository...'}
+                      <Button type="submit" size="sm" disabled={!isValid || isLoading}>
+                        {!isLoading ? 'Create repository' : 'Creating repository...'}
                       </Button>
                       <Button type="button" variant="outline" size="sm" onClick={handleCancel}>
                         Cancel

--- a/packages/playground/src/pages/sandbox-repo-create-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-create-page.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { SandboxLayout } from '..'
 import {
   Button,
@@ -37,9 +37,13 @@ export type FormFields = z.infer<typeof formSchema> // Automatically generate a 
 interface SandboxRepoCreatePageProps {
   onFormSubmit: (data: FormFields) => void
   onFormCancel: () => void
-  apiError?: string | null
+  apiError: string | null
 }
-const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({ onFormSubmit, apiError, onFormCancel }) => {
+const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
+  onFormSubmit,
+  apiError = null,
+  onFormCancel
+}) => {
   const {
     register,
     handleSubmit,
@@ -64,7 +68,7 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({ onFormSub
   const licenseValue = watch('license')
 
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
-  const [isSubmitted, setIsSubmitted] = useState<boolean>(false) // New state for tracking submission status
+  const [isSubmitted, setIsSubmitted] = useState<boolean>(false)
 
   const handleSelectChange = (fieldName: keyof FormFields, value: string) => {
     setValue(fieldName, value, { shouldValidate: true })
@@ -73,15 +77,23 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({ onFormSub
   const handleAccessChange = (value: '1' | '2') => {
     setValue('access', value, { shouldValidate: true })
   }
+  useEffect(() => {
+    if (apiError === null) {
+      reset()
+      setIsSubmitted(true)
+
+      setTimeout(() => {
+        setIsSubmitted(false)
+      }, 2000)
+    }
+  }, [apiError])
 
   const onSubmit: SubmitHandler<FormFields> = data => {
     setIsSubmitting(true)
+    onFormSubmit(data)
+
     setTimeout(() => {
-      onFormSubmit(data)
-      reset()
       setIsSubmitting(false)
-      setIsSubmitted(true)
-      setTimeout(() => setIsSubmitted(false), 2000)
     }, 2000)
   }
 


### PR DESCRIPTION
- Makes sure `success button` only visible when API call returns no errors. 
- Persists form data in case of an error, so user can make changes. 
- Removes `setTimeout`, and reduces state management within the component. Utilizes `react-query's` inbuilt states. 

 Below screen recordings should make bug fix clear:

Earlier:

https://github.com/user-attachments/assets/903009b9-de0a-4f6a-ae8d-3240829e3563

Now:

https://github.com/user-attachments/assets/19115816-a0b6-4c3a-aea2-a46c659f5ade



