### PR TITLE
fix: Follow up cleanup in AppContext from PR#321  

### DIFF
--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
+import { CodeServiceAPIClient } from '@harnessio/code-service-client'
 import { QueryClientProvider } from '@tanstack/react-query'
 import {
   ThemeProvider,
@@ -54,7 +55,21 @@ import { SandboxFileViewer } from './components/SandboxFileViewer'
 import PullRequestChangesPage from './pages/pull-request/pull-request-changes-page'
 import { ProjectSettingsGeneralPage } from './pages/project-settings/project-settings-general-page'
 
+const BASE_URL_PREFIX = `${window.apiUrl || ''}/api/v1`
+
 export default function App() {
+  new CodeServiceAPIClient({
+    urlInterceptor: (url: string) => `${BASE_URL_PREFIX}${url}`,
+    responseInterceptor: (response: Response) => {
+      switch (response.status) {
+        case 401:
+          window.location.href = '/signin'
+          break
+      }
+      return response
+    }
+  })
+
   const router = createBrowserRouter([
     {
       path: '/',

--- a/apps/gitness/src/framework/context/AppContext.tsx
+++ b/apps/gitness/src/framework/context/AppContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, ReactNode, useEffect, useLayoutEffect } from 'react'
+import { noop } from 'lodash-es'
 import { CodeServiceAPIClient, membershipSpaces, TypesSpace, TypesUser, getUser } from '@harnessio/code-service-client'
 
 interface AppContextType {
@@ -13,7 +14,14 @@ interface AppContextType {
 
 const BASE_URL_PREFIX = `${window.apiUrl || ''}/api/v1`
 
-const AppContext = createContext<AppContextType | undefined>(undefined)
+const AppContext = createContext<AppContextType>({
+  spaces: [],
+  setSpaces: noop,
+  addSpaces: noop,
+  isUserAuthorized: false,
+  setIsUserAuthorized: noop,
+  resetApp: noop
+})
 
 export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [spaces, setSpaces] = useState<TypesSpace[]>([])

--- a/apps/gitness/src/framework/context/AppContext.tsx
+++ b/apps/gitness/src/framework/context/AppContext.tsx
@@ -37,24 +37,19 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
 
   useEffect(() => {
     if (isAuthorized) {
-      const fetchData = async () => {
-        try {
-          const [memberships, user] = await Promise.all([
-            membershipSpaces({
-              queryParams: { page: 1, limit: 10, sort: 'identifier', order: 'asc' }
-            }),
-            getUser({})
-          ])
+      Promise.all([
+        membershipSpaces({
+          queryParams: { page: 1, limit: 10, sort: 'identifier', order: 'asc' }
+        }),
+        getUser({})
+      ])
+        .then(([memberships, user]) => {
           setCurrentUser(user)
-          if (memberships.length > 0) {
-            const spaceList = memberships.filter(item => item?.space).map(item => item.space as TypesSpace)
-            setSpaces(spaceList)
-          }
-        } catch (_e) {
-          /* Ignore/toast error */
-        }
-      }
-      fetchData()
+          setSpaces(memberships.filter(item => item?.space).map(item => item.space as TypesSpace))
+        })
+        .catch(_e => {
+          // Ignore/toast error
+        })
     }
   }, [isAuthorized])
 

--- a/apps/gitness/src/framework/hooks/useLocalStorage.ts
+++ b/apps/gitness/src/framework/hooks/useLocalStorage.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react'
+
+function useLocalStorage<T>(key: string, initialValue: T) {
+  // Initialize state from localStorage or fallback to initialValue
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    const item = localStorage.getItem(key)
+    return item ? JSON.parse(item) : initialValue
+  })
+
+  // Update both state and localStorage
+  const setValue = (value: T) => {
+    setStoredValue(value)
+    localStorage.setItem(key, JSON.stringify(value))
+  }
+
+  return [storedValue, setValue] as const
+}
+
+export default useLocalStorage

--- a/apps/gitness/src/pages/landing-page.tsx
+++ b/apps/gitness/src/pages/landing-page.tsx
@@ -1,23 +1,15 @@
-import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { MembershipSpacesOkResponse, membershipSpaces } from '@harnessio/code-service-client'
+import { useEffect } from 'react'
+import { useAppContext } from '../framework/context/AppContext'
 
 export const LandingPage: React.FC = () => {
   const navigate = useNavigate()
+  const { spaces } = useAppContext()
+
   useEffect(() => {
-    membershipSpaces({
-      queryParams: { page: 1, limit: 10, sort: 'identifier', order: 'asc' }
-    })
-      .then((memberships: MembershipSpacesOkResponse) => {
-        if (memberships.length === 0) {
-          navigate('/create-project')
-        } else if (memberships[0]?.space?.path) {
-          navigate(`${memberships[0].space.path}/repos`)
-        }
-      })
-      .catch(_e => {
-        /* Ignore/toast error */
-      })
-  }, [navigate])
+    if (spaces.length === 0) navigate('/create-project')
+    if (spaces?.[0]?.path) navigate(`${spaces[0].path}/repos`)
+  }, [spaces])
+
   return null
 }

--- a/apps/gitness/src/pages/landing-page.tsx
+++ b/apps/gitness/src/pages/landing-page.tsx
@@ -18,7 +18,7 @@ export const LandingPage: React.FC = () => {
         setCurrentUser(user)
 
         const spaceList = memberships.filter(item => item?.space).map(item => item.space as TypesSpace)
-        setSpaces(memberships.filter(item => item?.space).map(item => item.space as TypesSpace))
+        setSpaces(spaceList)
         if (spaceList.length === 0) navigate('/create-project')
         if (spaceList?.[0]?.path) navigate(`${spaceList[0].path}/repos`)
       })

--- a/apps/gitness/src/pages/landing-page.tsx
+++ b/apps/gitness/src/pages/landing-page.tsx
@@ -1,17 +1,23 @@
-import { useNavigate } from 'react-router-dom'
-import { useAppContext } from '../framework/context/AppContext'
 import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { MembershipSpacesOkResponse, membershipSpaces } from '@harnessio/code-service-client'
 
 export const LandingPage: React.FC = () => {
   const navigate = useNavigate()
-  const { spaces } = useAppContext()
   useEffect(() => {
-    if (!spaces.length) {
-      navigate('/create-project')
-    }
-    if (spaces[0]?.path) {
-      navigate(`${spaces[0].path}/repos`)
-    }
-  }, [spaces])
+    membershipSpaces({
+      queryParams: { page: 1, limit: 10, sort: 'identifier', order: 'asc' }
+    })
+      .then((memberships: MembershipSpacesOkResponse) => {
+        if (memberships.length === 0) {
+          navigate('/create-project')
+        } else if (memberships[0]?.space?.path) {
+          navigate(`${memberships[0].space.path}/repos`)
+        }
+      })
+      .catch(_e => {
+        /* Ignore/toast error */
+      })
+  }, [navigate])
   return null
 }

--- a/apps/gitness/src/pages/landing-page.tsx
+++ b/apps/gitness/src/pages/landing-page.tsx
@@ -1,15 +1,31 @@
 import { useNavigate } from 'react-router-dom'
 import { useEffect } from 'react'
 import { useAppContext } from '../framework/context/AppContext'
+import { TypesSpace, getUser, membershipSpaces } from '@harnessio/code-service-client'
 
 export const LandingPage: React.FC = () => {
   const navigate = useNavigate()
-  const { spaces } = useAppContext()
+  const { setCurrentUser, setSpaces } = useAppContext()
 
   useEffect(() => {
-    if (spaces.length === 0) navigate('/create-project')
-    if (spaces?.[0]?.path) navigate(`${spaces[0].path}/repos`)
-  }, [spaces])
+    Promise.all([
+      membershipSpaces({
+        queryParams: { page: 1, limit: 10, sort: 'identifier', order: 'asc' }
+      }),
+      getUser({})
+    ])
+      .then(([memberships, user]) => {
+        setCurrentUser(user)
+
+        const spaceList = memberships.filter(item => item?.space).map(item => item.space as TypesSpace)
+        setSpaces(memberships.filter(item => item?.space).map(item => item.space as TypesSpace))
+        if (spaceList.length === 0) navigate('/create-project')
+        if (spaceList?.[0]?.path) navigate(`${spaceList[0].path}/repos`)
+      })
+      .catch(_e => {
+        // Ignore/toast error
+      })
+  }, [])
 
   return null
 }

--- a/apps/gitness/src/pages/profile-settings/profile-settings-general-container.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-general-container.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React, { useState } from 'react'
 import {
   useGetUserQuery,
   GetUserOkResponse,
@@ -10,11 +9,8 @@ import {
   UpdateUserErrorResponse
 } from '@harnessio/code-service-client'
 import { SandboxSettingsAccountGeneralPage, ProfileFields, PasswordFields } from './profile-settings-general-page'
-import { useAppContext } from '../../framework/context/AppContext'
 
 export const SettingsProfileGeneralPage: React.FC = () => {
-  const navigate = useNavigate()
-  const { isUserAuthorized, resetApp } = useAppContext()
   const [apiError, setApiError] = useState<{ type: 'profile' | 'password'; message: string } | null>(null)
 
   const [userData, setUserData] = useState<ProfileFields>({
@@ -22,13 +18,6 @@ export const SettingsProfileGeneralPage: React.FC = () => {
     username: '',
     email: ''
   })
-
-  useEffect(() => {
-    if (!isUserAuthorized) {
-      resetApp()
-      navigate('/signin') // Redirect to sign-in page
-    }
-  }, [isUserAuthorized])
 
   const { isLoading: isLoadingUser } = useGetUserQuery(
     {},

--- a/apps/gitness/src/pages/signin.tsx
+++ b/apps/gitness/src/pages/signin.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { SignInPage, DataProps } from '@harnessio/playground'
 import { useOnLoginMutation } from '@harnessio/code-service-client'
 import { useNavigate } from 'react-router-dom'
@@ -7,14 +7,15 @@ import { useAppContext } from '../framework/context/AppContext'
 export const SignIn: React.FC = () => {
   const { setIsUserAuthorized } = useAppContext()
   const navigate = useNavigate()
-  const { mutate: login, isLoading, isSuccess } = useOnLoginMutation({ queryParams: { include_cookie: true } })
-
-  useEffect(() => {
-    if (isSuccess) {
-      setIsUserAuthorized(true)
-      navigate('/') // Redirect to Home page
+  const { mutate: login, isLoading } = useOnLoginMutation(
+    { queryParams: { include_cookie: true } },
+    {
+      onSuccess: () => {
+        setIsUserAuthorized(true)
+        navigate('/') // Redirect to Home page
+      }
     }
-  }, [isSuccess])
+  )
 
   return (
     <SignInPage

--- a/apps/gitness/src/pages/signin.tsx
+++ b/apps/gitness/src/pages/signin.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect } from 'react'
-import { SignInPage } from '@harnessio/playground'
+import { SignInPage, DataProps } from '@harnessio/playground'
 import { useOnLoginMutation } from '@harnessio/code-service-client'
 import { useNavigate } from 'react-router-dom'
-import { DataProps } from '@harnessio/playground'
 import { useAppContext } from '../framework/context/AppContext'
 
 export const SignIn: React.FC = () => {

--- a/apps/gitness/src/pages/signin.tsx
+++ b/apps/gitness/src/pages/signin.tsx
@@ -2,16 +2,13 @@ import React from 'react'
 import { SignInPage, DataProps } from '@harnessio/playground'
 import { useOnLoginMutation } from '@harnessio/code-service-client'
 import { useNavigate } from 'react-router-dom'
-import { useAppContext } from '../framework/context/AppContext'
 
 export const SignIn: React.FC = () => {
-  const { setIsUserAuthorized } = useAppContext()
   const navigate = useNavigate()
   const { mutate: login, isLoading } = useOnLoginMutation(
     { queryParams: { include_cookie: true } },
     {
       onSuccess: () => {
-        setIsUserAuthorized(true)
         navigate('/') // Redirect to Home page
       }
     }

--- a/apps/gitness/src/pages/signup.tsx
+++ b/apps/gitness/src/pages/signup.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { SignUpPage, SignUpDataProps } from '@harnessio/playground'
 import { useOnRegisterMutation } from '@harnessio/code-service-client'
-import { useNavigate } from 'react-router-dom'
-import { useAppContext } from '../framework/context/AppContext'
 
 export const SignUp: React.FC = () => {
-  const { setIsUserAuthorized } = useAppContext()
   const navigate = useNavigate()
 
   const {
@@ -17,7 +15,6 @@ export const SignUp: React.FC = () => {
 
   useEffect(() => {
     if (isSuccess) {
-      setIsUserAuthorized(true)
       navigate('/') // Redirect to Home page
     }
   }, [isSuccess])


### PR DESCRIPTION
Fixes include:

- Removing redundant `isAuthorized` flag from `AppContext`. If an api call is made without user being authorized, it should result in a `401` status code and log the user out.
- Cleans up `AppContext` to populate the context values from API response in consumer component. This keeps the context lean enough.
- Adds a `useLocalStorage` hook to save `projects/spaces` and `currentUser` to local storage for persistence. This helps when context values are lost on page refresh.
- Moves project fetch api to Landing page, to be able to appropriately route the user to either repo listing page of first project or `Create Project` page.