### PR TITLE
Finish integrate rules list

### DIFF
--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -344,7 +344,7 @@ export default function App() {
                   children: [
                     { index: true, element: <PullRequestSandboxListPage /> },
                     {
-                      path: 'compare/:diffRefs*?',
+                      path: 'compare',
                       element: <CreatePullRequest />
                     }
                   ]
@@ -371,6 +371,10 @@ export default function App() {
                     },
                     {
                       path: 'rules',
+                      element: <RepoSettingsGeneralPageContainer />
+                    },
+                    {
+                      path: 'rules/create',
                       element: <RepoBranchSettingsRulesPageContainer />,
                       children: [
                         {

--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -205,6 +205,24 @@ export default function App() {
                 {
                   path: 'general',
                   element: <RepoSettingsGeneralPageContainer />
+                },
+                {
+                  path: 'rules',
+                  element: <RepoSettingsGeneralPageContainer />
+                },
+                {
+                  path: 'rules/create',
+                  element: <RepoBranchSettingsRulesPageContainer />,
+                  children: [
+                    {
+                      path: ':identifier',
+                      element: <RepoBranchSettingsRulesPageContainer />
+                    }
+                  ]
+                },
+                {
+                  path: '*',
+                  element: <RepoSettingsPlaceholderPage />
                 }
               ]
             }

--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -344,7 +344,7 @@ export default function App() {
                   children: [
                     { index: true, element: <PullRequestSandboxListPage /> },
                     {
-                      path: 'compare',
+                      path: 'compare/:diffRefs*?',
                       element: <CreatePullRequest />
                     }
                   ]

--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -10,7 +10,8 @@ import {
   ForgotPasswordPage,
   NewPasswordPage,
   OTPPage,
-  SandboxRepoSettingsPage
+  SandboxRepoSettingsPage,
+  RepoSettingsPlaceholderPage
 } from '@harnessio/playground'
 import SnadboxRootWraper from './components/SandboxRootWrapper'
 import RootLayoutWrapper from './components/RootLayoutWrapper'
@@ -377,6 +378,10 @@ export default function App() {
                           element: <RepoBranchSettingsRulesPageContainer />
                         }
                       ]
+                    },
+                    {
+                      path: '*',
+                      element: <RepoSettingsPlaceholderPage />
                     }
                   ]
                 }

--- a/apps/gitness/src/framework/hooks/useGetRepoId.ts
+++ b/apps/gitness/src/framework/hooks/useGetRepoId.ts
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 import { PathParams } from '../../RouteDefinitions'
 
-export function useGetRepoId() {
+export function useGetRepoId(): string {
   const { repoId } = useParams<PathParams>()
   return repoId ?? ''
 }

--- a/apps/gitness/src/framework/hooks/useGetRepoId.ts
+++ b/apps/gitness/src/framework/hooks/useGetRepoId.ts
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom'
+import { PathParams } from '../../RouteDefinitions'
+
+export function usegetRepoId() {
+  const { repoId } = useParams<PathParams>()
+  return repoId ?? ''
+}

--- a/apps/gitness/src/framework/hooks/useGetRepoId.ts
+++ b/apps/gitness/src/framework/hooks/useGetRepoId.ts
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 import { PathParams } from '../../RouteDefinitions'
 
-export function usegetRepoId() {
+export function useGetRepoId() {
   const { repoId } = useParams<PathParams>()
   return repoId ?? ''
 }

--- a/apps/gitness/src/framework/hooks/useGetRepoPath.ts
+++ b/apps/gitness/src/framework/hooks/useGetRepoPath.ts
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom'
 import { PathParams } from '../../RouteDefinitions'
 import { useGetSpaceURLParam } from './useGetSpaceParam'
 
-export function useGetRepoRef() {
+export function useGetRepoRef(): string {
   const space = useGetSpaceURLParam()
   const { repoId } = useParams<PathParams>()
   return space && repoId ? `${space}/${repoId}/+` : ''

--- a/apps/gitness/src/framework/hooks/useGetRepoPath.ts
+++ b/apps/gitness/src/framework/hooks/useGetRepoPath.ts
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom'
 import { PathParams } from '../../RouteDefinitions'
 import { useGetSpaceURLParam } from './useGetSpaceParam'
 
-export function useGetRepoRef(): string {
+export function useGetRepoRef() {
   const space = useGetSpaceURLParam()
   const { repoId } = useParams<PathParams>()
   return space && repoId ? `${space}/${repoId}/+` : ''

--- a/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
@@ -1,5 +1,7 @@
 import { RepoBranchSettingsRulesPage, RepoBranchSettingsFormFields, BypassUsersList } from '@harnessio/playground'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
+import { usegetRepoId } from '../../framework/hooks/useGetRepoId'
+
 import { useState } from 'react'
 import {
   useRuleAddMutation,
@@ -17,6 +19,8 @@ export const RepoBranchSettingsRulesPageContainer = () => {
   const [preSetRuleData, setPreSetRuleData] = useState<RepoBranchSettingsFormFields | null>(null)
   const navigate = useNavigate()
   const repoRef = useGetRepoRef()
+  const repoName = usegetRepoId()
+
   const spaceId = useGetSpaceURLParam()
   const { identifier } = useParams()
 
@@ -64,8 +68,6 @@ export const RepoBranchSettingsRulesPageContainer = () => {
     { repo_ref: repoRef, rule_identifier: identifier! },
     {
       onSuccess: () => {
-        const repoName = repoRef.split('/')[1]
-
         navigate(`/sandbox/spaces/${spaceId}/repos/${repoName}/settings/general`)
       }
     }

--- a/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-sandbox-branch-rules-container.tsx
@@ -1,6 +1,6 @@
 import { RepoBranchSettingsRulesPage, RepoBranchSettingsFormFields, BypassUsersList } from '@harnessio/playground'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
-import { usegetRepoId } from '../../framework/hooks/useGetRepoId'
+import { useGetRepoId } from '../../framework/hooks/useGetRepoId'
 
 import { useState } from 'react'
 import {
@@ -19,7 +19,7 @@ export const RepoBranchSettingsRulesPageContainer = () => {
   const [preSetRuleData, setPreSetRuleData] = useState<RepoBranchSettingsFormFields | null>(null)
   const navigate = useNavigate()
   const repoRef = useGetRepoRef()
-  const repoName = usegetRepoId()
+  const repoName = useGetRepoId()
 
   const spaceId = useGetSpaceURLParam()
   const { identifier } = useParams()

--- a/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
@@ -168,7 +168,7 @@ export const RepoSettingsGeneralPageContainer = () => {
     }
   )
 
-  const { mutate: deleteRule, isLoading: isDeletingRule } = useRuleDeleteMutation(
+  const { mutate: deleteRule } = useRuleDeleteMutation(
     { repo_ref: repoRef }, // Assuming repoRef is available in your component
     {
       onMutate: async variables => {

--- a/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
@@ -5,11 +5,12 @@ import {
   AccessLevel,
   ErrorTypes,
   RepoData,
-  RuleDataType
+  RuleDataType,
+  DeleteTokenAlertDialog,
+  AlertDeleteDialog
 } from '@harnessio/playground'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
-
 import {
   useFindRepositoryQuery,
   FindRepositoryOkResponse,
@@ -40,12 +41,13 @@ import {
   RuleDeleteErrorResponse
 } from '@harnessio/code-service-client'
 import { useQueryClient } from '@tanstack/react-query'
-
 import { useNavigate } from 'react-router-dom'
 import { useState } from 'react'
+import { useGetRepoId } from '../../framework/hooks/useGetRepoId'
 
 export const RepoSettingsGeneralPageContainer = () => {
   const repoRef = useGetRepoRef()
+  const repoName = useGetRepoId()
   const navigate = useNavigate()
   const spaceId = useGetSpaceURLParam()
   const queryClient = useQueryClient()
@@ -61,6 +63,18 @@ export const RepoSettingsGeneralPageContainer = () => {
 
   const [securityScanning, setSecurityScanning] = useState<boolean>(false)
   const [apiError, setApiError] = useState<{ type: ErrorTypes; message: string } | null>(null)
+  const [isRulesAlertDeleteDialogOpen, setIsRulesAlertDeleteDialogOpen] = useState<boolean>(false)
+  const [isRepoAlertDeleteDialogOpen, setRepoAlertDeleteDialogOpen] = useState<boolean>(false)
+  const [alertDeleteParams, setAlertDeleteParams] = useState<string>('')
+
+  const closeRulesAlertDeleteDialog = () => setIsRulesAlertDeleteDialogOpen(false)
+  const openRulesAlertDeleteDialog = (identifier: string) => {
+    setAlertDeleteParams(identifier)
+    setIsRulesAlertDeleteDialogOpen(true)
+  }
+
+  const closeRepoAlertDeleteDialog = () => setRepoAlertDeleteDialogOpen(false)
+  const openRepoAlertDeleteDialog = () => setRepoAlertDeleteDialogOpen(true)
 
   const { isLoading: isLoadingRepoData } = useFindRepositoryQuery(
     { repo_ref: repoRef },
@@ -168,7 +182,7 @@ export const RepoSettingsGeneralPageContainer = () => {
     }
   )
 
-  const { mutate: deleteRule } = useRuleDeleteMutation(
+  const { mutate: deleteRule, isLoading: isDeletingRule } = useRuleDeleteMutation(
     { repo_ref: repoRef }, // Assuming repoRef is available in your component
     {
       onMutate: async variables => {
@@ -180,6 +194,7 @@ export const RepoSettingsGeneralPageContainer = () => {
         setRules(currentRules =>
           currentRules ? currentRules.filter(rule => rule.identifier !== variables.rule_identifier) : null
         )
+        setIsRulesAlertDeleteDialogOpen(false)
 
         // Return a context object with the previous rules data
         return { previousRulesData }
@@ -196,7 +211,7 @@ export const RepoSettingsGeneralPageContainer = () => {
         const message = error.message || 'Error deleting rule'
         setApiError({ type: ErrorTypes.DELETE_RULE, message })
       },
-      onSuccess: () => {
+      onSuccess: (_data: RuleDeleteOkResponse) => {
         setApiError(null)
       }
     }
@@ -319,10 +334,8 @@ export const RepoSettingsGeneralPageContainer = () => {
     }
   )
 
-  const handleDeleteRepository = () => {
-    if (window.confirm('Are you sure you want to delete this repository?')) {
-      deleteRepository({})
-    }
+  const handleDeleteRepository = (identifier: string) => {
+    deleteRepository({ repo_ref: identifier })
   }
 
   const handleRepoUpdate = (data: RepoUpdateData) => {
@@ -352,8 +365,6 @@ export const RepoSettingsGeneralPageContainer = () => {
   }
 
   const handleRuleClick = (identifier: string) => {
-    const repoName = repoRef.split('/')[1]
-
     const url = `/sandbox/spaces/${spaceId}/repos/${repoName}/settings/rules/${identifier}`
 
     navigate(url)
@@ -367,22 +378,41 @@ export const RepoSettingsGeneralPageContainer = () => {
     isLoadingRepoData: isLoadingBranches || isLoadingRepoData || isLoadingSecuritySettings,
     isUpdatingRepoData: updatingPublicAccess || updatingDescription || updatingBranch,
     isLoadingSecuritySettings,
-    isDeletingRepo: isDeletingRepo,
     isUpdatingSecuritySettings: UpdatingSecuritySettings
   }
   return (
-    <RepoSettingsGeneralPage
-      repoData={repoData}
-      handleRepoUpdate={handleRepoUpdate}
-      securityScanning={securityScanning}
-      handleUpdateSecuritySettings={handleUpdateSecuritySettings}
-      handleDeleteRepository={handleDeleteRepository}
-      apiError={apiError}
-      loadingStates={loadingStates}
-      isRepoUpdateSuccess={updatePublicAccessSuccess || updateDescriptionSuccess || updateBranchSuccess}
-      rules={rules}
-      handleRuleClick={handleRuleClick}
-      handleDeleteRule={handleDeleteRule}
-    />
+    <>
+      <RepoSettingsGeneralPage
+        repoData={repoData}
+        handleRepoUpdate={handleRepoUpdate}
+        securityScanning={securityScanning}
+        handleUpdateSecuritySettings={handleUpdateSecuritySettings}
+        apiError={apiError}
+        loadingStates={loadingStates}
+        isRepoUpdateSuccess={updatePublicAccessSuccess || updateDescriptionSuccess || updateBranchSuccess}
+        rules={rules}
+        handleRuleClick={handleRuleClick}
+        openRulesAlertDeleteDialog={openRulesAlertDeleteDialog}
+        openRepoAlertDeleteDialog={openRepoAlertDeleteDialog}
+      />
+      <DeleteTokenAlertDialog
+        open={isRulesAlertDeleteDialogOpen}
+        onClose={closeRulesAlertDeleteDialog}
+        deleteFn={handleDeleteRule}
+        error={apiError}
+        type="rule"
+        identifier={alertDeleteParams}
+        isLoading={isDeletingRule}
+      />
+      <AlertDeleteDialog
+        open={isRepoAlertDeleteDialogOpen}
+        onOpenChange={closeRepoAlertDeleteDialog}
+        handleDeleteRepository={handleDeleteRepository}
+        identifier={repoRef}
+        isDeletingRepo={isDeletingRepo}
+        error={apiError?.type === ErrorTypes.DELETE_REPO ? apiError.message : null}
+        type="repository"
+      />
+    </>
   )
 }

--- a/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
+++ b/apps/gitness/src/pages/repo-sandbox/repo-settings-general-container.tsx
@@ -365,7 +365,7 @@ export const RepoSettingsGeneralPageContainer = () => {
   }
 
   const handleRuleClick = (identifier: string) => {
-    const url = `/sandbox/spaces/${spaceId}/repos/${repoName}/settings/rules/${identifier}`
+    const url = `/sandbox/spaces/${spaceId}/repos/${repoName}/settings/rules/create/${identifier}`
 
     navigate(url)
   }

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -111,7 +111,6 @@ const router = createBrowserRouter([
                   },
                   {
                     path: 'general',
-                    // element: <RepoSettingsGeneralPage repoData={mockRepoData} />
                     element: <RepoSettingsGeneralPlaygroundContainer />
                   },
                   {

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -64,7 +64,6 @@ import SandboxPullRequestComparePage from './pages/sandbox-pull-request-compare-
 import { mockBypassUserData, mockStatusChecks } from './pages/mocks/repo-branch-settings/mockData'
 import { BypassUsersList } from './components/repo-settings/repo-branch-settings-rules/types'
 import { currentUser } from './pages/mocks/mockCurrentUserData'
-import { mockRepoData } from './pages/mocks/repo-settings/mockRepoData'
 
 const router = createBrowserRouter([
   // TEMPORARY LAYOUT SANDBOX

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -50,7 +50,7 @@ import { SandboxSettingsProjectGeneralPage } from './pages/sandbox-settings-proj
 import { SandboxSettingsProjectMembersPage } from './pages/sandbox-settings-project-members-page'
 import { SandboxRepoCreatePage } from './pages/sandbox-repo-create-page'
 import { SandboxRepoSettingsPage } from './pages/sandbox-repo-settings-page'
-import { RepoSettingsGeneralPage } from './pages/repo-settings-general-page'
+import { RepoSettingsGeneralPlaygroundContainer } from './pages/repo-settings-general-page-playground-container'
 import { RepoSettingsCollaborationsPage } from './pages/repo-settings-collaborations-page'
 import { RepoSettingsModerationPage } from './pages/repo-settings-moderation-page'
 import { RepoSettingsPlaceholderPage } from './pages/repo-settings-placeholder-page'
@@ -64,6 +64,7 @@ import SandboxPullRequestComparePage from './pages/sandbox-pull-request-compare-
 import { mockBypassUserData, mockStatusChecks } from './pages/mocks/repo-branch-settings/mockData'
 import { BypassUsersList } from './components/repo-settings/repo-branch-settings-rules/types'
 import { currentUser } from './pages/mocks/mockCurrentUserData'
+import { mockRepoData } from './pages/mocks/repo-settings/mockRepoData'
 
 const router = createBrowserRouter([
   // TEMPORARY LAYOUT SANDBOX
@@ -110,7 +111,8 @@ const router = createBrowserRouter([
                   },
                   {
                     path: 'general',
-                    element: <RepoSettingsGeneralPage />
+                    // element: <RepoSettingsGeneralPage repoData={mockRepoData} />
+                    element: <RepoSettingsGeneralPlaygroundContainer />
                   },
                   {
                     path: 'collaborations',

--- a/packages/playground/src/components/alert-delete-dialog-form.tsx
+++ b/packages/playground/src/components/alert-delete-dialog-form.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { Button, Input, Icon, ButtonGroup } from '@harnessio/canary'
+import { FormFieldSet } from '../index'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+
+const alertDeleteSchema = z.object({
+  verification: z.string().min(1, { message: 'To confirm, please type "DELETE".' })
+})
+
+type AlertDeleteFormFields = z.infer<typeof alertDeleteSchema>
+
+interface FormProjDeleteProps {
+  isLoading: boolean
+  error: string | null
+  deleteFn: (identifier: string) => void
+  onClose?: () => void
+  type: string
+  identifier: string
+}
+export const AlertDeleteDialogForm = ({
+  isLoading,
+  error,
+  deleteFn,
+  onClose,
+  type,
+  identifier
+}: FormProjDeleteProps) => {
+  const {
+    register,
+    formState: { errors },
+    watch
+  } = useForm<AlertDeleteFormFields>({
+    resolver: zodResolver(alertDeleteSchema)
+  })
+
+  const verification = watch('verification')
+
+  const handleDelete = () => {
+    if (verification === 'DELETE') deleteFn(identifier!)
+  }
+
+  return (
+    <FormFieldSet.Root className="mb-0">
+      <FormFieldSet.ControlGroup>
+        <FormFieldSet.Label htmlFor="verification" required>
+          To confirm, type “DELETE”
+        </FormFieldSet.Label>
+        <Input id="verification" {...register('verification')} placeholder="" />
+        {error && <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>{error}</FormFieldSet.Message>}
+        <ButtonGroup.Root className="justify-end mt-4">
+          <Button variant="outline" onClick={onClose} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button
+            size="default"
+            theme="error"
+            className="self-start"
+            variant="destructive"
+            disabled={isLoading || verification != 'DELETE'}
+            onClick={handleDelete}>
+            {isLoading ? `Deleting ${type}...` : `Yes, delete ${type}`}
+          </Button>
+        </ButtonGroup.Root>
+      </FormFieldSet.ControlGroup>
+    </FormFieldSet.Root>
+  )
+}

--- a/packages/playground/src/components/alert-delete-dialog-form.tsx
+++ b/packages/playground/src/components/alert-delete-dialog-form.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Input, Icon, ButtonGroup } from '@harnessio/canary'
+import { Button, Input, ButtonGroup } from '@harnessio/canary'
 import { FormFieldSet } from '../index'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -48,6 +48,11 @@ export const AlertDeleteDialogForm = ({
           To confirm, type “DELETE”
         </FormFieldSet.Label>
         <Input id="verification" {...register('verification')} placeholder="" />
+        {errors.verification && (
+          <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>
+            {errors.verification.message?.toString()}
+          </FormFieldSet.Message>
+        )}
         {error && <FormFieldSet.Message theme={FormFieldSet.MessageTheme.ERROR}>{error}</FormFieldSet.Message>}
         <ButtonGroup.Root className="justify-end mt-4">
           <Button variant="outline" onClick={onClose} disabled={isLoading}>

--- a/packages/playground/src/components/alert-delete-dialog.tsx
+++ b/packages/playground/src/components/alert-delete-dialog.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+import React from 'react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription
+} from '@harnessio/canary'
+import { AlertDeleteDialogForm } from './alert-delete-dialog-form'
+
+interface AlertDeleteDialogProps {
+  open: boolean
+  onOpenChange: () => void
+  handleDeleteRepository: (identifier: string) => void
+  identifier: string
+  isDeletingRepo: boolean
+  error: string | null
+  type: string
+}
+export const AlertDeleteDialog: React.FC<AlertDeleteDialogProps> = ({
+  open,
+  onOpenChange,
+  handleDeleteRepository,
+  identifier,
+  isDeletingRepo,
+  error,
+  type
+}) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader className="text-left">
+          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete your Repository and remove all data. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDeleteDialogForm
+          deleteFn={handleDeleteRepository}
+          identifier={identifier}
+          onClose={onOpenChange}
+          isLoading={isDeletingRepo}
+          error={error}
+          type={type}
+        />
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/packages/playground/src/components/alert-delete-dialog.tsx
+++ b/packages/playground/src/components/alert-delete-dialog.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import React from 'react'
 import {
   AlertDialog,

--- a/packages/playground/src/components/alert-delete-dialog.tsx
+++ b/packages/playground/src/components/alert-delete-dialog.tsx
@@ -32,7 +32,7 @@ export const AlertDeleteDialog: React.FC<AlertDeleteDialogProps> = ({
         <AlertDialogHeader className="text-left">
           <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
           <AlertDialogDescription>
-            This will permanently delete your Repository and remove all data. This action cannot be undone.
+            This will permanently delete your {type} and remove all data. This action cannot be undone.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDeleteDialogForm

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-delete.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-delete.tsx
@@ -5,7 +5,7 @@ import { ErrorTypes } from './types'
 export const RepoSettingsGeneralDelete: React.FC<{
   isLoading?: boolean
   apiError: { type: ErrorTypes; message: string } | null
-  openRepoAlertDeleteDialog: (identifier: string) => void
+  openRepoAlertDeleteDialog: () => void
 }> = ({ openRepoAlertDeleteDialog, apiError }) => {
   return (
     <>
@@ -27,7 +27,7 @@ export const RepoSettingsGeneralDelete: React.FC<{
 
       <ButtonGroup.Root>
         <>
-          <Button type="submit" size="sm" theme="error" onClick={() => openRepoAlertDeleteDialog('')}>
+          <Button type="submit" size="sm" theme="error" onClick={() => openRepoAlertDeleteDialog()}>
             Delete repository
           </Button>
         </>

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-delete.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-delete.tsx
@@ -4,10 +4,9 @@ import { ErrorTypes } from './types'
 
 export const RepoSettingsGeneralDelete: React.FC<{
   isLoading?: boolean
-  handleDeleteRepository: () => void
   apiError: { type: ErrorTypes; message: string } | null
-  isDeletingRepo: boolean
-}> = ({ handleDeleteRepository, apiError, isDeletingRepo }) => {
+  openRepoAlertDeleteDialog: (identifier: string) => void
+}> = ({ openRepoAlertDeleteDialog, apiError }) => {
   return (
     <>
       <Text size={4} weight="medium">
@@ -28,8 +27,8 @@ export const RepoSettingsGeneralDelete: React.FC<{
 
       <ButtonGroup.Root>
         <>
-          <Button type="submit" size="sm" disabled={isDeletingRepo} theme="error" onClick={handleDeleteRepository}>
-            {!isDeletingRepo ? 'Delete repository' : 'Deleting repository...'}
+          <Button type="submit" size="sm" theme="error" onClick={() => openRepoAlertDeleteDialog('')}>
+            Delete repository
           </Button>
         </>
       </ButtonGroup.Root>

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-delete.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-delete.tsx
@@ -27,7 +27,7 @@ export const RepoSettingsGeneralDelete: React.FC<{
 
       <ButtonGroup.Root>
         <>
-          <Button type="submit" size="sm" theme="error" onClick={() => openRepoAlertDeleteDialog()}>
+          <Button type="submit" size="sm" theme="error" onClick={openRepoAlertDeleteDialog}>
             Delete repository
           </Button>
         </>

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-form.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-form.tsx
@@ -106,6 +106,9 @@ export const RepoSettingsGeneralForm: React.FC<{
 
   return (
     <>
+      <Text size={5} weight={'medium'}>
+        Settings
+      </Text>
       <Text size={4} weight="medium">
         General settings
       </Text>

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
@@ -47,12 +47,12 @@ export const RepoSettingsGeneralRules = ({
   rules,
   apiError,
   handleRuleClick,
-  handleDeleteRule
+  openRulesAlertDeleteDialog
 }: {
   rules: RuleDataType[] | null
   apiError: { type: ErrorTypes; message: string } | null
   handleRuleClick: (identifier: string) => void
-  handleDeleteRule: (identifier: string) => void
+  openRulesAlertDeleteDialog: (identifier: string) => void
 }) => {
   return (
     <>
@@ -66,9 +66,9 @@ export const RepoSettingsGeneralRules = ({
               <SearchBox.Root placeholder="Search" />
             </ListActions.Left>
             <ListActions.Right>
-              <Button variant="outline">
-                <NavLink to="../rules">New branch rule</NavLink>
-              </Button>
+              <NavLink to="../rules">
+                <Button variant="outline">New branch rule</Button>
+              </NavLink>
             </ListActions.Right>
           </ListActions.Root>
 
@@ -96,7 +96,7 @@ export const RepoSettingsGeneralRules = ({
                   title={
                     <RepoSettingsToolTip
                       onEdit={handleRuleClick}
-                      onDelete={handleDeleteRule}
+                      onDelete={openRulesAlertDeleteDialog}
                       identifier={rule.identifier ?? ''}
                     />
                   }

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
@@ -4,7 +4,7 @@ import { Button, ListActions, SearchBox, Icon, Text, StackedList, Spacer } from 
 import { RepoSettingsToolTip } from './repo-settings-general-tooltip'
 import { NoData } from '../../no-data'
 import { NavLink } from 'react-router-dom'
-const Title = ({ title, iconName }: { title: string | undefined; iconName: 'green-tick' | 'cancel-grey' }) => {
+const Title = ({ title, iconName }: { title?: string; iconName: 'green-tick' | 'cancel-grey' }) => {
   return (
     <div className="flex gap-2 items-center">
       {<Icon name={iconName} />}

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { RuleDataType, ErrorTypes } from './types'
 import { Button, ListActions, SearchBox, Icon, Text, StackedList, Spacer } from '@harnessio/canary'
 import { RepoSettingsToolTip } from './repo-settings-general-tooltip'
+import { NoData } from '../../no-data'
+import { NavLink } from 'react-router-dom'
 const Title = ({ title, iconName }: { title: string | undefined; iconName: 'green-tick' | 'cancel-grey' }) => {
   return (
     <div className="flex gap-2 items-center">
@@ -54,25 +56,26 @@ export const RepoSettingsGeneralRules = ({
 }) => {
   return (
     <>
-      <Text size={4} weight="medium">
-        Rules
-      </Text>
-      <ListActions.Root>
-        <ListActions.Left>
-          <SearchBox.Root placeholder="Search" />
-        </ListActions.Left>
-        <ListActions.Right>
-          <Button variant="outline" onClick={() => {}}>
-            New branch rule
-          </Button>
-        </ListActions.Right>
-      </ListActions.Root>
-      {/* <Spacer size={6} /> */}
+      {rules && rules.length > 0 ? (
+        <>
+          <Text size={4} weight="medium">
+            Rules
+          </Text>
+          <ListActions.Root>
+            <ListActions.Left>
+              <SearchBox.Root placeholder="Search" />
+            </ListActions.Left>
+            <ListActions.Right>
+              <Button variant="outline">
+                <NavLink to="../rules">New branch rule</NavLink>
+              </Button>
+            </ListActions.Right>
+          </ListActions.Root>
 
-      <StackedList.Root>
-        {rules &&
-          rules.map(rule => {
-            return (
+          {/* <Spacer size={6} /> */}
+
+          <StackedList.Root>
+            {rules.map(rule => (
               <StackedList.Item key={rule.identifier} onClick={() => handleRuleClick(rule.identifier ?? '')}>
                 <StackedList.Field
                   title={
@@ -85,35 +88,41 @@ export const RepoSettingsGeneralRules = ({
                       bypassAllowed={rule.bypassAllowed ?? false}
                     />
                   }
+                  className="gap-0"
                 />
                 <StackedList.Field
                   label
                   secondary
                   title={
-                    // <div className="flex gap-1.5 items-center justify-end">
-                    //   <Icon name="vertical-ellipsis" size={14} className="text-tertiary-background" />
-                    // </div>
                     <RepoSettingsToolTip
                       onEdit={handleRuleClick}
                       onDelete={handleDeleteRule}
-                      identifier={rule.identifier}
+                      identifier={rule.identifier ?? ''}
                     />
                   }
                   right
                 />
               </StackedList.Item>
-            )
-          })}
+            ))}
 
-        {apiError && (apiError.type === ErrorTypes.FETCH_RULES || apiError.type === ErrorTypes.DELETE_RULE) && (
-          <>
-            <Spacer size={2} />
-            <Text size={1} className="text-destructive">
-              {apiError.message}
-            </Text>
-          </>
-        )}
-      </StackedList.Root>
+            {apiError && (apiError.type === ErrorTypes.FETCH_RULES || apiError.type === ErrorTypes.DELETE_RULE) && (
+              <>
+                <Spacer size={2} />
+                <Text size={1} className="text-destructive">
+                  {apiError.message}
+                </Text>
+              </>
+            )}
+          </StackedList.Root>
+        </>
+      ) : (
+        <NoData
+          iconName="no-data-folder"
+          title="No rules yet"
+          description={['There are no rules in this repository yet.']}
+          primaryButton={{ label: 'Create rule', to: '../rules' }}
+        />
+      )}
     </>
   )
 }

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
@@ -61,18 +61,20 @@ export const RepoSettingsGeneralRules = ({
           <Text size={4} weight="medium">
             Rules
           </Text>
+          <Spacer size={6} />
+
           <ListActions.Root>
             <ListActions.Left>
               <SearchBox.Root placeholder="Search" />
             </ListActions.Left>
             <ListActions.Right>
-              <NavLink to="../rules">
+              <NavLink to="../rules/create">
                 <Button variant="outline">New branch rule</Button>
               </NavLink>
             </ListActions.Right>
           </ListActions.Root>
 
-          {/* <Spacer size={6} /> */}
+          <Spacer size={6} />
 
           <StackedList.Root>
             {rules.map(rule => (
@@ -120,7 +122,7 @@ export const RepoSettingsGeneralRules = ({
           iconName="no-data-folder"
           title="No rules yet"
           description={['There are no rules in this repository yet.']}
-          primaryButton={{ label: 'Create rule', to: '../rules' }}
+          primaryButton={{ label: 'Create rule', to: '../rules/create' }}
         />
       )}
     </>

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
@@ -44,11 +44,13 @@ const Description = ({
 export const RepoSettingsGeneralRules = ({
   rules,
   apiError,
-  handleRuleClick
+  handleRuleClick,
+  handleDeleteRule
 }: {
   rules: RuleDataType[] | null
   apiError: { type: ErrorTypes; message: string } | null
   handleRuleClick: (identifier: string) => void
+  handleDeleteRule: (identifier: string) => void
 }) => {
   return (
     <>
@@ -91,7 +93,11 @@ export const RepoSettingsGeneralRules = ({
                     // <div className="flex gap-1.5 items-center justify-end">
                     //   <Icon name="vertical-ellipsis" size={14} className="text-tertiary-background" />
                     // </div>
-                    <RepoSettingsToolTip onEdit={handleRuleClick} identifier={rule.identifier} />
+                    <RepoSettingsToolTip
+                      onEdit={handleRuleClick}
+                      onDelete={handleDeleteRule}
+                      identifier={rule.identifier}
+                    />
                   }
                   right
                 />
@@ -99,7 +105,7 @@ export const RepoSettingsGeneralRules = ({
             )
           })}
 
-        {apiError && apiError.type === ErrorTypes.FETCH_RULES && (
+        {apiError && (apiError.type === ErrorTypes.FETCH_RULES || apiError.type === ErrorTypes.DELETE_RULE) && (
           <>
             <Spacer size={2} />
             <Text size={1} className="text-destructive">

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-rules.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { RuleDataType, ErrorTypes } from './types'
 import { Button, ListActions, SearchBox, Icon, Text, StackedList, Spacer } from '@harnessio/canary'
-
+import { RepoSettingsToolTip } from './repo-settings-general-tooltip'
 const Title = ({ title, iconName }: { title: string | undefined; iconName: 'green-tick' | 'cancel-grey' }) => {
   return (
     <div className="flex gap-2 items-center">
@@ -88,9 +88,10 @@ export const RepoSettingsGeneralRules = ({
                   label
                   secondary
                   title={
-                    <div className="flex gap-1.5 items-center justify-end">
-                      <Icon name="vertical-ellipsis" size={14} className="text-tertiary-background" />
-                    </div>
+                    // <div className="flex gap-1.5 items-center justify-end">
+                    //   <Icon name="vertical-ellipsis" size={14} className="text-tertiary-background" />
+                    // </div>
+                    <RepoSettingsToolTip onEdit={handleRuleClick} identifier={rule.identifier} />
                   }
                   right
                 />

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-tooltip.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-tooltip.tsx
@@ -11,7 +11,15 @@ import {
   DropdownMenuGroup
 } from '@harnessio/canary'
 
-export const RepoSettingsToolTip = ({ handleRuleClick, identifier }: {}) => {
+export const RepoSettingsToolTip = ({
+  onEdit,
+  identifier,
+  onDelete
+}: {
+  onEdit: (identifier: string) => void
+  identifier: string
+  onDelete: (identifier: string) => void
+}) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -21,7 +29,12 @@ export const RepoSettingsToolTip = ({ handleRuleClick, identifier }: {}) => {
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         <DropdownMenuGroup>
-          <DropdownMenuItem className="cursor-pointer" onSelect={() => handleRuleClick(identifier)}>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={e => {
+              e.stopPropagation()
+              onEdit(identifier)
+            }}>
             <DropdownMenuShortcut className="ml-0">
               <Icon name="edit-pen" className="mr-2" />
             </DropdownMenuShortcut>
@@ -30,8 +43,10 @@ export const RepoSettingsToolTip = ({ handleRuleClick, identifier }: {}) => {
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="cursor-pointer text-destructive"
-            // onSelect={() => onDelete(member)}
-          >
+            onClick={e => {
+              e.stopPropagation()
+              onDelete(identifier)
+            }}>
             <DropdownMenuShortcut className="ml-0">
               <Icon name="trash" className="mr-2 text-destructive" />
             </DropdownMenuShortcut>

--- a/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-tooltip.tsx
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/repo-settings-general-tooltip.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuShortcut,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  Icon,
+  Button,
+  DropdownMenuGroup
+} from '@harnessio/canary'
+
+export const RepoSettingsToolTip = ({ handleRuleClick, identifier }: {}) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="xs">
+          <Icon name="vertical-ellipsis" size={14} className="text-tertiary-background cursor-pointer" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuGroup>
+          <DropdownMenuItem className="cursor-pointer" onSelect={() => handleRuleClick(identifier)}>
+            <DropdownMenuShortcut className="ml-0">
+              <Icon name="edit-pen" className="mr-2" />
+            </DropdownMenuShortcut>
+            Edit rule
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="cursor-pointer text-destructive"
+            // onSelect={() => onDelete(member)}
+          >
+            <DropdownMenuShortcut className="ml-0">
+              <Icon name="trash" className="mr-2 text-destructive" />
+            </DropdownMenuShortcut>
+            Delete rule
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/packages/playground/src/components/repo-settings/repo-settings-general/types.ts
+++ b/packages/playground/src/components/repo-settings/repo-settings-general/types.ts
@@ -24,7 +24,8 @@ export enum ErrorTypes {
   FETCH_SECURITY = 'fetchSecurity',
   UPDATE_SECURITY = 'updateSecurity',
   DELETE_REPO = 'deleteRepo',
-  FETCH_RULES = 'fetchRules'
+  FETCH_RULES = 'fetchRules',
+  DELETE_RULE = 'deleteRule'
 }
 export interface RepoUpdateData {
   name: string

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -73,6 +73,7 @@ export * from './components/project-settings/members-list'
 export * from './components/filter'
 export * from './components/copy-button'
 export * from './components/profile-settings/delete-alert-dialog'
+export * from './components/alert-delete-dialog'
 
 export * from './pages/signin-page'
 export * from './pages/forgot-password-page'

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -112,6 +112,7 @@ export * from './pages/repo-branch-settings-rules-page'
 export * from './components/repo-settings/repo-branch-settings-rules/types'
 
 export * from './pages/sandbox-repo-create-page'
+export * from './pages/repo-settings-placeholder-page'
 
 export * from './layouts/SandboxPullRequestCompareLayout'
 

--- a/packages/playground/src/pages/mocks/repo-settings/mockRepoData.ts
+++ b/packages/playground/src/pages/mocks/repo-settings/mockRepoData.ts
@@ -1,0 +1,13 @@
+import { RepoData } from '../../../index'
+
+export const mockRepoData: RepoData = {
+  name: 'uuid',
+  description: 'optimistic updates',
+  defaultBranch: 'master',
+  isPublic: false,
+  branches: [
+    { name: 'main', sha: 'sha2576836394e3' },
+    { name: 'feature-branch-1', sha: 'sha38749348752' },
+    { name: 'feature-branch-2', sha: 'sha981e7543832' }
+  ]
+}

--- a/packages/playground/src/pages/mocks/repo-settings/mockRulesData.ts
+++ b/packages/playground/src/pages/mocks/repo-settings/mockRulesData.ts
@@ -1,0 +1,70 @@
+export const branchRules = [
+  {
+    created: 1730068869877,
+    updated: 1730068869877,
+    identifier: 'rule-1',
+    description: 'desc-1',
+    type: 'branch',
+    state: 'active',
+    pattern: {},
+    definition: {
+      bypass: {},
+      pullreq: {
+        approvals: {
+          require_code_owners: true
+        },
+        comments: {},
+        status_checks: {
+          require_uids: null
+        },
+        merge: {}
+      },
+      lifecycle: {}
+    },
+    created_by: {
+      id: 5,
+      uid: 'sanskar-sehgal',
+      display_name: 'sans',
+      email: 'sanskar.sehgal@harness.io',
+      type: 'user',
+      created: 1728591847687,
+      updated: 1729710072769
+    },
+    users: {},
+    uid: 'rule-1'
+  },
+  {
+    created: 1730068877284,
+    updated: 1730068877284,
+    identifier: 'rule-2',
+    description: 'desc-2',
+    type: 'branch',
+    state: 'active',
+    pattern: {},
+    definition: {
+      bypass: {},
+      pullreq: {
+        approvals: {
+          require_code_owners: true
+        },
+        comments: {},
+        status_checks: {
+          require_uids: null
+        },
+        merge: {}
+      },
+      lifecycle: {}
+    },
+    created_by: {
+      id: 5,
+      uid: 'sanskar-sehgal',
+      display_name: 'sans',
+      email: 'sanskar.sehgal@harness.io',
+      type: 'user',
+      created: 1728591847687,
+      updated: 1729710072769
+    },
+    users: {},
+    uid: 'rule-2'
+  }
+]

--- a/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
+++ b/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
@@ -112,6 +112,9 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
   }, [preSetRuleData])
   return (
     <>
+      <Text size={5} weight="medium" as="div" className="mb-8">
+        Create a rule
+      </Text>
       <form onSubmit={handleSubmit(onSubmit)}>
         <FormFieldSet.Root>
           <BranchSettingsRuleToggleField register={register} setValue={setValue} watch={watch} />

--- a/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
+++ b/packages/playground/src/pages/repo-branch-settings-rules-page.tsx
@@ -21,6 +21,7 @@ import {
   ActionType,
   MergeStrategy
 } from '../components/repo-settings/repo-branch-settings-rules/types'
+import { NavLink } from 'react-router-dom'
 
 type BranchSettingsErrors = {
   principals: string | null
@@ -159,7 +160,7 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
                       {!isLoading ? 'Create rule' : 'Creating rule...'}
                     </Button>
                     <Button type="button" variant="outline" size="sm">
-                      Cancel
+                      <NavLink to="../general">Cancel</NavLink>
                     </Button>
                   </>
                 ) : (
@@ -168,7 +169,7 @@ export const RepoBranchSettingsRulesPage: React.FC<RepoBranchSettingsRulesPagePr
                       {!isLoading ? 'Update rule' : 'Updating rule...'}
                     </Button>
                     <Button type="button" variant="outline" size="sm">
-                      Cancel
+                      <NavLink to="../general">Cancel</NavLink>
                     </Button>
                   </>
                 )}

--- a/packages/playground/src/pages/repo-settings-general-page-playground-container.tsx
+++ b/packages/playground/src/pages/repo-settings-general-page-playground-container.tsx
@@ -1,0 +1,30 @@
+import { RepoSettingsGeneralPage } from './repo-settings-general-page'
+import { mockRepoData } from './mocks/repo-settings/mockRepoData'
+import { noop } from 'lodash-es'
+import { branchRules } from './mocks/repo-settings/mockRulesData'
+import React from 'react'
+export const RepoSettingsGeneralPlaygroundContainer = () => {
+  const loadingStates = {
+    isLoadingRepoData: false,
+    isUpdatingRepoData: false,
+    isLoadingSecuritySettings: false,
+    isUpdatingSecuritySettings: false
+  }
+  return (
+    <>
+      <RepoSettingsGeneralPage
+        repoData={mockRepoData}
+        handleRepoUpdate={noop}
+        securityScanning={false}
+        handleUpdateSecuritySettings={noop}
+        apiError={null}
+        loadingStates={loadingStates}
+        isRepoUpdateSuccess={false}
+        rules={branchRules}
+        handleRuleClick={noop}
+        openRulesAlertDeleteDialog={noop}
+        openRepoAlertDeleteDialog={noop}
+      />
+    </>
+  )
+}

--- a/packages/playground/src/pages/repo-settings-general-page.tsx
+++ b/packages/playground/src/pages/repo-settings-general-page.tsx
@@ -16,7 +16,6 @@ interface ILoadingStates {
   isLoadingRepoData: boolean
   isUpdatingRepoData: boolean
   isLoadingSecuritySettings: boolean
-  isDeletingRepo: boolean
   isUpdatingSecuritySettings: boolean
 }
 interface RepoSettingsGeneralPageProps {
@@ -24,26 +23,26 @@ interface RepoSettingsGeneralPageProps {
   securityScanning: boolean
   handleUpdateSecuritySettings: (data: RepoSettingsSecurityFormFields) => void
   handleRepoUpdate: (data: RepoUpdateData) => void
-  handleDeleteRepository: () => void
   apiError: { type: ErrorTypes; message: string } | null
   loadingStates: ILoadingStates
   isRepoUpdateSuccess: boolean
   rules: RuleDataType[] | null
   handleRuleClick: (identifier: string) => void
-  handleDeleteRule: (identifier: string) => void
+  openRulesAlertDeleteDialog: (identifier: string) => void
+  openRepoAlertDeleteDialog: (identifier: string) => void
 }
 const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
   repoData,
   handleRepoUpdate,
   securityScanning,
   handleUpdateSecuritySettings,
-  handleDeleteRepository,
   apiError,
   loadingStates,
   isRepoUpdateSuccess,
   rules,
   handleRuleClick,
-  handleDeleteRule
+  openRulesAlertDeleteDialog,
+  openRepoAlertDeleteDialog
 }) => {
   return (
     <>
@@ -61,7 +60,7 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
           rules={rules}
           apiError={apiError}
           handleRuleClick={handleRuleClick}
-          handleDeleteRule={handleDeleteRule}
+          openRulesAlertDeleteDialog={openRulesAlertDeleteDialog}
         />
         <FormFieldSet.Separator />
         <RepoSettingsSecurityForm
@@ -72,11 +71,7 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
           isLoadingSecuritySettings={loadingStates?.isLoadingSecuritySettings}
         />
         <FormFieldSet.Separator />
-        <RepoSettingsGeneralDelete
-          handleDeleteRepository={handleDeleteRepository}
-          apiError={apiError}
-          isDeletingRepo={loadingStates.isDeletingRepo}
-        />
+        <RepoSettingsGeneralDelete apiError={apiError} openRepoAlertDeleteDialog={openRepoAlertDeleteDialog} />
       </FormFieldSet.Root>
     </>
   )

--- a/packages/playground/src/pages/repo-settings-general-page.tsx
+++ b/packages/playground/src/pages/repo-settings-general-page.tsx
@@ -29,7 +29,7 @@ interface RepoSettingsGeneralPageProps {
   rules: RuleDataType[] | null
   handleRuleClick: (identifier: string) => void
   openRulesAlertDeleteDialog: (identifier: string) => void
-  openRepoAlertDeleteDialog: (identifier: string) => void
+  openRepoAlertDeleteDialog: () => void
 }
 const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
   repoData,

--- a/packages/playground/src/pages/repo-settings-general-page.tsx
+++ b/packages/playground/src/pages/repo-settings-general-page.tsx
@@ -30,6 +30,7 @@ interface RepoSettingsGeneralPageProps {
   isRepoUpdateSuccess: boolean
   rules: RuleDataType[] | null
   handleRuleClick: (identifier: string) => void
+  handleDeleteRule: (identifier: string) => void
 }
 const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
   repoData,
@@ -41,7 +42,8 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
   loadingStates,
   isRepoUpdateSuccess,
   rules,
-  handleRuleClick
+  handleRuleClick,
+  handleDeleteRule
 }) => {
   return (
     <>
@@ -55,7 +57,12 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
           isRepoUpdateSuccess={isRepoUpdateSuccess}
         />
         <FormFieldSet.Separator />
-        <RepoSettingsGeneralRules rules={rules} apiError={apiError} handleRuleClick={handleRuleClick} />
+        <RepoSettingsGeneralRules
+          rules={rules}
+          apiError={apiError}
+          handleRuleClick={handleRuleClick}
+          handleDeleteRule={handleDeleteRule}
+        />
         <FormFieldSet.Separator />
         <RepoSettingsSecurityForm
           securityScanning={securityScanning}

--- a/packages/playground/src/pages/repo-settings-general-page.tsx
+++ b/packages/playground/src/pages/repo-settings-general-page.tsx
@@ -75,7 +75,7 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
           handleUpdateSecuritySettings={handleUpdateSecuritySettings}
           apiError={apiError}
           isUpdatingSecuritySettings={loadingStates.isUpdatingSecuritySettings}
-          isLoadingSecuritySettings={loadingStates?.isLoadingSecuritySettings}
+          isLoadingSecuritySettings={loadingStates.isLoadingSecuritySettings}
         />
         <FormFieldSet.Separator />
         <RepoSettingsGeneralDelete apiError={apiError} openRepoAlertDeleteDialog={openRepoAlertDeleteDialog} />

--- a/packages/playground/src/pages/repo-settings-general-page.tsx
+++ b/packages/playground/src/pages/repo-settings-general-page.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useEffect } from 'react'
 import { FormFieldSet } from '..'
 import { RepoSettingsGeneralForm } from '../components/repo-settings/repo-settings-general/repo-settings-general-form'
 import { RepoSettingsGeneralRules } from '../components/repo-settings/repo-settings-general/repo-settings-general-rules'
@@ -44,6 +44,10 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
   openRulesAlertDeleteDialog,
   openRepoAlertDeleteDialog
 }) => {
+  const rulesRef = useRef<HTMLDivElement | null>(null)
+  if (window.location.pathname.endsWith('/rules')) {
+    rulesRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }
   return (
     <>
       <FormFieldSet.Root>
@@ -56,12 +60,15 @@ const RepoSettingsGeneralPage: React.FC<RepoSettingsGeneralPageProps> = ({
           isRepoUpdateSuccess={isRepoUpdateSuccess}
         />
         <FormFieldSet.Separator />
-        <RepoSettingsGeneralRules
-          rules={rules}
-          apiError={apiError}
-          handleRuleClick={handleRuleClick}
-          openRulesAlertDeleteDialog={openRulesAlertDeleteDialog}
-        />
+        <div ref={rulesRef}>
+          <RepoSettingsGeneralRules
+            rules={rules}
+            apiError={apiError}
+            handleRuleClick={handleRuleClick}
+            openRulesAlertDeleteDialog={openRulesAlertDeleteDialog}
+          />
+        </div>
+
         <FormFieldSet.Separator />
         <RepoSettingsSecurityForm
           securityScanning={securityScanning}

--- a/packages/playground/src/pages/repo-settings-general-page.tsx
+++ b/packages/playground/src/pages/repo-settings-general-page.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useRef } from 'react'
 import { FormFieldSet } from '..'
 import { RepoSettingsGeneralForm } from '../components/repo-settings/repo-settings-general/repo-settings-general-form'
 import { RepoSettingsGeneralRules } from '../components/repo-settings/repo-settings-general/repo-settings-general-rules'

--- a/packages/playground/src/pages/sandbox-repo-settings-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-settings-page.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { PlaygroundListSettings } from '../settings/list-settings'
 import { SandboxLayout } from '../index'
-import { Navbar, Text, Spacer } from '@harnessio/canary'
+import { Navbar, Spacer } from '@harnessio/canary'
 import { NavLink, Outlet } from 'react-router-dom'
 
 const navItems = [
@@ -75,10 +75,7 @@ function SettingsContent() {
   return (
     <SandboxLayout.Content maxWidth="2xl">
       <Spacer size={4} />
-      {/* <Text size={5} weight={'medium'}>
-        Settings
-      </Text> */}
-      {/* <Spacer size={8} /> */}
+
       <Outlet />
     </SandboxLayout.Content>
   )

--- a/packages/playground/src/pages/sandbox-repo-settings-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-settings-page.tsx
@@ -75,10 +75,10 @@ function SettingsContent() {
   return (
     <SandboxLayout.Content maxWidth="2xl">
       <Spacer size={4} />
-      <Text size={5} weight={'medium'}>
+      {/* <Text size={5} weight={'medium'}>
         Settings
-      </Text>
-      <Spacer size={8} />
+      </Text> */}
+      {/* <Spacer size={8} /> */}
       <Outlet />
     </SandboxLayout.Content>
   )


### PR DESCRIPTION
- Introduces `useGetRepoId` to get the repo ID. 
- Creates a completely reusable `Delete Alert` dialog. 
- Adds default file to pages that are not yet implemented. 
- integrates delete repo with the `alert dialog`. 
- Adds drop down menu to repo-rules with options to edit/delete. 
- Adds `no-data` placeholder for rules-list. 
- This should complete our repo/branch rules flow

e2e vid:

https://github.com/user-attachments/assets/ae54f25f-0f68-4879-b824-864a72a510fe

