### PR TITLE
fix singin page

### DIFF
--- a/apps/gitness/src/layouts/RepoLayout.tsx
+++ b/apps/gitness/src/layouts/RepoLayout.tsx
@@ -1,40 +1,42 @@
 import React from 'react'
-import { Tabs, TabsList, TabsTrigger } from '@harnessio/canary'
 import { NavLink, Outlet } from 'react-router-dom'
 import Header from '../components/Header'
 
 const RepoLayout: React.FC = () => {
+  const baseClasses = 'h-full text-center flex items-center'
+
+  const getLinkClasses = (isActive: boolean) =>
+    `${baseClasses} ${isActive ? 'text-primary border-b border-primary' : 'text-tertiary-background hover:text-primary'}`
+
   return (
     <div>
       <Header />
-      <Tabs variant="navigation" defaultValue="summary">
-        <TabsList>
-          <NavLink to={`summary`}>
-            <TabsTrigger value="summary">Summary</TabsTrigger>
-          </NavLink>
-          <NavLink to={`code`}>
-            <TabsTrigger value="code">Files</TabsTrigger>
-          </NavLink>
-          <NavLink to={`pipelines`}>
-            <TabsTrigger value="pipelines">Pipelines</TabsTrigger>
-          </NavLink>
-          <NavLink to={`commits`}>
-            <TabsTrigger value="commits">Commits</TabsTrigger>
-          </NavLink>
-          <NavLink to={`pull-requests`}>
-            <TabsTrigger value="pull-requests">Pull Requests</TabsTrigger>
-          </NavLink>
-          <NavLink to={`webhooks`}>
-            <TabsTrigger value="webhooks">Webhooks</TabsTrigger>
-          </NavLink>
-          <NavLink to={`branches`}>
-            <TabsTrigger value="branches">Branches</TabsTrigger>
-          </NavLink>
-          <NavLink to={`settings`}>
-            <TabsTrigger value="settings">Settings</TabsTrigger>
-          </NavLink>
-        </TabsList>
-      </Tabs>
+      <div className="inline-flex items-center text-muted-foreground h-[44px] border-b border-border-background gap-6 justify-start w-full px-8">
+        <NavLink to="summary" className={({ isActive }) => getLinkClasses(isActive)}>
+          Summary
+        </NavLink>
+        <NavLink to="code" className={({ isActive }) => getLinkClasses(isActive)}>
+          Files
+        </NavLink>
+        <NavLink to="pipelines" className={({ isActive }) => getLinkClasses(isActive)}>
+          Pipelines
+        </NavLink>
+        <NavLink to="commits" className={({ isActive }) => getLinkClasses(isActive)}>
+          Commits
+        </NavLink>
+        <NavLink to="pull-requests" className={({ isActive }) => getLinkClasses(isActive)}>
+          Pull Requests
+        </NavLink>
+        <NavLink to="webhooks" className={({ isActive }) => getLinkClasses(isActive)}>
+          Webhooks
+        </NavLink>
+        <NavLink to="branches" className={({ isActive }) => getLinkClasses(isActive)}>
+          Branches
+        </NavLink>
+        <NavLink to="settings" className={({ isActive }) => getLinkClasses(isActive)}>
+          Settings
+        </NavLink>
+      </div>
       <main className="min-h-[calc(100vh-100px)] box-border overflow-hidden">
         <Outlet />
       </main>

--- a/apps/gitness/src/layouts/RepoSandboxLayout.tsx
+++ b/apps/gitness/src/layouts/RepoSandboxLayout.tsx
@@ -1,42 +1,42 @@
 import React from 'react'
-import { Tabs, TabsList, TabsTrigger } from '@harnessio/canary'
 import { SandboxLayout } from '@harnessio/playground'
 import { NavLink, Outlet } from 'react-router-dom'
 
 const RepoSandboxLayout: React.FC = () => {
+  const baseClasses = 'h-full text-center flex items-center'
+
+  const getLinkClasses = (isActive: boolean) =>
+    `${baseClasses} ${isActive ? 'text-primary border-b border-primary' : 'text-tertiary-background hover:text-primary'}`
+
   return (
     <>
       <SandboxLayout.SubHeader>
-        <Tabs variant="navigation" defaultValue="summary">
-          <TabsList>
-            <NavLink to={`summary`}>
-              <TabsTrigger value="summary">Summary</TabsTrigger>
-            </NavLink>
-            <NavLink to={`code`}>
-              <TabsTrigger value="code">Files</TabsTrigger>
-            </NavLink>
-            <NavLink to={`pipelines`}>
-              <TabsTrigger value="pipelines">Pipelines</TabsTrigger>
-            </NavLink>
-            <NavLink to={`commits`}>
-              <TabsTrigger value="commits">Commits</TabsTrigger>
-            </NavLink>
-            <NavLink to={`pull-requests`}>
-              <TabsTrigger value="pull-requests">Pull Requests</TabsTrigger>
-            </NavLink>
-            <NavLink to={`webhooks`}>
-              <TabsTrigger value="webhooks">Webhooks</TabsTrigger>
-            </NavLink>
-            <NavLink to={`branches`}>
-              <TabsTrigger value="branches">Branches</TabsTrigger>
-            </NavLink>
-            <NavLink to={`settings`}>
-              <TabsTrigger value="settings">Settings</TabsTrigger>
-            </NavLink>
-          </TabsList>
-        </Tabs>
-        {/* <main className="min-h-[calc(100vh-100px)] box-border overflow-hidden"> */}
-        {/* </main> */}
+        <div className="inline-flex items-center text-muted-foreground h-[44px] border-b border-border-background gap-6 justify-start w-full px-8">
+          <NavLink to="summary" className={({ isActive }) => getLinkClasses(isActive)}>
+            Summary
+          </NavLink>
+          <NavLink to="code" className={({ isActive }) => getLinkClasses(isActive)}>
+            Files
+          </NavLink>
+          <NavLink to="pipelines" className={({ isActive }) => getLinkClasses(isActive)}>
+            Pipelines
+          </NavLink>
+          <NavLink to="commits" className={({ isActive }) => getLinkClasses(isActive)}>
+            Commits
+          </NavLink>
+          <NavLink to="pull-requests" className={({ isActive }) => getLinkClasses(isActive)}>
+            Pull Requests
+          </NavLink>
+          <NavLink to="webhooks" className={({ isActive }) => getLinkClasses(isActive)}>
+            Webhooks
+          </NavLink>
+          <NavLink to="branches" className={({ isActive }) => getLinkClasses(isActive)}>
+            Branches
+          </NavLink>
+          <NavLink to="settings" className={({ isActive }) => getLinkClasses(isActive)}>
+            Settings
+          </NavLink>
+        </div>
       </SandboxLayout.SubHeader>
       <Outlet />
     </>

--- a/packages/playground/src/pages/signin-page.tsx
+++ b/packages/playground/src/pages/signin-page.tsx
@@ -82,11 +82,6 @@ export function SignInPage({ handleSignIn, isLoading }: PageProps) {
               <Label htmlFor="password" variant="sm">
                 Password
               </Label>
-              <Link to="/forgot">
-                <Button variant="link" size="xs" className="text-secondary-muted" type="button">
-                  Forgot password?
-                </Button>
-              </Link>
             </div>
             <Spacer size={1} />
             <Input

--- a/packages/playground/src/pages/signin-page.tsx
+++ b/packages/playground/src/pages/signin-page.tsx
@@ -1,17 +1,5 @@
 import React from 'react'
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  Button,
-  Input,
-  Label,
-  Icon,
-  Text,
-  Spacer,
-  Dock
-} from '@harnessio/canary'
+import { Card, CardContent, CardHeader, CardTitle, Button, Input, Label, Icon, Text, Spacer } from '@harnessio/canary'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'

--- a/packages/playground/src/pages/signin-page.tsx
+++ b/packages/playground/src/pages/signin-page.tsx
@@ -112,15 +112,11 @@ export function SignInPage({ handleSignIn, isLoading }: PageProps) {
           </Text>
         </CardContent>
       </Card>
-      {/* <Dock.Root> */}
-      {/* <div className="-0"> */}
+
       <Text size={1} color="tertiaryBackground">
         By joining, you agree to <a className="text-primary">Terms of Service</a> and{' '}
         <a className="text-primary">Privacy Policy</a>
       </Text>
-      {/* </div> */}
-
-      {/* </Dock.Root> */}
     </Floating1ColumnLayout>
   )
 }

--- a/packages/playground/src/pages/signin-page.tsx
+++ b/packages/playground/src/pages/signin-page.tsx
@@ -47,7 +47,7 @@ export function SignInPage({ handleSignIn, isLoading }: PageProps) {
   }
 
   return (
-    <Floating1ColumnLayout maxWidth="md" verticalCenter>
+    <Floating1ColumnLayout maxWidth="md" verticalCenter className="flex-col">
       <Card variant="plain" width="full">
         <CardHeader>
           <CardTitle className="flex flex-col place-items-center">
@@ -112,12 +112,15 @@ export function SignInPage({ handleSignIn, isLoading }: PageProps) {
           </Text>
         </CardContent>
       </Card>
-      <Dock.Root>
-        <Text size={1} color="tertiaryBackground">
-          By joining, you agree to <a className="text-primary">Terms of Service</a> and{' '}
-          <a className="text-primary">Privacy Policy</a>
-        </Text>
-      </Dock.Root>
+      {/* <Dock.Root> */}
+      {/* <div className="-0"> */}
+      <Text size={1} color="tertiaryBackground">
+        By joining, you agree to <a className="text-primary">Terms of Service</a> and{' '}
+        <a className="text-primary">Privacy Policy</a>
+      </Text>
+      {/* </div> */}
+
+      {/* </Dock.Root> */}
     </Floating1ColumnLayout>
   )
 }


### PR DESCRIPTION
- Removes forgot password link from `signin`. 
- Takes 3 tabs to move to `signin`. 
- TnC no longer overlaps with the `singin` component. 
-  Also fixes tab nav. Uses `isActive` from `Navlink`. Persists on refresh. 


3 tabs to signin - 


https://github.com/user-attachments/assets/e1d82054-cd67-46bb-8a72-2489519260c9

No overlap-

https://github.com/user-attachments/assets/a48ca12d-a85c-4eb3-807b-fe5ec42aa9dd




New tab-nav -


https://github.com/user-attachments/assets/af244d60-3361-4ef4-b08e-038f9c970c92



