### PR TITLE
feat: [PIPE-22045]: file explorer in gitness

### DIFF
--- a/apps/gitness/package.json
+++ b/apps/gitness/package.json
@@ -24,9 +24,12 @@
     "@harnessio/yaml-editor": "workspace:*",
     "@hookform/resolvers": "^3.6.0",
     "@tanstack/react-query": "4.36.1",
+    "clipboard-copy": "^3.1.0",
     "clsx": "^2.1.1",
+    "diff2html": "3.4.22",
     "event-source-polyfill": "^1.0.22",
     "jotai": "^2.6.3",
+    "lang-map": "^0.4.0",
     "lodash-es": "^4.17.21",
     "monaco-editor": "0.50.0",
     "npm-run-all": "^4.1.5",
@@ -35,8 +38,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
     "yaml": "^2.5.0",
-    "zod": "^3.23.8",
-    "diff2html": "3.4.22"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/apps/gitness/src/RouteDefinitions.ts
+++ b/apps/gitness/src/RouteDefinitions.ts
@@ -4,7 +4,7 @@ export type PathParams = {
   pipelineId?: string
   executionId?: string
   pullRequestId?: string
-  gitRef: string
+  gitRef?: string
   resourcePath?: string
 }
 

--- a/apps/gitness/src/components/FileContentViewer.tsx
+++ b/apps/gitness/src/components/FileContentViewer.tsx
@@ -3,7 +3,20 @@ import { CodeEditor } from '@harnessio/yaml-editor'
 import { themes } from '../pages/pipeline-edit/theme/monaco-theme'
 import copy from 'clipboard-copy'
 import { decodeGitContent, filenameToLanguage, formatBytes, getTrimmedSha } from '../utils/git-utils'
-import { ButtonGroup, Icon, Spacer, StackedList, Text, ToggleGroup, ToggleGroupItem } from '@harnessio/canary'
+import {
+  Button,
+  ButtonGroup,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Icon,
+  Spacer,
+  StackedList,
+  Text,
+  ToggleGroup,
+  ToggleGroupItem
+} from '@harnessio/canary'
 import { timeAgoFromISOTime } from '../pages/pipeline-edit/utils/time-utils'
 import { MarkdownViewer, PipelineStudioToolbarActions, TopDetails, TopTitle } from '@harnessio/playground'
 import { OpenapiGetContentOutput } from '@harnessio/code-service-client'
@@ -64,7 +77,23 @@ export default function FileContentViewer({ repoContent }: FileContentViewerProp
           onDownloadClick={() => undefined}
           onEditClick={() => setIsEditMode(true)}
         />
-        <Icon name="ellipsis" size={15} />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm_icon">
+              <Icon name="ellipsis" size={15} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem className="flex gap-1.5 items-center">
+              <Icon name="arrow-long" size={12} className="text-tertiary-background" />
+              <Text>View Raw</Text>
+            </DropdownMenuItem>
+            <DropdownMenuItem className="flex gap-1.5 items-center">
+              <Icon name="trash" size={12} className="text-tertiary-background" />
+              <Text>Delete</Text>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </ButtonGroup.Root>
     )
   }

--- a/apps/gitness/src/components/FileContentViewer.tsx
+++ b/apps/gitness/src/components/FileContentViewer.tsx
@@ -1,0 +1,130 @@
+import { useMemo, useState } from 'react'
+import { CodeEditor } from '@harnessio/yaml-editor'
+import { themes } from '../pages/pipeline-edit/theme/monaco-theme'
+import copy from 'clipboard-copy'
+import { decodeGitContent, filenameToLanguage, formatBytes, getTrimmedSha } from '../utils/git-utils'
+import { ButtonGroup, Icon, Spacer, StackedList, Text, ToggleGroup, ToggleGroupItem } from '@harnessio/canary'
+import { timeAgoFromISOTime } from '../pages/pipeline-edit/utils/time-utils'
+import { MarkdownViewer, PipelineStudioToolbarActions, TopDetails, TopTitle } from '@harnessio/playground'
+import { OpenapiGetContentOutput } from '@harnessio/code-service-client'
+
+interface FileContentViewerProps {
+  repoContent: OpenapiGetContentOutput
+}
+
+export type ViewTypeValue = 'preview' | 'code' | 'blame'
+
+export default function FileContentViewer({ repoContent }: FileContentViewerProps) {
+  const fileName = repoContent?.name || ''
+  const language = filenameToLanguage(fileName) || 'plaintext'
+  const fileContent = decodeGitContent(repoContent?.content?.data)
+  const [view, setView] = useState<ViewTypeValue>(language === 'markdown' ? 'preview' : 'code')
+  const [isEditMode, setIsEditMode] = useState<boolean>(false)
+  const latestFile = {
+    user: {
+      name: repoContent?.latest_commit?.author?.identity?.name || ''
+    },
+    lastCommitMessage: repoContent?.latest_commit?.message || '',
+    timestamp: repoContent?.latest_commit?.author?.when
+      ? timeAgoFromISOTime(repoContent?.latest_commit?.author.when)
+      : '',
+    sha: repoContent?.sha && getTrimmedSha(repoContent?.sha)
+  }
+
+  const themeConfig = useMemo(
+    () => ({
+      defaultTheme: 'dark',
+      themes
+    }),
+    []
+  )
+
+  const RightDetails = () => {
+    return (
+      <ButtonGroup.Root verticalAlign="center" spacing="2">
+        <Text size={2} weight="normal" color="tertiaryBackground">
+          {`${fileContent?.split('\n').length || 0} lines`}
+        </Text>
+        <Text size={2} weight="normal" color="tertiaryBackground">
+          |
+        </Text>
+        <Text size={2} weight="normal" color="tertiaryBackground" className="pr-3">
+          {formatBytes(repoContent?.content?.size)}
+        </Text>
+        <PipelineStudioToolbarActions
+          onCopyClick={() => copy(fileContent)}
+          onDownloadClick={() => undefined}
+          onEditClick={() => setIsEditMode(true)}
+        />
+        <Icon name="ellipsis" size={15} />
+      </ButtonGroup.Root>
+    )
+  }
+
+  return (
+    <>
+      <StackedList.Root>
+        <StackedList.Item disableHover isHeader className="py-2.5 px-3">
+          {latestFile ? (
+            <>
+              <StackedList.Field title={<TopTitle file={latestFile} />} />
+              <StackedList.Field right title={<TopDetails file={latestFile} />} />
+            </>
+          ) : (
+            <Text>No files available</Text>
+          )}
+        </StackedList.Item>
+      </StackedList.Root>
+      <Spacer size={5} />
+      <StackedList.Root>
+        <StackedList.Item disableHover isHeader className="py-2.5 px-3">
+          <ToggleGroup
+            onValueChange={(value: ViewTypeValue) => {
+              if (value) {
+                setView(value)
+              }
+            }}
+            value={view}
+            type="single"
+            unselectable={'on'}
+            className={'bg-primary-foreground p-0.5 border border-primary/10 rounded-lg'}>
+            {language === 'markdown' && (
+              <ToggleGroupItem
+                value={'preview'}
+                className="h-7 border border-transparent text-xs font-medium data-[state=on]:border-primary/10 rounded-md disabled:opacity-100">
+                Preview
+              </ToggleGroupItem>
+            )}
+            <ToggleGroupItem
+              value={'code'}
+              className="h-7 border border-transparent text-xs font-medium data-[state=on]:border-primary/10 rounded-md disabled:opacity-100">
+              Code
+            </ToggleGroupItem>
+            <ToggleGroupItem
+              value={'blame'}
+              className="h-7 border text-xs font-medium border-transparent data-[state=on]:border-white/10 text-tertiary-background data-[state=on]:text-primary rounded-md">
+              Blame
+            </ToggleGroupItem>
+          </ToggleGroup>
+          <StackedList.Field right title={<RightDetails />} />
+        </StackedList.Item>
+      </StackedList.Root>
+      <Spacer size={1} />
+      {language === 'markdown' && view === 'preview' ? (
+        <MarkdownViewer source={fileContent} />
+      ) : (
+        view === 'code' && (
+          <CodeEditor
+            language={language}
+            codeRevision={{ code: fileContent }}
+            onCodeRevisionChange={() => {}}
+            themeConfig={themeConfig}
+            options={{
+              readOnly: !isEditMode
+            }}
+          />
+        )
+      )}
+    </>
+  )
+}

--- a/apps/gitness/src/components/FileContentViewer.tsx
+++ b/apps/gitness/src/components/FileContentViewer.tsx
@@ -27,15 +27,15 @@ interface FileContentViewerProps {
 
 export type ViewTypeValue = 'preview' | 'code' | 'blame'
 
-const setDefaultView = (language: string): ViewTypeValue => {
-  return language === 'markdown' ? 'preview' : 'code'
+const getDefaultView = (language?: string): ViewTypeValue => {
+  return language && language === 'markdown' ? 'preview' : 'code'
 }
 
 export default function FileContentViewer({ repoContent }: FileContentViewerProps) {
   const fileName = repoContent?.name || ''
   const language = filenameToLanguage(fileName) || ''
   const fileContent = decodeGitContent(repoContent?.content?.data)
-  const [view, setView] = useState<ViewTypeValue>(setDefaultView(language))
+  const [view, setView] = useState<ViewTypeValue>(getDefaultView(language))
   const [isEditMode, setIsEditMode] = useState<boolean>(false)
   const latestFile = {
     user: {
@@ -57,7 +57,7 @@ export default function FileContentViewer({ repoContent }: FileContentViewerProp
   )
 
   useEffect(() => {
-    setView(setDefaultView(language))
+    setView(getDefaultView(language))
   }, [language])
 
   const RightDetails = () => {

--- a/apps/gitness/src/components/FileContentViewer.tsx
+++ b/apps/gitness/src/components/FileContentViewer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { CodeEditor } from '@harnessio/yaml-editor'
 import { themes } from '../pages/pipeline-edit/theme/monaco-theme'
 import copy from 'clipboard-copy'
@@ -14,11 +14,15 @@ interface FileContentViewerProps {
 
 export type ViewTypeValue = 'preview' | 'code' | 'blame'
 
+const setDefaultView = (language: string): ViewTypeValue => {
+  return language === 'markdown' ? 'preview' : 'code'
+}
+
 export default function FileContentViewer({ repoContent }: FileContentViewerProps) {
   const fileName = repoContent?.name || ''
-  const language = filenameToLanguage(fileName) || 'plaintext'
+  const language = filenameToLanguage(fileName) || ''
   const fileContent = decodeGitContent(repoContent?.content?.data)
-  const [view, setView] = useState<ViewTypeValue>(language === 'markdown' ? 'preview' : 'code')
+  const [view, setView] = useState<ViewTypeValue>(setDefaultView(language))
   const [isEditMode, setIsEditMode] = useState<boolean>(false)
   const latestFile = {
     user: {
@@ -39,6 +43,10 @@ export default function FileContentViewer({ repoContent }: FileContentViewerProp
     []
   )
 
+  useEffect(() => {
+    setView(setDefaultView(language))
+  }, [language])
+
   const RightDetails = () => {
     return (
       <ButtonGroup.Root verticalAlign="center" spacing="2">
@@ -49,7 +57,7 @@ export default function FileContentViewer({ repoContent }: FileContentViewerProp
           |
         </Text>
         <Text size={2} weight="normal" color="tertiaryBackground" className="pr-3">
-          {formatBytes(repoContent?.content?.size)}
+          {formatBytes(repoContent?.content?.size || 0)}
         </Text>
         <PipelineStudioToolbarActions
           onCopyClick={() => copy(fileContent)}

--- a/apps/gitness/src/components/FileExplorer.tsx
+++ b/apps/gitness/src/components/FileExplorer.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { FileExplorer } from '@harnessio/playground'
-import { useGetContentQuery, OpenapiContentInfo, getContent } from '@harnessio/code-service-client'
+import { OpenapiContentInfo, getContent, OpenapiGetContentOutput } from '@harnessio/code-service-client'
 import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
 import { normalizeGitRef } from '../utils/git-utils'
 import { PathParams } from '../RouteDefinitions'
 
 interface ExplorerProps {
   selectedBranch: string
+  repoDetails: OpenapiGetContentOutput
 }
 
 const generateLocalStorageKey = (repoRef: string, gitRef: string, keyType: string) => {
@@ -25,7 +26,7 @@ const sortEntriesByType = (entries: OpenapiContentInfo[]): OpenapiContentInfo[] 
   })
 }
 
-export default function Explorer({ selectedBranch }: ExplorerProps) {
+export default function Explorer({ selectedBranch, repoDetails }: ExplorerProps) {
   const repoRef = useGetRepoRef()
   const { spaceId, repoId, resourcePath } = useParams<PathParams>()
   const subResourcePath = useParams()['*'] || ''
@@ -45,12 +46,6 @@ export default function Explorer({ selectedBranch }: ExplorerProps) {
   const [folderContentsCache, setFolderContentsCache] = useState<{ [folderPath: string]: OpenapiContentInfo[] }>(() => {
     const storedFolderContents = localStorage.getItem(uniqueFolderContentsKey)
     return storedFolderContents ? JSON.parse(storedFolderContents) : {}
-  })
-
-  const { data: repoDetails } = useGetContentQuery({
-    path: '',
-    repo_ref: repoRef,
-    queryParams: { include_commit: true, git_ref: normalizeGitRef(selectedBranch) }
   })
 
   const mergeFolderTree = (initialEntries: OpenapiContentInfo[], existingTree: OpenapiContentInfo[]) => {

--- a/apps/gitness/src/components/FileViewer.tsx
+++ b/apps/gitness/src/components/FileViewer.tsx
@@ -1,6 +1,17 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useParams } from 'react-router-dom'
-import { SkeletonList, Summary, FileProps, SummaryItemType, NoData } from '@harnessio/playground'
+import { Link, useParams } from 'react-router-dom'
+import {
+  BreadcrumbItem,
+  BreadcrumbLink,
+  Button,
+  ButtonGroup,
+  cn,
+  Icon,
+  ListActions,
+  Spacer,
+  Text
+} from '@harnessio/canary'
+import { SkeletonList, Summary, FileProps, SummaryItemType, NoData, SandboxLayout } from '@harnessio/playground'
 import {
   useGetContentQuery,
   pathDetails,
@@ -13,12 +24,37 @@ import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
 import { getTrimmedSha, normalizeGitRef } from '../utils/git-utils'
 import { PathParams } from '../RouteDefinitions'
 import { timeAgoFromISOTime } from '../pages/pipeline-edit/utils/time-utils'
+import FileContentViewer from './FileContentViewer'
+
+interface PathParts {
+  path: string
+  parentPath: string
+}
+function splitPathWithParents(fullResourcePath: string) {
+  const pathParts = fullResourcePath?.split('/')
+  const result: PathParts[] = []
+  if (pathParts.length) {
+    let parentPath = ''
+
+    pathParts.map((path, index) => {
+      parentPath += (index === 0 ? '' : '/') + path
+
+      result.push({
+        path: path,
+        parentPath: parentPath
+      })
+    })
+  }
+  return result
+}
 
 export const FileViewer: React.FC = () => {
   const repoRef = useGetRepoRef()
-  const { gitRef, resourcePath } = useParams<PathParams>()
+  const { spaceId, repoId, gitRef, resourcePath } = useParams<PathParams>()
   const subResourcePath = useParams()['*'] || ''
+  const repoPath = `/${spaceId}/repos/${repoId}/code/${gitRef}`
   const fullResourcePath = subResourcePath ? resourcePath + '/' + subResourcePath : resourcePath
+  const pathParts = splitPathWithParents(fullResourcePath || '')
   const [files, setFiles] = useState<FileProps[]>([])
   const [loading, setLoading] = useState(false)
 
@@ -115,5 +151,68 @@ export const FileViewer: React.FC = () => {
         />
       )
   }
-  return repoDetails?.type === 'dir' ? renderListContent() : <>CODE VIEWER / EDITOR</>
+
+  return (
+    <SandboxLayout.Main fullWidth hasLeftSubPanel>
+      <SandboxLayout.Content>
+        <ListActions.Root>
+          <ListActions.Left>
+            <ButtonGroup.Root spacing="2">
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link to={repoPath}>
+                    <Text size={2} color="tertiaryBackground" className="hover:text-foreground">
+                      {repoId}
+                    </Text>
+                  </Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <Text size={2} color="tertiaryBackground">
+                /
+              </Text>
+              {pathParts?.map((path, index) => {
+                return (
+                  <>
+                    <BreadcrumbItem>
+                      <BreadcrumbLink asChild>
+                        <Link to={repoPath + '/~/' + path.parentPath}>
+                          <Text
+                            size={2}
+                            color="tertiaryBackground"
+                            className={cn('hover:text-foreground', {
+                              'text-primary': index === pathParts?.length - 1
+                            })}>
+                            {path.path}
+                          </Text>
+                        </Link>
+                      </BreadcrumbLink>
+                    </BreadcrumbItem>
+                    {index < pathParts?.length - 1 && (
+                      <Text size={2} color="tertiaryBackground">
+                        /
+                      </Text>
+                    )}
+                  </>
+                )
+              })}
+            </ButtonGroup.Root>
+          </ListActions.Left>
+          <ListActions.Right>
+            <Button variant="outline" size="sm">
+              Add file&nbsp;&nbsp;
+              <Icon name="chevron-down" size={11} className="chevron-down" />
+            </Button>
+          </ListActions.Right>
+        </ListActions.Root>
+        <Spacer size={5} />
+        {repoDetails?.type === 'dir' ? (
+          renderListContent()
+        ) : repoDetails?.content?.data ? (
+          <FileContentViewer repoContent={repoDetails} />
+        ) : (
+          <></>
+        )}
+      </SandboxLayout.Content>
+    </SandboxLayout.Main>
+  )
 }

--- a/apps/gitness/src/components/FileViewer.tsx
+++ b/apps/gitness/src/components/FileViewer.tsx
@@ -25,28 +25,7 @@ import { getTrimmedSha, normalizeGitRef } from '../utils/git-utils'
 import { PathParams } from '../RouteDefinitions'
 import { timeAgoFromISOTime } from '../pages/pipeline-edit/utils/time-utils'
 import FileContentViewer from './FileContentViewer'
-
-interface PathParts {
-  path: string
-  parentPath: string
-}
-function splitPathWithParents(fullResourcePath: string) {
-  const pathParts = fullResourcePath?.split('/')
-  const result: PathParts[] = []
-  if (pathParts.length) {
-    let parentPath = ''
-
-    pathParts.map((path, index) => {
-      parentPath += (index === 0 ? '' : '/') + path
-
-      result.push({
-        path: path,
-        parentPath: parentPath
-      })
-    })
-  }
-  return result
-}
+import { PathParts, splitPathWithParents } from '../utils/path-utils'
 
 export const FileViewer: React.FC = () => {
   const repoRef = useGetRepoRef()
@@ -170,7 +149,7 @@ export const FileViewer: React.FC = () => {
               <Text size={2} color="tertiaryBackground">
                 /
               </Text>
-              {pathParts?.map((path, index) => {
+              {pathParts?.map((path: PathParts, index: number) => {
                 return (
                   <>
                     <BreadcrumbItem>

--- a/apps/gitness/src/global.d.ts
+++ b/apps/gitness/src/global.d.ts
@@ -17,3 +17,8 @@ declare module 'monaco-editor/esm/vs/editor/standalone/browser/standaloneService
     get: (id: unknown) => { documentSymbolProvider: unknown }
   }
 }
+
+declare module 'lang-map' {
+  const languages: { languages: (name: string) => string[] }
+  export default languages
+}

--- a/apps/gitness/src/pages/repo/repo-files.tsx
+++ b/apps/gitness/src/pages/repo/repo-files.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate, Outlet } from 'react-router-dom'
-import { Button, ButtonGroup, Icon, ListActions, Spacer, Text } from '@harnessio/canary'
-import { BranchSelector, SandboxLayout, Filter } from '@harnessio/playground'
+import { Button, ButtonGroup, Icon } from '@harnessio/canary'
+import { BranchSelector, SandboxLayout } from '@harnessio/playground'
 import { useListBranchesQuery, useFindRepositoryQuery } from '@harnessio/code-service-client'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
 import { PathParams } from '../../RouteDefinitions'
@@ -52,9 +52,10 @@ export const RepoFiles: React.FC = () => {
             </Button>
           </ButtonGroup.Root>
         </div>
-
-        <Filter />
-
+        {/* <Filter /> */}
+        {/*  Add back when search api is available  
+          <SearchBox.Root width="full" placeholder="Search" /> 
+        */}
         <Explorer selectedBranch={selectedBranch} />
       </div>
     )
@@ -67,30 +68,7 @@ export const RepoFiles: React.FC = () => {
           <Sidebar />
         </SandboxLayout.Content>
       </SandboxLayout.LeftSubPanel>
-      <SandboxLayout.Main fullWidth hasLeftSubPanel>
-        <SandboxLayout.Content>
-          <ListActions.Root>
-            <ListActions.Left>
-              <ButtonGroup.Root spacing="2">
-                <Text size={2} color="tertiaryBackground">
-                  {repository?.identifier}
-                </Text>
-                <Text size={2} color="tertiaryBackground">
-                  /
-                </Text>
-              </ButtonGroup.Root>
-            </ListActions.Left>
-            <ListActions.Right>
-              <Button variant="outline" size="sm">
-                Add file&nbsp;&nbsp;
-                <Icon name="chevron-down" size={11} className="chevron-down" />
-              </Button>
-            </ListActions.Right>
-          </ListActions.Root>
-          <Spacer size={5} />
-          <Outlet />
-        </SandboxLayout.Content>
-      </SandboxLayout.Main>
+      <Outlet />
     </>
   )
 }

--- a/apps/gitness/src/utils/git-utils.ts
+++ b/apps/gitness/src/utils/git-utils.ts
@@ -121,7 +121,7 @@ export function formatBytes(bytes: number, decimals = 2) {
 
   const k = 1024
   const dm = decimals < 0 ? 0 : decimals
-  const sizes = ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
   const i = Math.floor(Math.log(bytes) / Math.log(k))
 
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`

--- a/apps/gitness/src/utils/git-utils.ts
+++ b/apps/gitness/src/utils/git-utils.ts
@@ -1,5 +1,131 @@
+import langMap from 'lang-map'
+
 export const REFS_TAGS_PREFIX = 'refs/tags/'
 export const REFS_BRANCH_PREFIX = 'refs/heads/'
+const MONACO_SUPPORTED_LANGUAGES = [
+  'abap',
+  'apex',
+  'azcli',
+  'bat',
+  'bicep',
+  'cameligo',
+  'clojure',
+  'coffee',
+  'cpp',
+  'csharp',
+  'csp',
+  'css',
+  'cypher',
+  'dart',
+  'dockerfile',
+  'ecl',
+  'elixir',
+  'flow9',
+  'freemarker2',
+  'fsharp',
+  'go',
+  'graphql',
+  'handlebars',
+  'hcl',
+  'html',
+  'ini',
+  'java',
+  'javascript',
+  'json',
+  'julia',
+  'kotlin',
+  'less',
+  'lexon',
+  'liquid',
+  'lua',
+  'm3',
+  'markdown',
+  'mips',
+  'msdax',
+  'mysql',
+  'objective-c',
+  'pascal',
+  'pascaligo',
+  'perl',
+  'pgsql',
+  'php',
+  'pla',
+  'postiats',
+  'powerquery',
+  'powershell',
+  'protobuf',
+  'pug',
+  'python',
+  'qsharp',
+  'r',
+  'razor',
+  'redis',
+  'redshift',
+  'restructuredtext',
+  'ruby',
+  'rust',
+  'sb',
+  'scala',
+  'scheme',
+  'scss',
+  'shell',
+  'solidity',
+  'sophia',
+  'sparql',
+  'sql',
+  'st',
+  'swift',
+  'systemverilog',
+  'tcl',
+  'twig',
+  'typescript',
+  'vb',
+  'wgsl',
+  'xml',
+  'yaml'
+]
+
+export const PLAIN_TEXT = 'plaintext'
+
+// Some of the below languages are mapped to Monaco's built-in supported languages
+// due to their similarity. We'll still need to get native support for them at
+// some point.
+const EXTENSION_TO_LANG: Record<string, string> = {
+  alpine: 'dockerfile',
+  bazel: 'python',
+  cc: 'cpp',
+  cs: 'csharp',
+  env: 'shell',
+  gitignore: 'shell',
+  jsx: 'typescript',
+  makefile: 'shell',
+  toml: 'ini',
+  tsx: 'typescript',
+  tf: 'hcl',
+  tfvars: 'hcl',
+  workspace: 'python',
+  tfstate: 'hcl',
+  ipynb: 'json'
+}
+
+/**
+ * Convert number of bytes into human readable format
+ *
+ * @param integer bytes     Number of bytes to convert
+ * @param integer precision Number of digits after the decimal separator
+ * @return string
+ * @link https://stackoverflow.com/a/18650828/1114931
+ */
+export function formatBytes(bytes: number, decimals = 2) {
+  if (!+bytes) return '0 Bytes'
+
+  const k = 1024
+  const dm = decimals < 0 ? 0 : decimals
+  const sizes = ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`
+}
 
 export const decodeGitContent = (content = '') => {
   try {
@@ -14,6 +140,23 @@ export const decodeGitContent = (content = '') => {
     }
   }
   return ''
+}
+
+export const filenameToLanguage = (name?: string): string | undefined => {
+  const extension = (name?.split('.').pop() || '').toLowerCase()
+  const lang = MONACO_SUPPORTED_LANGUAGES.find(l => l === extension) || EXTENSION_TO_LANG[extension]
+
+  if (lang) {
+    return lang
+  }
+
+  const map = langMap.languages(extension)
+
+  if (map?.length) {
+    return MONACO_SUPPORTED_LANGUAGES.find(_lang => map.includes(_lang)) || PLAIN_TEXT
+  }
+
+  return PLAIN_TEXT
 }
 
 export const isRefATag = (gitRef: string | undefined) => gitRef?.includes(REFS_TAGS_PREFIX) || false

--- a/apps/gitness/src/utils/path-utils.ts
+++ b/apps/gitness/src/utils/path-utils.ts
@@ -1,0 +1,22 @@
+export interface PathParts {
+  path: string
+  parentPath: string
+}
+
+export function splitPathWithParents(fullResourcePath: string) {
+  const pathParts = fullResourcePath?.split('/')
+  const result: PathParts[] = []
+  if (pathParts.length) {
+    let parentPath = ''
+
+    pathParts.map((path, index) => {
+      parentPath += (index === 0 ? '' : '/') + path
+
+      result.push({
+        path: path,
+        parentPath: parentPath
+      })
+    })
+  }
+  return result
+}

--- a/packages/playground/src/components/file-explorer.tsx
+++ b/packages/playground/src/components/file-explorer.tsx
@@ -16,7 +16,7 @@ function FolderItem({ children, key, value, isActive, content, chevronClass, lin
   return (
     <AccordionItem key={key} value={value || ''} className="border-none">
       <AccordionTrigger
-        className={cn('p-0 w-full group', 'text-tertiary-background data-[state=open]:text-primary')}
+        className={cn('p-0 w-full group', 'text-tertiary-background')}
         leftChevron
         rotateChevron
         chevronClass={chevronClass || 'text-tertiary-background group-hover:text-primary'}>
@@ -25,16 +25,9 @@ function FolderItem({ children, key, value, isActive, content, chevronClass, lin
             'text-primary': isActive
           })}>
           <div className="flex gap-2 items-center py-1 w-full">
-            <Icon
-              name="folder"
-              size={12}
-              className="min-w-[12px] group-hover:text-primary group-data-[state=open]:text-primary ease-in-out duration-100"
-            />
+            <Icon name="folder" size={12} className="min-w-[12px] group-hover:text-primary ease-in-out duration-100" />
             <Link to={link}>
-              <Text
-                as="p"
-                size={2}
-                className="text-inherit group-hover:text-primary group-data-[state=open]:text-primary ease-in-out duration-100 truncate">
+              <Text as="p" size={2} className="text-inherit group-hover:text-primary ease-in-out duration-100 truncate">
                 {children}
               </Text>
             </Link>
@@ -42,7 +35,7 @@ function FolderItem({ children, key, value, isActive, content, chevronClass, lin
         </div>
       </AccordionTrigger>
       {content && (
-        <AccordionContent className="pl-1.5 pb-0 flex gap-2 items-center py-1 overflow-hidden w-full">
+        <AccordionContent className="pl-3 pb-0 flex gap-2 items-center py-1 overflow-hidden w-full">
           {content}
         </AccordionContent>
       )}

--- a/packages/playground/src/components/repo-summary.tsx
+++ b/packages/playground/src/components/repo-summary.tsx
@@ -42,7 +42,7 @@ interface PageProps {
   files?: FileProps[]
 }
 
-const TopTitle = ({ file }: { file: Pick<FileProps, 'user' | 'lastCommitMessage' | 'timestamp' | 'sha'> }) => {
+export const TopTitle = ({ file }: { file: Pick<FileProps, 'user' | 'lastCommitMessage' | 'timestamp' | 'sha'> }) => {
   const { user, lastCommitMessage } = file
 
   return (
@@ -65,7 +65,7 @@ const TopTitle = ({ file }: { file: Pick<FileProps, 'user' | 'lastCommitMessage'
   )
 }
 
-const TopDetails = ({ file }: { file: Pick<FileProps, 'user' | 'lastCommitMessage' | 'timestamp' | 'sha'> }) => {
+export const TopDetails = ({ file }: { file: Pick<FileProps, 'user' | 'lastCommitMessage' | 'timestamp' | 'sha'> }) => {
   const { sha, timestamp } = file
   return (
     <ButtonGroup.Root verticalAlign="center" spacing="2">

--- a/packages/playground/src/layouts/SandboxLayout.tsx
+++ b/packages/playground/src/layouts/SandboxLayout.tsx
@@ -45,7 +45,7 @@ function LeftSubPanel({
   return (
     <section
       className={cn(
-        'fixed left-[220px] top-0 bottom-0 z-40 w-[248px] border-r border-border-background overflow-y-auto',
+        'fixed left-[220px] top-0 bottom-0 z-40 w-[300px] border-r border-border-background overflow-y-auto',
         paddingTopClass,
         className
       )}
@@ -95,11 +95,11 @@ function Main({
 
   const paddingLeftClass =
     hasLeftPanel && hasLeftSubPanel
-      ? 'pl-[calc(220px+248px)]'
+      ? 'pl-[calc(220px+300px)]'
       : hasLeftPanel
         ? 'pl-[220px]'
         : hasLeftSubPanel
-          ? 'pl-[248px]'
+          ? 'pl-[300px]'
           : ''
 
   if (fullWidth) {

--- a/packages/playground/src/pages/sandbox-repo-code-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-code-page.tsx
@@ -89,33 +89,41 @@ function Sidebar() {
         {sidebarItems.map(itm =>
           itm.type === 'file' ? (
             <Link to="#">
-              <FileExplorer.FileItem key={itm.id.toString()}>{itm.name}</FileExplorer.FileItem>
+              <FileExplorer.FileItem key={itm.id.toString()} link="">
+                {itm.name}
+              </FileExplorer.FileItem>
             </Link>
           ) : (
             <FileExplorer.FolderItem
               key={itm.id.toString()}
               value={itm.id.toString()}
+              link=""
               // isActive={itm_idx === 3}
               content={
-                <FileExplorer.Root onValueChange={noop}>
+                <FileExplorer.Root onValueChange={noop} value={[]}>
                   {sidebarItems.map(itm =>
                     itm.type === 'file' ? (
                       <Link to="#">
-                        <FileExplorer.FileItem key={itm.id.toString()}>{itm.name}</FileExplorer.FileItem>
+                        <FileExplorer.FileItem key={itm.id.toString()} link="">
+                          {itm.name}
+                        </FileExplorer.FileItem>
                       </Link>
                     ) : (
                       <FileExplorer.FolderItem
                         key={itm.id.toString()}
                         value={itm.id.toString()}
+                        link=""
                         content={
-                          <FileExplorer.Root onValueChange={noop}>
+                          <FileExplorer.Root onValueChange={noop} value={[]}>
                             {sidebarItems.map(itm =>
                               itm.type === 'file' ? (
                                 <Link to="#">
-                                  <FileExplorer.FileItem key={itm.id.toString()}>{itm.name}</FileExplorer.FileItem>
+                                  <FileExplorer.FileItem key={itm.id.toString()} link="">
+                                    {itm.name}
+                                  </FileExplorer.FileItem>
                                 </Link>
                               ) : (
-                                <FileExplorer.FolderItem key={itm.id.toString()} value={itm.id.toString()}>
+                                <FileExplorer.FolderItem key={itm.id.toString()} value={itm.id.toString()} link="">
                                   {itm.name}
                                 </FileExplorer.FolderItem>
                               )

--- a/packages/yaml-editor/src/components/CodeEditor.tsx
+++ b/packages/yaml-editor/src/components/CodeEditor.tsx
@@ -71,6 +71,8 @@ export function CodeEditor<T>(props: CodeEditorProps<T>): JSX.Element {
   return (
     <>
       <Editor
+        className="border rounded-md"
+        height={'75vh'}
         onChange={(value, data) => {
           currentRevisionRef.current = { code: value ?? '', revisionId: data.versionId }
           onCodeRevisionChange({ ...currentRevisionRef.current }, data)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@tanstack/react-query':
         specifier: 4.36.1
         version: 4.36.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clipboard-copy:
+        specifier: ^3.1.0
+        version: 3.2.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -56,6 +59,9 @@ importers:
       jotai:
         specifier: ^2.6.3
         version: 2.9.3(@types/react@18.3.3)(react@18.3.1)
+      lang-map:
+        specifier: ^0.4.0
+        version: 0.4.0
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -6214,6 +6220,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   eslint@9.6.0:
@@ -7427,6 +7434,13 @@ packages:
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
+  lang-map@0.4.0:
+    resolution: {integrity: sha512-oiSqZIEUnWdFeDNsp4HId4tAxdFbx5iMBOwA3666Fn2L8Khj8NiD9xRvMsGmKXopPVkaDFtSv3CJOmXFUB0Hcg==}
+    engines: {node: '>=0.10.0'}
+
+  language-map@1.5.0:
+    resolution: {integrity: sha512-n7gFZpe+DwEAX9cXVTw43i3wiudWDDtSn28RmdnS/HCPr284dQI/SztsamWanRr75oSlKSaGbV2nmWCTzGCoVg==}
 
   launch-editor@2.8.0:
     resolution: {integrity: sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==}
@@ -17763,6 +17777,12 @@ snapshots:
   kleur@4.1.5: {}
 
   kolorist@1.8.0: {}
+
+  lang-map@0.4.0:
+    dependencies:
+      language-map: 1.5.0
+
+  language-map@1.5.0: {}
 
   launch-editor@2.8.0:
     dependencies:


### PR DESCRIPTION
Adds Link to BreadCrumbs shown for Repo Code file destinations
Adds File Explorer sort and display folders first and then files
Adds File Content Viewer that uses monaco code editor to display content and lang-map to provide the proper language as per the filetype

Code View Content
<img width="1490" alt="Screenshot 2024-10-10 at 11 07 44 PM" src="https://github.com/user-attachments/assets/c1884b04-0e9b-44ff-9ff6-885bf2120874">


Markdown Preview
<img width="1490" alt="Screenshot 2024-10-10 at 11 08 23 PM" src="https://github.com/user-attachments/assets/7440cfa1-edeb-4c70-ba5a-a60dfad8cf7f">

