### PR TITLE
Playground: repo summary add line clamp and truncate

### DIFF
--- a/packages/playground/src/components/repo-summary.tsx
+++ b/packages/playground/src/components/repo-summary.tsx
@@ -119,11 +119,15 @@ export const Summary = ({ ...props }: PageProps) => {
                     ) : (
                       <Icon name="folder" size={14} className="text-tertiary-background" />
                     )}
-                    <Text color="primary">{file.name}</Text>
+                    <Text truncate color="primary">
+                      {file.name}
+                    </Text>
                   </ButtonGroup.Root>
                 </TableCell>
                 <TableCell>
-                  <Text color="tertiaryBackground">{file.lastCommitMessage}</Text>
+                  <Text color="tertiaryBackground" className="line-clamp-1">
+                    {file.lastCommitMessage}
+                  </Text>
                 </TableCell>
                 <TableCell className="text-right">
                   <Text color="tertiaryBackground" wrap="nowrap">


### PR DESCRIPTION
In Sandbox:

`Repo > Summary` now truncates the file name column and applies a line clamp = 1 to the commit msg.
<img width="1710" alt="Screenshot 2024-10-04 at 08 14 01" src="https://github.com/user-attachments/assets/9d641afe-c75c-4929-b1ef-f85c1022c38f">
