### PR TITLE
Create token and key flow 

### DIFF
--- a/apps/gitness/package.json
+++ b/apps/gitness/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@harnessio/canary": "workspace:*",
-    "@harnessio/code-service-client": "1.3.1",
+    "@harnessio/code-service-client": "1.3.4",
     "@harnessio/forms": "workspace:*",
     "@harnessio/playground": "workspace:*",
     "@harnessio/unified-pipeline": "workspace:*",

--- a/apps/gitness/package.json
+++ b/apps/gitness/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@harnessio/canary": "workspace:*",
-    "@harnessio/code-service-client": "1.3.0",
+    "@harnessio/code-service-client": "1.3.1",
     "@harnessio/forms": "workspace:*",
     "@harnessio/playground": "workspace:*",
     "@harnessio/unified-pipeline": "workspace:*",

--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -39,8 +39,6 @@ import { FileViewer } from './components/FileViewer'
 import PullRequestChangesPage from './pages/pull-request/pull-request-changes-page'
 import { Logout } from './pages/logout'
 
-import { TokenCreateDialog } from './pages/profile-settings/token-create/token-create-dialog'
-
 export default function App() {
   const router = createBrowserRouter([
     {
@@ -52,7 +50,6 @@ export default function App() {
         {
           path: ':spaceId/repos',
           element: <ReposListPage />
-          // element: <TokenCreateDialog />
         },
         {
           path: ':spaceId/repos/create',

--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -39,6 +39,8 @@ import { FileViewer } from './components/FileViewer'
 import PullRequestChangesPage from './pages/pull-request/pull-request-changes-page'
 import { Logout } from './pages/logout'
 
+import { TokenCreateDialog } from './pages/profile-settings/token-create/token-create-dialog'
+
 export default function App() {
   const router = createBrowserRouter([
     {
@@ -50,6 +52,7 @@ export default function App() {
         {
           path: ':spaceId/repos',
           element: <ReposListPage />
+          // element: <TokenCreateDialog />
         },
         {
           path: ':spaceId/repos/create',

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
@@ -18,8 +18,11 @@ import { TokenCreateDialog } from './token-create/token-create-dialog'
 import { SshKeyCreateDialog } from './ssh-key-create/ssh-key-create-dialog'
 import { TokenSuccessDialog } from './token-create/token-success-dialog'
 import { TokensList } from '@harnessio/playground'
+import { useQueryClient } from '@tanstack/react-query'
 
 export const SettingsProfileKeysPage = () => {
+  const queryClient = useQueryClient()
+
   const TEMP_USER_TOKENS_API_PATH = '/api/v1/user/tokens'
 
   const [publicKeys, setPublicKeys] = useState<ListPublicKeyOkResponse[]>([])
@@ -100,21 +103,13 @@ export const SettingsProfileKeysPage = () => {
       onSuccess: (newSshKey: CreatePublicKeyOkResponse) => {
         console.log(newSshKey)
         closeSshKeyDialog()
+        queryClient.invalidateQueries(['listPublicKey'])
       },
       onError: (error: CreatePublicKeyErrorResponse) => {
         console.error('Failed to create :', error)
       }
     }
   )
-
-  // const handleCreateToken = (tokenData: { identifier: string; lifetime: string }) => {
-  //   const convertedLifetime = parseInt(tokenData.lifetime, 10) * 24 * 60 * 60 * 1000 * 1000000
-  //   const body: CreateTokenRequestBody = {
-  //     identifier: tokenData.identifier,
-  //     lifetime: convertedLifetime
-  //   }
-  //   createTokenMutation.mutate({ body })
-  // }
 
   const handleCreateToken = (tokenData: { identifier: string; lifetime: string }) => {
     let body: CreateTokenRequestBody = {

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
@@ -7,11 +7,16 @@ import {
   useCreateTokenMutation,
   CreateTokenOkResponse,
   CreateTokenErrorResponse,
-  CreateTokenRequestBody
-
+  CreateTokenRequestBody,
+  useCreatePublicKeyMutation,
+  CreatePublicKeyRequestBody,
+  CreatePublicKeyOkResponse,
+  CreatePublicKeyErrorResponse
   // ListPublicKeyErrorResponse
 } from '@harnessio/code-service-client'
 import { TokenCreateDialog } from './token-create/token-create-dialog'
+import { SshKeyCreateDialog } from './ssh-key-create/ssh-key-create-dialog'
+import { TokenSuccessDialog } from './token-create/token-success-dialog'
 import { TokensList } from '@harnessio/playground'
 
 export const SettingsProfileKeysPage = () => {
@@ -21,8 +26,20 @@ export const SettingsProfileKeysPage = () => {
   const [tokens, setTokens] = useState<TokensList[]>([])
 
   const [openCreateTokenDialog, setCreateTokenDialog] = useState(false)
+  const [openSuccessTokenDialog, setSuccessTokenDialog] = useState(false)
+  const closeSuccessTokenDialog = () => setSuccessTokenDialog(false)
+
+  const [createdTokenData, setCreatedTokenData] = useState<{
+    identifier: string
+    lifetime: string
+    token: string
+  } | null>(null)
   const openTokenDialog = () => setCreateTokenDialog(true)
   const closeTokenDialog = () => setCreateTokenDialog(false)
+
+  const [saveSshKeyDialog, setSshKeyDialog] = useState(false)
+  const openSshKeyDialog = () => setSshKeyDialog(true)
+  const closeSshKeyDialog = () => setSshKeyDialog(false)
 
   const queryParams: ListPublicKeyQueryQueryParams = {
     page: 1,
@@ -44,21 +61,32 @@ export const SettingsProfileKeysPage = () => {
     }
   )
 
-  useEffect(() => {
+  const fetchTokens = () => {
     fetch(TEMP_USER_TOKENS_API_PATH)
       .then(resp => resp.json())
       .then(res => setTokens(res))
-    // .catch(err => console.log(err))
+      .catch(err => console.log(err))
+  }
+
+  useEffect(() => {
+    fetchTokens()
   }, [])
 
   const createTokenMutation = useCreateTokenMutation(
     { body: {} },
     {
       onSuccess: (newToken: CreateTokenOkResponse) => {
-        // Add the newly created token to the list of tokens
-        // setTokens(prevTokens => [...prevTokens, newToken])
-        console.log(newToken)
+        // console.log(newToken)
+        const tokenData = {
+          identifier: newToken.token.identifier,
+          lifetime: new Date(newToken.token.expires_at).toLocaleDateString(),
+          token: newToken.access_token
+        }
+
         closeTokenDialog()
+        setCreatedTokenData(tokenData)
+        setSuccessTokenDialog(true)
+        fetchTokens()
       },
       onError: (error: CreateTokenErrorResponse) => {
         console.error('Failed to create token:', error)
@@ -66,23 +94,71 @@ export const SettingsProfileKeysPage = () => {
     }
   )
 
-  const handleCreateToken = (tokenData: { identifier: string; lifetime: string }) => {
-    const convertedLifetime = parseInt(tokenData.lifetime, 10) * 24 * 60 * 60 * 1000
-    const body: CreateTokenRequestBody = {
-      identifier: tokenData.identifier,
-      lifetime: convertedLifetime
+  const createSshKeyMutation = useCreatePublicKeyMutation(
+    { body: {} },
+    {
+      onSuccess: (newSshKey: CreatePublicKeyOkResponse) => {
+        console.log(newSshKey)
+        closeSshKeyDialog()
+      },
+      onError: (error: CreatePublicKeyErrorResponse) => {
+        console.error('Failed to create :', error)
+      }
     }
+  )
+
+  // const handleCreateToken = (tokenData: { identifier: string; lifetime: string }) => {
+  //   const convertedLifetime = parseInt(tokenData.lifetime, 10) * 24 * 60 * 60 * 1000 * 1000000
+  //   const body: CreateTokenRequestBody = {
+  //     identifier: tokenData.identifier,
+  //     lifetime: convertedLifetime
+  //   }
+  //   createTokenMutation.mutate({ body })
+  // }
+
+  const handleCreateToken = (tokenData: { identifier: string; lifetime: string }) => {
+    let body: CreateTokenRequestBody = {
+      identifier: tokenData.identifier
+    }
+
+    if (tokenData.lifetime.toLowerCase() !== 'never') {
+      const convertedLifetime = parseInt(tokenData.lifetime, 10) * 24 * 60 * 60 * 1000 * 1000000
+      body.lifetime = convertedLifetime
+    }
+
     createTokenMutation.mutate({ body })
   }
 
+  const handleCreateSshKey = (sshKeyData: { content: string; identifier: string }) => {
+    const body: CreatePublicKeyRequestBody = {
+      content: sshKeyData.content,
+      identifier: sshKeyData.identifier,
+      usage: 'auth'
+    }
+
+    createSshKeyMutation.mutate({ body })
+  }
   return (
     <>
-      <SandboxSettingsAccountKeysPage publicKeys={publicKeys} tokens={tokens} openTokenDialog={openTokenDialog} />
+      <SandboxSettingsAccountKeysPage
+        publicKeys={publicKeys}
+        tokens={tokens}
+        openTokenDialog={openTokenDialog}
+        openSshKeyDialog={openSshKeyDialog}
+      />
       <TokenCreateDialog
         open={openCreateTokenDialog}
         onClose={closeTokenDialog}
         handleCreateToken={handleCreateToken}
       />
+      <SshKeyCreateDialog open={saveSshKeyDialog} onClose={closeSshKeyDialog} handleCreateSshKey={handleCreateSshKey} />
+      {createdTokenData && (
+        <TokenSuccessDialog
+          open={openSuccessTokenDialog}
+          onClose={closeSuccessTokenDialog}
+          tokenData={createdTokenData}
+        />
+      )}
     </>
   )
 }

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
@@ -32,13 +32,14 @@ export const SettingsProfileKeysPage = () => {
   const [openSuccessTokenDialog, setSuccessTokenDialog] = useState(false)
   const closeSuccessTokenDialog = () => setSuccessTokenDialog(false)
 
+  const openTokenDialog = () => setCreateTokenDialog(true)
+  const closeTokenDialog = () => setCreateTokenDialog(false)
+
   const [createdTokenData, setCreatedTokenData] = useState<{
     identifier: string
     lifetime: string
     token: string
   } | null>(null)
-  const openTokenDialog = () => setCreateTokenDialog(true)
-  const closeTokenDialog = () => setCreateTokenDialog(false)
 
   const [saveSshKeyDialog, setSshKeyDialog] = useState(false)
   const openSshKeyDialog = () => setSshKeyDialog(true)

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
@@ -73,6 +73,7 @@ export const SettingsProfileKeysPage = () => {
     }
   )
 
+  // TODO: replace with actual query hook once its fixed
   const fetchTokens = () => {
     fetch(TEMP_USER_TOKENS_API_PATH)
       .then(resp => resp.json())

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
@@ -18,14 +18,14 @@ import { TokenCreateDialog } from './token-create/token-create-dialog'
 import { SshKeyCreateDialog } from './ssh-key-create/ssh-key-create-dialog'
 import { TokenSuccessDialog } from './token-create/token-success-dialog'
 import { TokensList } from '@harnessio/playground'
-import { useQueryClient } from '@tanstack/react-query'
+// import { useQueryClient } from '@tanstack/react-query'
 
 export const SettingsProfileKeysPage = () => {
-  const queryClient = useQueryClient()
+  // const queryClient = useQueryClient()
 
   const TEMP_USER_TOKENS_API_PATH = '/api/v1/user/tokens'
 
-  const [publicKeys, setPublicKeys] = useState<ListPublicKeyOkResponse[]>([])
+  const [publicKeys, setPublicKeys] = useState<ListPublicKeyOkResponse>([])
   const [tokens, setTokens] = useState<TokensList[]>([])
 
   const [openCreateTokenDialog, setCreateTokenDialog] = useState(false)
@@ -54,7 +54,7 @@ export const SettingsProfileKeysPage = () => {
   useListPublicKeyQuery(
     { queryParams },
     {
-      onSuccess: (data: ListPublicKeyOkResponse[]) => {
+      onSuccess: (data: ListPublicKeyOkResponse) => {
         setPublicKeys(data)
       }
       // onError: (error: ListPublicKeyErrorResponse) => {
@@ -103,7 +103,7 @@ export const SettingsProfileKeysPage = () => {
       onSuccess: (newSshKey: CreatePublicKeyOkResponse) => {
         console.log(newSshKey)
         closeSshKeyDialog()
-        queryClient.invalidateQueries(['listPublicKey'])
+        setPublicKeys(prevKeys => [...prevKeys, newSshKey])
       },
       onError: (error: CreatePublicKeyErrorResponse) => {
         console.error('Failed to create :', error)

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
@@ -15,14 +15,17 @@ import {
   ListPublicKeyErrorResponse
 } from '@harnessio/code-service-client'
 import { TokenCreateDialog } from './token-create/token-create-dialog'
+import { TokenFormType } from './token-create/token-create-form'
 import { SshKeyCreateDialog } from './ssh-key-create/ssh-key-create-dialog'
 import { TokenSuccessDialog } from './token-create/token-success-dialog'
-import { TokensList } from '@harnessio/playground'
+import { TokensList, KeysList } from '@harnessio/playground'
 
 export const SettingsProfileKeysPage = () => {
+  const CONVERT_DAYS_TO_NANO_SECONDS = 24 * 60 * 60 * 1000 * 1000000
+
   const TEMP_USER_TOKENS_API_PATH = '/api/v1/user/tokens'
 
-  const [publicKeys, setPublicKeys] = useState<ListPublicKeyOkResponse>([])
+  const [publicKeys, setPublicKeys] = useState<KeysList[]>([])
   const [tokens, setTokens] = useState<TokensList[]>([])
   const [openCreateTokenDialog, setCreateTokenDialog] = useState(false)
   const [openSuccessTokenDialog, setSuccessTokenDialog] = useState(false)
@@ -32,11 +35,7 @@ export const SettingsProfileKeysPage = () => {
     message: string
   } | null>(null)
 
-  const [createdTokenData, setCreatedTokenData] = useState<{
-    identifier: string
-    lifetime: string
-    token: string
-  } | null>(null)
+  const [createdTokenData, setCreatedTokenData] = useState<(TokenFormType & { token: string }) | null>(null)
 
   const closeSuccessTokenDialog = () => setSuccessTokenDialog(false)
 
@@ -132,7 +131,7 @@ export const SettingsProfileKeysPage = () => {
     }
 
     if (tokenData.lifetime.toLowerCase() !== 'never') {
-      const convertedLifetime = parseInt(tokenData.lifetime, 10) * 24 * 60 * 60 * 1000 * 1000000
+      const convertedLifetime = parseInt(tokenData.lifetime, 10) * CONVERT_DAYS_TO_NANO_SECONDS
       body.lifetime = convertedLifetime
     }
 

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
@@ -35,12 +35,12 @@ const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPagePro
           <FormFieldSet.Root>
             {/* PERSONAL ACCESS TOKEN */}
             <FormFieldSet.Legend>
-              <div className="flex justify-between">
+              <span className="flex justify-between">
                 Personal access token
                 <Button type="button" variant="outline" className="text-primary" onClick={openTokenDialog}>
                   Add new token
                 </Button>
-              </div>
+              </span>
             </FormFieldSet.Legend>
             <FormFieldSet.ControlGroup>
               <>
@@ -63,12 +63,12 @@ const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPagePro
             {/* PERSONAL ACCESS TOKEN */}
             <FormFieldSet.Legend>My SSH keys</FormFieldSet.Legend>
             <FormFieldSet.SubLegend>
-              <div className="flex justify-between">
+              <span className="flex justify-between">
                 SSH keys allow you to establish a secure connection to your code repository.
                 <Button variant="outline" className="text-primary" type="button" onClick={openSshKeyDialog}>
                   Add new SSH key
                 </Button>
-              </div>
+              </span>
             </FormFieldSet.SubLegend>
             <FormFieldSet.ControlGroup>
               <>

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
@@ -13,11 +13,13 @@ interface SandboxSettingsAccountKeysPageProps {
   publicKeys: KeysList[]
   tokens: TokensList[]
   openTokenDialog: () => void
+  openSshKeyDialog: () => void
 }
 const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPageProps> = ({
   publicKeys,
   tokens,
-  openTokenDialog
+  openTokenDialog,
+  openSshKeyDialog
 }) => {
   return (
     <SandboxLayout.Main hasLeftPanel hasHeader hasSubHeader>
@@ -51,7 +53,7 @@ const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPagePro
             <FormFieldSet.SubLegend>
               <div className="flex justify-between">
                 SSH keys allow you to establish a secure connection to your code repository.
-                <Button variant="outline" className="text-primary">
+                <Button variant="outline" className="text-primary" type="button" onClick={openSshKeyDialog}>
                   Add new SSH key
                 </Button>
               </div>

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
@@ -8,19 +8,17 @@ import {
   ProfileTokensList,
   TokensList
 } from '@harnessio/playground'
-import { TokenCreateDialog } from './token-create/token-create-dialog'
 
 interface SandboxSettingsAccountKeysPageProps {
   publicKeys: KeysList[]
   tokens: TokensList[]
+  openTokenDialog: () => void
 }
-const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPageProps> = ({ publicKeys, tokens }) => {
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
-
-  const openDialog = () => setIsDialogOpen(true)
-
-  const closeDialog = () => setIsDialogOpen(false)
-
+const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPageProps> = ({
+  publicKeys,
+  tokens,
+  openTokenDialog
+}) => {
   return (
     <SandboxLayout.Main hasLeftPanel hasHeader hasSubHeader>
       <SandboxLayout.Content maxWidth="2xl">
@@ -35,7 +33,7 @@ const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPagePro
             <FormFieldSet.Legend>
               <div className="flex justify-between">
                 Personal access token
-                <Button type="button" variant="outline" className="text-primary" onClick={openDialog}>
+                <Button type="button" variant="outline" className="text-primary" onClick={openTokenDialog}>
                   Add new token
                 </Button>
               </div>
@@ -63,7 +61,6 @@ const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPagePro
             </FormFieldSet.ControlGroup>
           </FormFieldSet.Root>
         </form>
-        <TokenCreateDialog open={isDialogOpen} onClose={closeDialog} />
       </SandboxLayout.Content>
     </SandboxLayout.Main>
   )

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Spacer, Text } from '@harnessio/canary'
+import React, { useState } from 'react'
+import { Spacer, Text, Button } from '@harnessio/canary'
 import {
   FormFieldSet,
   SandboxLayout,
@@ -8,12 +8,19 @@ import {
   ProfileTokensList,
   TokensList
 } from '@harnessio/playground'
+import { TokenCreateDialog } from './token-create/token-create-dialog'
 
 interface SandboxSettingsAccountKeysPageProps {
   publicKeys: KeysList[]
   tokens: TokensList[]
 }
 const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPageProps> = ({ publicKeys, tokens }) => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+
+  const openDialog = () => setIsDialogOpen(true)
+
+  const closeDialog = () => setIsDialogOpen(false)
+
   return (
     <SandboxLayout.Main hasLeftPanel hasHeader hasSubHeader>
       <SandboxLayout.Content maxWidth="2xl">
@@ -25,7 +32,14 @@ const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPagePro
         <form>
           <FormFieldSet.Root>
             {/* PERSONAL ACCESS TOKEN */}
-            <FormFieldSet.Legend>Personal access token</FormFieldSet.Legend>
+            <FormFieldSet.Legend>
+              <div className="flex justify-between">
+                Personal access token
+                <Button type="button" variant="outline" className="text-primary" onClick={openDialog}>
+                  Add new token
+                </Button>
+              </div>
+            </FormFieldSet.Legend>
             <FormFieldSet.ControlGroup>
               <ProfileTokensList tokens={tokens} />
             </FormFieldSet.ControlGroup>
@@ -37,13 +51,19 @@ const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPagePro
             {/* PERSONAL ACCESS TOKEN */}
             <FormFieldSet.Legend>My SSH keys</FormFieldSet.Legend>
             <FormFieldSet.SubLegend>
-              SSH keys allow you to establish a secure connection to your code repository.
+              <div className="flex justify-between">
+                SSH keys allow you to establish a secure connection to your code repository.
+                <Button variant="outline" className="text-primary">
+                  Add new SSH key
+                </Button>
+              </div>
             </FormFieldSet.SubLegend>
             <FormFieldSet.ControlGroup>
               <ProfileKeysList publicKeys={publicKeys} />
             </FormFieldSet.ControlGroup>
           </FormFieldSet.Root>
         </form>
+        <TokenCreateDialog open={isDialogOpen} onClose={closeDialog} />
       </SandboxLayout.Content>
     </SandboxLayout.Main>
   )

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Spacer, Text, Button } from '@harnessio/canary'
 import {
   FormFieldSet,
@@ -14,12 +14,14 @@ interface SandboxSettingsAccountKeysPageProps {
   tokens: TokensList[]
   openTokenDialog: () => void
   openSshKeyDialog: () => void
+  error: { type: string; message: string } | null
 }
 const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPageProps> = ({
   publicKeys,
   tokens,
   openTokenDialog,
-  openSshKeyDialog
+  openSshKeyDialog,
+  error
 }) => {
   return (
     <SandboxLayout.Main hasLeftPanel hasHeader hasSubHeader>
@@ -41,7 +43,17 @@ const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPagePro
               </div>
             </FormFieldSet.Legend>
             <FormFieldSet.ControlGroup>
-              <ProfileTokensList tokens={tokens} />
+              <>
+                {(!error || error.type !== 'tokenFetch') && <ProfileTokensList tokens={tokens} />}
+                {error && error.type === 'tokenFetch' && (
+                  <>
+                    <Spacer size={2} />
+                    <Text size={1} className="text-destructive">
+                      {error.message}
+                    </Text>
+                  </>
+                )}
+              </>
             </FormFieldSet.ControlGroup>
           </FormFieldSet.Root>
           <FormFieldSet.Root>
@@ -59,7 +71,17 @@ const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPagePro
               </div>
             </FormFieldSet.SubLegend>
             <FormFieldSet.ControlGroup>
-              <ProfileKeysList publicKeys={publicKeys} />
+              <>
+                {(!error || error.type !== 'keyFetch') && <ProfileKeysList publicKeys={publicKeys} />}
+                {error && error.type === 'keyFetch' && (
+                  <>
+                    <Spacer size={2} />
+                    <Text size={1} className="text-destructive">
+                      {error.message}
+                    </Text>
+                  </>
+                )}
+              </>
             </FormFieldSet.ControlGroup>
           </FormFieldSet.Root>
         </form>

--- a/apps/gitness/src/pages/profile-settings/ssh-key-create/ssh-key-create-dialog.tsx
+++ b/apps/gitness/src/pages/profile-settings/ssh-key-create/ssh-key-create-dialog.tsx
@@ -1,13 +1,14 @@
-import { SshKeyCreateForm } from './ssh-key-create-form'
+import { SshKeyCreateForm, SshKeyFormType } from './ssh-key-create-form'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@harnessio/canary'
 
 interface SshKeyCreateDialogProps {
   open: boolean
   onClose: () => void
-  handleCreateSshKey: () => void
+  handleCreateSshKey: (data: SshKeyFormType) => void
+  error: { type: string; message: string } | null
 }
 
-export const SshKeyCreateDialog: React.FC<SshKeyCreateDialogProps> = ({ open, onClose, handleCreateSshKey }) => {
+export const SshKeyCreateDialog: React.FC<SshKeyCreateDialogProps> = ({ open, onClose, handleCreateSshKey, error }) => {
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-[500px]  bg-primary-background border-border">
@@ -15,7 +16,7 @@ export const SshKeyCreateDialog: React.FC<SshKeyCreateDialogProps> = ({ open, on
           <DialogTitle className="text-left">New SSH key</DialogTitle>
         </DialogHeader>
         <DialogDescription>
-          <SshKeyCreateForm handleCreateSshKey={handleCreateSshKey} />
+          <SshKeyCreateForm handleCreateSshKey={handleCreateSshKey} onClose={onClose} error={error} />
         </DialogDescription>
       </DialogContent>
     </Dialog>

--- a/apps/gitness/src/pages/profile-settings/ssh-key-create/ssh-key-create-dialog.tsx
+++ b/apps/gitness/src/pages/profile-settings/ssh-key-create/ssh-key-create-dialog.tsx
@@ -1,21 +1,21 @@
-import { TokenCreateForm } from './token-create-form'
+import { SshKeyCreateForm } from './ssh-key-create-form'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@harnessio/canary'
 
-interface TokenCreateDialogProps {
+interface SshKeyCreateDialogProps {
   open: boolean
   onClose: () => void
-  handleCreateToken: () => void
+  handleCreateSshKey: () => void
 }
 
-export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({ open, onClose, handleCreateToken }) => {
+export const SshKeyCreateDialog: React.FC<SshKeyCreateDialogProps> = ({ open, onClose, handleCreateSshKey }) => {
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-[500px]  bg-primary-background border-border">
         <DialogHeader>
-          <DialogTitle className="text-left">Create a token</DialogTitle>
+          <DialogTitle className="text-left">New SSH key</DialogTitle>
         </DialogHeader>
         <DialogDescription>
-          <TokenCreateForm handleCreateToken={handleCreateToken} />
+          <SshKeyCreateForm handleCreateSshKey={handleCreateSshKey} />
         </DialogDescription>
       </DialogContent>
     </Dialog>

--- a/apps/gitness/src/pages/profile-settings/ssh-key-create/ssh-key-create-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/ssh-key-create/ssh-key-create-form.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from 'react'
-import { Button, ButtonGroup, Input, Textarea } from '@harnessio/canary'
+import { Button, ButtonGroup, Input, Textarea, Spacer, Text } from '@harnessio/canary'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -13,28 +12,18 @@ const formSchema = z.object({
 export type SshKeyFormType = z.infer<typeof formSchema>
 
 interface SshKeyCreateFormProps {
-  onSubmit?: (data: SshKeyFormType) => void
-  onCancel?: () => void
   apiError?: string | null
   isLoading?: boolean
-  isSuccess?: boolean
+  onClose: () => void
   handleCreateSshKey: (data: SshKeyFormType) => void
+  error: { type: string; message: string } | null
 }
 
-export function SshKeyCreateForm({
-  onSubmit = () => {},
-  onCancel = () => {},
-  apiError = null,
-  isLoading = false,
-  isSuccess = false,
-  handleCreateSshKey
-}: SshKeyCreateFormProps) {
+export function SshKeyCreateForm({ isLoading, handleCreateSshKey, onClose, error }: SshKeyCreateFormProps) {
   const {
     register,
     handleSubmit,
-    setValue,
     watch,
-    reset,
     formState: { errors, isValid }
   } = useForm<SshKeyFormType>({
     resolver: zodResolver(formSchema),
@@ -45,21 +34,12 @@ export function SshKeyCreateForm({
     }
   })
 
-  const [isSubmitted, setIsSubmitted] = useState(false)
-
-  //   useEffect(() => {
-  //     if (isSuccess === true) {
-  //       reset()
-  //       setIsSubmitted(true)
-  //     }
-  //   }, [isSuccess, reset])
+  const content = watch('content')
+  const identifier = watch('identifier')
 
   const handleFormSubmit: SubmitHandler<SshKeyFormType> = data => {
-    // onSubmit(data)
-    console.log(data)
     handleCreateSshKey(data)
   }
-  const handleCancel = () => {}
 
   return (
     <>
@@ -70,7 +50,13 @@ export function SshKeyCreateForm({
             <FormFieldSet.Label htmlFor="identifier" required>
               New SSH key
             </FormFieldSet.Label>
-            <Input id="identifier" {...register('identifier')} placeholder="Enter the name" autoFocus />
+            <Input
+              id="identifier"
+              value={identifier}
+              {...register('identifier')}
+              placeholder="Enter the name"
+              autoFocus
+            />
             {errors.identifier && (
               <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
                 {errors.identifier.message?.toString()}
@@ -85,7 +71,7 @@ export function SshKeyCreateForm({
               Public key
             </FormFieldSet.Label>
             {/* <Input id="content" {...register('content')} autoFocus /> */}
-            <Textarea id="content" {...register('content')} />
+            <Textarea id="content" value={content} {...register('content')} />
             {errors.identifier && (
               <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
                 {errors.identifier.message?.toString()}
@@ -93,26 +79,28 @@ export function SshKeyCreateForm({
             )}
           </FormFieldSet.ControlGroup>
         </FormFieldSet.Root>
-
+        <>
+          {error && error.type === 'keyCreate' && (
+            <>
+              <Text size={1} className="text-destructive">
+                {error.message}
+              </Text>
+              <Spacer size={4} />
+            </>
+          )}
+        </>
         {/* SUBMIT BUTTONS */}
         <FormFieldSet.Root>
           <FormFieldSet.ControlGroup>
             <ButtonGroup.Root className="justify-end">
-              {!isSubmitted ? (
-                <>
-                  <Button type="button" variant="outline" size="sm" onClick={handleCancel}>
-                    Cancel
-                  </Button>
-                  <Button type="submit" size="sm" disabled={!isValid || isLoading}>
-                    {!isLoading ? 'Save' : 'Saving...'}
-                  </Button>
-                </>
-              ) : (
-                <Button variant="ghost" type="button" size="sm" theme="success" className="pointer-events-none">
-                  Generated Token&nbsp;&nbsp;
-                  <Icon name="tick" size={14} />
+              <>
+                <Button type="button" variant="outline" size="sm" onClick={onClose}>
+                  Cancel
                 </Button>
-              )}
+                <Button type="submit" size="sm" disabled={!isValid || isLoading}>
+                  {!isLoading ? 'Save' : 'Saving...'}
+                </Button>
+              </>
             </ButtonGroup.Root>
           </FormFieldSet.ControlGroup>
         </FormFieldSet.Root>

--- a/apps/gitness/src/pages/profile-settings/ssh-key-create/ssh-key-create-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/ssh-key-create/ssh-key-create-form.tsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect } from 'react'
+import { Button, ButtonGroup, Input, Textarea } from '@harnessio/canary'
+import { useForm, SubmitHandler } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { FormFieldSet } from '@harnessio/playground'
+
+const formSchema = z.object({
+  identifier: z.string().min(1, { message: 'Please provide a name' }),
+  content: z.string().min(1, { message: 'Please add the public key' })
+})
+
+export type SshKeyFormType = z.infer<typeof formSchema>
+
+interface SshKeyCreateFormProps {
+  onSubmit?: (data: SshKeyFormType) => void
+  onCancel?: () => void
+  apiError?: string | null
+  isLoading?: boolean
+  isSuccess?: boolean
+  handleCreateSshKey: (data: SshKeyFormType) => void
+}
+
+export function SshKeyCreateForm({
+  onSubmit = () => {},
+  onCancel = () => {},
+  apiError = null,
+  isLoading = false,
+  isSuccess = false,
+  handleCreateSshKey
+}: SshKeyCreateFormProps) {
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors, isValid }
+  } = useForm<SshKeyFormType>({
+    resolver: zodResolver(formSchema),
+    mode: 'onChange',
+    defaultValues: {
+      identifier: '',
+      content: ''
+    }
+  })
+
+  const [isSubmitted, setIsSubmitted] = useState(false)
+
+  const handleSelectChange = (fieldName: keyof SshKeyFormType, value: string) => {
+    setValue(fieldName, value, { shouldValidate: true })
+  }
+
+  //   useEffect(() => {
+  //     if (isSuccess === true) {
+  //       reset()
+  //       setIsSubmitted(true)
+  //     }
+  //   }, [isSuccess, reset])
+
+  const handleFormSubmit: SubmitHandler<SshKeyFormType> = data => {
+    // onSubmit(data)
+    console.log(data)
+    handleCreateSshKey(data)
+  }
+  const handleCancel = () => {}
+
+  return (
+    <>
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        {/* NAME */}
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <FormFieldSet.Label htmlFor="identifier" required>
+              New SSH key
+            </FormFieldSet.Label>
+            <Input id="identifier" {...register('identifier')} placeholder="Enter the name" autoFocus />
+            {errors.identifier && (
+              <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
+                {errors.identifier.message?.toString()}
+              </FormFieldSet.Message>
+            )}
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <FormFieldSet.Label htmlFor="content" required>
+              Public key
+            </FormFieldSet.Label>
+            {/* <Input id="content" {...register('content')} autoFocus /> */}
+            <Textarea id="content" {...register('content')} />
+            {errors.identifier && (
+              <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
+                {errors.identifier.message?.toString()}
+              </FormFieldSet.Message>
+            )}
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+
+        {/* SUBMIT BUTTONS */}
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <ButtonGroup.Root className="justify-end">
+              {!isSubmitted ? (
+                <>
+                  <Button type="button" variant="outline" size="sm" onClick={handleCancel}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" size="sm" disabled={!isValid || isLoading}>
+                    {!isLoading ? 'Save' : 'Saving...'}
+                  </Button>
+                </>
+              ) : (
+                <Button variant="ghost" type="button" size="sm" theme="success" className="pointer-events-none">
+                  Generated Token&nbsp;&nbsp;
+                  <Icon name="tick" size={14} />
+                </Button>
+              )}
+            </ButtonGroup.Root>
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+      </form>
+    </>
+  )
+}

--- a/apps/gitness/src/pages/profile-settings/ssh-key-create/ssh-key-create-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/ssh-key-create/ssh-key-create-form.tsx
@@ -70,7 +70,6 @@ export function SshKeyCreateForm({ isLoading, handleCreateSshKey, onClose, error
             <FormFieldSet.Label htmlFor="content" required>
               Public key
             </FormFieldSet.Label>
-            {/* <Input id="content" {...register('content')} autoFocus /> */}
             <Textarea id="content" value={content} {...register('content')} />
             {errors.identifier && (
               <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>

--- a/apps/gitness/src/pages/profile-settings/token-create/token-create-dialog.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-create-dialog.tsx
@@ -1,13 +1,21 @@
-import { TokenCreateForm } from './token-create-form'
+import { TokenCreateForm, TokenFormType } from './token-create-form'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@harnessio/canary'
 
 interface TokenCreateDialogProps {
   open: boolean
   onClose: () => void
-  handleCreateToken: () => void
+  handleCreateToken: (data: TokenFormType) => void
+  error: { type: string; message: string } | null
+  isLoading: boolean
 }
 
-export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({ open, onClose, handleCreateToken }) => {
+export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({
+  open,
+  onClose,
+  handleCreateToken,
+  error,
+  isLoading
+}) => {
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-[500px]  bg-primary-background border-border">
@@ -15,7 +23,12 @@ export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({ open, onCl
           <DialogTitle className="text-left">Create a token</DialogTitle>
         </DialogHeader>
         <DialogDescription>
-          <TokenCreateForm handleCreateToken={handleCreateToken} />
+          <TokenCreateForm
+            handleCreateToken={handleCreateToken}
+            onClose={onClose}
+            error={error}
+            isLoading={isLoading}
+          />
         </DialogDescription>
       </DialogContent>
     </Dialog>

--- a/apps/gitness/src/pages/profile-settings/token-create/token-create-dialog.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-create-dialog.tsx
@@ -4,9 +4,10 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, Sp
 interface TokenCreateDialogProps {
   open: boolean
   onClose: () => void
+  handleCreateToken: () => void
 }
 
-export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({ open, onClose }) => {
+export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({ open, onClose, handleCreateToken }) => {
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-[500px]  bg-primary-background border-border">
@@ -14,7 +15,7 @@ export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({ open, onCl
           <DialogTitle className="text-left">Create a token</DialogTitle>
         </DialogHeader>
         <DialogDescription>
-          <TokenCreateForm />
+          <TokenCreateForm handleCreateToken={handleCreateToken} />
         </DialogDescription>
       </DialogContent>
     </Dialog>

--- a/apps/gitness/src/pages/profile-settings/token-create/token-create-dialog.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-create-dialog.tsx
@@ -1,5 +1,5 @@
 import { TokenCreateForm, TokenFormType } from './token-create-form'
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@harnessio/canary'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@harnessio/canary'
 
 interface TokenCreateDialogProps {
   open: boolean
@@ -22,14 +22,7 @@ export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({
         <DialogHeader>
           <DialogTitle className="text-left">Create a token</DialogTitle>
         </DialogHeader>
-        <DialogDescription>
-          <TokenCreateForm
-            handleCreateToken={handleCreateToken}
-            onClose={onClose}
-            error={error}
-            isLoading={isLoading}
-          />
-        </DialogDescription>
+        <TokenCreateForm handleCreateToken={handleCreateToken} onClose={onClose} error={error} isLoading={isLoading} />
       </DialogContent>
     </Dialog>
   )

--- a/apps/gitness/src/pages/profile-settings/token-create/token-create-dialog.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-create-dialog.tsx
@@ -1,0 +1,22 @@
+import { TokenCreateForm } from './token-create-form'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, Spacer } from '@harnessio/canary'
+
+interface TokenCreateDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({ open, onClose }) => {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-[500px]  bg-primary-background border-border">
+        <DialogHeader>
+          <DialogTitle className="text-left">Create a token</DialogTitle>
+        </DialogHeader>
+        <DialogDescription>
+          <TokenCreateForm />
+        </DialogDescription>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
@@ -116,7 +116,7 @@ export function TokenCreateForm({
           </FormFieldSet.ControlGroup>
         </FormFieldSet.Root>
 
-        <FormFieldSet.Root className="mb-2">
+        <FormFieldSet.Root>
           <FormFieldSet.ControlGroup>
             <FormFieldSet.Label htmlFor="lifetime" required>
               Expiration
@@ -141,7 +141,7 @@ export function TokenCreateForm({
 
         {/* Expiration Info */}
         {isValid && (
-          <FormFieldSet.Root className="mb-4">
+          <FormFieldSet.Root>
             <FormFieldSet.ControlGroup>
               {watch('lifetime') === 'never' ? (
                 <Text color="tertiaryBackground">Token will never expire</Text>

--- a/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
@@ -17,18 +17,18 @@ import { z } from 'zod'
 import { FormFieldSet } from '@harnessio/playground'
 
 const formSchema = z.object({
-  name: z.string().min(1, { message: 'Please provide a name' }),
-  expiration: z.string().min(1, { message: 'Please select an expiration' })
+  identifier: z.string().min(1, { message: 'Please provide a name' }),
+  lifetime: z.string().min(1, { message: 'Please select an expiration' })
 })
 
 export type TokenFormType = z.infer<typeof formSchema>
 
 const expirationOptions = [
-  { value: '7d', label: '7 days' },
-  { value: '30d', label: '30 days' },
-  { value: '90d', label: '90 days' },
-  { value: '180d', label: '180 days' },
-  { value: '365d', label: '365 days' },
+  { value: '7', label: '7 days' },
+  { value: '30', label: '30 days' },
+  { value: '90', label: '90 days' },
+  { value: '180', label: '180 days' },
+  { value: '365', label: '365 days' },
   { value: 'never', label: 'Never' }
 ]
 
@@ -38,6 +38,7 @@ interface TokenCreateFormProps {
   apiError?: string | null
   isLoading?: boolean
   isSuccess?: boolean
+  handleCreateToken: (data: TokenFormType) => void
 }
 
 export function TokenCreateForm({
@@ -45,7 +46,8 @@ export function TokenCreateForm({
   onCancel = () => {},
   apiError = null,
   isLoading = false,
-  isSuccess = false
+  isSuccess = false,
+  handleCreateToken
 }: TokenCreateFormProps) {
   const {
     register,
@@ -58,12 +60,11 @@ export function TokenCreateForm({
     resolver: zodResolver(formSchema),
     mode: 'onChange',
     defaultValues: {
-      name: '',
-      expiration: '30d'
+      identifier: ''
     }
   })
 
-  const expirationValue = watch('expiration')
+  const expirationValue = watch('lifetime')
   const [isSubmitted, setIsSubmitted] = useState(false)
 
   const handleSelectChange = (fieldName: keyof TokenFormType, value: string) => {
@@ -80,6 +81,7 @@ export function TokenCreateForm({
   const handleFormSubmit: SubmitHandler<TokenFormType> = data => {
     // onSubmit(data)
     console.log(data)
+    handleCreateToken(data)
   }
   const handleCancel = () => {}
 
@@ -89,13 +91,13 @@ export function TokenCreateForm({
         {/* NAME */}
         <FormFieldSet.Root>
           <FormFieldSet.ControlGroup>
-            <FormFieldSet.Label htmlFor="name" required>
+            <FormFieldSet.Label htmlFor="identifier" required>
               Name
             </FormFieldSet.Label>
-            <Input id="name" {...register('name')} placeholder="Enter repository name" autoFocus />
-            {errors.name && (
+            <Input id="identifier" {...register('identifier')} placeholder="Enter token name" autoFocus />
+            {errors.identifier && (
               <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
-                {errors.name.message?.toString()}
+                {errors.identifier.message?.toString()}
               </FormFieldSet.Message>
             )}
           </FormFieldSet.ControlGroup>
@@ -103,9 +105,9 @@ export function TokenCreateForm({
 
         <FormFieldSet.Root>
           <FormFieldSet.ControlGroup>
-            <FormFieldSet.Label htmlFor="expiration">Expiration</FormFieldSet.Label>
-            <Select value={expirationValue} onValueChange={value => handleSelectChange('expiration', value)}>
-              <SelectTrigger id="expiration">
+            <FormFieldSet.Label htmlFor="lifetime">Expiration</FormFieldSet.Label>
+            <Select value={expirationValue} onValueChange={value => handleSelectChange('lifetime', value)}>
+              <SelectTrigger id="lifetime">
                 <SelectValue placeholder="Select" />
               </SelectTrigger>
               <SelectContent>
@@ -114,9 +116,9 @@ export function TokenCreateForm({
                 })}
               </SelectContent>
             </Select>
-            {errors.expiration && (
+            {errors.lifetime && (
               <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
-                {errors.expiration.message?.toString()}
+                {errors.lifetime.message?.toString()}
               </FormFieldSet.Message>
             )}
           </FormFieldSet.ControlGroup>

--- a/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
@@ -114,7 +114,11 @@ export function TokenCreateForm({ error, isLoading, handleCreateToken, onClose }
               </SelectTrigger>
               <SelectContent>
                 {expirationOptions.map(expirationOption => {
-                  return <SelectItem value={expirationOption.value}>{expirationOption.label}</SelectItem>
+                  return (
+                    <SelectItem key={expirationOption.value} value={expirationOption.value}>
+                      {expirationOption.label}
+                    </SelectItem>
+                  )
                 })}
               </SelectContent>
             </Select>

--- a/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
@@ -1,4 +1,3 @@
-import React, { useState, useEffect } from 'react'
 import {
   Button,
   ButtonGroup,
@@ -8,7 +7,8 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Text
+  Text,
+  Spacer
 } from '@harnessio/canary'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -31,57 +31,38 @@ const expirationOptions = [
 ]
 
 interface TokenCreateFormProps {
-  onSubmit?: (data: TokenFormType) => void
-  onCancel?: () => void
-  apiError?: string | null
-  isLoading?: boolean
-  isSuccess?: boolean
+  error: { type: string; message: string } | null
+  isLoading: boolean
   handleCreateToken: (data: TokenFormType) => void
+  onClose: () => void
 }
 
-export function TokenCreateForm({
-  onSubmit = () => {},
-  onCancel = () => {},
-  apiError = null,
-  isLoading = false,
-  isSuccess = false,
-  handleCreateToken
-}: TokenCreateFormProps) {
+export function TokenCreateForm({ error, isLoading, handleCreateToken, onClose }: TokenCreateFormProps) {
   const {
     register,
     handleSubmit,
     setValue,
     watch,
-    reset,
     formState: { errors, isValid }
   } = useForm<TokenFormType>({
     resolver: zodResolver(formSchema),
     mode: 'onChange',
     defaultValues: {
-      identifier: ''
+      identifier: '',
+      lifetime: ''
     }
   })
 
   const expirationValue = watch('lifetime')
-  const [isSubmitted, setIsSubmitted] = useState(false)
+  const identifier = watch('identifier')
 
   const handleSelectChange = (fieldName: keyof TokenFormType, value: string) => {
     setValue(fieldName, value, { shouldValidate: true })
   }
 
-  //   useEffect(() => {
-  //     if (isSuccess === true) {
-  //       reset()
-  //       setIsSubmitted(true)
-  //     }
-  //   }, [isSuccess, reset])
-
   const handleFormSubmit: SubmitHandler<TokenFormType> = data => {
-    // onSubmit(data)
-    console.log(data)
     handleCreateToken(data)
   }
-  const handleCancel = () => {}
 
   const calculateExpirationDate = (lifetime: string): string => {
     if (lifetime === 'never') return ''
@@ -107,7 +88,13 @@ export function TokenCreateForm({
             <FormFieldSet.Label htmlFor="identifier" required>
               Name
             </FormFieldSet.Label>
-            <Input id="identifier" {...register('identifier')} placeholder="Enter token name" autoFocus />
+            <Input
+              id="identifier"
+              value={identifier}
+              {...register('identifier')}
+              placeholder="Enter token name"
+              autoFocus
+            />
             {errors.identifier && (
               <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
                 {errors.identifier.message?.toString()}
@@ -154,25 +141,29 @@ export function TokenCreateForm({
           </FormFieldSet.Root>
         )}
 
+        <>
+          {error && error.type === 'tokenCreate' && (
+            <>
+              <Text size={1} className="text-destructive">
+                {error.message}
+              </Text>
+              <Spacer size={4} />
+            </>
+          )}
+        </>
+
         {/* SUBMIT BUTTONS */}
         <FormFieldSet.Root>
           <FormFieldSet.ControlGroup>
             <ButtonGroup.Root className="justify-end">
-              {!isSubmitted ? (
-                <>
-                  <Button type="button" variant="outline" size="sm" onClick={handleCancel}>
-                    Cancel
-                  </Button>
-                  <Button type="submit" size="sm" disabled={!isValid || isLoading}>
-                    {!isLoading ? 'Generate Token' : 'Generating Token...'}
-                  </Button>
-                </>
-              ) : (
-                <Button variant="ghost" type="button" size="sm" theme="success" className="pointer-events-none">
-                  Generated Token&nbsp;&nbsp;
-                  <Icon name="tick" size={14} />
+              <>
+                <Button type="button" variant="outline" size="sm" onClick={onClose}>
+                  Cancel
                 </Button>
-              )}
+                <Button type="submit" size="sm" disabled={!isValid || isLoading}>
+                  {!isLoading ? 'Generate Token' : 'Generating Token...'}
+                </Button>
+              </>
             </ButtonGroup.Root>
           </FormFieldSet.ControlGroup>
         </FormFieldSet.Root>

--- a/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
@@ -7,7 +7,8 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue
+  SelectValue,
+  Text
 } from '@harnessio/canary'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -24,9 +25,8 @@ export type TokenFormType = z.infer<typeof formSchema>
 const expirationOptions = [
   { value: '7', label: '7 days' },
   { value: '30', label: '30 days' },
+  { value: '60', label: '60 days' },
   { value: '90', label: '90 days' },
-  { value: '180', label: '180 days' },
-  { value: '365', label: '365 days' },
   { value: 'never', label: 'Never' }
 ]
 
@@ -83,6 +83,21 @@ export function TokenCreateForm({
   }
   const handleCancel = () => {}
 
+  const calculateExpirationDate = (lifetime: string): string => {
+    if (lifetime === 'never') return ''
+
+    const days = parseInt(lifetime, 10)
+    const expirationDate = new Date()
+    expirationDate.setDate(expirationDate.getDate() + days)
+
+    return expirationDate.toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    })
+  }
+
   return (
     <>
       <form onSubmit={handleSubmit(handleFormSubmit)}>
@@ -101,7 +116,7 @@ export function TokenCreateForm({
           </FormFieldSet.ControlGroup>
         </FormFieldSet.Root>
 
-        <FormFieldSet.Root>
+        <FormFieldSet.Root className="mb-2">
           <FormFieldSet.ControlGroup>
             <FormFieldSet.Label htmlFor="lifetime" required>
               Expiration
@@ -123,6 +138,21 @@ export function TokenCreateForm({
             )}
           </FormFieldSet.ControlGroup>
         </FormFieldSet.Root>
+
+        {/* Expiration Info */}
+        {isValid && (
+          <FormFieldSet.Root className="mb-4">
+            <FormFieldSet.ControlGroup>
+              {watch('lifetime') === 'never' ? (
+                <Text color="tertiaryBackground">Token will never expire</Text>
+              ) : (
+                <Text color="tertiaryBackground">
+                  Token will expire on {calculateExpirationDate(watch('lifetime'))}
+                </Text>
+              )}
+            </FormFieldSet.ControlGroup>
+          </FormFieldSet.Root>
+        )}
 
         {/* SUBMIT BUTTONS */}
         <FormFieldSet.Root>

--- a/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
@@ -1,0 +1,150 @@
+import React, { useState, useEffect } from 'react'
+import {
+  Button,
+  ButtonGroup,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Spacer,
+  Text
+} from '@harnessio/canary'
+import { useForm, SubmitHandler } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { FormFieldSet } from '@harnessio/playground'
+
+const formSchema = z.object({
+  name: z.string().min(1, { message: 'Please provide a name' }),
+  expiration: z.string().min(1, { message: 'Please select an expiration' })
+})
+
+export type TokenFormType = z.infer<typeof formSchema>
+
+const expirationOptions = [
+  { value: '7d', label: '7 days' },
+  { value: '30d', label: '30 days' },
+  { value: '90d', label: '90 days' },
+  { value: '180d', label: '180 days' },
+  { value: '365d', label: '365 days' },
+  { value: 'never', label: 'Never' }
+]
+
+interface TokenCreateFormProps {
+  onSubmit?: (data: TokenFormType) => void
+  onCancel?: () => void
+  apiError?: string | null
+  isLoading?: boolean
+  isSuccess?: boolean
+}
+
+export function TokenCreateForm({
+  onSubmit = () => {},
+  onCancel = () => {},
+  apiError = null,
+  isLoading = false,
+  isSuccess = false
+}: TokenCreateFormProps) {
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors, isValid }
+  } = useForm<TokenFormType>({
+    resolver: zodResolver(formSchema),
+    mode: 'onChange',
+    defaultValues: {
+      name: '',
+      expiration: '30d'
+    }
+  })
+
+  const expirationValue = watch('expiration')
+  const [isSubmitted, setIsSubmitted] = useState(false)
+
+  const handleSelectChange = (fieldName: keyof TokenFormType, value: string) => {
+    setValue(fieldName, value, { shouldValidate: true })
+  }
+
+  //   useEffect(() => {
+  //     if (isSuccess === true) {
+  //       reset()
+  //       setIsSubmitted(true)
+  //     }
+  //   }, [isSuccess, reset])
+
+  const handleFormSubmit: SubmitHandler<TokenFormType> = data => {
+    // onSubmit(data)
+    console.log(data)
+  }
+  const handleCancel = () => {}
+
+  return (
+    <>
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        {/* NAME */}
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <FormFieldSet.Label htmlFor="name" required>
+              Name
+            </FormFieldSet.Label>
+            <Input id="name" {...register('name')} placeholder="Enter repository name" autoFocus />
+            {errors.name && (
+              <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
+                {errors.name.message?.toString()}
+              </FormFieldSet.Message>
+            )}
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <FormFieldSet.Label htmlFor="expiration">Expiration</FormFieldSet.Label>
+            <Select value={expirationValue} onValueChange={value => handleSelectChange('expiration', value)}>
+              <SelectTrigger id="expiration">
+                <SelectValue placeholder="Select" />
+              </SelectTrigger>
+              <SelectContent>
+                {expirationOptions.map(expirationOption => {
+                  return <SelectItem value={expirationOption.value}>{expirationOption.label}</SelectItem>
+                })}
+              </SelectContent>
+            </Select>
+            {errors.expiration && (
+              <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
+                {errors.expiration.message?.toString()}
+              </FormFieldSet.Message>
+            )}
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+
+        {/* SUBMIT BUTTONS */}
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <ButtonGroup.Root className="justify-end">
+              {!isSubmitted ? (
+                <>
+                  <Button type="button" variant="outline" size="sm" onClick={handleCancel}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" size="sm" disabled={!isValid || isLoading}>
+                    {!isLoading ? 'Generate Token' : 'Generating Token...'}
+                  </Button>
+                </>
+              ) : (
+                <Button variant="ghost" type="button" size="sm" theme="success" className="pointer-events-none">
+                  Generated Token&nbsp;&nbsp;
+                  <Icon name="tick" size={14} />
+                </Button>
+              )}
+            </ButtonGroup.Root>
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+      </form>
+    </>
+  )
+}

--- a/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-create-form.tsx
@@ -7,9 +7,7 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
-  Spacer,
-  Text
+  SelectValue
 } from '@harnessio/canary'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -105,7 +103,9 @@ export function TokenCreateForm({
 
         <FormFieldSet.Root>
           <FormFieldSet.ControlGroup>
-            <FormFieldSet.Label htmlFor="lifetime">Expiration</FormFieldSet.Label>
+            <FormFieldSet.Label htmlFor="lifetime" required>
+              Expiration
+            </FormFieldSet.Label>
             <Select value={expirationValue} onValueChange={value => handleSelectChange('lifetime', value)}>
               <SelectTrigger id="lifetime">
                 <SelectValue placeholder="Select" />

--- a/apps/gitness/src/pages/profile-settings/token-create/token-success-dialog.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-success-dialog.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { TokenSuccessForm } from './token-success-form'
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@harnessio/canary'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@harnessio/canary'
 
 interface TokenCreateDialogProps {
   open: boolean
@@ -19,9 +19,7 @@ export const TokenSuccessDialog: React.FC<TokenCreateDialogProps> = ({ open, onC
         <DialogHeader>
           <DialogTitle className="text-left">Create a token</DialogTitle>
         </DialogHeader>
-        <DialogDescription>
-          <TokenSuccessForm defaultValues={tokenData} onClose={onClose} />
-        </DialogDescription>
+        <TokenSuccessForm defaultValues={tokenData} onClose={onClose} />
       </DialogContent>
     </Dialog>
   )

--- a/apps/gitness/src/pages/profile-settings/token-create/token-success-dialog.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-success-dialog.tsx
@@ -5,7 +5,11 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 interface TokenCreateDialogProps {
   open: boolean
   onClose: () => void
-  tokenData: any
+  tokenData: {
+    identifier: string
+    lifetime: string
+    token: string
+  }
 }
 
 export const TokenSuccessDialog: React.FC<TokenCreateDialogProps> = ({ open, onClose, tokenData }) => {
@@ -16,7 +20,7 @@ export const TokenSuccessDialog: React.FC<TokenCreateDialogProps> = ({ open, onC
           <DialogTitle className="text-left">Create a token</DialogTitle>
         </DialogHeader>
         <DialogDescription>
-          <TokenSuccessForm defaultValues={tokenData} />
+          <TokenSuccessForm defaultValues={tokenData} onClose={onClose} />
         </DialogDescription>
       </DialogContent>
     </Dialog>

--- a/apps/gitness/src/pages/profile-settings/token-create/token-success-dialog.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-success-dialog.tsx
@@ -1,13 +1,14 @@
-import { TokenCreateForm } from './token-create-form'
+import React from 'react'
+import { TokenSuccessForm } from './token-success-form'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@harnessio/canary'
 
 interface TokenCreateDialogProps {
   open: boolean
   onClose: () => void
-  handleCreateToken: () => void
+  tokenData: any
 }
 
-export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({ open, onClose, handleCreateToken }) => {
+export const TokenSuccessDialog: React.FC<TokenCreateDialogProps> = ({ open, onClose, tokenData }) => {
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-[500px]  bg-primary-background border-border">
@@ -15,7 +16,7 @@ export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({ open, onCl
           <DialogTitle className="text-left">Create a token</DialogTitle>
         </DialogHeader>
         <DialogDescription>
-          <TokenCreateForm handleCreateToken={handleCreateToken} />
+          <TokenSuccessForm defaultValues={tokenData} />
         </DialogDescription>
       </DialogContent>
     </Dialog>

--- a/apps/gitness/src/pages/profile-settings/token-create/token-success-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-success-form.tsx
@@ -1,0 +1,93 @@
+import { useEffect } from 'react'
+import { Button, ButtonGroup, Input, Text } from '@harnessio/canary'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { FormFieldSet, CopyButton } from '@harnessio/playground'
+
+const formSchema = z.object({
+  identifier: z.string(),
+  lifetime: z.string(),
+  token: z.string()
+})
+
+export type TokenSuccessFormType = z.infer<typeof formSchema>
+
+interface TokenCreateFormProps {
+  defaultValues: TokenSuccessFormType
+}
+
+export function TokenSuccessForm({ defaultValues }: TokenCreateFormProps) {
+  const {
+    setValue
+    // formState: { errors, isValid }
+  } = useForm<TokenSuccessFormType>({
+    resolver: zodResolver(formSchema),
+    // mode: 'onChange',
+    defaultValues: defaultValues
+  })
+
+  useEffect(() => {
+    if (defaultValues) {
+      setValue('identifier', defaultValues.identifier)
+      setValue('lifetime', defaultValues.lifetime)
+      setValue('token', defaultValues.token)
+    }
+  }, [defaultValues, setValue])
+
+  return (
+    <>
+      <form>
+        {/* NAME */}
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <FormFieldSet.Label htmlFor="identifier">Name</FormFieldSet.Label>
+            <Input id="identifier" value={defaultValues?.identifier} readOnly right={<CopyButton />} />
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <FormFieldSet.Label htmlFor="lifetime">Expiration</FormFieldSet.Label>
+            <Input id="lifetime" value={defaultValues?.lifetime} readOnly />
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+
+        {/* Expiration Info */}
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <FormFieldSet.Label htmlFor="token">Token</FormFieldSet.Label>
+            <Input
+              id="token"
+              value={defaultValues?.token}
+              readOnly
+              right={<CopyButton />}
+              autoFocus
+              className="overflow-hidden text-ellipsis whitespace-nowrap"
+            />
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <Text>
+              Your token has been generated. Please make sure to copy and store your token somewhere safe, you won’t be
+              able to see it again.
+            </Text>
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+
+        {/* SUBMIT BUTTONS */}
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <ButtonGroup.Root className="justify-end">
+              <Button type="button" variant="outline" size="default" onClick={() => {}}>
+                Got it
+              </Button>
+            </ButtonGroup.Root>
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+      </form>
+    </>
+  )
+}

--- a/apps/gitness/src/pages/profile-settings/token-create/token-success-form.tsx
+++ b/apps/gitness/src/pages/profile-settings/token-create/token-success-form.tsx
@@ -15,15 +15,12 @@ export type TokenSuccessFormType = z.infer<typeof formSchema>
 
 interface TokenCreateFormProps {
   defaultValues: TokenSuccessFormType
+  onClose: () => void
 }
 
-export function TokenSuccessForm({ defaultValues }: TokenCreateFormProps) {
-  const {
-    setValue
-    // formState: { errors, isValid }
-  } = useForm<TokenSuccessFormType>({
+export function TokenSuccessForm({ defaultValues, onClose }: TokenCreateFormProps) {
+  const { setValue } = useForm<TokenSuccessFormType>({
     resolver: zodResolver(formSchema),
-    // mode: 'onChange',
     defaultValues: defaultValues
   })
 
@@ -42,7 +39,12 @@ export function TokenSuccessForm({ defaultValues }: TokenCreateFormProps) {
         <FormFieldSet.Root>
           <FormFieldSet.ControlGroup>
             <FormFieldSet.Label htmlFor="identifier">Name</FormFieldSet.Label>
-            <Input id="identifier" value={defaultValues?.identifier} readOnly right={<CopyButton />} />
+            <Input
+              id="identifier"
+              value={defaultValues?.identifier}
+              readOnly
+              right={<CopyButton name={defaultValues?.identifier} />}
+            />
           </FormFieldSet.ControlGroup>
         </FormFieldSet.Root>
 
@@ -61,7 +63,7 @@ export function TokenSuccessForm({ defaultValues }: TokenCreateFormProps) {
               id="token"
               value={defaultValues?.token}
               readOnly
-              right={<CopyButton />}
+              right={<CopyButton name={defaultValues?.token} />}
               autoFocus
               className="overflow-hidden text-ellipsis whitespace-nowrap"
             />
@@ -81,7 +83,7 @@ export function TokenSuccessForm({ defaultValues }: TokenCreateFormProps) {
         <FormFieldSet.Root>
           <FormFieldSet.ControlGroup>
             <ButtonGroup.Root className="justify-end">
-              <Button type="button" variant="outline" size="default" onClick={() => {}}>
+              <Button type="button" variant="outline" size="default" onClick={onClose}>
                 Got it
               </Button>
             </ButtonGroup.Root>

--- a/packages/canary/src/components/button.tsx
+++ b/packages/canary/src/components/button.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils'
 import { CanaryOutletFactory, CanaryOutletName } from '@/lib/CanaryOutletFactory'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-[4px] text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-[4px] text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50 disabled:cursor-not-allowed',
   {
     variants: {
       variant: {

--- a/packages/playground/src/components/copy-button.tsx
+++ b/packages/playground/src/components/copy-button.tsx
@@ -22,7 +22,7 @@ export const CopyButton = ({ name }: { name: string }) => {
   const changeIcon = copied ? 'tick' : 'clone'
 
   return (
-    <Button variant="ghost" size="xs" onClick={() => setCopied(true)}>
+    <Button variant="ghost" size="xs" type="button" onClick={() => setCopied(true)}>
       <Icon name={changeIcon} size={16} className={iconCopyStyle} />
     </Button>
   )

--- a/packages/playground/src/components/ssh-key-create-dialog.tsx
+++ b/packages/playground/src/components/ssh-key-create-dialog.tsx
@@ -1,0 +1,23 @@
+import { SshKeyCreateForm } from './ssh-key-create-form'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@harnessio/canary'
+import React from 'react'
+
+interface SshKeyCreateDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+export const SshKeyCreateDialog: React.FC<SshKeyCreateDialogProps> = ({ open, onClose }) => {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-[500px]  bg-primary-background border-border">
+        <DialogHeader>
+          <DialogTitle className="text-left">New SSH key</DialogTitle>
+        </DialogHeader>
+        <DialogDescription>
+          <SshKeyCreateForm />
+        </DialogDescription>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/playground/src/components/ssh-key-create-form.tsx
+++ b/packages/playground/src/components/ssh-key-create-form.tsx
@@ -66,7 +66,6 @@ export function SshKeyCreateForm() {
             <FormFieldSet.Label htmlFor="content" required>
               Public key
             </FormFieldSet.Label>
-            {/* <Input id="content" {...register('content')} autoFocus /> */}
             <Textarea id="content" {...register('content')} />
             {errors.identifier && (
               <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>

--- a/packages/playground/src/components/ssh-key-create-form.tsx
+++ b/packages/playground/src/components/ssh-key-create-form.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from 'react'
-import { Button, ButtonGroup, Input, Textarea } from '@harnessio/canary'
+import React, { useState } from 'react'
+import { Button, ButtonGroup, Input, Textarea, Icon } from '@harnessio/canary'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { FormFieldSet } from '@harnessio/playground'
+import { FormFieldSet } from '../index'
 
 const formSchema = z.object({
   identifier: z.string().min(1, { message: 'Please provide a name' }),
@@ -12,28 +12,10 @@ const formSchema = z.object({
 
 export type SshKeyFormType = z.infer<typeof formSchema>
 
-interface SshKeyCreateFormProps {
-  onSubmit?: (data: SshKeyFormType) => void
-  onCancel?: () => void
-  apiError?: string | null
-  isLoading?: boolean
-  isSuccess?: boolean
-  handleCreateSshKey: (data: SshKeyFormType) => void
-}
-
-export function SshKeyCreateForm({
-  onSubmit = () => {},
-  onCancel = () => {},
-  apiError = null,
-  isLoading = false,
-  isSuccess = false,
-  handleCreateSshKey
-}: SshKeyCreateFormProps) {
+export function SshKeyCreateForm() {
   const {
     register,
     handleSubmit,
-    setValue,
-    watch,
     reset,
     formState: { errors, isValid }
   } = useForm<SshKeyFormType>({
@@ -46,19 +28,19 @@ export function SshKeyCreateForm({
   })
 
   const [isSubmitted, setIsSubmitted] = useState(false)
-
-  //   useEffect(() => {
-  //     if (isSuccess === true) {
-  //       reset()
-  //       setIsSubmitted(true)
-  //     }
-  //   }, [isSuccess, reset])
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const handleFormSubmit: SubmitHandler<SshKeyFormType> = data => {
-    // onSubmit(data)
-    console.log(data)
-    handleCreateSshKey(data)
+    setIsSubmitting(true)
+    setTimeout(() => {
+      console.log('SSH key created:', data)
+      reset()
+      setIsSubmitting(false)
+      setIsSubmitted(true)
+      setTimeout(() => setIsSubmitted(false), 2000)
+    }, 2000)
   }
+
   const handleCancel = () => {}
 
   return (
@@ -103,13 +85,13 @@ export function SshKeyCreateForm({
                   <Button type="button" variant="outline" size="sm" onClick={handleCancel}>
                     Cancel
                   </Button>
-                  <Button type="submit" size="sm" disabled={!isValid || isLoading}>
-                    {!isLoading ? 'Save' : 'Saving...'}
+                  <Button type="submit" size="sm" disabled={!isValid || isSubmitting}>
+                    {!isSubmitting ? 'Save' : 'Saving...'}
                   </Button>
                 </>
               ) : (
                 <Button variant="ghost" type="button" size="sm" theme="success" className="pointer-events-none">
-                  Generated Token&nbsp;&nbsp;
+                  Key Saved&nbsp;&nbsp;
                   <Icon name="tick" size={14} />
                 </Button>
               )}

--- a/packages/playground/src/components/token-create-dialog.tsx
+++ b/packages/playground/src/components/token-create-dialog.tsx
@@ -1,0 +1,22 @@
+import { TokenCreateForm } from './token-create-form'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@harnessio/canary'
+import React from 'react'
+interface TokenCreateDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+export const TokenCreateDialog: React.FC<TokenCreateDialogProps> = ({ open, onClose }) => {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-[500px]  bg-primary-background border-border">
+        <DialogHeader>
+          <DialogTitle className="text-left">Create a token</DialogTitle>
+        </DialogHeader>
+        <DialogDescription>
+          <TokenCreateForm />
+        </DialogDescription>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/playground/src/components/token-create-form.tsx
+++ b/packages/playground/src/components/token-create-form.tsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react'
+import {
+  Button,
+  ButtonGroup,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Text,
+  Icon
+} from '@harnessio/canary'
+import { useForm, SubmitHandler } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { FormFieldSet } from '../index'
+
+const formSchema = z.object({
+  identifier: z.string().min(1, { message: 'Please provide a name' }),
+  lifetime: z.string().min(1, { message: 'Please select an expiration' })
+})
+
+export type TokenFormType = z.infer<typeof formSchema>
+
+const expirationOptions = [
+  { value: '7', label: '7 days' },
+  { value: '30', label: '30 days' },
+  { value: '60', label: '60 days' },
+  { value: '90', label: '90 days' },
+  { value: 'never', label: 'Never' }
+]
+
+export function TokenCreateForm() {
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors, isValid }
+  } = useForm<TokenFormType>({
+    resolver: zodResolver(formSchema),
+    mode: 'onChange',
+    defaultValues: {
+      identifier: ''
+    }
+  })
+
+  const expirationValue = watch('lifetime')
+  const [isSubmitted, setIsSubmitted] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSelectChange = (fieldName: keyof TokenFormType, value: string) => {
+    setValue(fieldName, value, { shouldValidate: true })
+  }
+
+  const handleFormSubmit: SubmitHandler<TokenFormType> = data => {
+    setIsSubmitting(true)
+    setTimeout(() => {
+      console.log('Token created:', data)
+      reset()
+      setIsSubmitting(false)
+      setIsSubmitted(true)
+      setTimeout(() => setIsSubmitted(false), 2000)
+    }, 2000)
+  }
+
+  const handleCancel = () => {}
+
+  const calculateExpirationDate = (lifetime: string): string => {
+    if (lifetime === 'never') return ''
+
+    const days = parseInt(lifetime, 10)
+    const expirationDate = new Date()
+    expirationDate.setDate(expirationDate.getDate() + days)
+
+    return expirationDate.toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    })
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        {/* NAME */}
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <FormFieldSet.Label htmlFor="identifier" required>
+              Name
+            </FormFieldSet.Label>
+            <Input id="identifier" {...register('identifier')} placeholder="Enter token name" autoFocus />
+            {errors.identifier && (
+              <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
+                {errors.identifier.message?.toString()}
+              </FormFieldSet.Message>
+            )}
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <FormFieldSet.Label htmlFor="lifetime" required>
+              Expiration
+            </FormFieldSet.Label>
+            <Select value={expirationValue} onValueChange={value => handleSelectChange('lifetime', value)}>
+              <SelectTrigger id="lifetime">
+                <SelectValue placeholder="Select" />
+              </SelectTrigger>
+              <SelectContent>
+                {expirationOptions.map(expirationOption => {
+                  return <SelectItem value={expirationOption.value}>{expirationOption.label}</SelectItem>
+                })}
+              </SelectContent>
+            </Select>
+            {errors.lifetime && (
+              <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
+                {errors.lifetime.message?.toString()}
+              </FormFieldSet.Message>
+            )}
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+
+        {/* Expiration Info */}
+        {isValid && (
+          <FormFieldSet.Root>
+            <FormFieldSet.ControlGroup>
+              {watch('lifetime') === 'never' ? (
+                <Text color="tertiaryBackground">Token will never expire</Text>
+              ) : (
+                <Text color="tertiaryBackground">
+                  Token will expire on {calculateExpirationDate(watch('lifetime'))}
+                </Text>
+              )}
+            </FormFieldSet.ControlGroup>
+          </FormFieldSet.Root>
+        )}
+
+        {/* SUBMIT BUTTONS */}
+        <FormFieldSet.Root>
+          <FormFieldSet.ControlGroup>
+            <ButtonGroup.Root className="justify-end">
+              {!isSubmitted ? (
+                <>
+                  <Button type="button" variant="outline" size="sm" onClick={handleCancel}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" size="sm" disabled={!isValid || isSubmitting}>
+                    {!isSubmitting ? 'Generate Token' : 'Generating Token...'}
+                  </Button>
+                </>
+              ) : (
+                <Button variant="ghost" type="button" size="sm" theme="success" className="pointer-events-none">
+                  Token Generated&nbsp;&nbsp;
+                  <Icon name="tick" size={14} />
+                </Button>
+              )}
+            </ButtonGroup.Root>
+          </FormFieldSet.ControlGroup>
+        </FormFieldSet.Root>
+      </form>
+    </>
+  )
+}

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -65,6 +65,7 @@ export * from './components/pagination'
 export * from './components/profile-settings-keys-list'
 export * from './components/profile-settings-tokens-list'
 export * from './components/filter'
+export * from './components/copy-button'
 
 export * from './pages/signin-page'
 export * from './pages/create-project-page'

--- a/packages/playground/src/pages/sandbox-settings-account-keys-page.tsx
+++ b/packages/playground/src/pages/sandbox-settings-account-keys-page.tsx
@@ -1,12 +1,20 @@
-import React from 'react'
-import { Spacer, Text } from '@harnessio/canary'
+import React, { useState } from 'react'
+import { Spacer, Text, Button } from '@harnessio/canary'
 import { FormFieldSet, SandboxLayout } from '..'
 import { ProfileKeysList } from '../components/profile-settings-keys-list'
 import { ProfileTokensList } from '../components/profile-settings-tokens-list'
 import { mockKeys } from './mocks/profile-settings/mockKeyList'
 import { mockTokens } from './mocks/profile-settings/mockTokensList'
+import { TokenCreateDialog } from '../components/token-create-dialog'
+import { SshKeyCreateDialog } from '../components/ssh-key-create-dialog'
 
 function SandboxSettingsAccountKeysPage() {
+  const [openCreateTokenDialog, setCreateTokenDialog] = useState(false)
+  const [saveSshKeyDialog, setSshKeyDialog] = useState(false)
+
+  const closeSshKeyDialog = () => setSshKeyDialog(false)
+  const closeTokenDialog = () => setCreateTokenDialog(false)
+
   return (
     <SandboxLayout.Main hasLeftPanel hasHeader hasSubHeader>
       <SandboxLayout.Content maxWidth="2xl">
@@ -18,7 +26,18 @@ function SandboxSettingsAccountKeysPage() {
         <form>
           <FormFieldSet.Root>
             {/* PERSONAL ACCESS TOKEN */}
-            <FormFieldSet.Legend>Personal access token</FormFieldSet.Legend>
+            <FormFieldSet.Legend>
+              <div className="flex justify-between">
+                Personal access token
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="text-primary"
+                  onClick={() => setCreateTokenDialog(true)}>
+                  Add new token
+                </Button>
+              </div>
+            </FormFieldSet.Legend>
             <FormFieldSet.ControlGroup>
               <ProfileTokensList tokens={mockTokens} />
             </FormFieldSet.ControlGroup>
@@ -30,13 +49,20 @@ function SandboxSettingsAccountKeysPage() {
             {/* PERSONAL ACCESS TOKEN */}
             <FormFieldSet.Legend>My SSH keys</FormFieldSet.Legend>
             <FormFieldSet.SubLegend>
-              SSH keys allow you to establish a secure connection to your code repository.
+              <div className="flex justify-between">
+                SSH keys allow you to establish a secure connection to your code repository.
+                <Button variant="outline" className="text-primary" type="button" onClick={() => setSshKeyDialog(true)}>
+                  Add new SSH key
+                </Button>
+              </div>
             </FormFieldSet.SubLegend>
             <FormFieldSet.ControlGroup>
               <ProfileKeysList publicKeys={mockKeys} />
             </FormFieldSet.ControlGroup>
           </FormFieldSet.Root>
         </form>
+        <TokenCreateDialog open={openCreateTokenDialog} onClose={closeTokenDialog} />
+        <SshKeyCreateDialog open={saveSshKeyDialog} onClose={closeSshKeyDialog} />
       </SandboxLayout.Content>
     </SandboxLayout.Main>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/canary
       '@harnessio/code-service-client':
-        specifier: 1.3.1
-        version: 1.3.1
+        specifier: 1.3.4
+        version: 1.3.4
       '@harnessio/forms':
         specifier: workspace:*
         version: link:../../packages/forms
@@ -2497,8 +2497,8 @@ packages:
   '@git-diff-view/shiki@0.0.16':
     resolution: {integrity: sha512-qKw0rN3O5H4xhDS7ExPlZpRVWOEIJuaNOPuj/JqNJqDvc7pGZry2nMVEyy5dmiIKcO+4QrzYXlP71PdoHj+HIQ==}
 
-  '@harnessio/code-service-client@1.3.1':
-    resolution: {integrity: sha512-hPa0teHlptMzmFM2vshbmjIW0fZ5EvHeziw1WT29InJCzoUIKxk71WfvMUdRpUpeuYKN6HWzSkM+nw6THLntPw==}
+  '@harnessio/code-service-client@1.3.4':
+    resolution: {integrity: sha512-rKY1uW7gRKrVkyo/t1VSHsX/+XlWCWKcszqjzAYy13EuVaLxi15GOmjx2S0xLrZaQUOk+iemx/5P4M2qQv8pqg==}
 
   '@harnessio/icons-noir@0.2.1':
     resolution: {integrity: sha512-gJJmolPrbwVfwznPN6zjOuUqVKCYb7Q/ZvZMR5WvlNdTxl8/UukhtGiCCEdy/JRU4zcZqm24FW2L40+Qv2Tz0Q==}
@@ -11475,7 +11475,7 @@ snapshots:
     dependencies:
       shiki: 1.17.5
 
-  '@harnessio/code-service-client@1.3.1': {}
+  '@harnessio/code-service-client@1.3.4': {}
 
   '@harnessio/icons-noir@0.2.1(@harnessio/svg-icon-react@0.2.1(@harnessio/svg-icon@0.2.1)(react@18.3.1))(@harnessio/svg-icon@0.2.1)(react@18.3.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/canary
       '@harnessio/code-service-client':
-        specifier: 1.3.0
-        version: 1.3.0
+        specifier: 1.3.1
+        version: 1.3.1
       '@harnessio/forms':
         specifier: workspace:*
         version: link:../../packages/forms
@@ -2497,8 +2497,8 @@ packages:
   '@git-diff-view/shiki@0.0.16':
     resolution: {integrity: sha512-qKw0rN3O5H4xhDS7ExPlZpRVWOEIJuaNOPuj/JqNJqDvc7pGZry2nMVEyy5dmiIKcO+4QrzYXlP71PdoHj+HIQ==}
 
-  '@harnessio/code-service-client@1.3.0':
-    resolution: {integrity: sha512-z3V6Bt/xahvk2g2tMdz8w9Ac54ToiGUb6v3I2Mn/EoAu41bbj+Kjj/Ymu234DXwQQz/w47IbWDC2IH7//gmF7Q==}
+  '@harnessio/code-service-client@1.3.1':
+    resolution: {integrity: sha512-hPa0teHlptMzmFM2vshbmjIW0fZ5EvHeziw1WT29InJCzoUIKxk71WfvMUdRpUpeuYKN6HWzSkM+nw6THLntPw==}
 
   '@harnessio/icons-noir@0.2.1':
     resolution: {integrity: sha512-gJJmolPrbwVfwznPN6zjOuUqVKCYb7Q/ZvZMR5WvlNdTxl8/UukhtGiCCEdy/JRU4zcZqm24FW2L40+Qv2Tz0Q==}
@@ -11475,7 +11475,7 @@ snapshots:
     dependencies:
       shiki: 1.17.5
 
-  '@harnessio/code-service-client@1.3.0': {}
+  '@harnessio/code-service-client@1.3.1': {}
 
   '@harnessio/icons-noir@0.2.1(@harnessio/svg-icon-react@0.2.1(@harnessio/svg-icon@0.2.1)(react@18.3.1))(@harnessio/svg-icon@0.2.1)(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
- Implemented new functionality for creating and managing personal access tokens, including a token creation form and success dialog.
- Added support for SSH key management, with a new form for adding SSH keys and associated dialogs.
- Updated the profile settings page to include buttons for adding new tokens and SSH keys.
- Integrated new components into the Playground package, including TokenCreateDialog, SshKeyCreateDialog, and their respective forms, to provide reusable UI elements for token and SSH key management.
- Demoed in standup on 10/9. 

Complete Flow:

https://github.com/user-attachments/assets/7d7808ae-bcbf-4271-a2a6-dd463f7eb08d

Error handling:


https://github.com/user-attachments/assets/668b0500-8f54-491a-8cc0-d7f61fca6f39



