### PR TITLE
feat: [pipe-22240]: pr checks

### DIFF
--- a/apps/gitness/src/layouts/PullRequestLayout.tsx
+++ b/apps/gitness/src/layouts/PullRequestLayout.tsx
@@ -72,7 +72,8 @@ const PullRequestLayout: React.FC = () => {
                 </Badge>
               </TabsTrigger>
             </NavLink>
-            <NavLink to={`checks`}>
+            {/* TODO: checks page will direct to execution details page for now */}
+            {/* <NavLink to={`checks`}>
               <TabsTrigger value={PullRequestTab.CHECKS}>
                 <Icon size={14} name="checks" />
                 Checks
@@ -80,7 +81,7 @@ const PullRequestLayout: React.FC = () => {
                   9
                 </Badge>
               </TabsTrigger>
-            </NavLink>
+            </NavLink> */}
           </TabsList>
         </Tabs>
         <Spacer size={8} />

--- a/apps/gitness/src/pages/pull-request/pull-request-conversation-page.tsx
+++ b/apps/gitness/src/pages/pull-request/pull-request-conversation-page.tsx
@@ -52,6 +52,7 @@ export default function PullRequestConversationPage() {
   } = usePullRequestData()
   const { currentUser: currentUserData } = useAppContext()
   const [checkboxBypass, setCheckboxBypass] = useState(false)
+  const { spaceId, repoId } = useParams<PathParams>()
 
   const repoRef = useGetRepoRef()
   const { pullRequestId } = useParams<PathParams>()
@@ -249,6 +250,8 @@ export default function PullRequestConversationPage() {
           <>
             {/* TODO: fix handleaction for comment section in panel */}
             <PullRequestPanel
+              spaceId={spaceId}
+              repoId={repoId}
               changesInfo={{
                 header: changesInfo?.title,
                 content: changesInfo?.statusMessage,

--- a/apps/gitness/src/pages/pull-request/utils.ts
+++ b/apps/gitness/src/pages/pull-request/utils.ts
@@ -1,7 +1,7 @@
 import { TypesCodeOwnerEvaluationEntry } from '@harnessio/code-service-client'
 import { EnumPullReqReviewDecisionExtended, PullReqReviewDecision, TypeCheckData } from './types/types'
 import { ExecutionState, extractInfoForCodeOwnerContentProps } from '../../types'
-import { isEmpty } from 'lodash-es'
+import { get, isEmpty } from 'lodash-es'
 import type * as Diff2Html from 'diff2html'
 import HoganJsUtils from 'diff2html/lib/hoganjs-utils'
 
@@ -481,3 +481,6 @@ export function generateAlphaNumericHash(length: number) {
 
   return result
 }
+
+export const getErrorMessage = (error: unknown): string | undefined =>
+  error ? (get(error, 'data.error', get(error, 'data.message', get(error, 'message', error))) as string) : undefined

--- a/packages/playground/src/components/pull-request/pull-request-panel.tsx
+++ b/packages/playground/src/components/pull-request/pull-request-panel.tsx
@@ -45,6 +45,8 @@ interface PullRequestPanelProps extends PullRequestChangesSectionProps {
   resolvedCommentArr?: { params: number[] }
   requiresCommentApproval?: boolean
   checkboxBypass?: boolean
+  spaceId?: string
+  repoId?: string
   setCheckboxBypass?: (value: boolean) => void
   ruleViolationArr:
     | {
@@ -135,7 +137,9 @@ const PullRequestPanel = ({
   resolvedCommentArr,
   ruleViolationArr,
   checkboxBypass,
-  setCheckboxBypass
+  setCheckboxBypass,
+  spaceId,
+  repoId
 }: PullRequestPanelProps) => {
   const mergeable = useMemo(() => pullReqMetadata?.merge_check_status === MergeCheckStatus.MERGEABLE, [pullReqMetadata])
   const isClosed = pullReqMetadata?.state === PullRequestState.CLOSED
@@ -204,7 +208,7 @@ const PullRequestPanel = ({
                           ? 'warning'
                           : 'error'
                     }
-                    disabled={!checkboxBypass}
+                    disabled={!checkboxBypass && ruleViolation}
                     onClick={actions[0]?.action}
                     dropdown={
                       <DropdownMenu>
@@ -260,7 +264,7 @@ const PullRequestPanel = ({
           {(!!resolvedCommentArr || requiresCommentApproval) && !pullReqMetadata?.merged && (
             <PullRequestCommentSection commentsInfo={commentsInfo} />
           )}
-          <PullRequestCheckSection checkData={checkData} checksInfo={checksInfo} />
+          <PullRequestCheckSection checkData={checkData} checksInfo={checksInfo} spaceId={spaceId} repoId={repoId} />
 
           {!pullReqMetadata?.merged && (
             <PullRequestMergeSection

--- a/packages/playground/src/components/pull-request/sections/pull-request-changes-section.tsx
+++ b/packages/playground/src/components/pull-request/sections/pull-request-changes-section.tsx
@@ -226,10 +226,9 @@ const PullRequestChangesSection = ({
     !isEmpty(changeReqEvaluations) ||
     !isEmpty(codeOwners) ||
     false
-
   return (
     <AccordionItem value="item-1">
-      <AccordionTrigger className="text-left">
+      <AccordionTrigger hideChevron={!viewBtn} className="text-left">
         <StackedList.Field
           title={<LineTitle text={changesInfo.header} icon={getStatusIcon(changesInfo.status)} />}
           description={<LineDescription text={changesInfo.content} />}

--- a/packages/playground/src/components/pull-request/sections/pull-request-check-section.tsx
+++ b/packages/playground/src/components/pull-request/sections/pull-request-check-section.tsx
@@ -16,13 +16,19 @@ import { EnumCheckStatus, TypeCheckData } from '../interfaces'
 import { ExecutionState } from '../../execution/types'
 import { timeDistance } from '../../../utils/utils'
 import { LineDescription, LineTitle } from '../pull-request-line-title'
+import { Link } from 'react-router-dom'
 
+interface ExecutionPayloadType {
+  execution_number: number
+}
 interface PullRequestMergeSectionProps {
   checkData: TypeCheckData[]
   checksInfo: { header: string; content: string; status: EnumCheckStatus }
+  spaceId?: string
+  repoId?: string
 }
 
-const PullRequestCheckSection = ({ checkData, checksInfo }: PullRequestMergeSectionProps) => {
+const PullRequestCheckSection = ({ checkData, checksInfo, spaceId, repoId }: PullRequestMergeSectionProps) => {
   const getStatusIcon = (status: EnumCheckStatus) => {
     switch (status) {
       // TODO: fix icons to use from nucleo
@@ -50,7 +56,7 @@ const PullRequestCheckSection = ({ checkData, checksInfo }: PullRequestMergeSect
             Show more
           </Text>
         </AccordionTrigger>
-        <AccordionContent className="pl-6 flex flex-col">
+        <AccordionContent className={cn('pl-6 flex flex-col', { 'pb-0': checkData.length === 1 })}>
           {checkData.map(check => {
             const time = timeDistance(check.check.created, check.check.updated)
 
@@ -87,9 +93,13 @@ const PullRequestCheckSection = ({ checkData, checksInfo }: PullRequestMergeSect
               }
             ></Link> */}
                     {check.check.status !== ExecutionState.PENDING && (
-                      <Text size={1} color="tertiaryBackground">
-                        Details
-                      </Text>
+                      <Link
+                        to={`/${spaceId}/repos/${repoId}/pipelines/${check.check.identifier}/executions/${(check.check.payload?.data as ExecutionPayloadType).execution_number}`}
+                        replace>
+                        <Text size={1} color="tertiaryBackground">
+                          Details
+                        </Text>
+                      </Link>
                     )}
                   </div>
                   <div className="col-span-1 flex justify-end">

--- a/packages/playground/src/layouts/SandboxPullRequestCompareLayout.tsx
+++ b/packages/playground/src/layouts/SandboxPullRequestCompareLayout.tsx
@@ -134,7 +134,7 @@ const SandboxPullRequestCompare: React.FC<SandboxPullRequestCompareProps> = ({
               <TabTriggerItem value="changes" icon="changes" label="Changes" badgeCount={1} />
             </TabsList>
             <TabsContent value="overview">
-              <Spacer size={1} />
+              <Spacer size={4} />
               <PullRequestCompareForm
                 register={register}
                 ref={formRef} // Pass the ref to the form

--- a/packages/playground/src/pages/pull-request-conversation-page.tsx
+++ b/packages/playground/src/pages/pull-request-conversation-page.tsx
@@ -172,6 +172,8 @@ export default function PullRequestConversationPage() {
         leftColumn={
           <>
             <PullRequestPanel
+              spaceId={undefined}
+              repoId={undefined}
               changesInfo={mockChangesData}
               checksInfo={checksInfo}
               commentsInfo={commentsInfo}


### PR DESCRIPTION
For the moment, we won’t have a checks tab and we will navigate traffic from pr page in the prpanel check section to the execution log details page

also other minor fixes 
- fix bypass state in pr panel
- hide chevron in change section when there is nothing to show
- fix css in panel