### PR TITLE
feat: Adding "No data" and "No search results" views for listing pages

### DIFF
--- a/apps/gitness/src/pages/pipeline-list.tsx
+++ b/apps/gitness/src/pages/pipeline-list.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import {
   Button,
   ListPagination,
@@ -18,13 +18,17 @@ import {
   PaddingListLayout,
   SkeletonList,
   Filter,
-  useCommonFilter
+  useCommonFilter,
+  NoData,
+  NoSearchResults
 } from '@harnessio/playground'
 import { ExecutionState } from '../types'
 import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
 import { usePagination } from '../framework/hooks/usePagination'
+import { PathParams } from '../RouteDefinitions'
 
 export default function PipelinesPage() {
+  const { spaceId, repoId } = useParams<PathParams>()
   // hardcoded
   const totalPages = 10
   const repoRef = useGetRepoRef()
@@ -50,6 +54,29 @@ export default function PipelinesPage() {
     if (isFetching) {
       return <SkeletonList />
     }
+
+    if (!pipelines?.length) {
+      if (query) {
+        return (
+          <NoSearchResults
+            iconName="no-search-magnifying-glass"
+            title="No search results"
+            description={['Check your spelling and filter options,', 'or search for a different keyword.']}
+            primaryButton={{ label: 'Clear search' }}
+            secondaryButton={{ label: 'Clear filters' }}
+          />
+        )
+      }
+      return (
+        <NoData
+          iconName="no-data-folder"
+          title="No pipelines yet"
+          description={['There are no pipelines in this repository yet.']}
+          primaryButton={{ label: 'Create pipeline', to: `/${spaceId}/repos/${repoId}/pipelines/create` }}
+        />
+      )
+    }
+
     return (
       <PipelineList
         pipelines={pipelines?.map((item: TypesPipeline) => ({
@@ -86,7 +113,6 @@ export default function PipelinesPage() {
             <Link to="create">Create Pipeline</Link>
           </Button>
         </div>
-
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />

--- a/apps/gitness/src/pages/pipeline-list.tsx
+++ b/apps/gitness/src/pages/pipeline-list.tsx
@@ -96,25 +96,32 @@ export default function PipelinesPage() {
     )
   }
 
+  const pipelinesExist = (pipelines?.length ?? 0) > 0
+
   return (
     <>
-      <PaddingListLayout>
-        <Text size={5} weight={'medium'}>
-          Pipelines
-        </Text>
-        <Spacer size={6} />
-        <div className="flex justify-between gap-5">
-          <div className="flex-1">
-            <Filter />
-          </div>
-          <Button variant="default" asChild>
-            <Link to="create">Create Pipeline</Link>
-          </Button>
-        </div>
+      <PaddingListLayout spaceTop={false}>
+        <Spacer size={2} />
+        {pipelinesExist && (
+          <>
+            <Text size={5} weight={'medium'}>
+              Pipelines
+            </Text>
+            <Spacer size={6} />
+            <div className="flex justify-between gap-5">
+              <div className="flex-1">
+                <Filter />
+              </div>
+              <Button variant="default" asChild>
+                <Link to="create">Create Pipeline</Link>
+              </Button>
+            </div>
+          </>
+        )}
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />
-        {(pipelines?.length ?? 0) > 0 && (
+        {pipelinesExist && (
           <ListPagination.Root>
             <Pagination>
               <PaginationContent>

--- a/apps/gitness/src/pages/pipeline-list.tsx
+++ b/apps/gitness/src/pages/pipeline-list.tsx
@@ -51,9 +51,7 @@ export default function PipelinesPage() {
   const LinkComponent = ({ to, children }: { to: string; children: React.ReactNode }) => <Link to={to}>{children}</Link>
 
   const renderListContent = () => {
-    if (isFetching) {
-      return <SkeletonList />
-    }
+    if (isFetching) return <SkeletonList />
 
     if (!pipelines?.length) {
       if (query) {

--- a/apps/gitness/src/pages/pipeline-list.tsx
+++ b/apps/gitness/src/pages/pipeline-list.tsx
@@ -102,7 +102,11 @@ export default function PipelinesPage() {
     <>
       <PaddingListLayout spaceTop={false}>
         <Spacer size={2} />
-        {pipelinesExist && (
+        {/**
+         * Show if pipelines exist.
+         * Additionally, show if query(search) is applied.
+         */}
+        {(query || pipelinesExist) && (
           <>
             <Text size={5} weight={'medium'}>
               Pipelines

--- a/apps/gitness/src/pages/pull-request-list-page.tsx
+++ b/apps/gitness/src/pages/pull-request-list-page.tsx
@@ -196,7 +196,7 @@ function PullRequestListPage() {
       <PaddingListLayout spaceTop={false}>
         <Spacer size={2} />
         {/**
-         * Show if branches exist.
+         * Show if pull requests exist.
          * Additionally, show if query(search) is applied.
          */}
         {(query || pullRequestsExist) && (

--- a/apps/gitness/src/pages/pull-request-list-page.tsx
+++ b/apps/gitness/src/pages/pull-request-list-page.tsx
@@ -195,7 +195,11 @@ function PullRequestListPage() {
     <>
       <PaddingListLayout spaceTop={false}>
         <Spacer size={2} />
-        {pullRequestsExist && (
+        {/**
+         * Show if branches exist.
+         * Additionally, show if query(search) is applied.
+         */}
+        {(query || pullRequestsExist) && (
           <>
             <Text size={5} weight={'medium'}>
               Pull Requests

--- a/apps/gitness/src/pages/pull-request-list-page.tsx
+++ b/apps/gitness/src/pages/pull-request-list-page.tsx
@@ -17,7 +17,8 @@ import {
   PullRequestList,
   NoData,
   useCommonFilter,
-  Filter
+  Filter,
+  NoSearchResults
 } from '@harnessio/playground'
 import { ListPullReqQueryQueryParams, TypesPullReq, useListPullReqQuery } from '@harnessio/code-service-client'
 import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
@@ -142,7 +143,18 @@ function PullRequestListPage() {
     if (isFetching) {
       return <SkeletonList />
     }
-    if (pullrequests?.length === 0) {
+    if (!pullrequests?.length) {
+      if (query) {
+        return (
+          <NoSearchResults
+            iconName="no-search-magnifying-glass"
+            title="No search results"
+            description={['Check your spelling and filter options,', 'or search for a different keyword.']}
+            primaryButton={{ label: 'Clear search' }}
+            secondaryButton={{ label: 'Clear filters' }}
+          />
+        )
+      }
       return (
         <NoData
           insideTabView
@@ -150,10 +162,7 @@ function PullRequestListPage() {
           title="No Pull Requests yet"
           description={['There are no pull requests in this repository yet.']}
           primaryButton={{
-            label: 'Create pull requests'
-          }}
-          secondaryButton={{
-            label: 'Import pull requests'
+            label: 'Open a pull request'
           }}
         />
       )

--- a/apps/gitness/src/pages/pull-request-list-page.tsx
+++ b/apps/gitness/src/pages/pull-request-list-page.tsx
@@ -189,28 +189,32 @@ function PullRequestListPage() {
     )
   }
 
+  const pullRequestsExist = (pullrequests?.length ?? 0) > 0
+
   return (
     <>
       <PaddingListLayout spaceTop={false}>
         <Spacer size={2} />
-        <Text size={5} weight={'medium'}>
-          Pull Requests
-        </Text>
-        <Spacer size={6} />
-
-        <div className="flex justify-between gap-5 items-center">
-          <div className="flex-1">
-            <Filter sortOptions={SortOptions} />
-          </div>
-          <Button variant="default" asChild>
-            <Link to="#">New pull request</Link>
-          </Button>
-        </div>
-
+        {pullRequestsExist && (
+          <>
+            <Text size={5} weight={'medium'}>
+              Pull Requests
+            </Text>
+            <Spacer size={6} />
+            <div className="flex justify-between gap-5 items-center">
+              <div className="flex-1">
+                <Filter sortOptions={SortOptions} />
+              </div>
+              <Button variant="default" asChild>
+                <Link to="#">New pull request</Link>
+              </Button>
+            </div>
+          </>
+        )}
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />
-        {(pullrequests?.length ?? 0) > 0 && (
+        {pullRequestsExist && (
           <ListPagination.Root>
             <Pagination>
               <PaginationContent>

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -123,25 +123,31 @@ export function ReposBranchesListPage() {
     )
   }
 
+  const branchesExist = (branches?.length ?? 0) > 0
+
   return (
     <PaddingListLayout spaceTop={false}>
       <Spacer size={2} />
-      <Text size={5} weight={'medium'}>
-        Branches
-      </Text>
-      <Spacer size={6} />
-      <div className="flex justify-between gap-5 items-center">
-        <div className="flex-1">
-          <Filter sortOptions={sortOptions} />
-        </div>
-        <Button variant="default" asChild>
-          <Link to="create">Create Branch</Link>
-        </Button>
-      </div>
+      {branchesExist && (
+        <>
+          <Text size={5} weight={'medium'}>
+            Branches
+          </Text>
+          <Spacer size={6} />
+          <div className="flex justify-between gap-5 items-center">
+            <div className="flex-1">
+              <Filter sortOptions={sortOptions} />
+            </div>
+            <Button variant="default" asChild>
+              <Link to="create">Create Branch</Link>
+            </Button>
+          </div>
+        </>
+      )}
       <Spacer size={5} />
       {renderListContent()}
       <Spacer size={8} />
-      {(branches?.length ?? 0) > 0 && (
+      {branchesExist && (
         <ListPagination.Root>
           <Pagination>
             <PaginationContent>

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -128,7 +128,11 @@ export function ReposBranchesListPage() {
   return (
     <PaddingListLayout spaceTop={false}>
       <Spacer size={2} />
-      {branchesExist && (
+      {/**
+       * Show if branches exist.
+       * Additionally, show if query(search) is applied.
+       */}
+      {(query || branchesExist) && (
         <>
           <Text size={5} weight={'medium'}>
             Branches

--- a/apps/gitness/src/pages/repo/repo-commits.tsx
+++ b/apps/gitness/src/pages/repo/repo-commits.tsx
@@ -72,28 +72,27 @@ export default function RepoCommitsPage() {
   const selectBranch = (branch: string) => {
     setSelectedBranch(branch)
   }
-  const renderContent = () => {
-    if (isFetchingCommits) {
-      return <SkeletonList />
-    }
+  const renderListContent = () => {
+    if (isFetchingCommits) return <SkeletonList />
+
     // @ts-expect-error remove "@ts-expect-error" once CodeServiceClient Response for useListCommitsQuery is fixed
-    if (commitData?.commits?.length) {
-      return (
-        <PullRequestCommits
-          // @ts-expect-error remove "@ts-expect-error" once CodeServiceClient Response for useListCommitsQuery is fixed
-          data={commitData?.commits.map((item: TypesCommit) => ({
-            sha: item.sha,
-            parent_shas: item.parent_shas,
-            title: item.title,
-            message: item.message,
-            author: item.author,
-            committer: item.committer
-          }))}
-        />
-      )
-    } else {
+    const commitsLists = commitData?.commits
+    if (!commitsLists?.length) {
       return <NoData iconName="no-data-folder" title="No commits yet" description={['There are no commits yet.']} />
     }
+
+    return (
+      <PullRequestCommits
+        data={commitsLists.map((item: TypesCommit) => ({
+          sha: item.sha,
+          parent_shas: item.parent_shas,
+          title: item.title,
+          message: item.message,
+          author: item.author,
+          committer: item.committer
+        }))}
+      />
+    )
   }
 
   return (
@@ -110,14 +109,14 @@ export default function RepoCommitsPage() {
             branchList={branches.map(item => ({
               name: item.name || ''
             }))}
-            selectBranch={branch => selectBranch(branch)}
+            selectBranch={(branch: string) => selectBranch(branch)}
           />
         )}
 
         <Filter showSearch={false} sortOptions={sortOptions} />
       </div>
       <Spacer size={5} />
-      {renderContent()}
+      {renderListContent()}
       <Spacer size={8} />
 
       <ListPagination.Root>

--- a/apps/gitness/src/pages/repo/repo-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-list.tsx
@@ -20,7 +20,7 @@ import {
   NoData,
   NoSearchResults
 } from '@harnessio/playground'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
 import { usePagination } from '../../framework/hooks/usePagination'
 import Header from '../../components/Header'
@@ -37,18 +37,20 @@ const LinkComponent = ({ to, children }: { to: string; children: React.ReactNode
 export default function ReposListPage() {
   // hardcoded
   const totalPages = 10
-  const navigate = useNavigate()
   const space = useGetSpaceURLParam()
 
   const { query, sort } = useCommonFilter<ListReposQueryQueryParams['sort']>()
 
-  const { isFetching, data } = useListReposQuery({ queryParams: { sort, query }, space_ref: `${space}/+` })
+  const { isFetching, data: repositories } = useListReposQuery({
+    queryParams: { sort, query },
+    space_ref: `${space}/+`
+  })
   const { currentPage, previousPage, nextPage, handleClick } = usePagination(1, totalPages)
 
   const renderListContent = () => {
     if (isFetching) return <SkeletonList />
 
-    if (!data?.length) {
+    if (!repositories?.length) {
       if (query) {
         return (
           <NoSearchResults
@@ -76,10 +78,11 @@ export default function ReposListPage() {
         />
       )
     }
+
     return (
       <RepoList
         LinkComponent={LinkComponent}
-        repos={data?.map((repo: RepoRepositoryOutput) => {
+        repos={repositories?.map((repo: RepoRepositoryOutput) => {
           return {
             id: repo.id,
             name: repo.identifier,
@@ -107,14 +110,14 @@ export default function ReposListPage() {
           <div className="flex-1">
             <Filter sortOptions={sortOptions} />
           </div>
-          <Button variant="default" onClick={() => navigate(`/sandbox/spaces/${space}/repos/create`)}>
-            Create Repository
+          <Button variant="default" asChild>
+            <Link to={`/sandbox/spaces/${space}/repos/create`}>Create Repository</Link>
           </Button>
         </div>
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />
-        {(data?.length ?? 0) > 0 && (
+        {repositories?.length && (
           <ListPagination.Root>
             <Pagination>
               <PaginationContent>

--- a/apps/gitness/src/pages/repo/repo-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-list.tsx
@@ -102,7 +102,11 @@ export default function ReposListPage() {
     <>
       <Header />
       <PaddingListLayout>
-        {repositories?.length && (
+        {/**
+         * Show if repositories exist.
+         * Additionally, show if query(search) is applied.
+         */}
+        {(query || repositories?.length) && (
           <>
             <Text size={5} weight={'medium'}>
               Repositories

--- a/apps/gitness/src/pages/repo/repo-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-list.tsx
@@ -102,18 +102,22 @@ export default function ReposListPage() {
     <>
       <Header />
       <PaddingListLayout>
-        <Text size={5} weight={'medium'}>
-          Repositories
-        </Text>
-        <Spacer size={6} />
-        <div className="flex justify-between gap-5">
-          <div className="flex-1">
-            <Filter sortOptions={sortOptions} />
-          </div>
-          <Button variant="default" asChild>
-            <Link to={`/sandbox/spaces/${space}/repos/create`}>Create Repository</Link>
-          </Button>
-        </div>
+        {repositories?.length && (
+          <>
+            <Text size={5} weight={'medium'}>
+              Repositories
+            </Text>
+            <Spacer size={6} />
+            <div className="flex justify-between gap-5">
+              <div className="flex-1">
+                <Filter sortOptions={sortOptions} />
+              </div>
+              <Button variant="default" asChild>
+                <Link to={`/sandbox/spaces/${space}/repos/create`}>Create Repository</Link>
+              </Button>
+            </div>
+          </>
+        )}
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />

--- a/apps/gitness/src/pages/repo/repo-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-list.tsx
@@ -11,7 +11,15 @@ import {
   Text
 } from '@harnessio/canary'
 import { useListReposQuery, RepoRepositoryOutput, ListReposQueryQueryParams } from '@harnessio/code-service-client'
-import { PaddingListLayout, SkeletonList, RepoList, Filter, useCommonFilter, NoData } from '@harnessio/playground'
+import {
+  PaddingListLayout,
+  SkeletonList,
+  RepoList,
+  Filter,
+  useCommonFilter,
+  NoData,
+  NoSearchResults
+} from '@harnessio/playground'
 import { Link, useNavigate } from 'react-router-dom'
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
 import { usePagination } from '../../framework/hooks/usePagination'
@@ -40,7 +48,18 @@ export default function ReposListPage() {
   const renderListContent = () => {
     if (isFetching) return <SkeletonList />
 
-    if (!data || data?.length === 0)
+    if (!data?.length) {
+      if (query) {
+        return (
+          <NoSearchResults
+            iconName="no-search-magnifying-glass"
+            title="No search results"
+            description={['Check your spelling and filter options,', 'or search for a different keyword.']}
+            primaryButton={{ label: 'Clear search' }}
+            secondaryButton={{ label: 'Clear filters' }}
+          />
+        )
+      }
       return (
         <NoData
           iconName="no-data-folder"
@@ -56,6 +75,7 @@ export default function ReposListPage() {
           secondaryButton={{ label: 'Import repository', to: '' }}
         />
       )
+    }
     return (
       <RepoList
         LinkComponent={LinkComponent}
@@ -83,16 +103,14 @@ export default function ReposListPage() {
           Repositories
         </Text>
         <Spacer size={6} />
-        {data && data.length > 0 && (
-          <div className="flex justify-between gap-5">
-            <div className="flex-1">
-              <Filter sortOptions={sortOptions} />
-            </div>
-            <Button variant="default" onClick={() => navigate(`/sandbox/spaces/${space}/repos/create`)}>
-              Create Repository
-            </Button>
+        <div className="flex justify-between gap-5">
+          <div className="flex-1">
+            <Filter sortOptions={sortOptions} />
           </div>
-        )}
+          <Button variant="default" onClick={() => navigate(`/sandbox/spaces/${space}/repos/create`)}>
+            Create Repository
+          </Button>
+        </div>
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />

--- a/apps/gitness/src/pages/repo/repo-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-list.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import {
   Button,
   ListPagination,
@@ -20,7 +21,6 @@ import {
   NoData,
   NoSearchResults
 } from '@harnessio/playground'
-import { Link } from 'react-router-dom'
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
 import { usePagination } from '../../framework/hooks/usePagination'
 import Header from '../../components/Header'

--- a/apps/gitness/src/pages/repo/repo-webhooks.tsx
+++ b/apps/gitness/src/pages/repo/repo-webhooks.tsx
@@ -69,29 +69,32 @@ function RepoWebhooksListPage() {
     return <WebhooksList webhooks={webhooks} LinkComponent={LinkComponent} />
   }
 
+  const webhooksExist = (webhooks?.length ?? 0) > 0
+
   return (
     <>
       <PaddingListLayout spaceTop={false}>
         <Spacer size={2} />
-        <Text size={5} weight={'medium'}>
-          Webhooks
-        </Text>
-        <Spacer size={6} />
-
-        <div className="flex justify-between gap-5 items-center">
-          <div className="flex-1">
-            <Filter />
-          </div>
-          <Button variant="default" asChild>
-            <Link to="#">Create webhook</Link>
-          </Button>
-        </div>
-
+        {webhooksExist && (
+          <>
+            <Text size={5} weight={'medium'}>
+              Webhooks
+            </Text>
+            <Spacer size={6} />
+            <div className="flex justify-between gap-5 items-center">
+              <div className="flex-1">
+                <Filter />
+              </div>
+              <Button variant="default" asChild>
+                <Link to="#">Create webhook</Link>
+              </Button>
+            </div>
+          </>
+        )}
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />
-
-        {(webhooks?.length ?? 0) > 0 && (
+        {webhooksExist && (
           <ListPagination.Root>
             <Pagination>
               <PaginationContent>

--- a/apps/gitness/src/pages/repo/repo-webhooks.tsx
+++ b/apps/gitness/src/pages/repo/repo-webhooks.tsx
@@ -76,7 +76,7 @@ function RepoWebhooksListPage() {
       <PaddingListLayout spaceTop={false}>
         <Spacer size={2} />
         {/**
-         * Show if branches exist.
+         * Show if webhooks exist.
          * Additionally, show if query(search) is applied.
          */}
         {(query || webhooksExist) && (

--- a/apps/gitness/src/pages/repo/repo-webhooks.tsx
+++ b/apps/gitness/src/pages/repo/repo-webhooks.tsx
@@ -75,7 +75,11 @@ function RepoWebhooksListPage() {
     <>
       <PaddingListLayout spaceTop={false}>
         <Spacer size={2} />
-        {webhooksExist && (
+        {/**
+         * Show if branches exist.
+         * Additionally, show if query(search) is applied.
+         */}
+        {(query || webhooksExist) && (
           <>
             <Text size={5} weight={'medium'}>
               Webhooks

--- a/apps/gitness/src/pages/repo/repo-webhooks.tsx
+++ b/apps/gitness/src/pages/repo/repo-webhooks.tsx
@@ -13,7 +13,15 @@ import {
   PaginationNext
 } from '@harnessio/canary'
 // import { NoSearchResults } from '../components/no-search-results'
-import { Filter, NoData, PaddingListLayout, SkeletonList, useCommonFilter, WebhooksList } from '@harnessio/playground'
+import {
+  Filter,
+  NoData,
+  PaddingListLayout,
+  SkeletonList,
+  useCommonFilter,
+  WebhooksList,
+  NoSearchResults
+} from '@harnessio/playground'
 import { useListWebhooksQuery } from '@harnessio/code-service-client'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
 import { usePagination } from '../../framework/hooks/usePagination'
@@ -33,23 +41,32 @@ function RepoWebhooksListPage() {
   const { currentPage, previousPage, nextPage, handleClick } = usePagination(1, totalPages)
 
   const renderListContent = () => {
-    if (isFetching) {
-      return <SkeletonList />
-    }
-    if (webhooks?.length) {
-      return <WebhooksList webhooks={webhooks} LinkComponent={LinkComponent} />
-    } else {
+    if (isFetching) return <SkeletonList />
+
+    if (!webhooks?.length) {
+      if (query) {
+        return (
+          <NoSearchResults
+            iconName="no-search-magnifying-glass"
+            title="No search results"
+            description={['Check your spelling and filter options,', 'or search for a different keyword.']}
+            primaryButton={{ label: 'Clear search' }}
+            secondaryButton={{ label: 'Clear filters' }}
+          />
+        )
+      }
       return (
         <NoData
           insideTabView
           iconName="no-data-webhooks"
           title="No webhooks yet"
-          description={['There are no webhooks in this repository yet.', 'Create new or import an existing webhook.']}
+          description={['There are no webhooks in this repository yet.']}
           primaryButton={{ label: 'Create webhook' }}
-          secondaryButton={{ label: 'Import webhook' }}
         />
       )
     }
+
+    return <WebhooksList webhooks={webhooks} LinkComponent={LinkComponent} />
   }
 
   return (


### PR DESCRIPTION
Fixed for below listing pages:

- Pipelines
- Repositories
- Webhooks
- Pull requests
- Branches

Samples:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2a0a6630-6d53-456f-83d4-2dbabcfaee76">

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0c0f8f8b-f291-4820-a66f-9ad44af590f5">
