### PR TITLE
Add filters to repo and children screens

### DIFF
--- a/apps/gitness/src/pages/pipeline-list.tsx
+++ b/apps/gitness/src/pages/pipeline-list.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom'
 import {
   Button,
-  ListActions,
   ListPagination,
   Pagination,
   PaginationContent,
@@ -9,28 +8,33 @@ import {
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
-  SearchBox,
   Spacer,
   Text
 } from '@harnessio/canary'
 import { useListPipelinesQuery, TypesPipeline } from '@harnessio/code-service-client'
-import { PipelineList, MeterState, PaddingListLayout, SkeletonList } from '@harnessio/playground'
+import {
+  PipelineList,
+  MeterState,
+  PaddingListLayout,
+  SkeletonList,
+  Filter,
+  useCommonFilter
+} from '@harnessio/playground'
 import { ExecutionState } from '../types'
 import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
 import { usePagination } from '../framework/hooks/usePagination'
-
-const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' }, { name: 'Filter option 3' }]
-const sortOptions = [{ name: 'Sort option 1' }, { name: 'Sort option 2' }, { name: 'Sort option 3' }]
-const viewOptions = [{ name: 'View option 1' }, { name: 'View option 2' }]
 
 export default function PipelinesPage() {
   // hardcoded
   const totalPages = 10
   const repoRef = useGetRepoRef()
+
+  const { query } = useCommonFilter()
+
   const { data: pipelines, isFetching } = useListPipelinesQuery(
     {
       repo_ref: repoRef,
-      queryParams: { page: 0, limit: 10, query: '', latest: true }
+      queryParams: { page: 0, limit: 10, query: query?.trim(), latest: true }
     },
     /* To enable mock data */
     {
@@ -74,20 +78,15 @@ export default function PipelinesPage() {
           Pipelines
         </Text>
         <Spacer size={6} />
-        <ListActions.Root>
-          <ListActions.Left>
-            <SearchBox.Root placeholder="Search pipelines" />
-          </ListActions.Left>
-          <ListActions.Right>
-            <ListActions.Dropdown title="Filter" items={filterOptions} />
-            <ListActions.Dropdown title="Sort" items={sortOptions} />
-            <ListActions.Dropdown title="View" items={viewOptions} />
+        <div className="flex justify-between gap-5">
+          <div className="flex-1">
+            <Filter />
+          </div>
+          <Button variant="default" asChild>
+            <Link to="create">Create Pipeline</Link>
+          </Button>
+        </div>
 
-            <Button variant="default" asChild>
-              <Link to="create">Create Pipeline</Link>
-            </Button>
-          </ListActions.Right>
-        </ListActions.Root>
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />

--- a/apps/gitness/src/pages/pull-request-list-page.tsx
+++ b/apps/gitness/src/pages/pull-request-list-page.tsx
@@ -7,19 +7,25 @@ import {
   PaginationPrevious,
   PaginationLink,
   PaginationNext,
-  Text
+  Text,
+  Button
 } from '@harnessio/canary'
 import { Link } from 'react-router-dom'
-import { PaddingListLayout, SkeletonList, PullRequestList, NoData, useCommonFilter } from '@harnessio/playground'
-import { TypesPullReq, useListPullReqQuery } from '@harnessio/code-service-client'
+import {
+  PaddingListLayout,
+  SkeletonList,
+  PullRequestList,
+  NoData,
+  useCommonFilter,
+  Filter
+} from '@harnessio/playground'
+import { ListPullReqQueryQueryParams, TypesPullReq, useListPullReqQuery } from '@harnessio/code-service-client'
 import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
 import { usePagination } from '../framework/hooks/usePagination'
 import { timeAgoFromEpochTime } from './pipeline-edit/utils/time-utils'
 import { DropdownItemProps } from '../../../../packages/canary/dist/components/list-actions'
 
-// const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' }, { name: 'Filter option 3' }]
-
-const sortOptions = [
+const SortOptions = [
   { name: 'Created', value: 'created' },
   { name: 'Edited', value: 'edited' },
   { name: 'Merged', value: 'merged' },
@@ -34,12 +40,12 @@ function PullRequestListPage() {
   const repoRef = useGetRepoRef()
   const { currentPage, previousPage, nextPage, handleClick } = usePagination(1, totalPages)
 
-  const { Filter, sort } = useCommonFilter({ sortOptions })
+  const { sort, query } = useCommonFilter<ListPullReqQueryQueryParams['sort']>()
 
   const { data: pullrequests, isFetching } = useListPullReqQuery(
     {
       repo_ref: repoRef,
-      queryParams: { page: 0, limit: 20, query: '', sort }
+      queryParams: { page: 0, limit: 20, query: query?.trim(), sort }
     },
     /* To enable mock data */
     {
@@ -183,8 +189,14 @@ function PullRequestListPage() {
         </Text>
         <Spacer size={6} />
 
-        {/* ⭐️ Filter Component */}
-        <Filter />
+        <div className="flex justify-between gap-5 items-center">
+          <div className="flex-1">
+            <Filter sortOptions={SortOptions} />
+          </div>
+          <Button variant="default" asChild>
+            <Link to="#">New pull request</Link>
+          </Button>
+        </div>
 
         <Spacer size={5} />
         {renderListContent()}

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -1,8 +1,7 @@
 import { useEffect } from 'react'
-import { SkeletonList, NoData, PaddingListLayout, BranchesList } from '@harnessio/playground'
+import { SkeletonList, NoData, PaddingListLayout, BranchesList, Filter, useCommonFilter } from '@harnessio/playground'
 import {
   Button,
-  ListActions,
   ListPagination,
   Pagination,
   PaginationContent,
@@ -10,7 +9,6 @@ import {
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
-  SearchBox,
   Spacer,
   Text
 } from '@harnessio/canary'
@@ -21,13 +19,17 @@ import {
   TypesBranch,
   ListBranchesErrorResponse,
   useCalculateCommitDivergenceMutation,
-  useFindRepositoryQuery
+  useFindRepositoryQuery,
+  ListBranchesQueryQueryParams
 } from '@harnessio/code-service-client'
 import { orderSortDate } from '../../types'
 import { timeAgoFromISOTime } from '../pipeline-edit/utils/time-utils'
+import { Link } from 'react-router-dom'
 
-const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' }, { name: 'Filter option 3' }]
-const sortOptions = [{ name: 'Sort option 1' }, { name: 'Sort option 2' }, { name: 'Sort option 3' }]
+const sortOptions = [
+  { name: 'Date', value: 'date' },
+  { name: 'Name', value: 'name' }
+]
 
 export function ReposBranchesListPage() {
   // lack of data: total branches
@@ -39,13 +41,15 @@ export function ReposBranchesListPage() {
   const { currentPage, previousPage, nextPage, handleClick } = usePagination(1, totalPages)
   const { data: repoMetadata } = useFindRepositoryQuery({ repo_ref: repoRef })
 
+  const { sort, query } = useCommonFilter<ListBranchesQueryQueryParams['sort']>()
+
   const {
     isLoading,
     data: brancheslistData,
     isError
   } = useListBranchesQuery(
     {
-      queryParams: { page: currentPage, limit: 20, sort: 'date', order: orderSortDate.DESC, include_commit: true },
+      queryParams: { page: currentPage, limit: 20, sort, query, order: orderSortDate.DESC, include_commit: true },
       repo_ref: repoRef
     },
     {
@@ -133,24 +137,18 @@ export function ReposBranchesListPage() {
   return (
     <PaddingListLayout spaceTop={false}>
       <Spacer size={2} />
-      {(brancheslistData?.length ?? 0) > 0 && (
-        <>
-          <Text size={5} weight={'medium'}>
-            Branches
-          </Text>
-          <Spacer size={6} />
-          <ListActions.Root>
-            <ListActions.Left>
-              <SearchBox.Root placeholder="Search branches" />
-            </ListActions.Left>
-            <ListActions.Right>
-              <ListActions.Dropdown title="Filter" items={filterOptions} />
-              <ListActions.Dropdown title="Sort" items={sortOptions} />
-              <Button variant="default">Create Branch</Button>
-            </ListActions.Right>
-          </ListActions.Root>
-        </>
-      )}
+      <Text size={5} weight={'medium'}>
+        Branches
+      </Text>
+      <Spacer size={6} />
+      <div className="flex justify-between gap-5 items-center">
+        <div className="flex-1">
+          <Filter sortOptions={sortOptions} />
+        </div>
+        <Button variant="default" asChild>
+          <Link to="create">Create Branch</Link>
+        </Button>
+      </div>
       <Spacer size={5} />
       {renderContent()}
       <Spacer size={8} />

--- a/apps/gitness/src/pages/repo/repo-commits.tsx
+++ b/apps/gitness/src/pages/repo/repo-commits.tsx
@@ -10,7 +10,14 @@ import {
   PaginationLink,
   PaginationNext
 } from '@harnessio/canary'
-import { BranchSelector, NoData, PaddingListLayout, PullRequestCommits, SkeletonList } from '@harnessio/playground'
+import {
+  BranchSelector,
+  Filter,
+  NoData,
+  PaddingListLayout,
+  PullRequestCommits,
+  SkeletonList
+} from '@harnessio/playground'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
 import { usePagination } from '../../framework/hooks/usePagination'
 
@@ -23,7 +30,6 @@ import {
 import { useEffect, useState } from 'react'
 import { normalizeGitRef } from '../../utils/git-utils'
 
-const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' }, { name: 'Filter option 3' }]
 const sortOptions = [{ name: 'Sort option 1' }, { name: 'Sort option 2' }, { name: 'Sort option 3' }]
 
 export default function RepoCommitsPage() {
@@ -47,6 +53,9 @@ export default function RepoCommitsPage() {
 
     queryParams: { page: currentPage, limit: 10, git_ref: normalizeGitRef(selectedBranch), include_stats: true }
   })
+
+  // 🚨 API not supporting sort, so waiting for API changes
+  // const { sort } = useCommonFilter()
 
   // logic once we have dynamic pagination set up
 
@@ -95,23 +104,19 @@ export default function RepoCommitsPage() {
         Commits
       </Text>
       <Spacer size={6} />
-      <ListActions.Root>
-        <ListActions.Left>
-          {!isFetchingBranches && branches && (
-            <BranchSelector
-              name={selectedBranch}
-              branchList={branches.map(item => ({
-                name: item.name || ''
-              }))}
-              selectBranch={branch => selectBranch(branch)}
-            />
-          )}
-        </ListActions.Left>
-        <ListActions.Right>
-          <ListActions.Dropdown title="Filter" items={filterOptions} />
-          <ListActions.Dropdown title="Sort" items={sortOptions} />
-        </ListActions.Right>
-      </ListActions.Root>
+      <div className="flex justify-between gap-5">
+        {!isFetchingBranches && branches && (
+          <BranchSelector
+            name={selectedBranch}
+            branchList={branches.map(item => ({
+              name: item.name || ''
+            }))}
+            selectBranch={branch => selectBranch(branch)}
+          />
+        )}
+
+        <Filter showSearch={false} sortOptions={sortOptions} />
+      </div>
       <Spacer size={5} />
       {renderContent()}
       <Spacer size={8} />

--- a/apps/gitness/src/pages/repo/repo-commits.tsx
+++ b/apps/gitness/src/pages/repo/repo-commits.tsx
@@ -1,5 +1,4 @@
 import {
-  ListActions,
   Spacer,
   Text,
   ListPagination,

--- a/apps/gitness/src/pages/repo/repo-files.tsx
+++ b/apps/gitness/src/pages/repo/repo-files.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate, Outlet } from 'react-router-dom'
-import { Button, ButtonGroup, Icon, ListActions, SearchBox, Spacer, Text } from '@harnessio/canary'
-import { BranchSelector, SandboxLayout } from '@harnessio/playground'
+import { Button, ButtonGroup, Icon, ListActions, Spacer, Text } from '@harnessio/canary'
+import { BranchSelector, SandboxLayout, Filter } from '@harnessio/playground'
 import { useListBranchesQuery, useFindRepositoryQuery } from '@harnessio/code-service-client'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
 import { PathParams } from '../../RouteDefinitions'
@@ -52,7 +52,9 @@ export const RepoFiles: React.FC = () => {
             </Button>
           </ButtonGroup.Root>
         </div>
-        <SearchBox.Root width="full" placeholder="Search" />
+
+        <Filter />
+
         <Explorer selectedBranch={selectedBranch} />
       </div>
     )

--- a/apps/gitness/src/pages/repo/repo-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-list.tsx
@@ -12,8 +12,8 @@ import {
   Spacer,
   Text
 } from '@harnessio/canary'
-import { useListReposQuery, RepoRepositoryOutput } from '@harnessio/code-service-client'
-import { PaddingListLayout, SkeletonList, RepoList } from '@harnessio/playground'
+import { useListReposQuery, RepoRepositoryOutput, ListReposQueryQueryParams } from '@harnessio/code-service-client'
+import { PaddingListLayout, SkeletonList, RepoList, Filter, useCommonFilter } from '@harnessio/playground'
 import { Link, useNavigate } from 'react-router-dom'
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
 import { usePagination } from '../../framework/hooks/usePagination'
@@ -21,9 +21,11 @@ import { usePagination } from '../../framework/hooks/usePagination'
 import Header from '../../components/Header'
 import { timeAgoFromEpochTime } from '../pipeline-edit/utils/time-utils'
 
-const filterOptions = [{ name: 'Filter option 1' }, { name: 'Filter option 2' }, { name: 'Filter option 3' }]
-const sortOptions = [{ name: 'Sort option 1' }, { name: 'Sort option 2' }, { name: 'Sort option 3' }]
-const viewOptions = [{ name: 'View option 1' }, { name: 'View option 2' }]
+const sortOptions = [
+  { name: 'Created', value: 'created' },
+  { name: 'Identifier', value: 'identifier' },
+  { name: 'Updated', value: 'updated' }
+]
 
 const LinkComponent = ({ to, children }: { to: string; children: React.ReactNode }) => <Link to={to}>{children}</Link>
 
@@ -32,7 +34,10 @@ export default function ReposListPage() {
   const totalPages = 10
   const navigate = useNavigate()
   const space = useGetSpaceURLParam()
-  const { isFetching, data } = useListReposQuery({ queryParams: {}, space_ref: `${space}/+` })
+
+  const { query, sort } = useCommonFilter<ListReposQueryQueryParams['sort']>()
+
+  const { isFetching, data } = useListReposQuery({ queryParams: { sort, query }, space_ref: `${space}/+` })
   const { currentPage, previousPage, nextPage, handleClick } = usePagination(1, totalPages)
 
   const renderListContent = () => {
@@ -68,19 +73,14 @@ export default function ReposListPage() {
           Repositories
         </Text>
         <Spacer size={6} />
-        <ListActions.Root>
-          <ListActions.Left>
-            <SearchBox.Root placeholder="Search repositories" />
-          </ListActions.Left>
-          <ListActions.Right>
-            <ListActions.Dropdown title="Filter" items={filterOptions} />
-            <ListActions.Dropdown title="Sort" items={sortOptions} />
-            <ListActions.Dropdown title="View" items={viewOptions} />
-            <Button variant="default" onClick={() => navigate(`/sandbox/spaces/${space}/repos/create`)}>
-              Create Repo
-            </Button>
-          </ListActions.Right>
-        </ListActions.Root>
+        <div className="flex justify-between gap-5">
+          <div className="flex-1">
+            <Filter sortOptions={sortOptions} />
+          </div>
+          <Button variant="default" onClick={() => navigate(`/sandbox/spaces/${space}/repos/create`)}>
+            Create Repo
+          </Button>
+        </div>
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />

--- a/apps/gitness/src/pages/repo/repo-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-list.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  ListActions,
   ListPagination,
   Pagination,
   PaginationContent,
@@ -8,7 +7,6 @@ import {
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
-  SearchBox,
   Spacer,
   Text
 } from '@harnessio/canary'

--- a/apps/gitness/src/pages/repo/repo-summary.tsx
+++ b/apps/gitness/src/pages/repo/repo-summary.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Button, ButtonGroup, Icon, ListActions, SearchBox, Spacer, StackedList, Text } from '@harnessio/canary'
+import { Button, ButtonGroup, Icon, ListActions, Spacer, StackedList, Text } from '@harnessio/canary'
 import {
   Floating1ColumnLayout,
   FullWidth2ColumnLayout,

--- a/apps/gitness/src/pages/repo/repo-summary.tsx
+++ b/apps/gitness/src/pages/repo/repo-summary.tsx
@@ -10,7 +10,9 @@ import {
   FileProps,
   SummaryItemType,
   NoData,
-  MarkdownViewer
+  MarkdownViewer,
+  Filter,
+  useCommonFilter
 } from '@harnessio/playground'
 import {
   useListBranchesQuery,
@@ -41,13 +43,15 @@ export const RepoSummary: React.FC = () => {
 
   const [selectedBranch, setSelectedBranch] = useState<string>('')
 
+  const { query } = useCommonFilter()
+
   const branchList = branches?.map(item => ({
     name: item?.name
   }))
 
   const { data: repoSummary } = useSummaryQuery({
     repo_ref: repoRef,
-    queryParams: { include_commit: false, sort: 'date', order: 'asc', limit: 20, page: 1, query: '' }
+    queryParams: { include_commit: false, sort: 'date', order: 'asc', limit: 20, page: 1, query }
   })
 
   const { branch_count, default_branch_commit_count, pull_req_summary, tag_count } = repoSummary || {}
@@ -170,7 +174,8 @@ export const RepoSummary: React.FC = () => {
                     branchList={branchList}
                     selectBranch={branch => selectBranch(branch)}
                   />
-                  <SearchBox.Root placeholder="Search" />
+
+                  <Filter />
                 </ButtonGroup.Root>
               </ListActions.Left>
               <ListActions.Right>

--- a/apps/gitness/src/pages/repo/repo-webhooks.tsx
+++ b/apps/gitness/src/pages/repo/repo-webhooks.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import {
   Spacer,
-  ListActions,
   Button,
-  SearchBox,
   Text,
   ListPagination,
   Pagination,
@@ -15,7 +13,7 @@ import {
   PaginationNext
 } from '@harnessio/canary'
 // import { NoSearchResults } from '../components/no-search-results'
-import { NoData, PaddingListLayout, SkeletonList, WebhooksList } from '@harnessio/playground'
+import { Filter, NoData, PaddingListLayout, SkeletonList, useCommonFilter, WebhooksList } from '@harnessio/playground'
 import { useListWebhooksQuery } from '@harnessio/code-service-client'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
 import { usePagination } from '../../framework/hooks/usePagination'
@@ -25,9 +23,12 @@ function RepoWebhooksListPage() {
   const totalPages = 10
   const LinkComponent = ({ to, children }: { to: string; children: React.ReactNode }) => <Link to={to}>{children}</Link>
   const repoRef = useGetRepoRef()
+
+  const { query } = useCommonFilter()
+
   const { data: webhooks, isFetching } = useListWebhooksQuery({
     repo_ref: repoRef,
-    queryParams: { order: 'asc', limit: 20, page: 1 }
+    queryParams: { order: 'asc', limit: 20, page: 1, query }
   })
   const { currentPage, previousPage, nextPage, handleClick } = usePagination(1, totalPages)
 
@@ -59,16 +60,16 @@ function RepoWebhooksListPage() {
           Webhooks
         </Text>
         <Spacer size={6} />
-        <ListActions.Root>
-          <ListActions.Left>
-            <SearchBox.Root placeholder="Search webhooks" />
-          </ListActions.Left>
-          <ListActions.Right>
-            <Button variant="default" asChild>
-              <Link to="#">Create webhook</Link>
-            </Button>
-          </ListActions.Right>
-        </ListActions.Root>
+
+        <div className="flex justify-between gap-5 items-center">
+          <div className="flex-1">
+            <Filter />
+          </div>
+          <Button variant="default" asChild>
+            <Link to="#">Create webhook</Link>
+          </Button>
+        </div>
+
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />

--- a/packages/canary/src/components/list-actions.tsx
+++ b/packages/canary/src/components/list-actions.tsx
@@ -3,6 +3,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Text } from './text'
 import { Icon } from './icon'
 import { CheckIcon } from '@radix-ui/react-icons'
+import { cn } from '@/lib/utils'
 
 interface DropdownItemProps {
   name: string
@@ -32,7 +33,12 @@ function Dropdown({ title, items, onChange, selectedValue }: DropdownProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className="flex items-center text-tertiary-background gap-1.5 hover:text-primary cursor-pointer ease-in-out duration-100">
-        <Text weight={selectedValue ? 'bold' : 'normal'} size={2} className="text-primary/80">
+        {selectedValue && <span className="h-[4px] w-[4px] bg-primary rounded-full"></span>}
+        <Text
+          size={2}
+          className={cn('text-primary/80', {
+            ['font-bold']: selectedValue
+          })}>
           {title}
         </Text>
         <Icon name="chevron-down" size={12} className="chevron-down" />

--- a/packages/canary/src/components/search-box.tsx
+++ b/packages/canary/src/components/search-box.tsx
@@ -3,6 +3,7 @@ import { Input } from './input'
 import { Icon } from './icon'
 import { Text } from './text'
 import { cn } from '@/lib/utils'
+import { noop } from 'lodash-es'
 
 enum TextSize {
   'text-[12px]' = 0,
@@ -28,10 +29,13 @@ interface SearchBoxProps {
   shortcutModifier?: string
   textSize?: TextSize
   onSearch?: () => void
+  handleChange?: React.ChangeEventHandler<HTMLInputElement>
   showOnFocus?: boolean // New prop to control dialog appearance on focus
+  defaultValue?: string
+  className?: string
 }
 
-function Root({
+const Root = ({
   textSize = TextSize['text-sm'],
   placeholder,
   width = 'fixed',
@@ -39,8 +43,11 @@ function Root({
   shortcutLetter,
   shortcutModifier,
   onSearch,
-  showOnFocus = false // Default to false
-}: SearchBoxProps) {
+  handleChange = noop,
+  defaultValue,
+  showOnFocus = false,
+  className
+}: SearchBoxProps) => {
   const textSizeClass = TextSize[textSize]
 
   const handleSearch = () => {
@@ -86,7 +93,7 @@ function Root({
   }, [hasShortcut, shortcutLetter, shortcutModifier, handleSearch])
 
   return (
-    <div className={cn('relative', width === 'full' ? 'w-full' : 'w-96')}>
+    <div className={cn('relative', width === 'full' ? 'w-full' : 'w-96', className)}>
       <Icon
         name="search"
         size={12}
@@ -106,6 +113,7 @@ function Root({
         // className={cn('border-input-foreground pl-7', textSizeClass, { 'pr-10': hasShortcut })}
 
         // Start of temporary fix
+        defaultValue={defaultValue}
         className={cn('border-input-foreground', textSizeClass)}
         style={{
           paddingLeft: '1.75rem', // Equivalent to 'pl-7' in Tailwind (28px)
@@ -114,6 +122,7 @@ function Root({
         // End of temporary fix
         onKeyDown={handleKeyDown}
         onFocus={handleFocus}
+        onInput={handleChange}
       />
     </div>
   )

--- a/packages/playground/src/components/filter.tsx
+++ b/packages/playground/src/components/filter.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { ListActions, SearchBox } from '@harnessio/canary'
+import { useCommonFilter } from '../hooks/useCommonFilter'
+import { debounce, isEmpty } from 'lodash-es'
+import { DropdownItemProps } from '@harnessio/canary/dist/components/list-actions'
+
+interface FilterProps {
+  sortOptions?: DropdownItemProps[]
+  showSearch?: boolean
+}
+
+const Filter = <S,>({ sortOptions, showSearch = true }: FilterProps) => {
+  const { sort, query, handleSearch, handleDropdownChange } = useCommonFilter<S>()
+  return (
+    <ListActions.Root>
+      <ListActions.Left>
+        {showSearch && (
+          <SearchBox.Root
+            width="full"
+            className="max-w-96"
+            defaultValue={query}
+            handleChange={debounce((e: React.ChangeEvent<HTMLInputElement>) => handleSearch(e), 300)}
+            placeholder="Search"
+          />
+        )}
+      </ListActions.Left>
+      <ListActions.Right>
+        {!isEmpty(sortOptions) && (
+          <ListActions.Dropdown
+            selectedValue={sort as string | null}
+            onChange={handleDropdownChange('sort')}
+            title="Sort"
+            items={sortOptions!}
+          />
+        )}
+      </ListActions.Right>
+    </ListActions.Root>
+  )
+}
+
+export { Filter }

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -64,6 +64,7 @@ export * from './components/webhook-list'
 export * from './components/pagination'
 export * from './components/profile-settings-keys-list'
 export * from './components/profile-settings-tokens-list'
+export * from './components/filter'
 
 export * from './pages/signin-page'
 export * from './pages/create-project-page'


### PR DESCRIPTION
Summary:
Added filters for repo and children screens.

Filter status across screens:
<img width="645" alt="image" src="https://github.com/user-attachments/assets/3bd2e4be-439d-4a37-a723-23d1c9de059e">

Link: https://harness.atlassian.net/wiki/spaces/CDNG/pages/22066757999/Unified+Pipeline+UI+filter+progress