### PR TITLE
Add gitignore/license options to create repo page

### DIFF
--- a/apps/gitness/src/pages/repo/repo-create-page.tsx
+++ b/apps/gitness/src/pages/repo/repo-create-page.tsx
@@ -7,7 +7,9 @@ import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
 import {
   useCreateRepositoryMutation,
   OpenapiCreateRepositoryRequest,
-  CreateRepositoryErrorResponse
+  CreateRepositoryErrorResponse,
+  useListGitignoreQuery,
+  useListLicensesQuery
 } from '@harnessio/code-service-client'
 
 export const CreateRepo = () => {
@@ -21,8 +23,8 @@ export const CreateRepo = () => {
       default_branch: 'main',
       parent_ref: spaceId,
       description: data.description,
-      // git_ignore: data.gitignore,
-      // license: data.license,
+      git_ignore: data.gitignore,
+      license: data.license,
       is_public: data.access === '1',
       readme: true,
       identifier: data.name
@@ -46,6 +48,10 @@ export const CreateRepo = () => {
     )
   }
 
+  const { data: { body: gitIgnoreOptions } = {} } = useListGitignoreQuery({})
+
+  const { data: { body: licenseOptions } = {} } = useListLicensesQuery({})
+
   const onCancel = () => {
     navigate(`/${spaceId}/repos`)
   }
@@ -58,6 +64,8 @@ export const CreateRepo = () => {
         apiError={apiError}
         isLoading={createRepositoryMutation.isLoading}
         isSuccess={createRepositoryMutation.isSuccess}
+        gitIgnoreOptions={gitIgnoreOptions}
+        licenseOptions={licenseOptions}
       />
     </>
   )

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -75,6 +75,7 @@ import { mockBypassUserData, mockStatusChecks } from './pages/mocks/repo-branch-
 import { BypassUsersList } from './components/repo-settings/repo-branch-settings-rules/types'
 import { currentUser } from './pages/mocks/mockCurrentUserData'
 import { mockUsersData } from './data/mockUsersData'
+import { gitIgnoreOptions, licenseOptions } from './data/mockCreateRepoData'
 
 const router = createBrowserRouter([
   // TEMPORARY LAYOUT SANDBOX
@@ -93,7 +94,17 @@ const router = createBrowserRouter([
           },
           {
             path: 'create',
-            element: <SandboxRepoCreatePage apiError="" isLoading isSuccess onFormCancel={noop} onFormSubmit={noop} />
+            element: (
+              <SandboxRepoCreatePage
+                apiError=""
+                isLoading={false}
+                isSuccess={false}
+                onFormCancel={noop}
+                onFormSubmit={noop}
+                licenseOptions={licenseOptions}
+                gitIgnoreOptions={gitIgnoreOptions}
+              />
+            )
           },
           {
             path: ':repoId',

--- a/packages/playground/src/data/mockCreateRepoData.ts
+++ b/packages/playground/src/data/mockCreateRepoData.ts
@@ -1,0 +1,40 @@
+export const gitIgnoreOptions = [
+  'AL',
+  'Actionscript',
+  'Ada',
+  'Agda',
+  'Android',
+  'AppEngine',
+  'AppceleratorTitanium',
+  'ArchLinuxPackages',
+  'Autotools',
+  'C++',
+  'C',
+  'CFWheels',
+  'CMake',
+  'CONTRIBUTING.md',
+  'CUDA'
+]
+
+export const licenseOptions = [
+  {
+    label: 'None',
+    value: 'none'
+  },
+  {
+    label: 'Academic Free License v3.0',
+    value: 'afl-3.0'
+  },
+  {
+    label: 'Apache license 2.0',
+    value: 'apache-2.0'
+  },
+  {
+    label: 'Artistic license 2.0',
+    value: 'artistic-2.0'
+  },
+  {
+    label: 'Boost Software License 1.0',
+    value: 'bsl-1.0'
+  }
+]

--- a/packages/playground/src/pages/sandbox-repo-create-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-create-page.tsx
@@ -29,8 +29,8 @@ import { MessageTheme } from '../components/form-field-set'
 const formSchema = z.object({
   name: z.string().min(1, { message: 'Please provide a name' }),
   description: z.string(),
-  gitignore: z.enum(['', '1', '2', '3']),
-  license: z.enum(['', '1', '2', '3']),
+  gitignore: z.string().optional(),
+  license: z.string().optional(),
   access: z.enum(['1', '2'], { errorMap: () => ({ message: 'Please select who has access' }) })
 })
 
@@ -42,13 +42,17 @@ interface SandboxRepoCreatePageProps {
   apiError: string | null
   isLoading: boolean
   isSuccess: boolean
+  gitIgnoreOptions?: string[]
+  licenseOptions?: { value?: string; label?: string }[]
 }
 const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
   onFormSubmit,
   apiError = null,
   onFormCancel,
   isLoading,
-  isSuccess
+  isSuccess,
+  gitIgnoreOptions,
+  licenseOptions
 }) => {
   const {
     register,
@@ -65,7 +69,7 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
       description: '',
       gitignore: '',
       license: '',
-      access: '1'
+      access: '2'
     }
   })
 
@@ -145,9 +149,7 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
             {/* ACCESS */}
             <FormFieldSet.Root box shaded>
               <FormFieldSet.ControlGroup>
-                <FormFieldSet.Label htmlFor="access" required>
-                  Who has access?
-                </FormFieldSet.Label>
+                <FormFieldSet.Label htmlFor="access">Who has access?</FormFieldSet.Label>
                 <RadioGroup value={accessValue} onValueChange={handleAccessChange} id="access">
                   <FormFieldSet.Option
                     control={<RadioGroupItem value="1" id="access-public" />}
@@ -179,9 +181,14 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
                     <SelectValue placeholder="Select" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="1">.gitignore option 1</SelectItem>
-                    <SelectItem value="2">.gitignore option 2</SelectItem>
-                    <SelectItem value="3">.gitignore option 3</SelectItem>
+                    {gitIgnoreOptions &&
+                      gitIgnoreOptions?.map(option => {
+                        return (
+                          <SelectItem key={option} value={option}>
+                            {option}
+                          </SelectItem>
+                        )
+                      })}
                   </SelectContent>
                 </Select>
                 {errors.gitignore && (
@@ -199,9 +206,12 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
                     <SelectValue placeholder="Select" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="1">License option 1</SelectItem>
-                    <SelectItem value="2">License option 2</SelectItem>
-                    <SelectItem value="3">License option 3</SelectItem>
+                    {licenseOptions &&
+                      licenseOptions?.map(option => (
+                        <SelectItem key={option.value} value={option.value ?? ''}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
                   </SelectContent>
                 </Select>
                 <FormFieldSet.Caption>

--- a/packages/playground/src/pages/sandbox-repo-create-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-create-page.tsx
@@ -77,8 +77,6 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
   const gitignoreValue = watch('gitignore')
   const licenseValue = watch('license')
 
-  const [isSubmitted, setIsSubmitted] = useState<boolean>(false)
-
   const handleSelectChange = (fieldName: keyof FormFields, value: string) => {
     setValue(fieldName, value, { shouldValidate: true })
   }
@@ -90,7 +88,6 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
   useEffect(() => {
     if (isSuccess === true) {
       reset()
-      setIsSubmitted(true)
     }
   }, [isSuccess])
 
@@ -235,21 +232,14 @@ const SandboxRepoCreatePage: React.FC<SandboxRepoCreatePageProps> = ({
             <FormFieldSet.Root>
               <FormFieldSet.ControlGroup>
                 <ButtonGroup.Root>
-                  {!isSubmitted ? (
-                    <>
-                      <Button type="submit" size="sm" disabled={!isValid || isLoading}>
-                        {!isLoading ? 'Create repository' : 'Creating repository...'}
-                      </Button>
-                      <Button type="button" variant="outline" size="sm" onClick={handleCancel}>
-                        Cancel
-                      </Button>
-                    </>
-                  ) : (
-                    <Button variant="ghost" type="button" size="sm" theme="success" className="pointer-events-none">
-                      Repository created&nbsp;&nbsp;
-                      <Icon name="tick" size={14} />
+                  <>
+                    <Button type="submit" size="sm" disabled={!isValid || isLoading}>
+                      {!isLoading ? 'Create repository' : 'Creating repository...'}
                     </Button>
-                  )}
+                    <Button type="button" variant="outline" size="sm" onClick={handleCancel}>
+                      Cancel
+                    </Button>
+                  </>
                 </ButtonGroup.Root>
               </FormFieldSet.ControlGroup>
             </FormFieldSet.Root>

--- a/packages/playground/src/pages/sandbox-repo-create-page.tsx
+++ b/packages/playground/src/pages/sandbox-repo-create-page.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { SandboxLayout } from '..'
 import {
   Alert,
   AlertDescription,
   Button,
   ButtonGroup,
-  Icon,
   Input,
   RadioGroup,
   RadioGroupItem,


### PR DESCRIPTION
- Adds gitignore/license dropdown to `create repo`
- mocks data in playground
- minor fixes to form in `create repo` page