### PR TITLE
Playground: very temporary fix for Gitness searchbox padding issue

### DIFF
--- a/packages/canary/src/components/search-box.tsx
+++ b/packages/canary/src/components/search-box.tsx
@@ -102,7 +102,16 @@ function Root({
       )}
       <Input
         placeholder={placeholder}
-        className={cn('border-input-foreground pl-7', textSizeClass, { 'pr-10': hasShortcut })}
+        // TODO: Restore the line and remove temp fix below
+        // className={cn('border-input-foreground pl-7', textSizeClass, { 'pr-10': hasShortcut })}
+
+        // Start of temporary fix
+        className={cn('border-input-foreground', textSizeClass)}
+        style={{
+          paddingLeft: '1.75rem', // Equivalent to 'pl-7' in Tailwind (28px)
+          paddingRight: hasShortcut ? '2.5rem' : undefined // Equivalent to 'pr-10' in Tailwind (40px) if `hasShortcut` is true
+        }}
+        // End of temporary fix
         onKeyDown={handleKeyDown}
         onFocus={handleFocus}
       />


### PR DESCRIPTION
This is a very short term fix for the Gitness-specific issue where the `<Searchbox />` component cannot handle tailwind padding, and therefore the left icon overlays the text.

This is a symptom of how the products/modules build tailwind, which must be addressed. Once addressed, this fix will no longer be required.