### PR TITLE
Integrate rules list

### DIFF
--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -370,7 +370,13 @@ export default function App() {
                     },
                     {
                       path: 'rules',
-                      element: <RepoBranchSettingsRulesPageContainer />
+                      element: <RepoBranchSettingsRulesPageContainer />,
+                      children: [
+                        {
+                          path: ':identifier',
+                          element: <RepoBranchSettingsRulesPageContainer />
+                        }
+                      ]
                     }
                   ]
                 }

--- a/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
@@ -10,7 +10,6 @@ import {
   // RuleAddRequestBody,
   useRuleGetQuery,
   RuleGetOkResponse,
-  RuleGetErrorResponse,
   useRuleUpdateMutation
   // RuleUpdateOkResponse,
   // RuleUpdateErrorResponse
@@ -20,7 +19,7 @@ import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
 import { transformDataFromApi, transformFormOutput } from '../../utils/repo-branch-rules-utils'
 
 export const RepoBranchSettingsRulesPageContainer = () => {
-  const [preSetRuleData, setPreSetRuleData] = useState()
+  const [preSetRuleData, setPreSetRuleData] = useState<RepoBranchSettingsFormFields | null>(null)
   const navigate = useNavigate()
   const repoRef = useGetRepoRef()
   const spaceId = useGetSpaceURLParam()
@@ -34,10 +33,6 @@ export const RepoBranchSettingsRulesPageContainer = () => {
           const transformedData = transformDataFromApi(data)
           setPreSetRuleData(transformedData)
           // setApiError(null)
-        },
-        onError: (error: RuleGetErrorResponse) => {
-          console.error('Error fetching rule:', error)
-          // setApiError(error.message || 'Error fetching rule')
         }
       }
     )
@@ -46,7 +41,6 @@ export const RepoBranchSettingsRulesPageContainer = () => {
   const {
     mutate: addRule,
     error: addRuleError,
-    // isSuccess: addRuleSuccess,
     isLoading: addingRule
   } = useRuleAddMutation(
     { repo_ref: repoRef },
@@ -55,15 +49,12 @@ export const RepoBranchSettingsRulesPageContainer = () => {
         const repoName = repoRef.split('/')[1]
 
         navigate(`/sandbox/spaces/${spaceId}/repos/${repoName}/settings/general`)
-      },
-      onError: (error: RuleGetErrorResponse) => {
-        console.error('Error fetching rule:', error)
-        // setApiError(error.message || 'Error fetching rule')
       }
     }
   )
 
   const { data: principals, error: principalsError } = useListPrincipalsQuery({
+    // @ts-expect-error : BE issue - not implemnted
     queryParams: { page: 1, limit: 100, type: 'user' }
   })
 
@@ -75,7 +66,6 @@ export const RepoBranchSettingsRulesPageContainer = () => {
   const {
     mutate: updateRule,
     error: updateRuleError,
-    isSuccess: updateRuleSuccess,
     isLoading: updatingRule
   } = useRuleUpdateMutation(
     { repo_ref: repoRef, rule_identifier: identifier! },
@@ -84,10 +74,6 @@ export const RepoBranchSettingsRulesPageContainer = () => {
         const repoName = repoRef.split('/')[1]
 
         navigate(`/sandbox/spaces/${spaceId}/repos/${repoName}/settings/general`)
-      },
-      onError: (error: RuleGetErrorResponse) => {
-        console.error('Error fetching rule:', error)
-        // setApiError(error.message || 'Error fetching rule')
       }
     }
   )
@@ -98,8 +84,6 @@ export const RepoBranchSettingsRulesPageContainer = () => {
     if (identifier) {
       // Update existing rule
       updateRule({
-        // repo_ref: repoRef,
-        // rule_identifier: identifier,
         body: formattedData
       })
     } else {
@@ -113,10 +97,9 @@ export const RepoBranchSettingsRulesPageContainer = () => {
   const errors = {
     principals: principalsError?.message || null,
     statusChecks: statusChecksError?.message || null,
-    addRule: addRuleError?.message || null
+    addRule: addRuleError?.message || null,
+    updateRule: updateRuleError?.message || null
   }
-
-  // console.log('in branch rules general container', preSetRuleData)
 
   return (
     <RepoBranchSettingsRulesPage
@@ -124,8 +107,7 @@ export const RepoBranchSettingsRulesPageContainer = () => {
       principals={principals as BypassUsersList[]}
       recentStatusChecks={recentStatusChecks}
       apiErrors={errors}
-      // addRuleSuccess={addRuleSuccess}
-      isLoading={addingRule}
+      isLoading={addingRule || updatingRule}
       preSetRuleData={preSetRuleData}
     />
   )

--- a/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
@@ -5,14 +5,9 @@ import {
   useRuleAddMutation,
   useListPrincipalsQuery,
   useListStatusCheckRecentQuery,
-  // EnumMergeMethod,
-  // EnumRuleState,
-  // RuleAddRequestBody,
   useRuleGetQuery,
   RuleGetOkResponse,
   useRuleUpdateMutation
-  // RuleUpdateOkResponse,
-  // RuleUpdateErrorResponse
 } from '@harnessio/code-service-client'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'

--- a/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
@@ -20,17 +20,16 @@ export const RepoBranchSettingsRulesPageContainer = () => {
   const spaceId = useGetSpaceURLParam()
   const { identifier } = useParams()
 
-  if (identifier?.length) {
-    useRuleGetQuery(
-      { repo_ref: repoRef, rule_identifier: identifier },
-      {
-        onSuccess: (data: RuleGetOkResponse) => {
-          const transformedData = transformDataFromApi(data)
-          setPreSetRuleData(transformedData)
-        }
-      }
-    )
-  }
+  useRuleGetQuery(
+    { repo_ref: repoRef, rule_identifier: identifier ?? '' },
+    {
+      onSuccess: (data: RuleGetOkResponse) => {
+        const transformedData = transformDataFromApi(data)
+        setPreSetRuleData(transformedData)
+      },
+      enabled: !!identifier
+    }
+  )
 
   const {
     mutate: addRule,
@@ -94,6 +93,8 @@ export const RepoBranchSettingsRulesPageContainer = () => {
     addRule: addRuleError?.message || null,
     updateRule: updateRuleError?.message || null
   }
+
+  // console.log(preSetRuleData)
 
   return (
     <RepoBranchSettingsRulesPage

--- a/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
@@ -27,7 +27,6 @@ export const RepoBranchSettingsRulesPageContainer = () => {
         onSuccess: (data: RuleGetOkResponse) => {
           const transformedData = transformDataFromApi(data)
           setPreSetRuleData(transformedData)
-          // setApiError(null)
         }
       }
     )

--- a/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
@@ -94,8 +94,6 @@ export const RepoBranchSettingsRulesPageContainer = () => {
     updateRule: updateRuleError?.message || null
   }
 
-  // console.log(preSetRuleData)
-
   return (
     <RepoBranchSettingsRulesPage
       handleRuleUpdate={handleRuleUpdate}

--- a/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
@@ -314,11 +314,8 @@ export const RepoSettingsGeneralPageContainer = () => {
     })
   }
 
-  const handleRuleClick = identifier => {
+  const handleRuleClick = (identifier: string) => {
     const repoName = repoRef.split('/')[1]
-    // const queryParams = new URLSearchParams({
-    //   identifier: identifier
-    // }).toString()
 
     const url = `/sandbox/spaces/${spaceId}/repos/${repoName}/settings/rules/${identifier}`
 

--- a/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
@@ -316,11 +316,13 @@ export const RepoSettingsGeneralPageContainer = () => {
 
   const handleRuleClick = identifier => {
     const repoName = repoRef.split('/')[1]
-    const queryParams = new URLSearchParams({
-      identifier: identifier
-    }).toString()
+    // const queryParams = new URLSearchParams({
+    //   identifier: identifier
+    // }).toString()
 
-    navigate(`/sandbox/spaces/${spaceId}/repos/${repoName}/settings/rules?${queryParams}`)
+    const url = `/sandbox/spaces/${spaceId}/repos/${repoName}/settings/rules/${identifier}`
+
+    navigate(url)
   }
   const loadingStates = {
     isLoadingRepoData: isLoadingBranches || isLoadingRepoData || isLoadingSecuritySettings,

--- a/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
@@ -313,6 +313,15 @@ export const RepoSettingsGeneralPageContainer = () => {
       }
     })
   }
+
+  const handleRuleClick = identifier => {
+    const repoName = repoRef.split('/')[1]
+    const queryParams = new URLSearchParams({
+      identifier: identifier
+    }).toString()
+
+    navigate(`/sandbox/spaces/${spaceId}/repos/${repoName}/settings/rules?${queryParams}`)
+  }
   const loadingStates = {
     isLoadingRepoData: isLoadingBranches || isLoadingRepoData || isLoadingSecuritySettings,
     isUpdatingRepoData: updatingPublicAccess || updatingDescription || updatingBranch,
@@ -331,6 +340,7 @@ export const RepoSettingsGeneralPageContainer = () => {
       loadingStates={loadingStates}
       isRepoUpdateSuccess={updatePublicAccessSuccess || updateDescriptionSuccess || updateBranchSuccess}
       rules={rules}
+      handleRuleClick={handleRuleClick}
     />
   )
 }

--- a/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
@@ -4,7 +4,8 @@ import {
   SecurityScanning,
   AccessLevel,
   ErrorTypes,
-  RepoData
+  RepoData,
+  RuleDataType
 } from '@harnessio/playground'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
@@ -30,7 +31,10 @@ import {
   UpdateSecuritySettingsErrorResponse,
   useDeleteRepositoryMutation,
   DeleteRepositoryOkResponse,
-  DeleteRepositoryErrorResponse
+  DeleteRepositoryErrorResponse,
+  useRuleListQuery,
+  RuleListOkResponse,
+  RuleListErrorResponse
 } from '@harnessio/code-service-client'
 import { useQueryClient } from '@tanstack/react-query'
 
@@ -50,6 +54,8 @@ export const RepoSettingsGeneralPageContainer = () => {
     isPublic: false,
     branches: []
   })
+  const [rules, setRules] = useState<RuleDataType[] | null>(null)
+
   const [securityScanning, setSecurityScanning] = useState<boolean>(false)
   const [apiError, setApiError] = useState<{ type: ErrorTypes; message: string } | null>(null)
 
@@ -77,7 +83,6 @@ export const RepoSettingsGeneralPageContainer = () => {
     {
       repo_ref: repoRef,
       queryParams: {
-        include_commit: false,
         order: 'asc',
         page: 1,
         limit: 100
@@ -94,6 +99,32 @@ export const RepoSettingsGeneralPageContainer = () => {
       onError: (error: ListBranchesErrorResponse) => {
         const message = error.message || 'Error fetching branches'
         setApiError({ type: ErrorTypes.FETCH_BRANCH, message })
+      }
+    }
+  )
+
+  useRuleListQuery(
+    {
+      repo_ref: repoRef,
+      queryParams: {}
+    },
+    {
+      onSuccess: (data: RuleListOkResponse) => {
+        const rulesData = data.map(rule => {
+          return {
+            targetPatternsCount: (rule.pattern?.include?.length ?? 0) + (rule.pattern?.exclude?.length ?? 0),
+            rulesAppliedCount: Object.keys(rule.definition ?? {}).length,
+            bypassAllowed: rule.definition?.bypass?.repo_owners === true,
+            identifier: rule.identifier,
+            state: rule.state ? String(rule.state) : undefined
+          }
+        })
+        setRules(rulesData)
+        setApiError(null)
+      },
+      onError: (error: RuleListErrorResponse) => {
+        const message = error.message || 'Error fetching rules'
+        setApiError({ type: ErrorTypes.FETCH_RULES, message })
       }
     }
   )
@@ -299,6 +330,7 @@ export const RepoSettingsGeneralPageContainer = () => {
       apiError={apiError}
       loadingStates={loadingStates}
       isRepoUpdateSuccess={updatePublicAccessSuccess || updateDescriptionSuccess || updateBranchSuccess}
+      rules={rules}
     />
   )
 }

--- a/apps/gitness/src/utils/repo-branch-rules-utils.ts
+++ b/apps/gitness/src/utils/repo-branch-rules-utils.ts
@@ -1,0 +1,135 @@
+import { Rule, RepoBranchSettingsFormFields } from '@harnessio/playground'
+import { EnumMergeMethod, EnumRuleState, RuleAddRequestBody, RuleGetOkResponse } from '@harnessio/code-service-client'
+
+const ruleIds = [
+  'require_latest_commit',
+  'require_no_change_request',
+  'comments',
+  'status_checks',
+  'merge',
+  'delete_branch'
+]
+
+const extractBranchRules = (definition: any) => {
+  const rules = []
+
+  for (const rule of ruleIds) {
+    let checked = false
+    let submenu: string[] = []
+    let selectOptions: string[] = []
+
+    switch (rule) {
+      case 'require_latest_commit':
+        checked = definition?.pullreq?.approvals?.require_latest_commit || false
+        break
+      case 'require_no_change_request':
+        checked = definition?.pullreq?.approvals?.require_no_change_request || false
+        break
+      case 'comments':
+        checked = definition?.pullreq?.comments?.require_resolve_all || false
+        break
+      case 'status_checks':
+        checked = definition?.pullreq?.status_checks?.require_identifiers?.length > 0
+        selectOptions = definition?.pullreq?.status_checks?.require_identifiers || []
+        break
+      case 'merge':
+        checked = definition?.pullreq?.merge?.strategies_allowed?.length > 0
+        submenu = definition?.pullreq?.merge?.strategies_allowed || []
+        break
+      case 'delete_branch':
+        checked = definition?.pullreq?.merge?.delete_branch || false
+        break
+      default:
+        continue
+    }
+
+    rules.push({
+      id: rule,
+      checked,
+      submenu,
+      selectOptions
+    })
+  }
+
+  return rules
+}
+
+export const transformDataFromApi = (data: RuleGetOkResponse) => {
+  const includedPatterns = data?.pattern?.include || []
+  const excludedPatterns = data?.pattern?.exclude || []
+  const formatPatterns = [
+    ...includedPatterns.map(pat => ({ pattern: pat, option: 'Include' })),
+    ...excludedPatterns.map(pat => ({ pattern: pat, option: 'Exclude' }))
+  ]
+
+  const rules = extractBranchRules(data.definition)
+
+  return {
+    identifier: data.identifier,
+    description: data.description,
+    pattern: data?.pattern?.default,
+    patterns: formatPatterns,
+    rules: rules,
+    state: data.state === 'active',
+    bypass: data?.definition?.bypass?.user_ids,
+    access: '1',
+    default: data?.pattern?.default,
+    repo_owners: data?.definition?.bypass?.repo_owners
+  }
+}
+
+export const transformFormOutput = (formOutput: RepoBranchSettingsFormFields) => {
+  const rulesMap = formOutput.rules.reduce<Record<string, Rule>>((acc, rule) => {
+    acc[rule.id] = rule
+    return acc
+  }, {})
+
+  const { include, exclude } = formOutput.patterns.reduce<{ include: string[]; exclude: string[] }>(
+    (acc, currentPattern) => {
+      if (currentPattern.option === 'Include') {
+        acc.include.push(currentPattern.pattern)
+      } else if (currentPattern.option === 'Exclude') {
+        acc.exclude.push(currentPattern.pattern)
+      }
+      return acc
+    },
+    { include: [], exclude: [] }
+  )
+
+  const transformed: RuleAddRequestBody = {
+    identifier: formOutput.identifier,
+    type: 'branch',
+    description: formOutput.description,
+    state: (formOutput.state === true ? 'active' : 'disabled') as EnumRuleState,
+    pattern: {
+      default: formOutput.default || false,
+      include,
+      exclude
+    },
+    definition: {
+      bypass: {
+        user_ids: formOutput.bypass,
+        repo_owners: formOutput.repo_owners || false
+      },
+      pullreq: {
+        approvals: {
+          require_code_owners: true,
+          require_latest_commit: rulesMap['require_latest_commit']?.checked || false,
+          require_no_change_request: rulesMap['require_no_change_request']?.checked || false
+        },
+        comments: {
+          require_resolve_all: rulesMap['comments']?.checked || false
+        },
+        merge: {
+          strategies_allowed: (rulesMap['merge']?.submenu || []) as EnumMergeMethod[],
+          delete_branch: rulesMap['delete_branch']?.checked || false
+        },
+        status_checks: {
+          require_identifiers: rulesMap['status_checks']?.selectOptions || []
+        }
+      }
+    }
+  }
+
+  return transformed
+}

--- a/apps/gitness/src/utils/repo-branch-rules-utils.ts
+++ b/apps/gitness/src/utils/repo-branch-rules-utils.ts
@@ -5,7 +5,13 @@ import {
   PatternsButtonType,
   MergeStrategy
 } from '@harnessio/playground'
-import { EnumMergeMethod, EnumRuleState, RuleAddRequestBody, RuleGetOkResponse } from '@harnessio/code-service-client'
+import {
+  EnumMergeMethod,
+  EnumRuleState,
+  OpenapiRuleDefinition,
+  RuleAddRequestBody,
+  RuleGetOkResponse
+} from '@harnessio/code-service-client'
 
 const ruleIds = [
   BranchRuleId.REQUIRE_LATEST_COMMIT,
@@ -18,13 +24,14 @@ const ruleIds = [
 
 // Util to transform API response into expected-form format for branch-rules-edit
 
-const extractBranchRules = definition => {
+const extractBranchRules = (data: RuleGetOkResponse) => {
   const rules = []
 
   for (const rule of ruleIds) {
     let checked = false
     let submenu: EnumMergeMethod[] = []
     let selectOptions: string[] = []
+    const definition = data?.definition as OpenapiRuleDefinition
 
     switch (rule) {
       case BranchRuleId.REQUIRE_LATEST_COMMIT:
@@ -37,11 +44,11 @@ const extractBranchRules = definition => {
         checked = definition?.pullreq?.comments?.require_resolve_all || false
         break
       case BranchRuleId.STATUS_CHECKS:
-        checked = definition?.pullreq?.status_checks?.require_identifiers?.length > 0
+        checked = (definition?.pullreq?.status_checks?.require_identifiers?.length ?? 0) > 0
         selectOptions = definition?.pullreq?.status_checks?.require_identifiers || []
         break
       case BranchRuleId.MERGE:
-        checked = definition?.pullreq?.merge?.strategies_allowed?.length > 0
+        checked = (definition?.pullreq?.merge?.strategies_allowed?.length ?? 0) > 0
         submenu = definition?.pullreq?.merge?.strategies_allowed || []
         break
       case BranchRuleId.DELETE_BRANCH:
@@ -70,7 +77,7 @@ export const transformDataFromApi = (data: RuleGetOkResponse) => {
     ...excludedPatterns.map(pat => ({ pattern: pat, option: PatternsButtonType.EXCLUDE }))
   ]
 
-  const rules = extractBranchRules(data.definition)
+  const rules = extractBranchRules(data)
 
   return {
     identifier: data.identifier || '',

--- a/apps/gitness/src/utils/repo-branch-rules-utils.ts
+++ b/apps/gitness/src/utils/repo-branch-rules-utils.ts
@@ -1,4 +1,10 @@
-import { Rule, RepoBranchSettingsFormFields, BranchRuleId, PatternsButtonType } from '@harnessio/playground'
+import {
+  Rule,
+  RepoBranchSettingsFormFields,
+  BranchRuleId,
+  PatternsButtonType,
+  MergeStrategy
+} from '@harnessio/playground'
 import { EnumMergeMethod, EnumRuleState, RuleAddRequestBody, RuleGetOkResponse } from '@harnessio/code-service-client'
 
 const ruleIds = [
@@ -9,6 +15,8 @@ const ruleIds = [
   BranchRuleId.MERGE,
   BranchRuleId.DELETE_BRANCH
 ]
+
+// Util to transform API response into expected-form format for branch-rules-edit
 
 const extractBranchRules = (definition: any) => {
   const rules = []
@@ -78,6 +86,8 @@ export const transformDataFromApi = (data: RuleGetOkResponse) => {
   }
 }
 
+// Util to transform form format to expected-API format for branch-rules-edit
+
 export const transformFormOutput = (formOutput: RepoBranchSettingsFormFields) => {
   const rulesMap = formOutput.rules.reduce<Record<string, Rule>>((acc, rule) => {
     acc[rule.id] = rule
@@ -121,7 +131,7 @@ export const transformFormOutput = (formOutput: RepoBranchSettingsFormFields) =>
           require_resolve_all: rulesMap['comments']?.checked || false
         },
         merge: {
-          strategies_allowed: (rulesMap['merge']?.submenu || []) as EnumMergeMethod[],
+          strategies_allowed: (rulesMap['merge']?.submenu || []) as MergeStrategy[],
           delete_branch: rulesMap['delete_branch']?.checked || false
         },
         status_checks: {

--- a/apps/gitness/src/utils/repo-branch-rules-utils.ts
+++ b/apps/gitness/src/utils/repo-branch-rules-utils.ts
@@ -18,7 +18,7 @@ const ruleIds = [
 
 // Util to transform API response into expected-form format for branch-rules-edit
 
-const extractBranchRules = (definition: any) => {
+const extractBranchRules = definition => {
   const rules = []
 
   for (const rule of ruleIds) {

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/reducers/repo-branch-settings-reducer.ts
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/reducers/repo-branch-settings-reducer.ts
@@ -1,9 +1,55 @@
+// import { Rule, Action, ActionType } from '../types'
+
+// export const branchSettingsReducer = (state: Rule[], action: Action): Rule[] => {
+//   switch (action.type) {
+//     case ActionType.TOGGLE_RULE:
+//       return state.map(rule => (rule.id === action.ruleId ? { ...rule, checked: action.checked } : rule))
+//     case ActionType.TOGGLE_SUBMENU:
+//       return state.map(rule => {
+//         if (rule.id === action.ruleId) {
+//           const updatedSubmenu = action.checked
+//             ? [...(rule.submenu || []), action.submenuId]
+//             : (rule.submenu || []).filter(id => id !== action.submenuId)
+//           return { ...rule, submenu: updatedSubmenu }
+//         }
+//         return rule
+//       })
+
+//     case ActionType.SET_SELECT_OPTION:
+//       return state.map(rule =>
+//         rule.id === action.ruleId
+//           ? {
+//               ...rule,
+//               selectOptions: rule.selectOptions.includes(action.checkName)
+//                 ? rule.selectOptions.filter((option: string) => option !== action.checkName)
+//                 : [...rule.selectOptions, action.checkName]
+//             }
+//           : rule
+//       )
+//     case ActionType.SET_INITIAL_RULES:
+//       return action.payload || []
+//     default:
+//       return state
+//   }
+// }
+
 import { Rule, Action, ActionType } from '../types'
 
 export const branchSettingsReducer = (state: Rule[], action: Action): Rule[] => {
   switch (action.type) {
     case ActionType.TOGGLE_RULE:
-      return state.map(rule => (rule.id === action.ruleId ? { ...rule, checked: action.checked } : rule))
+      return state.map(rule => {
+        if (rule.id === action.ruleId) {
+          const updatedRule = { ...rule, checked: action.checked }
+          if (!action.checked) {
+            updatedRule.submenu = []
+            updatedRule.selectOptions = []
+          }
+          return updatedRule
+        }
+        return rule
+      })
+
     case ActionType.TOGGLE_SUBMENU:
       return state.map(rule => {
         if (rule.id === action.ruleId) {
@@ -26,8 +72,10 @@ export const branchSettingsReducer = (state: Rule[], action: Action): Rule[] => 
             }
           : rule
       )
+
     case ActionType.SET_INITIAL_RULES:
       return action.payload || []
+
     default:
       return state
   }

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/reducers/repo-branch-settings-reducer.ts
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/reducers/repo-branch-settings-reducer.ts
@@ -1,39 +1,4 @@
-// import { Rule, Action, ActionType } from '../types'
-
-// export const branchSettingsReducer = (state: Rule[], action: Action): Rule[] => {
-//   switch (action.type) {
-//     case ActionType.TOGGLE_RULE:
-//       return state.map(rule => (rule.id === action.ruleId ? { ...rule, checked: action.checked } : rule))
-//     case ActionType.TOGGLE_SUBMENU:
-//       return state.map(rule => {
-//         if (rule.id === action.ruleId) {
-//           const updatedSubmenu = action.checked
-//             ? [...(rule.submenu || []), action.submenuId]
-//             : (rule.submenu || []).filter(id => id !== action.submenuId)
-//           return { ...rule, submenu: updatedSubmenu }
-//         }
-//         return rule
-//       })
-
-//     case ActionType.SET_SELECT_OPTION:
-//       return state.map(rule =>
-//         rule.id === action.ruleId
-//           ? {
-//               ...rule,
-//               selectOptions: rule.selectOptions.includes(action.checkName)
-//                 ? rule.selectOptions.filter((option: string) => option !== action.checkName)
-//                 : [...rule.selectOptions, action.checkName]
-//             }
-//           : rule
-//       )
-//     case ActionType.SET_INITIAL_RULES:
-//       return action.payload || []
-//     default:
-//       return state
-//   }
-// }
-
-import { Rule, Action, ActionType } from '../types'
+import { Rule, Action, ActionType, MergeStrategy } from '../types'
 
 export const branchSettingsReducer = (state: Rule[], action: Action): Rule[] => {
   switch (action.type) {
@@ -56,7 +21,7 @@ export const branchSettingsReducer = (state: Rule[], action: Action): Rule[] => 
           const updatedSubmenu = action.checked
             ? [...(rule.submenu || []), action.submenuId]
             : (rule.submenu || []).filter(id => id !== action.submenuId)
-          return { ...rule, submenu: updatedSubmenu }
+          return { ...rule, submenu: updatedSubmenu as MergeStrategy[] }
         }
         return rule
       })

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/reducers/repo-branch-settings-reducer.ts
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/reducers/repo-branch-settings-reducer.ts
@@ -26,6 +26,8 @@ export const branchSettingsReducer = (state: Rule[], action: Action): Rule[] => 
             }
           : rule
       )
+    case ActionType.SET_INITIAL_RULES:
+      return action.payload || []
     default:
       return state
   }

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-data.tsx
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-data.tsx
@@ -1,38 +1,39 @@
+import { BranchRuleId, MergeStrategy } from './types'
 export const branchRules = [
   {
-    id: 'require_latest_commit',
+    id: BranchRuleId.REQUIRE_LATEST_COMMIT,
     label: 'Request approval of new changes',
     description: 'Require re-approval when there are new changes in the pull request'
   },
   {
-    id: 'require_no_change_request',
+    id: BranchRuleId.REQUIRE_NO_CHANGE_REQUEST,
     label: 'Require resolution of change requests',
     description: 'All change requests on a pull request must be resolved before it can be merged'
   },
   {
-    id: 'comments',
+    id: BranchRuleId.COMMENTS,
     label: 'Require comment resolution',
     description: 'All comments on a pull request must be resolved before it can be merged'
   },
   {
-    id: 'status_checks',
+    id: BranchRuleId.STATUS_CHECKS,
     label: 'Require status checks to pass',
     description: 'Selected status checks must pass before a pull request can be merged',
     hasSelect: true
   },
   {
-    id: 'merge',
+    id: BranchRuleId.MERGE,
     label: 'Limit merge strategies',
     description: 'Limit which merge strategies are available to merge a pull request',
     hasSubmenu: true,
     submenuOptions: [
-      { id: 'merge', label: 'Allow Merge Commit' },
-      { id: 'squash', label: 'Allow Squash and Merge' },
-      { id: 'rebase', label: 'Allow Rebase and Merge' }
+      { id: MergeStrategy.Merge, label: 'Allow Merge Commit' },
+      { id: MergeStrategy.Squash, label: 'Allow Squash and Merge' },
+      { id: MergeStrategy.Rebase, label: 'Allow Rebase and Merge' }
     ]
   },
   {
-    id: 'delete_branch',
+    id: BranchRuleId.DELETE_BRANCH,
     label: 'Auto delete branch on merge',
     description: 'Automatically delete the source branch of a pull request after it is merged'
   }

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-fields.tsx
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-fields.tsx
@@ -47,7 +47,11 @@ export const BranchSettingsRuleToggleField: React.FC<FieldProps> = ({ register, 
   </StackedList.Root>
 )
 
-export const BranchSettingsRuleNameField: React.FC<FieldProps> = ({ register, errors, disabled }) => (
+export const BranchSettingsRuleNameField: React.FC<FieldProps & { disabled: boolean }> = ({
+  register,
+  errors,
+  disabled
+}) => (
   <FormFieldSet.ControlGroup>
     <FormFieldSet.Label htmlFor="identifier" required>
       Name
@@ -94,33 +98,14 @@ export const BranchSettingsRuleTargetPatternsField: React.FC<FieldProps> = ({ se
   return (
     <FormFieldSet.ControlGroup>
       <FormFieldSet.Label htmlFor="target-patterns">Target Patterns</FormFieldSet.Label>
-      <div className="flex gap-4">
-        <div className="flex-[2.5]">
+      <div className="grid grid-rows-1 grid-cols-4">
+        <div className="col-span-3 mr-2">
           <Input id="pattern" {...register!('pattern')} placeholder="Enter the target patterns" />
-          <Text size={2} as="p" color="tertiaryBackground" className="max-w-[100%] mt-2">
-            Match branches using globstar patterns (e.g.”golden”, “feature-*”, “releases/**”)
-          </Text>
-          <div className="mt-2">
-            {patterns &&
-              patterns.map(pattern => (
-                <Badge
-                  variant="outline"
-                  theme={pattern.option === PatternsButtonType.INCLUDE ? 'success' : 'destructive'}
-                  key={pattern.pattern}
-                  pattern={pattern}
-                  className="mx-1">
-                  {pattern.pattern}
-                  <button className="ml-2" onClick={() => handleRemovePattern(pattern.pattern)}>
-                    <Icon name="x-mark" size={12} className="text-current" />
-                  </button>
-                </Badge>
-              ))}
-          </div>
         </div>
         <Button
           variant="split"
           type="button"
-          className="pl-0 pr-0 min-w-28"
+          className="pl-0 pr-0 min-w-28 col-span-1"
           onClick={handleAddPattern}
           dropdown={
             <DropdownMenu key="dropdown-menu">
@@ -143,10 +128,35 @@ export const BranchSettingsRuleTargetPatternsField: React.FC<FieldProps> = ({ se
           }>
           {selectedOption}
         </Button>
+        {/* <Text size={2} as="p" color="tertiaryBackground" className="max-w-[100%]">
+          Match branches using globstar patterns (e.g.”golden”, “feature-*”, “releases/**”)
+        </Text> */}
+        {/* <div className="col-span-4"> */}
+
+        {/* </div> */}
 
         {errors!.pattern && (
           <FormFieldSet.Message theme={MessageTheme.ERROR}>{errors!.pattern.message?.toString()}</FormFieldSet.Message>
         )}
+      </div>
+      <Text size={2} as="p" color="tertiaryBackground" className="max-w-[100%]">
+        Match branches using globstar patterns (e.g.”golden”, “feature-*”, “releases/**”)
+      </Text>
+      <div className="flex flex-wrap">
+        {patterns &&
+          patterns.map(pattern => (
+            <Badge
+              variant="outline"
+              theme={pattern.option === PatternsButtonType.INCLUDE ? 'success' : 'destructive'}
+              key={pattern.pattern}
+              pattern={pattern}
+              className="mx-1 my-1 inline-flex">
+              {pattern.pattern}
+              <button className="ml-2" onClick={() => handleRemovePattern(pattern.pattern)}>
+                <Icon name="x-mark" size={12} className="text-current" />
+              </button>
+            </Badge>
+          ))}
       </div>
     </FormFieldSet.ControlGroup>
   )

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-fields.tsx
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-fields.tsx
@@ -47,12 +47,12 @@ export const BranchSettingsRuleToggleField: React.FC<FieldProps> = ({ register, 
   </StackedList.Root>
 )
 
-export const BranchSettingsRuleNameField: React.FC<FieldProps> = ({ register, errors }) => (
+export const BranchSettingsRuleNameField: React.FC<FieldProps> = ({ register, errors, disabled }) => (
   <FormFieldSet.ControlGroup>
     <FormFieldSet.Label htmlFor="identifier" required>
       Name
     </FormFieldSet.Label>
-    <Input id="name" {...register!('identifier')} placeholder="Enter rule name" autoFocus />
+    <Input id="name" {...register!('identifier')} placeholder="Enter rule name" autoFocus disabled={disabled} />
     {errors!.identifier && (
       <FormFieldSet.Message theme={MessageTheme.ERROR}>{errors!.identifier.message?.toString()}</FormFieldSet.Message>
     )}

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-fields.tsx
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-fields.tsx
@@ -20,7 +20,7 @@ import {
 } from '@harnessio/canary'
 import { FormFieldSet, MessageTheme } from '../../../index'
 import { branchRules } from './repo-branch-settings-rules-data'
-import { FieldProps, Rule, Dispatch, BypassUsersList, ActionType, MergeStrategy } from './types'
+import { FieldProps, Rule, Dispatch, BypassUsersList, ActionType, MergeStrategy, PatternsButtonType } from './types'
 
 export const BranchSettingsRuleToggleField: React.FC<FieldProps> = ({ register, watch, setValue }) => (
   <StackedList.Root className="border-none">
@@ -72,7 +72,9 @@ export const BranchSettingsRuleDescriptionField: React.FC<FieldProps> = ({ regis
 )
 
 export const BranchSettingsRuleTargetPatternsField: React.FC<FieldProps> = ({ setValue, watch, register, errors }) => {
-  const [selectedOption, setSelectedOption] = useState<'Include' | 'Exclude'>('Include')
+  const [selectedOption, setSelectedOption] = useState<PatternsButtonType.INCLUDE | PatternsButtonType.EXCLUDE>(
+    PatternsButtonType.INCLUDE
+  )
 
   const patterns = watch!('patterns') || []
 
@@ -103,7 +105,7 @@ export const BranchSettingsRuleTargetPatternsField: React.FC<FieldProps> = ({ se
               patterns.map(pattern => (
                 <Badge
                   variant="outline"
-                  theme={pattern.option === 'Include' ? 'success' : 'destructive'}
+                  theme={pattern.option === PatternsButtonType.INCLUDE ? 'success' : 'destructive'}
                   key={pattern.pattern}
                   pattern={pattern}
                   className="mx-1">
@@ -129,8 +131,12 @@ export const BranchSettingsRuleTargetPatternsField: React.FC<FieldProps> = ({ se
               </span>
               <DropdownMenuContent align="end" className="mt-1">
                 <DropdownMenuGroup>
-                  <DropdownMenuItem onSelect={() => setSelectedOption('Include')}>Include</DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => setSelectedOption('Exclude')}>Exclude</DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => setSelectedOption(PatternsButtonType.INCLUDE)}>
+                    Include
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => setSelectedOption(PatternsButtonType.EXCLUDE)}>
+                    Exclude
+                  </DropdownMenuItem>
                 </DropdownMenuGroup>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-fields.tsx
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-fields.tsx
@@ -83,7 +83,9 @@ export const BranchSettingsRuleTargetPatternsField: React.FC<FieldProps> = ({ se
   const patterns = watch!('patterns') || []
 
   const handleAddPattern = () => {
+    console.log('here')
     const pattern = watch!('pattern')
+    console.log(pattern)
     if (pattern && !patterns.some(p => p.pattern === pattern)) {
       setValue!('patterns', [...patterns, { pattern, option: selectedOption }])
       setValue!('pattern', '')
@@ -98,43 +100,44 @@ export const BranchSettingsRuleTargetPatternsField: React.FC<FieldProps> = ({ se
   return (
     <FormFieldSet.ControlGroup>
       <FormFieldSet.Label htmlFor="target-patterns">Target Patterns</FormFieldSet.Label>
-      <div className="grid grid-rows-1 grid-cols-4">
-        <div className="col-span-3 mr-2">
-          <Input id="pattern" {...register!('pattern')} placeholder="Enter the target patterns" />
+      <div className="grid grid-rows-1 grid-cols-5">
+        <div className="col-span-4 mr-2">
+          <Input
+            id="pattern"
+            {...register!('pattern')}
+            leftStyle={true}
+            left={
+              <Button
+                variant="split"
+                type="button"
+                className="pl-0 pr-0 min-w-28"
+                dropdown={
+                  <DropdownMenu key="dropdown-menu">
+                    <span>
+                      <DropdownMenuTrigger insideSplitButton>
+                        <Icon name="chevron-down" className="chevron-down" />
+                      </DropdownMenuTrigger>
+                    </span>
+                    <DropdownMenuContent align="end" className="mt-1">
+                      <DropdownMenuGroup>
+                        <DropdownMenuItem onSelect={() => setSelectedOption(PatternsButtonType.INCLUDE)}>
+                          Include
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onSelect={() => setSelectedOption(PatternsButtonType.EXCLUDE)}>
+                          Exclude
+                        </DropdownMenuItem>
+                      </DropdownMenuGroup>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                }>
+                {selectedOption}
+              </Button>
+            }
+          />
         </div>
-        <Button
-          variant="split"
-          type="button"
-          className="pl-0 pr-0 min-w-28 col-span-1"
-          onClick={handleAddPattern}
-          dropdown={
-            <DropdownMenu key="dropdown-menu">
-              <span>
-                <DropdownMenuTrigger insideSplitButton>
-                  <Icon name="chevron-down" className="chevron-down" />
-                </DropdownMenuTrigger>
-              </span>
-              <DropdownMenuContent align="end" className="mt-1">
-                <DropdownMenuGroup>
-                  <DropdownMenuItem onSelect={() => setSelectedOption(PatternsButtonType.INCLUDE)}>
-                    Include
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => setSelectedOption(PatternsButtonType.EXCLUDE)}>
-                    Exclude
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          }>
-          {selectedOption}
+        <Button variant="outline" type="button" className="col-span-1" onClick={handleAddPattern}>
+          Add
         </Button>
-        {/* <Text size={2} as="p" color="tertiaryBackground" className="max-w-[100%]">
-          Match branches using globstar patterns (e.g.”golden”, “feature-*”, “releases/**”)
-        </Text> */}
-        {/* <div className="col-span-4"> */}
-
-        {/* </div> */}
-
         {errors!.pattern && (
           <FormFieldSet.Message theme={MessageTheme.ERROR}>{errors!.pattern.message?.toString()}</FormFieldSet.Message>
         )}
@@ -163,7 +166,7 @@ export const BranchSettingsRuleTargetPatternsField: React.FC<FieldProps> = ({ se
 }
 
 export const BranchSettingsRuleDefaultBranchField: React.FC<FieldProps> = ({ register, errors, watch, setValue }) => (
-  <FormFieldSet.ControlGroup className="min-h-8">
+  <FormFieldSet.ControlGroup className="min-h-8 justify-center">
     <FormFieldSet.Option
       control={
         <Checkbox
@@ -175,6 +178,7 @@ export const BranchSettingsRuleDefaultBranchField: React.FC<FieldProps> = ({ reg
       }
       id="default-branch"
       label="Default Branch"
+      className="mt-0"
     />
 
     {errors!.default && (
@@ -242,7 +246,7 @@ export const BranchSettingsRuleBypassListField: React.FC<FieldProps & { bypassOp
 }
 
 export const BranchSettingsRuleEditPermissionsField: React.FC<FieldProps> = ({ register, errors, watch, setValue }) => (
-  <FormFieldSet.ControlGroup className="min-h-8">
+  <FormFieldSet.ControlGroup className="min-h-8 justify-center">
     <FormFieldSet.Option
       control={
         <Checkbox
@@ -254,6 +258,7 @@ export const BranchSettingsRuleEditPermissionsField: React.FC<FieldProps> = ({ r
       }
       id="edit-permissons"
       label="Allow users with edit permission on the repository to bypass"
+      className="mt-0"
     />
 
     {errors!.repo_owners && (

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-fields.tsx
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-fields.tsx
@@ -83,9 +83,7 @@ export const BranchSettingsRuleTargetPatternsField: React.FC<FieldProps> = ({ se
   const patterns = watch!('patterns') || []
 
   const handleAddPattern = () => {
-    console.log('here')
     const pattern = watch!('pattern')
-    console.log(pattern)
     if (pattern && !patterns.some(p => p.pattern === pattern)) {
       setValue!('patterns', [...patterns, { pattern, option: selectedOption }])
       setValue!('pattern', '')

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-schema.tsx
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-schema.tsx
@@ -12,7 +12,6 @@ export const repoBranchSettingsFormSchema = z.object({
   ),
   state: z.boolean(),
   bypass: z.array(z.number()),
-  access: z.enum(['1', '2']),
   default: z.boolean().optional(),
   repo_owners: z.boolean().optional(),
   rules: z.array(

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-schema.tsx
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-schema.tsx
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { PatternsButtonType } from './types'
 
 export const repoBranchSettingsFormSchema = z.object({
   identifier: z.string().min(1, 'Name is required'),
@@ -7,7 +8,7 @@ export const repoBranchSettingsFormSchema = z.object({
   patterns: z.array(
     z.object({
       pattern: z.string(),
-      option: z.enum(['Include', 'Exclude'])
+      option: z.enum([PatternsButtonType.INCLUDE, PatternsButtonType.EXCLUDE])
     })
   ),
   state: z.boolean(),

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/types.ts
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/types.ts
@@ -20,13 +20,15 @@ export type Rule = {
 export enum ActionType {
   TOGGLE_RULE = 'TOGGLE_RULE',
   TOGGLE_SUBMENU = 'TOGGLE_SUBMENU',
-  SET_SELECT_OPTION = 'SET_SELECT_OPTION'
+  SET_SELECT_OPTION = 'SET_SELECT_OPTION',
+  SET_INITIAL_RULES = 'SET_INITAL_RULES'
 }
 
 export type Action =
   | { type: ActionType.TOGGLE_RULE; ruleId: string; checked: boolean }
   | { type: ActionType.TOGGLE_SUBMENU; ruleId: string; submenuId: string; checked: boolean }
   | { type: ActionType.SET_SELECT_OPTION; ruleId: string; checkName: string }
+  | { type: ActionType.SET_INITIAL_RULES; payload: Rule[] }
 
 export type Dispatch = (action: Action) => void
 

--- a/packages/playground/src/components/repo-settings/repo-branch-settings-rules/types.ts
+++ b/packages/playground/src/components/repo-settings/repo-branch-settings-rules/types.ts
@@ -48,3 +48,17 @@ export interface BypassUsersList {
   created: number
   updated: number
 }
+
+export enum BranchRuleId {
+  REQUIRE_LATEST_COMMIT = 'require_latest_commit',
+  REQUIRE_NO_CHANGE_REQUEST = 'require_no_change_request',
+  COMMENTS = 'comments',
+  STATUS_CHECKS = 'status_checks',
+  MERGE = 'merge',
+  DELETE_BRANCH = 'delete_branch'
+}
+
+export enum PatternsButtonType {
+  INCLUDE = 'Include',
+  EXCLUDE = 'Exclude'
+}

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-delete.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-delete.tsx
@@ -17,7 +17,7 @@ export const RepoSettingsGeneralDelete: React.FC<{
         This will permanently delete this repository, and everything contained in it.{' '}
       </Text>
 
-      {apiError && apiError.type === 'deleteRepo' && (
+      {apiError && apiError.type === ErrorTypes.DELETE_REPO && (
         <>
           <Spacer size={2} />
           <Text size={1} className="text-destructive">

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { RuleDataType, ErrorTypes } from './types'
 import { Button, ListActions, SearchBox, Icon, Text, StackedList, Spacer } from '@harnessio/canary'
-import { Link } from 'react-router-dom'
 
 const Title = ({ title, iconName }: { title: string | undefined; iconName: 'green-tick' | 'cancel-grey' }) => {
   return (
@@ -48,7 +47,7 @@ export const RepoSettingsGeneralRules = ({
   apiError: { type: ErrorTypes; message: string } | null
   handleRuleClick: (identifier: string) => void
 }) => {
-  console.log('rules from compoenents', rules)
+  // console.log('rules from compoenents', rules)
   return (
     <>
       <Text size={4} weight="medium">

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { RuleDataType } from './types'
-import { Button, ListActions, SearchBox, Icon, Text, StackedList } from '@harnessio/canary'
+import { RuleDataType, ErrorTypes } from './types'
+import { Button, ListActions, SearchBox, Icon, Text, StackedList, Spacer } from '@harnessio/canary'
 
 const Title = ({ title, iconName }: { title: string | undefined; iconName: 'green-tick' | 'cancel-grey' }) => {
   return (
@@ -38,7 +38,13 @@ const Description = ({
   )
 }
 
-export const RepoSettingsGeneralRules = ({ rules }: { rules: RuleDataType[] | null }) => {
+export const RepoSettingsGeneralRules = ({
+  rules,
+  apiError
+}: {
+  rules: RuleDataType[] | null
+  apiError: { type: ErrorTypes; message: string } | null
+}) => {
   return (
     <>
       <Text size={4} weight="medium">
@@ -86,6 +92,15 @@ export const RepoSettingsGeneralRules = ({ rules }: { rules: RuleDataType[] | nu
               </StackedList.Item>
             )
           })}
+
+        {apiError && apiError.type === ErrorTypes.FETCH_RULES && (
+          <>
+            <Spacer size={2} />
+            <Text size={1} className="text-destructive">
+              {apiError.message}
+            </Text>
+          </>
+        )}
       </StackedList.Root>
     </>
   )

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
@@ -21,20 +21,23 @@ const Description = ({
   bypassAllowed: boolean
 }) => {
   return (
-    <div className="pl-[24px]">
-      {targetPatternsCount} target patterns | {rulesAppliedCount} rules applied |{' '}
+    // <div className="pl-[24px]">
+    <Text color="tertiaryBackground" as="div" className="pl-[24px] gap-1 flex items-center">
+      {targetPatternsCount} target patterns <span className="text-2xl text-tertiary">|</span> {rulesAppliedCount} rules
+      applied <span className="text-2xl text-tertiary">|</span>
       {bypassAllowed ? (
-        <>
-          <Icon name="tick" className="text-success inline" size={15} />
+        <div>
+          <Icon name="tick" className="text-success inline" size={12} />
           <span> bypass allowed</span>
-        </>
+        </div>
       ) : (
-        <>
-          <Icon name="x-mark" className="text-destructive inline" size={15} />
+        <div>
+          <Icon name="x-mark" className="text-destructive inline" size={12} />
           <span> bypass not allowed</span>
-        </>
+        </div>
       )}
-    </div>
+    </Text>
+    // </div>
   )
 }
 
@@ -47,7 +50,6 @@ export const RepoSettingsGeneralRules = ({
   apiError: { type: ErrorTypes; message: string } | null
   handleRuleClick: (identifier: string) => void
 }) => {
-  // console.log('rules from compoenents', rules)
   return (
     <>
       <Text size={4} weight="medium">

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
+import { RuleDataType } from './types'
 import { Button, ListActions, SearchBox, Icon, Text, StackedList } from '@harnessio/canary'
 
-const Title = ({ title, iconName }: { title: string; iconName: 'green-tick' | 'cancel-grey' }) => {
+const Title = ({ title, iconName }: { title: string | undefined; iconName: 'green-tick' | 'cancel-grey' }) => {
   return (
     <div className="flex gap-2 items-center">
       {<Icon name={iconName} />}
@@ -10,7 +11,34 @@ const Title = ({ title, iconName }: { title: string; iconName: 'green-tick' | 'c
   )
 }
 
-export const RepoSettingsGeneralRules = () => {
+const Description = ({
+  targetPatternsCount,
+  rulesAppliedCount,
+  bypassAllowed
+}: {
+  targetPatternsCount: number
+  rulesAppliedCount: number
+  bypassAllowed: boolean
+}) => {
+  return (
+    <div className="pl-[24px]">
+      {targetPatternsCount} target patterns | {rulesAppliedCount} rules applied |{' '}
+      {bypassAllowed ? (
+        <>
+          <Icon name="tick" className="text-success inline" size={15} />
+          <span> bypass allowed</span>
+        </>
+      ) : (
+        <>
+          <Icon name="x-mark" className="text-destructive inline" size={15} />
+          <span> bypass not allowed</span>
+        </>
+      )}
+    </div>
+  )
+}
+
+export const RepoSettingsGeneralRules = ({ rules }: { rules: RuleDataType[] | null }) => {
   return (
     <>
       <Text size={4} weight="medium">
@@ -29,43 +57,35 @@ export const RepoSettingsGeneralRules = () => {
       {/* <Spacer size={6} /> */}
 
       <StackedList.Root>
-        <StackedList.Item>
-          <StackedList.Field
-            title={<Title title="testtt" iconName="green-tick" />}
-            description={
-              <div className="pl-[24px]">
-                3 target patterns | 2 rules applied | <Icon name="tick" className="text-success inline" size={15} />{' '}
-                bypass allowed
-              </div>
-            }
-          />
-          <StackedList.Field
-            label
-            secondary
-            title={
-              <div className="flex gap-1.5 items-center justify-end">
-                <Icon name="vertical-ellipsis" size={14} className="text-tertiary-background" />
-              </div>
-            }
-            right
-          />
-        </StackedList.Item>
-        <StackedList.Item>
-          <StackedList.Field
-            title={<Title title="test" iconName="cancel-grey" />}
-            description={<div className="pl-[24px]">0 target patterns | 1 rules applied</div>}
-          />
-          <StackedList.Field
-            label
-            secondary
-            title={
-              <div className="flex gap-1.5 items-center justify-end">
-                <Icon name="vertical-ellipsis" size={14} className="text-tertiary-background" />
-              </div>
-            }
-            right
-          />
-        </StackedList.Item>
+        {rules &&
+          rules.map(rule => {
+            return (
+              <StackedList.Item key={rule.identifier}>
+                <StackedList.Field
+                  title={
+                    <Title title={rule.identifier} iconName={rule.state === 'active' ? 'green-tick' : 'cancel-grey'} />
+                  }
+                  description={
+                    <Description
+                      targetPatternsCount={rule.targetPatternsCount ?? 0}
+                      rulesAppliedCount={rule.rulesAppliedCount ?? 0}
+                      bypassAllowed={rule.bypassAllowed ?? false}
+                    />
+                  }
+                />
+                <StackedList.Field
+                  label
+                  secondary
+                  title={
+                    <div className="flex gap-1.5 items-center justify-end">
+                      <Icon name="vertical-ellipsis" size={14} className="text-tertiary-background" />
+                    </div>
+                  }
+                  right
+                />
+              </StackedList.Item>
+            )
+          })}
       </StackedList.Root>
     </>
   )

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { RuleDataType, ErrorTypes } from './types'
 import { Button, ListActions, SearchBox, Icon, Text, StackedList, Spacer } from '@harnessio/canary'
+import { Link } from 'react-router-dom'
 
 const Title = ({ title, iconName }: { title: string | undefined; iconName: 'green-tick' | 'cancel-grey' }) => {
   return (
@@ -40,11 +41,14 @@ const Description = ({
 
 export const RepoSettingsGeneralRules = ({
   rules,
-  apiError
+  apiError,
+  handleRuleClick
 }: {
   rules: RuleDataType[] | null
   apiError: { type: ErrorTypes; message: string } | null
+  handleRuleClick: (identifier: string) => void
 }) => {
+  console.log('rules from compoenents', rules)
   return (
     <>
       <Text size={4} weight="medium">
@@ -66,7 +70,7 @@ export const RepoSettingsGeneralRules = ({
         {rules &&
           rules.map(rule => {
             return (
-              <StackedList.Item key={rule.identifier}>
+              <StackedList.Item key={rule.identifier} onClick={() => handleRuleClick(rule.identifier ?? '')}>
                 <StackedList.Field
                   title={
                     <Title title={rule.identifier} iconName={rule.state === 'active' ? 'green-tick' : 'cancel-grey'} />

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-security.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-security.tsx
@@ -89,7 +89,7 @@ export const RepoSettingsSecurityForm: React.FC<RepoSettingsSecurityFormProps> =
           )}
         </FormFieldSet.ControlGroup>
 
-        {apiError && (apiError.type === 'fetchSecurity' || apiError.type === 'updateSecurity') && (
+        {apiError && (apiError.type === ErrorTypes.FETCH_SECURITY || apiError.type === ErrorTypes.UPDATE_SECURITY) && (
           <>
             <Spacer size={2} />
             <Text size={1} className="text-destructive">

--- a/packages/playground/src/components/repo-settings/repo-settings-general/types.ts
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/types.ts
@@ -23,7 +23,8 @@ export enum ErrorTypes {
   UPDATE_ACCESS = 'updateAccess',
   FETCH_SECURITY = 'fetchSecurity',
   UPDATE_SECURITY = 'updateSecurity',
-  DELETE_REPO = 'deleteRepo'
+  DELETE_REPO = 'deleteRepo',
+  FETCH_RULES = 'fetchRules'
 }
 export interface RepoUpdateData {
   name: string
@@ -33,4 +34,12 @@ export interface RepoUpdateData {
 }
 export interface SecurityScanning {
   secretScanning: boolean
+}
+
+export interface RuleDataType {
+  targetPatternsCount?: number
+  rulesAppliedCount?: number
+  bypassAllowed?: boolean
+  identifier?: string
+  state?: string
 }

--- a/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
+++ b/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
@@ -33,7 +33,7 @@ interface RepoBranchSettingsRulesPageProps {
   principals?: BypassUsersList[]
   recentStatusChecks?: string[]
   apiErrors?: BranchSettingsErrors
-  addRuleSuccess: boolean
+  // addRuleSuccess: boolean
 }
 
 export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPageProps> = ({
@@ -42,10 +42,10 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
   principals,
   recentStatusChecks,
   apiErrors,
-  addRuleSuccess,
+  // addRuleSuccess,
   preSetRuleData
 }) => {
-  console.log(preSetRuleData)
+  // console.log(preSetRuleData)
   const {
     register,
     handleSubmit,
@@ -79,22 +79,24 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
     }))
   )
 
+  console.log('rules shoud update every sibngle time', rules)
+
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false)
 
   const onSubmit: SubmitHandler<RepoBranchSettingsFormFields> = data => {
     setIsSubmitted(true)
     const formData = { ...data, rules }
-    console.log(formData)
+    // console.log(formData)
     handleRuleUpdate(formData)
     reset()
   }
-  useEffect(() => {
-    if (isSubmitted && addRuleSuccess) {
-      setTimeout(() => {
-        setIsSubmitted(false)
-      }, 1000)
-    }
-  }, [isSubmitted, addRuleSuccess])
+  // useEffect(() => {
+  //   if (isSubmitted && addRuleSuccess) {
+  //     setTimeout(() => {
+  //       setIsSubmitted(false)
+  //     }, 1000)
+  //   }
+  // }, [isSubmitted, addRuleSuccess])
 
   useEffect(() => {
     if (preSetRuleData) {
@@ -103,7 +105,7 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
         description: preSetRuleData?.description || '',
         pattern: '',
         patterns: preSetRuleData?.patterns || [],
-        state: preSetRuleData?.state || true,
+        state: preSetRuleData?.state && true,
         default: preSetRuleData?.default || false,
         repo_owners: preSetRuleData?.repo_owners || false,
         bypass: preSetRuleData?.bypass || [],
@@ -126,7 +128,7 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
       <form onSubmit={handleSubmit(onSubmit)}>
         <FormFieldSet.Root>
           <BranchSettingsRuleToggleField register={register} setValue={setValue} watch={watch} />
-          <BranchSettingsRuleNameField register={register} errors={errors} />
+          <BranchSettingsRuleNameField register={register} errors={errors} disabled={!!preSetRuleData} />
           <BranchSettingsRuleDescriptionField register={register} errors={errors} />
           <BranchSettingsRuleTargetPatternsField
             watch={watch}
@@ -160,7 +162,7 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
           <FormFieldSet.Root className="mt-0">
             <FormFieldSet.ControlGroup>
               <ButtonGroup.Root>
-                {!isSubmitted || !addRuleSuccess ? (
+                {!isSubmitted /*|| !addRuleSuccess*/ ? (
                   <>
                     <Button type="submit" size="sm" disabled={!isValid || isLoading}>
                       {!isLoading ? 'Create rule' : 'Creating rule...'}

--- a/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
+++ b/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
@@ -17,7 +17,8 @@ import { branchRules } from '../components/repo-settings/repo-branch-settings-ru
 import { repoBranchSettingsFormSchema } from '../components/repo-settings/repo-branch-settings-rules/repo-branch-settings-rules-schema'
 import {
   RepoBranchSettingsFormFields,
-  BypassUsersList
+  BypassUsersList,
+  ActionType
 } from '../components/repo-settings/repo-branch-settings-rules/types'
 
 type BranchSettingsErrors = {
@@ -41,8 +42,10 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
   principals,
   recentStatusChecks,
   apiErrors,
-  addRuleSuccess
+  addRuleSuccess,
+  preSetRuleData
 }) => {
+  console.log(preSetRuleData)
   const {
     register,
     handleSubmit,
@@ -62,10 +65,10 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
       default: false,
       repo_owners: false,
       bypass: [],
-      access: '1',
       rules: []
     }
   })
+
   const [rules, dispatch] = useReducer(
     branchSettingsReducer,
     branchRules.map(rule => ({
@@ -81,6 +84,7 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
   const onSubmit: SubmitHandler<RepoBranchSettingsFormFields> = data => {
     setIsSubmitted(true)
     const formData = { ...data, rules }
+    console.log(formData)
     handleRuleUpdate(formData)
     reset()
   }
@@ -91,6 +95,32 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
       }, 1000)
     }
   }, [isSubmitted, addRuleSuccess])
+
+  useEffect(() => {
+    if (preSetRuleData) {
+      reset({
+        identifier: preSetRuleData?.identifier || '',
+        description: preSetRuleData?.description || '',
+        pattern: '',
+        patterns: preSetRuleData?.patterns || [],
+        state: preSetRuleData?.state || true,
+        default: preSetRuleData?.default || false,
+        repo_owners: preSetRuleData?.repo_owners || false,
+        bypass: preSetRuleData?.bypass || [],
+        rules: []
+      })
+
+      dispatch({
+        type: ActionType.SET_INITIAL_RULES,
+        payload: preSetRuleData?.rules?.map(rule => ({
+          id: rule.id,
+          checked: rule.checked || false,
+          submenu: rule.submenu || [],
+          selectOptions: rule.selectOptions || []
+        }))
+      })
+    }
+  }, [preSetRuleData])
   return (
     <>
       <form onSubmit={handleSubmit(onSubmit)}>

--- a/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
+++ b/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useReducer, useEffect } from 'react'
-import { Button, ButtonGroup, Icon, useZodForm, Spacer, Text } from '@harnessio/canary'
+import React, { useReducer, useEffect } from 'react'
+import { Button, ButtonGroup, useZodForm, Spacer, Text } from '@harnessio/canary'
 import { SubmitHandler } from 'react-hook-form'
 import {
   BranchSettingsRuleToggleField,
@@ -18,7 +18,8 @@ import { repoBranchSettingsFormSchema } from '../components/repo-settings/repo-b
 import {
   RepoBranchSettingsFormFields,
   BypassUsersList,
-  ActionType
+  ActionType,
+  MergeStrategy
 } from '../components/repo-settings/repo-branch-settings-rules/types'
 
 type BranchSettingsErrors = {
@@ -103,7 +104,7 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
         payload: preSetRuleData?.rules?.map(rule => ({
           id: rule.id,
           checked: rule.checked || false,
-          submenu: rule.submenu || [],
+          submenu: (rule.submenu || []) as MergeStrategy[],
           selectOptions: rule.selectOptions || []
         }))
       })

--- a/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
+++ b/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
@@ -25,6 +25,7 @@ type BranchSettingsErrors = {
   principals: string | null
   statusChecks: string | null
   addRule: string | null
+  updateRule: string | null
 }
 
 interface RepoBranchSettingsRulesPageProps {
@@ -33,7 +34,7 @@ interface RepoBranchSettingsRulesPageProps {
   principals?: BypassUsersList[]
   recentStatusChecks?: string[]
   apiErrors?: BranchSettingsErrors
-  // addRuleSuccess: boolean
+  preSetRuleData?: RepoBranchSettingsFormFields | null
 }
 
 export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPageProps> = ({
@@ -42,10 +43,8 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
   principals,
   recentStatusChecks,
   apiErrors,
-  // addRuleSuccess,
   preSetRuleData
 }) => {
-  // console.log(preSetRuleData)
   const {
     register,
     handleSubmit,
@@ -86,7 +85,6 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
   const onSubmit: SubmitHandler<RepoBranchSettingsFormFields> = data => {
     setIsSubmitted(true)
     const formData = { ...data, rules }
-    // console.log(formData)
     handleRuleUpdate(formData)
     reset()
   }
@@ -150,14 +148,15 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
           />
           <BranchSettingsRuleListField rules={rules} dispatch={dispatch} recentStatusChecks={recentStatusChecks} />
 
-          {apiErrors && (apiErrors.principals || apiErrors.statusChecks || apiErrors.addRule) && (
-            <>
-              <Spacer size={2} />
-              <Text size={1} className="text-destructive">
-                {apiErrors.principals || apiErrors.statusChecks || apiErrors.addRule}
-              </Text>
-            </>
-          )}
+          {apiErrors &&
+            (apiErrors.principals || apiErrors.statusChecks || apiErrors.addRule || apiErrors.updateRule) && (
+              <>
+                <Spacer size={2} />
+                <Text size={1} className="text-destructive">
+                  {apiErrors.principals || apiErrors.statusChecks || apiErrors.addRule}
+                </Text>
+              </>
+            )}
 
           <FormFieldSet.Root className="mt-0">
             <FormFieldSet.ControlGroup>

--- a/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
+++ b/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
@@ -78,23 +78,11 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
     }))
   )
 
-  console.log('rules shoud update every sibngle time', rules)
-
-  const [isSubmitted, setIsSubmitted] = useState<boolean>(false)
-
   const onSubmit: SubmitHandler<RepoBranchSettingsFormFields> = data => {
-    setIsSubmitted(true)
     const formData = { ...data, rules }
     handleRuleUpdate(formData)
     reset()
   }
-  // useEffect(() => {
-  //   if (isSubmitted && addRuleSuccess) {
-  //     setTimeout(() => {
-  //       setIsSubmitted(false)
-  //     }, 1000)
-  //   }
-  // }, [isSubmitted, addRuleSuccess])
 
   useEffect(() => {
     if (preSetRuleData) {
@@ -161,7 +149,7 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
           <FormFieldSet.Root className="mt-0">
             <FormFieldSet.ControlGroup>
               <ButtonGroup.Root>
-                {!isSubmitted /*|| !addRuleSuccess*/ ? (
+                {!preSetRuleData ? (
                   <>
                     <Button type="submit" size="sm" disabled={!isValid || isLoading}>
                       {!isLoading ? 'Create rule' : 'Creating rule...'}
@@ -171,10 +159,14 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
                     </Button>
                   </>
                 ) : (
-                  <Button variant="ghost" type="button" size="sm" theme="success" className="pointer-events-none">
-                    Rule created&nbsp;&nbsp;
-                    <Icon name="tick" size={14} />
-                  </Button>
+                  <>
+                    <Button type="submit" size="sm" disabled={!isValid || isLoading}>
+                      {!isLoading ? 'Update rule' : 'Updating rule...'}
+                    </Button>
+                    <Button type="button" variant="outline" size="sm">
+                      Cancel
+                    </Button>
+                  </>
                 )}
               </ButtonGroup.Root>
             </FormFieldSet.ControlGroup>

--- a/packages/playground/src/pages/repo-settings-general-page.tsx
+++ b/packages/playground/src/pages/repo-settings-general-page.tsx
@@ -29,6 +29,7 @@ interface RepoSettingsGeneralPageProps {
   loadingStates: ILoadingStates
   isRepoUpdateSuccess: boolean
   rules: RuleDataType[] | null
+  handleRuleClick: (identifier: string) => void
 }
 const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
   repoData,
@@ -39,7 +40,8 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
   apiError,
   loadingStates,
   isRepoUpdateSuccess,
-  rules
+  rules,
+  handleRuleClick
 }) => {
   return (
     <>
@@ -53,7 +55,7 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
           isRepoUpdateSuccess={isRepoUpdateSuccess}
         />
         <FormFieldSet.Separator />
-        <RepoSettingsGeneralRules rules={rules} apiError={apiError} />
+        <RepoSettingsGeneralRules rules={rules} apiError={apiError} handleRuleClick={handleRuleClick} />
         <FormFieldSet.Separator />
         <RepoSettingsSecurityForm
           securityScanning={securityScanning}

--- a/packages/playground/src/pages/repo-settings-general-page.tsx
+++ b/packages/playground/src/pages/repo-settings-general-page.tsx
@@ -53,7 +53,7 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
           isRepoUpdateSuccess={isRepoUpdateSuccess}
         />
         <FormFieldSet.Separator />
-        <RepoSettingsGeneralRules rules={rules} />
+        <RepoSettingsGeneralRules rules={rules} apiError={apiError} />
         <FormFieldSet.Separator />
         <RepoSettingsSecurityForm
           securityScanning={securityScanning}

--- a/packages/playground/src/pages/repo-settings-general-page.tsx
+++ b/packages/playground/src/pages/repo-settings-general-page.tsx
@@ -4,7 +4,12 @@ import { RepoSettingsGeneralForm } from '../components/repo-settings/repo-settin
 import { RepoSettingsGeneralRules } from '../components/repo-settings/repo-settings-general/repo-settings-general-rules'
 import { RepoSettingsSecurityForm } from '../components/repo-settings/repo-settings-general/repo-settings-general-security'
 import { RepoSettingsGeneralDelete } from '../components/repo-settings/repo-settings-general/repo-settings-general-delete'
-import { RepoData, RepoUpdateData, ErrorTypes } from '../components/repo-settings/repo-settings-general/types'
+import {
+  RepoData,
+  RepoUpdateData,
+  ErrorTypes,
+  RuleDataType
+} from '../components/repo-settings/repo-settings-general/types'
 import { RepoSettingsSecurityFormFields } from '../components/repo-settings/repo-settings-general/repo-settings-general-security'
 
 interface ILoadingStates {
@@ -23,6 +28,7 @@ interface RepoSettingsGeneralPageProps {
   apiError: { type: ErrorTypes; message: string } | null
   loadingStates: ILoadingStates
   isRepoUpdateSuccess: boolean
+  rules: RuleDataType[] | null
 }
 const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
   repoData,
@@ -32,7 +38,8 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
   handleDeleteRepository,
   apiError,
   loadingStates,
-  isRepoUpdateSuccess
+  isRepoUpdateSuccess,
+  rules
 }) => {
   return (
     <>
@@ -46,7 +53,7 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
           isRepoUpdateSuccess={isRepoUpdateSuccess}
         />
         <FormFieldSet.Separator />
-        <RepoSettingsGeneralRules />
+        <RepoSettingsGeneralRules rules={rules} />
         <FormFieldSet.Separator />
         <RepoSettingsSecurityForm
           securityScanning={securityScanning}


### PR DESCRIPTION
- Adds the `repo-branch-rules-page` to `gitness` with minor fixes. 
- Uses HTTP restful URL pattern, no query params. 
- changes button to `update rule` on rule edit. 
- Minor fixes such as increasing pipe size, text no longer breaking, icons made smaller, etc.
- Adds `dropdown` in input to `include/exclude` button. 

e2e vid:

https://github.com/user-attachments/assets/e9218506-17a8-4b13-b90b-040f60a86580

