### PR TITLE
fix: Minor fixes for Execution listing and details page

### DIFF
--- a/apps/gitness/src/framework/hooks/useLogs.ts
+++ b/apps/gitness/src/framework/hooks/useLogs.ts
@@ -53,6 +53,7 @@ export const useLogs = ({
     }
     return () => {
       if (eventSourceRef.current) eventSourceRef.current.close()
+      setLogs([])
     }
   }, [executionNum, pipelineId, repoPath, stageNum, stepNum, stepStatus])
   return { logs }

--- a/packages/canary/src/components/treeview.tsx
+++ b/packages/canary/src/components/treeview.tsx
@@ -237,7 +237,7 @@ const Folder = forwardRef<HTMLDivElement, FolderProps & React.HTMLAttributes<HTM
                 {element}&nbsp;<span className="text-[#787887]">({React.Children.count(children)})</span>
               </span>
             </div>
-            <span className="text-ring">{duration ?? '--'}</span>
+            <span className="text-muted-foreground">{duration ?? '--'}</span>
           </div>
         </AccordionPrimitive.Trigger>
         <AccordionPrimitive.Content className="text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down relative overflow-hidden h-full">
@@ -312,7 +312,7 @@ const File = forwardRef<
               <div className="flex self-center h-4 w-4 mr-1">{getStatusIcon(status)}</div>
               <span className="ml-1 font-normal text-sm">{children}</span>
             </div>
-            <span className="text-ring">{duration ?? '--'}</span>
+            <span className="text-muted-foreground">{duration ?? '--'}</span>
           </div>
         </AccordionPrimitive.Trigger>
       </AccordionPrimitive.Item>

--- a/packages/canary/src/components/treeview.tsx
+++ b/packages/canary/src/components/treeview.tsx
@@ -1,15 +1,8 @@
 import { ScrollArea } from '@radix-ui/react-scroll-area'
 import { cn } from '../lib/utils'
 import * as AccordionPrimitive from '@radix-ui/react-accordion'
-import {
-  NavArrowRight,
-  NavArrowDown,
-  Circle,
-  CheckCircleSolid,
-  XmarkCircleSolid,
-  Refresh,
-  ClockSolid
-} from '@harnessio/icons-noir'
+import { NavArrowRight, NavArrowDown } from '@harnessio/icons-noir'
+import { Icon as CanaryIcon } from '@harnessio/canary'
 import React, { createContext, forwardRef, useCallback, useContext, useEffect, useState } from 'react'
 
 /**
@@ -34,20 +27,18 @@ type ExecutionDetail = {
 const getStatusIcon = (status: Status): React.ReactElement => {
   switch (status) {
     case Status.IN_PROGRESS:
-      return <Refresh size="16" className="animate-spin text-warning" />
+      return <CanaryIcon size={16} name="running" className="animate-spin text-warning" />
     case Status.SUCCESS:
-      return <CheckCircleSolid color="#63E9A6" size="16" />
+      return <CanaryIcon name="success" size={16} />
     case Status.FAILED:
-      return <XmarkCircleSolid color="#db6662" size="16" />
-    case Status.QUEUED:
-      return <ClockSolid size="16" />
+      return <CanaryIcon name="fail" size={16} />
     case Status.WAITING_ON_DEPENDENCIES:
-      return <ClockSolid size="16" />
+    case Status.QUEUED:
+      return <CanaryIcon name="pending-clock" size={16} />
     case Status.SKIPPED:
-      return <Circle size="16" />
     case Status.UNKNOWN:
     default:
-      return <Circle size="16" />
+      return <CanaryIcon name="circle" size={16} />
   }
 }
 
@@ -246,7 +237,7 @@ const Folder = forwardRef<HTMLDivElement, FolderProps & React.HTMLAttributes<HTM
                 {element}&nbsp;<span className="text-[#787887]">({React.Children.count(children)})</span>
               </span>
             </div>
-            <span className="text-[#93939F]">{duration ?? '--'}</span>
+            <span className="text-ring">{duration ?? '--'}</span>
           </div>
         </AccordionPrimitive.Trigger>
         <AccordionPrimitive.Content className="text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down relative overflow-hidden h-full">
@@ -321,7 +312,7 @@ const File = forwardRef<
               <div className="flex self-center h-4 w-4 mr-1">{getStatusIcon(status)}</div>
               <span className="ml-1 font-normal text-sm">{children}</span>
             </div>
-            <span className="text-[#93939F]">{duration ?? '--'}</span>
+            <span className="text-ring">{duration ?? '--'}</span>
           </div>
         </AccordionPrimitive.Trigger>
       </AccordionPrimitive.Item>

--- a/packages/canary/src/components/treeview.tsx
+++ b/packages/canary/src/components/treeview.tsx
@@ -2,7 +2,7 @@ import { ScrollArea } from '@radix-ui/react-scroll-area'
 import { cn } from '../lib/utils'
 import * as AccordionPrimitive from '@radix-ui/react-accordion'
 import { NavArrowRight, NavArrowDown } from '@harnessio/icons-noir'
-import { Icon as CanaryIcon } from '@harnessio/canary'
+import { Icon as CanaryIcon } from '../components/icon'
 import React, { createContext, forwardRef, useCallback, useContext, useEffect, useState } from 'react'
 
 /**

--- a/packages/canary/src/components/treeview.tsx
+++ b/packages/canary/src/components/treeview.tsx
@@ -234,7 +234,7 @@ const Folder = forwardRef<HTMLDivElement, FolderProps & React.HTMLAttributes<HTM
             <div className="flex items-baseline">
               <div className="flex self-center mr-1">{getStatusIcon(status)}</div>
               <span className="ml-1 font-normal text-sm">
-                {element}&nbsp;<span className="text-[#787887]">({React.Children.count(children)})</span>
+                {element}&nbsp;<span className="text-muted-foreground">({React.Children.count(children)})</span>
               </span>
             </div>
             <span className="text-muted-foreground">{duration ?? '--'}</span>

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { noop } from 'lodash-es'
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 import { TooltipProvider } from '@harnessio/canary'
 import { ThemeProvider } from './components/theme-provider'
@@ -72,7 +73,7 @@ const router = createBrowserRouter([
           },
           {
             path: 'create',
-            element: <SandboxRepoCreatePage />
+            element: <SandboxRepoCreatePage apiError="" isLoading isSuccess onFormCancel={noop} onFormSubmit={noop} />
           },
           {
             path: ':repoId',

--- a/packages/playground/src/components/execution/console-logs.tsx
+++ b/packages/playground/src/components/execution/console-logs.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import { Text } from '@harnessio/canary'
 import { LivelogLine } from './types'
+import { formatDuration } from '../../utils/TimeUtils'
 
 interface ConsoleLogsProps {
   logs: LivelogLine[]
@@ -34,38 +35,22 @@ export const createStreamedLogLineElement = (log: LivelogLine) => {
   return lineElement
 }
 
-const formatTimestamp = (timestamp: number): string => {
-  const date = new Date(timestamp)
-
-  const hours = String(date.getUTCHours()).padStart(2, '0')
-  const minutes = String(date.getUTCMinutes()).padStart(2, '0')
-  const seconds = String(date.getUTCSeconds()).padStart(2, '0')
-  const milliseconds = String(date.getUTCMilliseconds()).padStart(3, '0')
-
-  // Convert milliseconds to MsMsMsMS format
-  const milliSecs = milliseconds.padEnd(4, '0') // Pad to 4 digits
-
-  return `${hours}:${minutes}:${seconds}.${milliSecs}`
-}
-
-const ConsoleLogs: FC<ConsoleLogsProps> = ({ logs }) => {
-  return (
-    <>
-      {logs.map((log, index) => {
-        return (
-          <div className="flex items-baseline leading-[21px] mb-2" key={index}>
-            {log?.pos && typeof log.pos === 'number' && (
-              <Text className={'text-log flex justify-end min-w-5'}>{log.pos + 1}</Text>
-            )}
-            <div className="text-ring font-mono text-sm font-normal ml-2 flex gap-1">
-              {log?.time ? <Text>[{formatTimestamp(log.time)}]</Text> : null}
-              {log?.out && <Text className="text-ring">{log.out}</Text>}
-            </div>
-          </div>
-        )
-      })}
-    </>
-  )
-}
+const ConsoleLogs: FC<ConsoleLogsProps> = ({ logs }) => (
+  <>
+    {logs.map(({ pos, time, out }, index) => (
+      <div className="flex items-baseline justify-between leading-[21px] mb-2" key={index}>
+        <div className="flex items-baseline">
+          {pos !== undefined && !isNaN(pos) && pos >= 0 && (
+            <Text className="text-log flex justify-end min-w-5">{pos + 1}</Text>
+          )}
+          {out && <Text className="text-ring font-mono text-sm font-normal ml-2 flex gap-1">{out}</Text>}
+        </div>
+        <Text className="text-log font-mono text-sm font-normal mr-2 flex gap-1">
+          {formatDuration(time ? time * 1_000 : 0)}
+        </Text>
+      </div>
+    ))}
+  </>
+)
 
 export default ConsoleLogs

--- a/packages/playground/src/components/execution/console-logs.tsx
+++ b/packages/playground/src/components/execution/console-logs.tsx
@@ -45,9 +45,7 @@ const ConsoleLogs: FC<ConsoleLogsProps> = ({ logs }) => (
           )}
           {out && <Text className="text-ring font-mono text-sm font-normal ml-2 flex gap-1">{out}</Text>}
         </div>
-        <Text className="text-log font-mono text-sm font-normal mr-2 flex gap-1">
-          {formatDuration(time ? time * 1_000 : 0)}
-        </Text>
+        <Text className="text-log text-sm font-normal mr-2 flex gap-1">{formatDuration(time ? time * 1_000 : 0)}</Text>
       </div>
     ))}
   </>

--- a/packages/playground/src/components/execution/step-execution.tsx
+++ b/packages/playground/src/components/execution/step-execution.tsx
@@ -3,10 +3,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger, Input, Button, Text, ScrollAr
 import { Copy, Edit, Download } from '@harnessio/icons-noir'
 import ConsoleLogs from './console-logs'
 import { Layout } from '../layout/layout'
-import { ExecutionState, ExecutionStatus } from './execution-status'
+import { ExecutionStatus } from './execution-status'
 import { getFormattedDuration } from '../../utils/TimeUtils'
 import { KeyValuePair, KeyValueTable } from './key-value-table'
-import { LivelogLine } from './types'
+import { ExecutionState, LivelogLine } from './types'
 
 export interface StepProps {
   name?: string

--- a/packages/playground/src/components/pipeline-list.tsx
+++ b/packages/playground/src/components/pipeline-list.tsx
@@ -30,18 +30,9 @@ interface PageProps {
 }
 
 const Title = ({ status, title }: { status?: ExecutionState; title: string }) => {
-  const isValidStatus = (status: ExecutionState | undefined): status is ExecutionState =>
-    [ExecutionState.SUCCESS, ExecutionState.ERROR, ExecutionState.FAILURE, ExecutionState.RUNNING].includes(
-      status as ExecutionState
-    )
-
   return (
     <div className="flex gap-2 items-center">
-      {isValidStatus(status) ? (
-        <ExecutionStatus.Icon status={status} />
-      ) : (
-        <div className="w-4 h-4 rounded-full bg-primary/5 border border-muted border-dotted" />
-      )}
+      {status && <ExecutionStatus.Icon status={status} />}
       <Text truncate>{title}</Text>
     </div>
   )

--- a/packages/playground/src/utils/TimeUtils.ts
+++ b/packages/playground/src/utils/TimeUtils.ts
@@ -24,3 +24,32 @@ export const getFormattedDuration = (startTs = 0, endTs = 0): string => {
 
   return parts.join(' ')
 }
+
+/**
+ * Formats duration in milliseconds to human-readable duration format.
+ * For 3723000 is formatted as "1h 2m 3s".
+ * @param durationInMs
+ * @returns
+ */
+export const formatDuration = (durationInMs: number): string => {
+  if (!durationInMs) return '0s'
+  const seconds = Math.floor(durationInMs / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+
+  const remainingSeconds = seconds % 60
+  const remainingMinutes = minutes % 60
+  const formatted = []
+
+  if (hours > 0) {
+    formatted.push(new Intl.NumberFormat().format(hours) + 'h')
+  }
+  if (remainingMinutes > 0) {
+    formatted.push(new Intl.NumberFormat().format(remainingMinutes) + 'm')
+  }
+  if (remainingSeconds > 0) {
+    formatted.push(new Intl.NumberFormat().format(remainingSeconds) + 's')
+  }
+
+  return formatted.join(' ')
+}


### PR DESCRIPTION
- Logs cleanup when navigating from one step to another in Execution tree view.
- Replacing Icon noir with Canary icons.
- Fix few type issues in `packages/playground`.
- Fix time formatting for console logs.
- Fixing Execution list view for different execution statuses.


![image](https://github.com/user-attachments/assets/15f98969-a3e6-4c20-a7f4-2d9326dd9a43)
