### PR TITLE
feat: Add pagination on few more pages, cleanup conditional rendering logic

### DIFF
--- a/apps/gitness/src/pages/execution-list.tsx
+++ b/apps/gitness/src/pages/execution-list.tsx
@@ -30,7 +30,6 @@ export default function ExecutionsListPage() {
   const {
     data: { body: executions, headers } = {},
     isFetching,
-    error,
     isSuccess
   } = useListExecutionsQuery({
     repo_ref: repoRef,
@@ -83,9 +82,6 @@ export default function ExecutionsListPage() {
           />
         </>
       )
-    } else {
-      console.log({ error })
-      return <></>
     }
   }
 

--- a/apps/gitness/src/pages/execution-list.tsx
+++ b/apps/gitness/src/pages/execution-list.tsx
@@ -117,13 +117,11 @@ export default function ExecutionsListPage() {
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />
-        {totalPages > 1 && (
-          <PaginationComponent
-            totalPages={totalPages}
-            currentPage={page}
-            goToPage={(pageNum: number) => setPage(pageNum)}
-          />
-        )}
+        <PaginationComponent
+          totalPages={totalPages}
+          currentPage={page}
+          goToPage={(pageNum: number) => setPage(pageNum)}
+        />
       </PaddingListLayout>
       <RunPipelineDialog
         open={openRunPipeline}

--- a/apps/gitness/src/pages/pipeline-list.tsx
+++ b/apps/gitness/src/pages/pipeline-list.tsx
@@ -107,13 +107,11 @@ export default function PipelinesPage() {
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />
-        {totalPages > 1 && (
-          <PaginationComponent
-            totalPages={totalPages}
-            currentPage={page}
-            goToPage={(pageNum: number) => setPage(pageNum)}
-          />
-        )}
+        <PaginationComponent
+          totalPages={totalPages}
+          currentPage={page}
+          goToPage={(pageNum: number) => setPage(pageNum)}
+        />
       </PaddingListLayout>
     </>
   )

--- a/apps/gitness/src/pages/pipeline-list.tsx
+++ b/apps/gitness/src/pages/pipeline-list.tsx
@@ -27,7 +27,7 @@ export default function PipelinesPage() {
 
   const { data: { body: pipelines, headers } = {}, isFetching } = useListPipelinesQuery({
     repo_ref: repoRef,
-    queryParams: { page, limit: 10, query: query?.trim(), latest: true }
+    queryParams: { page, query, latest: true }
   })
 
   const totalPages = parseInt(headers?.get(PageResponseHeader.xTotalPages) || '')

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-container.tsx
@@ -1,15 +1,12 @@
 import { SandboxSettingsAccountKeysPage } from './profile-settings-keys-page'
 import { useState } from 'react'
 import {
-  useListPublicKeyQuery,
-  ListPublicKeyQueryQueryParams,
   useCreateTokenMutation,
   CreateTokenErrorResponse,
   CreateTokenRequestBody,
   useCreatePublicKeyMutation,
   CreatePublicKeyRequestBody,
   CreatePublicKeyErrorResponse,
-  ListPublicKeyErrorResponse,
   useDeletePublicKeyMutation,
   useDeleteTokenMutation,
   DeleteTokenErrorResponse,
@@ -27,7 +24,7 @@ import { ApiErrorType, AlertDeleteParams } from './types'
 export const SettingsProfileKeysPage = () => {
   const CONVERT_DAYS_TO_NANO_SECONDS = 24 * 60 * 60 * 1000 * 1000000
 
-  const [publicKeys, setPublicKeys] = useState<KeysList[]>([])
+  const [, setPublicKeys] = useState<KeysList[]>([])
   const [tokens, setTokens] = useState<TokensList[]>([])
   const [openCreateTokenDialog, setCreateTokenDialog] = useState(false)
   const [openSuccessTokenDialog, setSuccessTokenDialog] = useState(false)
@@ -62,13 +59,6 @@ export const SettingsProfileKeysPage = () => {
     setAlertParams({ identifier, type })
   }
 
-  const queryParams: ListPublicKeyQueryQueryParams = {
-    page: 1,
-    limit: 30,
-    sort: 'created',
-    order: 'asc'
-  }
-
   useListTokensQuery(
     {},
     {
@@ -80,20 +70,6 @@ export const SettingsProfileKeysPage = () => {
       onError: (error: ListTokensErrorResponse) => {
         const message = error.message || 'An unknown error occurred.'
         setApiError({ type: ApiErrorType.TokenFetch, message: message })
-      }
-    }
-  )
-
-  useListPublicKeyQuery(
-    { queryParams },
-    {
-      onSuccess: ({ body: data }) => {
-        setPublicKeys(data)
-        setApiError(null)
-      },
-      onError: (error: ListPublicKeyErrorResponse) => {
-        const message = error.message || 'An unknown error occurred.'
-        setApiError({ type: ApiErrorType.KeyFetch, message: message })
       }
     }
   )
@@ -200,12 +176,13 @@ export const SettingsProfileKeysPage = () => {
   return (
     <>
       <SandboxSettingsAccountKeysPage
-        publicKeys={publicKeys}
+        setPublicKeys={setPublicKeys}
         tokens={tokens}
         openTokenDialog={openTokenDialog}
         openSshKeyDialog={openSshKeyDialog}
         openAlertDeleteDialog={openAlertDeleteDialog}
         error={apiError}
+        setApiError={setApiError}
       />
       <TokenCreateDialog
         open={openCreateTokenDialog}

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
@@ -7,58 +7,32 @@ import {
   ProfileKeysList,
   KeysList,
   ProfileTokensList,
-  TokensList
+  TokensList,
+  PaginationComponent
 } from '@harnessio/playground'
-import { ListPublicKeyErrorResponse, useListPublicKeyQuery } from '@harnessio/code-service-client'
-import { AlertDeleteParams, ApiErrorType } from './types'
+import { AlertDeleteParams } from './types'
 import { PageResponseHeader } from '../../types'
-import { PaginationComponent } from '../../../../../packages/playground/dist'
 
 interface SandboxSettingsAccountKeysPageProps {
+  publicKeys: KeysList[]
   tokens: TokensList[]
-  setPublicKeys: React.Dispatch<React.SetStateAction<KeysList[]>>
   openTokenDialog: () => void
   openSshKeyDialog: () => void
   openAlertDeleteDialog: (data: AlertDeleteParams) => void
   error: { type: string; message: string } | null
-  setApiError: React.Dispatch<
-    React.SetStateAction<{
-      type: ApiErrorType
-      message: string
-    } | null>
-  >
+  headers?: Headers
 }
 const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPageProps> = ({
+  publicKeys,
   tokens,
-  setPublicKeys,
   openTokenDialog,
   openSshKeyDialog,
   openAlertDeleteDialog,
   error,
-  setApiError
+  headers
 }) => {
   const [page, setPage] = useQueryState('page', parseAsInteger.withDefault(1))
-  const { data: { body: publicKeys = [], headers } = {} } = useListPublicKeyQuery(
-    {
-      queryParams: {
-        page,
-        sort: 'created',
-        order: 'asc'
-      }
-    },
-    {
-      onSuccess: ({ body: data }) => {
-        setPublicKeys(data)
-      },
-      onError: (error: ListPublicKeyErrorResponse) => {
-        const message = error.message || 'An unknown error occurred.'
-        setApiError({ type: ApiErrorType.KeyFetch, message: message })
-      }
-    }
-  )
-
   const totalPages = parseInt(headers?.get(PageResponseHeader.xTotalPages) || '')
-
   return (
     <SandboxLayout.Main hasLeftPanel hasHeader hasSubHeader>
       <SandboxLayout.Content>

--- a/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-keys-page.tsx
@@ -113,13 +113,11 @@ const SandboxSettingsAccountKeysPage: React.FC<SandboxSettingsAccountKeysPagePro
                 {(!error || error.type !== 'keyFetch') && (
                   <>
                     <ProfileKeysList publicKeys={publicKeys} openAlertDeleteDialog={openAlertDeleteDialog} />
-                    {totalPages > 1 ? (
-                      <PaginationComponent
-                        totalPages={totalPages}
-                        currentPage={page}
-                        goToPage={(pageNum: number) => setPage(pageNum)}
-                      />
-                    ) : null}
+                    <PaginationComponent
+                      totalPages={totalPages}
+                      currentPage={page}
+                      goToPage={(pageNum: number) => setPage(pageNum)}
+                    />
                   </>
                 )}
                 {error && error.type === 'keyFetch' && (

--- a/apps/gitness/src/pages/pull-request-commits-page.tsx
+++ b/apps/gitness/src/pages/pull-request-commits-page.tsx
@@ -1,20 +1,28 @@
+import { useParams } from 'react-router-dom'
+import { parseAsInteger, useQueryState } from 'nuqs'
 import { Spacer } from '@harnessio/canary'
-import { NoData, PullRequestCommits, SkeletonList } from '@harnessio/playground'
+import { NoData, PaginationComponent, PullRequestCommits, SkeletonList } from '@harnessio/playground'
 import { useListPullReqCommitsQuery, TypesCommit } from '@harnessio/code-service-client'
 import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
-import { useParams } from 'react-router-dom'
 import { PathParams } from '../RouteDefinitions'
+import { PageResponseHeader } from '../types'
 
 export default function PullRequestCommitsPage() {
   const repoRef = useGetRepoRef()
   const { pullRequestId } = useParams<PathParams>()
   const prId = (pullRequestId && Number(pullRequestId)) || -1
 
-  const { data: { body: commitData } = {}, isFetching } = useListPullReqCommitsQuery({
+  const [page, setPage] = useQueryState('page', parseAsInteger.withDefault(1))
+
+  const { data: { body: commitData, headers } = {}, isFetching } = useListPullReqCommitsQuery({
     repo_ref: repoRef,
     pullreq_number: prId,
-    queryParams: { page: 0, limit: 10 }
+    queryParams: { page }
   })
+
+  const xNextPage = parseInt(headers?.get(PageResponseHeader.xNextPage) || '')
+  const xPrevPage = parseInt(headers?.get(PageResponseHeader.xPrevPage) || '')
+
   const renderContent = () => {
     if (isFetching) {
       return <SkeletonList />
@@ -47,7 +55,14 @@ export default function PullRequestCommitsPage() {
     <>
       {renderContent()}
       <Spacer size={8} />
-      {/* TODO: actually add pagination when apis are implemented */}
+      {(!isNaN(xNextPage) || !isNaN(xPrevPage)) && (
+        <PaginationComponent
+          nextPage={xNextPage}
+          previousPage={xPrevPage}
+          currentPage={page}
+          goToPage={(pageNum: number) => setPage(pageNum)}
+        />
+      )}
     </>
   )
 }

--- a/apps/gitness/src/pages/pull-request-commits-page.tsx
+++ b/apps/gitness/src/pages/pull-request-commits-page.tsx
@@ -55,14 +55,12 @@ export default function PullRequestCommitsPage() {
     <>
       {renderContent()}
       <Spacer size={8} />
-      {(!isNaN(xNextPage) || !isNaN(xPrevPage)) && (
-        <PaginationComponent
-          nextPage={xNextPage}
-          previousPage={xPrevPage}
-          currentPage={page}
-          goToPage={(pageNum: number) => setPage(pageNum)}
-        />
-      )}
+      <PaginationComponent
+        nextPage={xNextPage}
+        previousPage={xPrevPage}
+        currentPage={page}
+        goToPage={(pageNum: number) => setPage(pageNum)}
+      />
     </>
   )
 }

--- a/apps/gitness/src/pages/pull-request-list-page.tsx
+++ b/apps/gitness/src/pages/pull-request-list-page.tsx
@@ -129,13 +129,11 @@ function PullRequestListPage() {
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />
-        {totalPages > 1 && (
-          <PaginationComponent
-            totalPages={totalPages}
-            currentPage={page}
-            goToPage={(pageNum: number) => setPage(pageNum)}
-          />
-        )}
+        <PaginationComponent
+          totalPages={totalPages}
+          currentPage={page}
+          goToPage={(pageNum: number) => setPage(pageNum)}
+        />
       </PaddingListLayout>
     </>
   )

--- a/apps/gitness/src/pages/pull-request-list-page.tsx
+++ b/apps/gitness/src/pages/pull-request-list-page.tsx
@@ -39,7 +39,7 @@ function PullRequestListPage() {
 
   const { data: { body: pullrequests, headers } = {}, isFetching } = useListPullReqQuery({
     repo_ref: repoRef,
-    queryParams: { page, query, sort, limit: 20 }
+    queryParams: { page, query, sort }
   })
 
   const totalPages = parseInt(headers?.get(PageResponseHeader.xTotalPages) || '')

--- a/apps/gitness/src/pages/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-branch-list.tsx
@@ -146,14 +146,12 @@ export function ReposBranchesListPage() {
       <Spacer size={5} />
       {renderListContent()}
       <Spacer size={8} />
-      {(!isNaN(xNextPage) || !isNaN(xPrevPage)) && (
-        <PaginationComponent
-          nextPage={xNextPage}
-          previousPage={xPrevPage}
-          currentPage={page}
-          goToPage={(pageNum: number) => setPage(pageNum)}
-        />
-      )}
+      <PaginationComponent
+        nextPage={xNextPage}
+        previousPage={xPrevPage}
+        currentPage={page}
+        goToPage={(pageNum: number) => setPage(pageNum)}
+      />
     </PaddingListLayout>
   )
 }

--- a/apps/gitness/src/pages/repo/repo-commits.tsx
+++ b/apps/gitness/src/pages/repo/repo-commits.tsx
@@ -48,11 +48,6 @@ export default function RepoCommitsPage() {
 
   // logic once we have dynamic pagination set up
 
-  // const totalPages = useMemo(() => {
-  //   if (!commitData || !commitData.total_commits) return 0
-  //   return Math.ceil(commitData.total_commits / 10)
-  // }, [commitData])
-
   useEffect(() => {
     if (repository?.body?.default_branch) {
       setSelectedBranch(repository.body.default_branch)

--- a/apps/gitness/src/pages/repo/repo-commits.tsx
+++ b/apps/gitness/src/pages/repo/repo-commits.tsx
@@ -103,14 +103,12 @@ export default function RepoCommitsPage() {
       <Spacer size={5} />
       {renderListContent()}
       <Spacer size={8} />
-      {(!isNaN(xNextPage) || !isNaN(xPrevPage)) && (
-        <PaginationComponent
-          nextPage={xNextPage}
-          previousPage={xPrevPage}
-          currentPage={page}
-          goToPage={(pageNum: number) => setPage(pageNum)}
-        />
-      )}
+      <PaginationComponent
+        nextPage={xNextPage}
+        previousPage={xPrevPage}
+        currentPage={page}
+        goToPage={(pageNum: number) => setPage(pageNum)}
+      />
     </PaddingListLayout>
   )
 }

--- a/apps/gitness/src/pages/repo/repo-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-list.tsx
@@ -99,7 +99,7 @@ export default function ReposListPage() {
          * Show if repositories exist.
          * Additionally, show if query(search) is applied.
          */}
-        {(query || repositories?.length) && (
+        {(query || (repositories?.length || 0) > 0) && (
           <>
             <Text size={5} weight={'medium'}>
               Repositories

--- a/apps/gitness/src/pages/repo/repo-list.tsx
+++ b/apps/gitness/src/pages/repo/repo-list.tsx
@@ -118,13 +118,11 @@ export default function ReposListPage() {
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />
-        {totalPages > 1 && (
-          <PaginationComponent
-            totalPages={totalPages}
-            currentPage={page}
-            goToPage={(pageNum: number) => setPage(pageNum)}
-          />
-        )}
+        <PaginationComponent
+          totalPages={totalPages}
+          currentPage={page}
+          goToPage={(pageNum: number) => setPage(pageNum)}
+        />
       </PaddingListLayout>
     </>
   )

--- a/apps/gitness/src/pages/repo/repo-webhooks.tsx
+++ b/apps/gitness/src/pages/repo/repo-webhooks.tsx
@@ -89,13 +89,11 @@ function RepoWebhooksListPage() {
         <Spacer size={5} />
         {renderListContent()}
         <Spacer size={8} />
-        {totalPages > 1 && (
-          <PaginationComponent
-            totalPages={totalPages}
-            currentPage={page}
-            goToPage={(pageNum: number) => setPage(pageNum)}
-          />
-        )}
+        <PaginationComponent
+          totalPages={totalPages}
+          currentPage={page}
+          goToPage={(pageNum: number) => setPage(pageNum)}
+        />
       </PaddingListLayout>
     </>
   )

--- a/apps/gitness/src/pages/sandbox-execution-list.tsx
+++ b/apps/gitness/src/pages/sandbox-execution-list.tsx
@@ -123,13 +123,11 @@ export default function SandboxExecutionsListPage() {
           <Spacer size={5} />
           {renderListContent()}
           <Spacer size={8} />
-          {totalPages > 1 && (
-            <PaginationComponent
-              totalPages={totalPages}
-              currentPage={page}
-              goToPage={(pageNum: number) => setPage(pageNum)}
-            />
-          )}
+          <PaginationComponent
+            totalPages={totalPages}
+            currentPage={page}
+            goToPage={(pageNum: number) => setPage(pageNum)}
+          />
         </SandboxLayout.Content>
       </SandboxLayout.Main>
       <RunPipelineDialog

--- a/apps/gitness/src/pages/sandbox-pipeline-list.tsx
+++ b/apps/gitness/src/pages/sandbox-pipeline-list.tsx
@@ -69,13 +69,11 @@ export default function SandboxPipelinesPage() {
           <Spacer size={5} />
           {renderListContent()}
           <Spacer size={8} />
-          {totalPages > 1 && (
-            <PaginationComponent
-              totalPages={totalPages}
-              currentPage={page}
-              goToPage={(pageNum: number) => setPage(pageNum)}
-            />
-          )}
+          <PaginationComponent
+            totalPages={totalPages}
+            currentPage={page}
+            goToPage={(pageNum: number) => setPage(pageNum)}
+          />
         </SandboxLayout.Content>
       </SandboxLayout.Main>
     </>

--- a/packages/playground/src/components/pagination.tsx
+++ b/packages/playground/src/components/pagination.tsx
@@ -90,6 +90,11 @@ export const PaginationComponent: React.FC<PaginationComponentProps> = ({
   currentPage,
   goToPage
 }) => {
+  // Render nothing if `totalPages` is absent or <= 1, and both `nextPage` and `previousPage` are absent
+  if ((!totalPages || totalPages <= 1) && !nextPage && !previousPage) {
+    return null
+  }
+
   return (
     <ListPagination.Root>
       <Pagination>

--- a/packages/playground/src/pages/sandbox-settings-account-page.tsx
+++ b/packages/playground/src/pages/sandbox-settings-account-page.tsx
@@ -16,7 +16,7 @@ function SandboxSettingsAccountPage() {
               <TabsTrigger value="general">General</TabsTrigger>
             </NavLink>
             <NavLink to={`keys`}>
-              <TabsTrigger value="keys">Keys and tokens</TabsTrigger>
+              <TabsTrigger value="keys">Keys and Tokens</TabsTrigger>
             </NavLink>
           </TabsList>
         </Tabs>


### PR DESCRIPTION
Integrates pagination on following pages:

1. Tokens and Keys > SSH keys
2. Pull Request Details > Commits

Also, cleans up Pagination component to avoid conditional rendering based on presence/absence of pagination response headers.