### PR TITLE
feat: Add "+ Create a new project" option to Project selector dropdown

### DIFF
--- a/apps/gitness/src/components/Header.tsx
+++ b/apps/gitness/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Topbar, Text } from '@harnessio/canary'
+import { useEffect, useState } from 'react'
 import { TopBarWidget, Project } from '@harnessio/playground'
 import { useNavigate } from 'react-router-dom'
 import { TypesMembershipSpace } from '@harnessio/code-service-client'
@@ -9,34 +9,33 @@ export default function Header() {
   const navigate = useNavigate()
   const space = useGetSpaceURLParam()
   const { spaces } = useAppContext()
+  const [projects, setProjects] = useState<Project[]>([])
+  const [selectedProject, setSelectedProject] = useState<Project | undefined>(undefined)
 
-  const projectsItem =
-    spaces?.map((space: TypesMembershipSpace) => ({
-      id: space?.space?.id,
-      name: space?.space?.path
-    })) || []
+  useEffect(() => {
+    if (spaces.length > 0) {
+      const _projects = spaces.map((space: TypesMembershipSpace) => ({
+        id: space?.space?.id,
+        name: space?.space?.path
+      }))
+      setProjects([..._projects, { id: 'create-project', name: '+ Create a new project' }])
+    }
+  }, [spaces])
 
-  if (projectsItem.length === 0) {
-    return (
-      <Topbar.Root>
-        <Topbar.Left>
-          <Text size={2} weight="medium" className="text-primary">
-            Please create a new project
-          </Text>
-        </Topbar.Left>
-      </Topbar.Root>
-    )
-  }
+  useEffect(() => setSelectedProject(projects.find(item => item.name === space)), [space, projects])
 
   return (
     <TopBarWidget
-      projects={projectsItem}
-      onSelectProject={(selectedProject: Project) => {
-        if (selectedProject?.name) {
-          navigate(`/${selectedProject.name}/repos`)
+      projects={projects}
+      onSelectProject={(project: Project) => {
+        setSelectedProject(project)
+        if (project?.id === 'create-project') {
+          navigate('/create-project')
+        } else if (project?.name) {
+          navigate(`/${project.name}/repos`)
         }
       }}
-      preselectedProject={projectsItem.find(item => item.name === space)}
+      preselectedProject={selectedProject}
     />
   )
 }

--- a/apps/gitness/src/components/Header.tsx
+++ b/apps/gitness/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { TopBarWidget, Project } from '@harnessio/playground'
 import { useNavigate } from 'react-router-dom'
-import { TypesMembershipSpace } from '@harnessio/code-service-client'
+import { TypesSpace } from '@harnessio/code-service-client'
 import { useAppContext } from '../framework/context/AppContext'
 import { useGetSpaceURLParam } from '../framework/hooks/useGetSpaceParam'
 
@@ -9,16 +9,18 @@ export default function Header() {
   const navigate = useNavigate()
   const space = useGetSpaceURLParam()
   const { spaces } = useAppContext()
-  const [projects, setProjects] = useState<Project[]>([])
+  const [projects, setProjects] = useState<Project[]>([{ id: 'create-project', name: '+ Create a new project' }])
   const [selectedProject, setSelectedProject] = useState<Project | undefined>(undefined)
 
   useEffect(() => {
     if (spaces.length > 0) {
-      const _projects = spaces.map((space: TypesMembershipSpace) => ({
-        id: space?.space?.id,
-        name: space?.space?.path
-      }))
-      setProjects([..._projects, { id: 'create-project', name: '+ Create a new project' }])
+      setProjects((existingProjects: Project[]) => [
+        ...spaces.map((space: TypesSpace) => ({
+          id: space?.id,
+          name: space?.path
+        })),
+        ...existingProjects
+      ])
     }
   }, [spaces])
 

--- a/apps/gitness/src/framework/context/AppContext.tsx
+++ b/apps/gitness/src/framework/context/AppContext.tsx
@@ -1,17 +1,17 @@
 import React, { createContext, useContext, useState, ReactNode, useEffect, useLayoutEffect } from 'react'
 import {
   CodeServiceAPIClient,
-  TypesMembershipSpace,
   membershipSpaces,
   TypesSpace,
   TypesUser,
-  getUser
+  getUser,
+  MembershipSpacesOkResponse
 } from '@harnessio/code-service-client'
 import useToken from '../hooks/useToken'
 
 interface AppContextType {
-  spaces: TypesMembershipSpace[]
-  setSpaces: (spaces: TypesMembershipSpace[]) => void
+  spaces: TypesSpace[]
+  setSpaces: (spaces: TypesSpace[]) => void
   addSpaces: (newSpaces: TypesSpace[]) => void
   currentUser?: TypesUser
 }
@@ -22,7 +22,7 @@ const AppContext = createContext<AppContextType | undefined>(undefined)
 
 export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const { token } = useToken()
-  const [spaces, setSpaces] = useState<TypesMembershipSpace[]>([])
+  const [spaces, setSpaces] = useState<TypesSpace[]>([])
   const [currentUser, setCurrentUser] = useState<TypesUser>()
 
   useLayoutEffect(() => {
@@ -50,10 +50,12 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     if (token) {
       membershipSpaces({
         queryParams: { page: 1, limit: 10, sort: 'identifier', order: 'asc' }
-      }).then(response => {
-        setSpaces(response)
+      }).then((response: MembershipSpacesOkResponse) => {
+        if (response.length > 0) {
+          const spaceList = response.filter(item => item?.space).map(item => item.space as TypesSpace)
+          setSpaces(spaceList)
+        }
       })
-
       getUser({}).then(_currentUser => {
         setCurrentUser(_currentUser)
       })

--- a/apps/gitness/src/pages/create-project.tsx
+++ b/apps/gitness/src/pages/create-project.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
   useCreateSpaceMutation,
   OpenapiCreateSpaceRequest,
@@ -6,12 +7,11 @@ import {
   CreateSpaceOkResponse
 } from '@harnessio/code-service-client'
 import { CreateProjectPage } from '@harnessio/playground'
-import { useNavigate } from 'react-router-dom'
 import { useAppContext } from '../framework/context/AppContext'
 
 export default function CreateProject() {
   const navigate = useNavigate()
-  const { addSpaces } = useAppContext() // Get the spaces and addSpace function from context
+  const { addSpaces } = useAppContext()
   const [apiError, setApiError] = useState<string | null>(null)
 
   // Set up the mutation hook with the form data


### PR DESCRIPTION
- Adds a `+ Create a new project` option to Project selector dropdown.
- Reroutes to the newly created project and also selects it in the dropdown.
- Makes reaching `/create-project` easier.

https://github.com/user-attachments/assets/1f246c01-b1f4-4f2f-b715-6caf94d79b73