### PR TITLE
Add common filter hook with sort filter

### DIFF
--- a/apps/gitness/src/pages/pull-request-list-page.tsx
+++ b/apps/gitness/src/pages/pull-request-list-page.tsx
@@ -34,12 +34,12 @@ function PullRequestListPage() {
   const repoRef = useGetRepoRef()
   const { currentPage, previousPage, nextPage, handleClick } = usePagination(1, totalPages)
 
-  const { Filter, sort } = useCommonFilter({ sortOptions: sortOptions })
+  const { Filter, sort } = useCommonFilter({ sortOptions })
 
   const { data: pullrequests, isFetching } = useListPullReqQuery(
     {
       repo_ref: repoRef,
-      queryParams: { page: 0, limit: 10, query: '', sort: sort }
+      queryParams: { page: 0, limit: 10, query: '', sort }
     },
     /* To enable mock data */
     {

--- a/apps/gitness/src/pages/pull-request-list-page.tsx
+++ b/apps/gitness/src/pages/pull-request-list-page.tsx
@@ -1,26 +1,31 @@
 import {
   Spacer,
-  ListActions,
   ListPagination,
-  SearchBox,
   Pagination,
   PaginationContent,
   PaginationItem,
   PaginationPrevious,
   PaginationLink,
   PaginationNext,
-  Button,
   Text
 } from '@harnessio/canary'
 import { Link } from 'react-router-dom'
-import { PaddingListLayout, SkeletonList, PullRequestList, NoData } from '@harnessio/playground'
+import { PaddingListLayout, SkeletonList, PullRequestList, NoData, useCommonFilter } from '@harnessio/playground'
 import { TypesPullReq, useListPullReqQuery } from '@harnessio/code-service-client'
 import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
 import { usePagination } from '../framework/hooks/usePagination'
 import { timeAgoFromEpochTime } from './pipeline-edit/utils/time-utils'
+import { DropdownItemProps } from '../../../../packages/canary/dist/components/list-actions'
 
-const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' }, { name: 'Filter option 3' }]
-const sortOptions = [{ name: 'Sort option 1' }, { name: 'Sort option 2' }, { name: 'Sort option 3' }]
+// const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' }, { name: 'Filter option 3' }]
+
+const sortOptions = [
+  { name: 'Created', value: 'created' },
+  { name: 'Edited', value: 'edited' },
+  { name: 'Merged', value: 'merged' },
+  { name: 'Number', value: 'number' },
+  { name: 'Updated', value: 'updated' }
+] as const satisfies DropdownItemProps[]
 
 function PullRequestListPage() {
   // hardcoded
@@ -29,10 +34,12 @@ function PullRequestListPage() {
   const repoRef = useGetRepoRef()
   const { currentPage, previousPage, nextPage, handleClick } = usePagination(1, totalPages)
 
+  const { Filter, sort } = useCommonFilter({ sortOptions: sortOptions })
+
   const { data: pullrequests, isFetching } = useListPullReqQuery(
     {
       repo_ref: repoRef,
-      queryParams: { page: 0, limit: 10, query: '' }
+      queryParams: { page: 0, limit: 10, query: '', sort: sort }
     },
     /* To enable mock data */
     {
@@ -175,18 +182,10 @@ function PullRequestListPage() {
           Pull Requests
         </Text>
         <Spacer size={6} />
-        <ListActions.Root>
-          <ListActions.Left>
-            <SearchBox.Root placeholder="Search pull requests" />
-          </ListActions.Left>
-          <ListActions.Right>
-            <ListActions.Dropdown title="Filter" items={filterOptions} />
-            <ListActions.Dropdown title="Sort" items={sortOptions} />
-            <Button variant="default" asChild>
-              <Link to="edit">Create Pull Request</Link>
-            </Button>
-          </ListActions.Right>
-        </ListActions.Root>
+
+        {/* ⭐️ Filter Component */}
+        <Filter />
+
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />

--- a/packages/canary/src/components/list-actions.tsx
+++ b/packages/canary/src/components/list-actions.tsx
@@ -2,12 +2,18 @@ import React from 'react'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './dropdown-menu'
 import { Text } from './text'
 import { Icon } from './icon'
+import { CheckIcon } from '@radix-ui/react-icons'
+
+interface DropdownItemProps {
+  name: string
+  value?: string
+}
 
 interface DropdownProps {
   title: string
-  items: {
-    name: string
-  }[]
+  items: Array<DropdownItemProps>
+  onChange?: (value: string) => void
+  selectedValue?: string | null
 }
 
 function Root({ children }: { children: React.ReactNode }) {
@@ -22,19 +28,24 @@ function Right({ children }: { children: React.ReactNode }) {
   return <div className="flex gap-6 items-center">{children}</div>
 }
 
-function Dropdown({ title, items }: DropdownProps) {
+function Dropdown({ title, items, onChange, selectedValue }: DropdownProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className="flex items-center text-tertiary-background gap-1.5 hover:text-primary cursor-pointer ease-in-out duration-100">
-        <Text size={2} className="text-primary/80">
+        <Text weight={selectedValue ? 'bold' : 'normal'} size={2} className="text-primary/80">
           {title}
         </Text>
-        <Icon name="chevron-down" size={12} className="chevron-down " />
+        <Icon name="chevron-down" size={12} className="chevron-down" />
       </DropdownMenuTrigger>
       {items && (
         <DropdownMenuContent align="end">
           {items.map((i, i_idx) => {
-            return <DropdownMenuItem key={i_idx}>{i.name}</DropdownMenuItem>
+            return (
+              <DropdownMenuItem className="cursor-pointer" onClick={() => onChange?.(i.value ?? i.name)} key={i_idx}>
+                <div className="w-4 mr-1">{Boolean(i.value) && selectedValue === i.value ? <CheckIcon /> : null}</div>
+                {i.name}
+              </DropdownMenuItem>
+            )
           })}
         </DropdownMenuContent>
       )}
@@ -43,3 +54,4 @@ function Dropdown({ title, items }: DropdownProps) {
 }
 
 export { Root, Left, Right, Dropdown }
+export type { DropdownItemProps, DropdownProps }

--- a/packages/playground/src/hooks/useCommonFilter.tsx
+++ b/packages/playground/src/hooks/useCommonFilter.tsx
@@ -1,0 +1,53 @@
+import React, { useCallback } from 'react'
+import { Button, ListActions, SearchBox } from '@harnessio/canary'
+import { Link, useSearchParams } from 'react-router-dom'
+import { DropdownItemProps } from '@harnessio/canary/dist/components/list-actions'
+
+interface CommmonFilterProps<T> {
+  sortOptions: T
+}
+
+function useCommonFilter<const T extends DropdownItemProps[]>({ sortOptions }: CommmonFilterProps<T>) {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const sort = searchParams.get('sort')
+
+  const handleChange = useCallback((property: string) => {
+    return (selectedValue: string | null) => {
+      setSearchParams(params => {
+        const currentValue = params.get(property)
+
+        if (selectedValue && currentValue !== selectedValue) {
+          params.set(property, selectedValue)
+        } else params.delete(property)
+
+        return params
+      })
+    }
+  }, [])
+
+  const Filter = () => (
+    <ListActions.Root>
+      <ListActions.Left>
+        <SearchBox.Root placeholder="Search" />
+      </ListActions.Left>
+      <ListActions.Right>
+        {/* Add other filters here */}
+        {/* <ListActions.Dropdown title="Filter" items={filterOptions} /> */}
+        {/* <ListActions.Dropdown title="View" items={viewOptions} /> */}
+        <ListActions.Dropdown selectedValue={sort} onChange={handleChange('sort')} title="Sort" items={sortOptions} />
+
+        <Button variant="default" asChild>
+          <Link to="create">Create Pipeline</Link>
+        </Button>
+      </ListActions.Right>
+    </ListActions.Root>
+  )
+
+  return {
+    Filter,
+    sort: (sort as T[number]['value']) || undefined
+  }
+}
+
+export { useCommonFilter }

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -80,6 +80,9 @@ export * from './components/contact-card'
 export * from './constants/ExecutionConstants'
 export * from './components/execution/execution-tree-utils'
 
+// HOOKS
+export * from './hooks/useCommonFilter'
+
 export * as FormFieldSet from './components/form-field-set'
 
 // SANDBOX LAYOUTS


### PR DESCRIPTION
### Screen recording

https://github.com/user-attachments/assets/f8c1f097-1e24-49e6-961e-e0e97cfb1472

---

#### Added proper types for return values

<img width="1395" alt="image" src="https://github.com/user-attachments/assets/71018817-0370-44e0-84fe-06fc8c76afb3">

---

### DIfferent states

#### When no filter is applied

<img width="311" alt="image" src="https://github.com/user-attachments/assets/db071b4f-a82d-4ef5-842c-314adc540f08">

#### When a filter is applied

> [!NOTE]
>  Label will be bold if that filter is applied and on clicking the current selected filter item, the filter will be removed

<img width="270" alt="image" src="https://github.com/user-attachments/assets/bf8bbb02-497b-4352-9bb4-a2e4c8aa0355">
