### PR TITLE
feat: Remove usage of "token" from Local Storage

### DIFF
--- a/apps/gitness/package.json
+++ b/apps/gitness/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@harnessio/canary": "workspace:*",
-    "@harnessio/code-service-client": "1.3.6",
+    "@harnessio/code-service-client": "1.3.18",
     "@harnessio/forms": "workspace:*",
     "@harnessio/playground": "workspace:*",
     "@harnessio/unified-pipeline": "workspace:*",

--- a/apps/gitness/src/framework/context/AppContext.tsx
+++ b/apps/gitness/src/framework/context/AppContext.tsx
@@ -14,6 +14,7 @@ interface AppContextType {
   addSpaces: (newSpaces: TypesSpace[]) => void
   isUserAuthorized: boolean
   setIsUserAuthorized: React.Dispatch<React.SetStateAction<boolean>>
+  resetApp: () => void
   currentUser?: TypesUser
 }
 
@@ -55,6 +56,12 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     }
   }, [isAuthorized])
 
+  const resetApp = (): void => {
+    setSpaces([])
+    setCurrentUser({})
+    setIsAuthorized(false)
+  }
+
   const addSpaces = (newSpaces: TypesSpace[]) => {
     setSpaces(prevSpaces => [...prevSpaces, ...newSpaces])
   }
@@ -67,7 +74,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
         addSpaces,
         currentUser,
         isUserAuthorized: isAuthorized,
-        setIsUserAuthorized: setIsAuthorized
+        setIsUserAuthorized: setIsAuthorized,
+        resetApp
       }}>
       {children}
     </AppContext.Provider>

--- a/apps/gitness/src/framework/hooks/useSpaceSSE.tsx
+++ b/apps/gitness/src/framework/hooks/useSpaceSSE.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { isEqual } from 'lodash-es'
 import { EventSourcePolyfill } from 'event-source-polyfill'
-import useToken from './useToken'
 
 type UseSpaceSSEProps = {
   space: string
@@ -16,7 +15,6 @@ const useSpaceSSE = ({ space, events: _events, onEvent, onError, shouldRun = tru
   //   const { standalone, routingId, hooks } = useAppContext()
   const [events, setEvents] = useState(_events)
   const eventSourceRef = useRef<EventSource | null>(null)
-  const { token: bearerToken } = useToken()
   useEffect(() => {
     if (!isEqual(events, _events)) {
       setEvents(_events)
@@ -70,7 +68,7 @@ const useSpaceSSE = ({ space, events: _events, onEvent, onError, shouldRun = tru
         eventSourceRef.current = null
       }
     }
-  }, [space, events, shouldRun, onEvent, onError, bearerToken])
+  }, [space, events, shouldRun, onEvent, onError])
 }
 
 export default useSpaceSSE

--- a/apps/gitness/src/pages/logout.tsx
+++ b/apps/gitness/src/pages/logout.tsx
@@ -1,16 +1,25 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import useToken from '../framework/hooks/useToken'
 import { Button } from '@harnessio/canary'
+import { useOpLogoutMutation } from '@harnessio/code-service-client'
+import { useAppContext } from '../framework/context/AppContext'
 
 export const Logout: React.FC = () => {
+  const { setIsUserAuthorized } = useAppContext()
   const navigate = useNavigate()
-  const { removeToken } = useToken()
+  const { mutate: logout, isSuccess } = useOpLogoutMutation({})
+
+  useEffect(() => {
+    if (isSuccess) {
+      setIsUserAuthorized(false)
+      navigate('/signin') // Redirect to sign-in page
+    }
+  }, [isSuccess])
 
   const handleLogout = () => {
-    removeToken() // Remove the token when the user logs out
-    navigate('/signin') // Redirect to sign-in page
+    logout({})
   }
+
   return (
     <Button theme="error" type="button" size="sm" onClick={handleLogout}>
       Log Out

--- a/apps/gitness/src/pages/logout.tsx
+++ b/apps/gitness/src/pages/logout.tsx
@@ -5,13 +5,13 @@ import { useOpLogoutMutation } from '@harnessio/code-service-client'
 import { useAppContext } from '../framework/context/AppContext'
 
 export const Logout: React.FC = () => {
-  const { setIsUserAuthorized } = useAppContext()
+  const { resetApp } = useAppContext()
   const navigate = useNavigate()
   const { mutate: logout, isSuccess } = useOpLogoutMutation({})
 
   useEffect(() => {
     if (isSuccess) {
-      setIsUserAuthorized(false)
+      resetApp()
       navigate('/signin') // Redirect to sign-in page
     }
   }, [isSuccess])

--- a/apps/gitness/src/pages/profile-settings/profile-settings-general-container.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-general-container.tsx
@@ -1,6 +1,5 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { SandboxSettingsAccountGeneralPage, ProfileFields, PasswordFields } from './profile-settings-general-page'
-import { useNavigate } from 'react-router-dom'
 import React from 'react'
 import {
   useGetUserQuery,
@@ -11,7 +10,6 @@ import {
   UpdateUserOkResponse,
   UpdateUserErrorResponse
 } from '@harnessio/code-service-client'
-import useToken from '../../framework/hooks/useToken'
 
 export const SettingsProfileGeneralPage: React.FC = () => {
   const [apiError, setApiError] = useState<{ type: 'profile' | 'password'; message: string } | null>(null)
@@ -21,15 +19,6 @@ export const SettingsProfileGeneralPage: React.FC = () => {
     username: '',
     email: ''
   })
-
-  const { token } = useToken()
-  const navigate = useNavigate()
-
-  useEffect(() => {
-    if (!token) {
-      navigate('/signin')
-    }
-  }, [token])
 
   const { isLoading: isLoadingUser } = useGetUserQuery(
     {},

--- a/apps/gitness/src/pages/signin.tsx
+++ b/apps/gitness/src/pages/signin.tsx
@@ -3,20 +3,17 @@ import { SignInPage } from '@harnessio/playground'
 import { useOnLoginMutation } from '@harnessio/code-service-client'
 import { useNavigate } from 'react-router-dom'
 import { DataProps } from '@harnessio/playground'
-import useToken from '../framework/hooks/useToken'
+import { useAppContext } from '../framework/context/AppContext'
 
 export const SignIn: React.FC = () => {
+  const { setIsUserAuthorized } = useAppContext()
   const navigate = useNavigate()
-  const { mutate: login, isLoading, isSuccess, data } = useOnLoginMutation({ queryParams: { include_cookie: true } })
-  const { setToken } = useToken()
+  const { mutate: login, isLoading, isSuccess } = useOnLoginMutation({ queryParams: { include_cookie: true } })
 
   useEffect(() => {
     if (isSuccess) {
-      // Redirect to the home page
-      if (data?.access_token) {
-        setToken(data.access_token)
-      }
-      navigate('/')
+      setIsUserAuthorized(true)
+      navigate('/') // Redirect to Home page
     }
   }, [isSuccess])
 

--- a/apps/gitness/src/pages/signup.tsx
+++ b/apps/gitness/src/pages/signup.tsx
@@ -1,28 +1,26 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { SignUpPage, SignUpDataProps } from '@harnessio/playground'
 import { useOnRegisterMutation } from '@harnessio/code-service-client'
-import useToken from '../framework/hooks/useToken'
 import { useNavigate } from 'react-router-dom'
+import { useAppContext } from '../framework/context/AppContext'
 
 export const SignUp: React.FC = () => {
+  const { setIsUserAuthorized } = useAppContext()
   const navigate = useNavigate()
-  const { setToken } = useToken()
 
   const {
     mutate: register,
     isLoading,
+    isSuccess,
     error
-  } = useOnRegisterMutation(
-    { queryParams: { include_cookie: true } },
-    {
-      onSuccess: data => {
-        if (data?.access_token) {
-          setToken(data.access_token)
-          navigate('/')
-        }
-      }
+  } = useOnRegisterMutation({ queryParams: { include_cookie: true } })
+
+  useEffect(() => {
+    if (isSuccess) {
+      setIsUserAuthorized(true)
+      navigate('/') // Redirect to Home page
     }
-  )
+  }, [isSuccess])
 
   const handleSignUp = (data: SignUpDataProps) => {
     register({

--- a/packages/playground/src/components/execution/console-logs.tsx
+++ b/packages/playground/src/components/execution/console-logs.tsx
@@ -37,17 +37,21 @@ export const createStreamedLogLineElement = (log: LivelogLine) => {
 
 const ConsoleLogs: FC<ConsoleLogsProps> = ({ logs }) => (
   <>
-    {logs.map(({ pos, time, out }, index) => (
-      <div className="flex items-baseline justify-between leading-[21px] mb-2" key={index}>
-        <div className="flex items-baseline">
-          {pos !== undefined && !isNaN(pos) && pos >= 0 && (
-            <Text className="text-log flex justify-end min-w-5">{pos + 1}</Text>
-          )}
-          {out && <Text className="text-ring font-mono text-sm font-normal ml-2 flex gap-1">{out}</Text>}
+    {logs
+      .filter(item => item !== null)
+      .map(({ pos, time, out }, index) => (
+        <div className="flex items-baseline justify-between leading-[21px] mb-2" key={index}>
+          <div className="flex items-baseline">
+            {pos !== undefined && !isNaN(pos) && pos >= 0 && (
+              <Text className="text-log flex justify-end min-w-5">{pos + 1}</Text>
+            )}
+            {out && <Text className="text-ring font-mono text-sm font-normal ml-2 flex gap-1">{out}</Text>}
+          </div>
+          <Text className="text-log text-sm font-normal mr-2 flex gap-1">
+            {formatDuration(time ? time * 1_000 : 0)}
+          </Text>
         </div>
-        <Text className="text-log text-sm font-normal mr-2 flex gap-1">{formatDuration(time ? time * 1_000 : 0)}</Text>
-      </div>
-    ))}
+      ))}
   </>
 )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/canary
       '@harnessio/code-service-client':
-        specifier: 1.3.6
-        version: 1.3.6
+        specifier: 1.3.18
+        version: 1.3.18
       '@harnessio/forms':
         specifier: workspace:*
         version: link:../../packages/forms
@@ -2512,8 +2512,8 @@ packages:
   '@git-diff-view/shiki@0.0.16':
     resolution: {integrity: sha512-qKw0rN3O5H4xhDS7ExPlZpRVWOEIJuaNOPuj/JqNJqDvc7pGZry2nMVEyy5dmiIKcO+4QrzYXlP71PdoHj+HIQ==}
 
-  '@harnessio/code-service-client@1.3.6':
-    resolution: {integrity: sha512-R/URJoa+LfHI/2EunTlH+tzYgPEQDeI79futMKZ5lL3sz0el02SLzBLQse6EeuPsdCg7Yi39KD/ewgrljFjyTQ==}
+  '@harnessio/code-service-client@1.3.18':
+    resolution: {integrity: sha512-q1+/YNkIlTK5iAiilwQNAn4CSF4iPWPhQ8OO7RR7sVMHwlNRdz8nKySkpWcMKujLPA9ztBwOq7eL0A9kx+hDCA==}
 
   '@harnessio/icons-noir@0.2.1':
     resolution: {integrity: sha512-gJJmolPrbwVfwznPN6zjOuUqVKCYb7Q/ZvZMR5WvlNdTxl8/UukhtGiCCEdy/JRU4zcZqm24FW2L40+Qv2Tz0Q==}
@@ -11627,7 +11627,7 @@ snapshots:
     dependencies:
       shiki: 1.17.5
 
-  '@harnessio/code-service-client@1.3.6': {}
+  '@harnessio/code-service-client@1.3.18': {}
 
   '@harnessio/icons-noir@0.2.1(@harnessio/svg-icon-react@0.2.1(@harnessio/svg-icon@0.2.1)(react@18.3.1))(@harnessio/svg-icon@0.2.1)(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
With this change, there would be no need of saving `token` in Local Storage. Instead api calls would have `Cookie` set on them for authorization.

- Removes all references of usage of `token` from LS.
- Fixes login, logout and signup pages.