### PR TITLE
feat: delay showing loader for small duration

### DIFF
--- a/packages/playground/src/components/loaders/skeleton-list.tsx
+++ b/packages/playground/src/components/loaders/skeleton-list.tsx
@@ -8,25 +8,28 @@ const getRandomPercentageWidth = (min: number, max: number) => `${Math.floor(Mat
 const getRandomPixelWidth = (min: number, max: number) => `${Math.floor(Math.random() * (max - min + 1)) + min}px`
 
 interface SkeletonListProps {
-  delay?: number
+  className?: string
 }
 
-export const SkeletonList = ({ delay = 300 }: SkeletonListProps) => {
+export const SkeletonList = ({ className }: SkeletonListProps) => {
   const listItems = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
-  let startDelayTimer: number
+  // do a first render with visible=false
   const [visible, setVisible] = useState(false)
+  // immediately re-render with visible=true to trigger the transition delay
   useEffect(() => {
-    startDelayTimer = setTimeout(() => {
-      setVisible(true)
-    }, delay)
-    return () => {
-      clearTimeout(startDelayTimer)
-    }
+    setVisible(true)
   }, [])
 
   return (
-    <div className={cn('relative w-full h-full transition-opacity', { ['opacity-0']: !visible })}>
+    <div
+      className={cn(
+        'relative w-full h-full transition-opacity duration-500 ease-in-out delay-500',
+        {
+          'opacity-0': !visible
+        },
+        className
+      )}>
       {listItems && listItems.length > 0 && (
         <StackedList.Root>
           {listItems.map((itm, itm_idx) => (

--- a/packages/playground/src/components/loaders/skeleton-list.tsx
+++ b/packages/playground/src/components/loaders/skeleton-list.tsx
@@ -1,5 +1,5 @@
-import { Skeleton, StackedList } from '@harnessio/canary'
-import React from 'react'
+import { cn, Skeleton, StackedList } from '@harnessio/canary'
+import React, { useEffect, useState } from 'react'
 
 // Helper function to generate random percentage width within a range
 const getRandomPercentageWidth = (min: number, max: number) => `${Math.floor(Math.random() * (max - min + 1)) + min}%`
@@ -7,11 +7,26 @@ const getRandomPercentageWidth = (min: number, max: number) => `${Math.floor(Mat
 // Helper function to generate random pixel width within a range
 const getRandomPixelWidth = (min: number, max: number) => `${Math.floor(Math.random() * (max - min + 1)) + min}px`
 
-export const SkeletonList = () => {
+interface SkeletonListProps {
+  delay?: number
+}
+
+export const SkeletonList = ({ delay = 100 }: SkeletonListProps) => {
   const listItems = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
+  let startDelayTimer: number
+  const [visible, setVisible] = useState(false)
+  useEffect(() => {
+    startDelayTimer = setTimeout(() => {
+      setVisible(true)
+    }, delay)
+    return () => {
+      clearTimeout(startDelayTimer)
+    }
+  }, [])
+
   return (
-    <div className="relative w-full h-full">
+    <div className={cn('relative w-full h-full', { ['hidden']: !visible })}>
       {listItems && listItems.length > 0 && (
         <StackedList.Root>
           {listItems.map((itm, itm_idx) => (

--- a/packages/playground/src/components/loaders/skeleton-list.tsx
+++ b/packages/playground/src/components/loaders/skeleton-list.tsx
@@ -11,7 +11,7 @@ interface SkeletonListProps {
   delay?: number
 }
 
-export const SkeletonList = ({ delay = 100 }: SkeletonListProps) => {
+export const SkeletonList = ({ delay = 300 }: SkeletonListProps) => {
   const listItems = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
   let startDelayTimer: number
@@ -26,7 +26,7 @@ export const SkeletonList = ({ delay = 100 }: SkeletonListProps) => {
   }, [])
 
   return (
-    <div className={cn('relative w-full h-full', { ['hidden']: !visible })}>
+    <div className={cn('relative w-full h-full transition-opacity', { ['opacity-0']: !visible })}>
       {listItems && listItems.length > 0 && (
         <StackedList.Root>
           {listItems.map((itm, itm_idx) => (


### PR DESCRIPTION
feat: only show skeleton loader if the API is taking longer than a certain time

- add a customisable (default 300ms) delay before showing the skeleton list loader
- fade-in the loader for a smoother experience