### PR TITLE
Theme fix for Markdown Preview

### DIFF
--- a/apps/gitness/src/pages/profile-settings/profile-settings-general-page.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-general-page.tsx
@@ -3,7 +3,7 @@ import { useForm, SubmitHandler } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Button, ButtonGroup, Input, Spacer, Text, Icon, Avatar, AvatarImage, AvatarFallback } from '@harnessio/canary'
-import { SandboxLayout, FormFieldSet, SkeletonList, getInitials } from '@harnessio/views'
+import { SandboxLayout, FormFieldSet, SkeletonList, getInitials, ModeToggle } from '@harnessio/views'
 const profileSchema = z.object({
   name: z.string().min(1, { message: 'Please provide your name' }),
   username: z.string().min(1, { message: 'Please provide a username' }),
@@ -212,6 +212,11 @@ const SettingsAccountGeneralPage: React.FC<SettingsAccountGeneralPageProps> = ({
                   {profileErrors.email.message?.toString()}
                 </FormFieldSet.Message>
               )}
+            </FormFieldSet.ControlGroup>
+
+            <FormFieldSet.ControlGroup>
+              <FormFieldSet.Label>Theme</FormFieldSet.Label>
+              <ModeToggle />
             </FormFieldSet.ControlGroup>
 
             {error && error.type === 'profile' && (

--- a/packages/canary/src/styles.css
+++ b/packages/canary/src/styles.css
@@ -47,10 +47,10 @@
     --card-foreground: 240 10% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 240 10% 3.9%;
-    --primary: 240 5.9% 10%;
-    --primary-background: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
-    --primary-muted: var(--grey-70);
+    --primary: var(--black);
+    --primary-background: var(--white);
+    --primary-foreground: var(--grey-98);
+    --primary-muted: var(--grey-60);
     --primary-accent: 216 100% 60%;
     --secondary: 240 4.8% 95.9%;
     --secondary-foreground: 240 5.9% 10%;

--- a/packages/views/src/components/markdown-viewer.tsx
+++ b/packages/views/src/components/markdown-viewer.tsx
@@ -73,6 +73,7 @@ export function MarkdownViewer({
     },
     [navigate]
   )
+
   return (
     <div
       role="button"
@@ -84,7 +85,7 @@ export function MarkdownViewer({
       ref={ref}>
       <MarkdownPreview
         source={source}
-        className="prose prose-invert !bg-background !max-w-full"
+        className="prose dark:prose-invert !bg-background !max-w-full"        
         // warpperElement={{ 'data-color-mode': darkMode ? 'dark' : 'light' }}
         rehypeRewrite={(node, _index, parent) => {
           if ((node as unknown as HTMLDivElement).tagName === 'a') {

--- a/packages/views/src/components/markdown-viewer.tsx
+++ b/packages/views/src/components/markdown-viewer.tsx
@@ -85,7 +85,7 @@ export function MarkdownViewer({
       ref={ref}>
       <MarkdownPreview
         source={source}
-        className="prose dark:prose-invert !bg-background !max-w-full"        
+        className="prose dark:prose-invert !bg-background !max-w-full"
         // warpperElement={{ 'data-color-mode': darkMode ? 'dark' : 'light' }}
         rehypeRewrite={(node, _index, parent) => {
           if ((node as unknown as HTMLDivElement).tagName === 'a') {

--- a/packages/views/src/components/theme-provider.tsx
+++ b/packages/views/src/components/theme-provider.tsx
@@ -26,9 +26,11 @@ export function ThemeProvider({
   storageKey = 'canary-ui-theme',
   ...props
 }: ThemeProviderProps) {
+  const getMediaQuery = () => window.matchMedia('(prefers-color-scheme: dark)')
+
   const [theme, setThemeState] = useState<Theme>(() => (localStorage.getItem(storageKey) as Theme) || defaultTheme)
   const [systemTheme, setSystemTheme] = useState<'dark' | 'light'>(() =>
-    window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    getMediaQuery().matches ? 'dark' : 'light'
   )
 
   useEffect(() => {
@@ -38,8 +40,6 @@ export function ThemeProvider({
     const applyTheme = theme === 'system' ? systemTheme : theme
     root.classList.add(applyTheme)
   }, [theme, systemTheme])  
-
-  const getMediaQuery = () => window.matchMedia('(prefers-color-scheme: dark)')
 
   useEffect(() => {
     const updateSystemTheme = () => setSystemTheme(getMediaQuery().matches ? 'dark' : 'light')

--- a/packages/views/src/components/theme-provider.tsx
+++ b/packages/views/src/components/theme-provider.tsx
@@ -37,20 +37,21 @@ export function ThemeProvider({
 
     const applyTheme = theme === 'system' ? systemTheme : theme
     root.classList.add(applyTheme)
-  }, [theme, systemTheme])
+  }, [theme, systemTheme])  
+
+  const getMediaQuery = () => window.matchMedia('(prefers-color-scheme: dark)')
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-    const updateSystemTheme = () => setSystemTheme(mediaQuery.matches ? 'dark' : 'light')
+    const updateSystemTheme = () => setSystemTheme(getMediaQuery().matches ? 'dark' : 'light')
 
     // Update system theme on initial load if theme is 'system'
     if (theme === 'system') {
       updateSystemTheme()
     }
 
-    mediaQuery.addEventListener('change', updateSystemTheme)
+    getMediaQuery().addEventListener('change', updateSystemTheme)
 
-    return () => mediaQuery.removeEventListener('change', updateSystemTheme)
+    return () => getMediaQuery().removeEventListener('change', updateSystemTheme)
   }, [theme])
 
   const setTheme = (newTheme: Theme) => {
@@ -59,7 +60,7 @@ export function ThemeProvider({
 
     // If new theme is 'system', immediately apply the current system theme
     if (newTheme === 'system') {
-      setSystemTheme(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+      setSystemTheme(getMediaQuery().matches ? 'dark' : 'light')
     }
   }
 

--- a/packages/views/src/components/theme-provider.tsx
+++ b/packages/views/src/components/theme-provider.tsx
@@ -29,9 +29,7 @@ export function ThemeProvider({
   const getMediaQuery = () => window.matchMedia('(prefers-color-scheme: dark)')
 
   const [theme, setThemeState] = useState<Theme>(() => (localStorage.getItem(storageKey) as Theme) || defaultTheme)
-  const [systemTheme, setSystemTheme] = useState<'dark' | 'light'>(() =>
-    getMediaQuery().matches ? 'dark' : 'light'
-  )
+  const [systemTheme, setSystemTheme] = useState<'dark' | 'light'>(() => (getMediaQuery().matches ? 'dark' : 'light'))
 
   useEffect(() => {
     const root = window.document.documentElement
@@ -39,7 +37,7 @@ export function ThemeProvider({
 
     const applyTheme = theme === 'system' ? systemTheme : theme
     root.classList.add(applyTheme)
-  }, [theme, systemTheme])  
+  }, [theme, systemTheme])
 
   useEffect(() => {
     const updateSystemTheme = () => setSystemTheme(getMediaQuery().matches ? 'dark' : 'light')

--- a/packages/views/src/components/theme-provider.tsx
+++ b/packages/views/src/components/theme-provider.tsx
@@ -40,21 +40,27 @@ export function ThemeProvider({
   }, [theme, systemTheme])
 
   useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const updateSystemTheme = () => setSystemTheme(mediaQuery.matches ? 'dark' : 'light')
+
+    // Update system theme on initial load if theme is 'system'
     if (theme === 'system') {
-      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-      const handleChange = (e: MediaQueryListEvent) => {
-        setSystemTheme(e.matches ? 'dark' : 'light')
-      }
-
-      mediaQuery.addEventListener('change', handleChange)
-
-      return () => mediaQuery.removeEventListener('change', handleChange)
+      updateSystemTheme()
     }
+
+    mediaQuery.addEventListener('change', updateSystemTheme)
+
+    return () => mediaQuery.removeEventListener('change', updateSystemTheme)
   }, [theme])
 
   const setTheme = (newTheme: Theme) => {
     localStorage.setItem(storageKey, newTheme)
     setThemeState(newTheme)
+
+    // If new theme is 'system', immediately apply the current system theme
+    if (newTheme === 'system') {
+      setSystemTheme(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+    }
   }
 
   const value = {

--- a/packages/views/src/components/theme-provider.tsx
+++ b/packages/views/src/components/theme-provider.tsx
@@ -27,17 +27,28 @@ export function ThemeProvider({
   ...props
 }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<Theme>(() => (localStorage.getItem(storageKey) as Theme) || defaultTheme)
+  const [systemTheme, setSystemTheme] = useState<'dark' | 'light'>(() =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  )
 
   useEffect(() => {
     const root = window.document.documentElement
-
     root.classList.remove('light', 'dark')
 
+    const applyTheme = theme === 'system' ? systemTheme : theme
+    root.classList.add(applyTheme)
+  }, [theme, systemTheme])
+
+  useEffect(() => {
     if (theme === 'system') {
-      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-      root.classList.add(systemTheme)
-    } else {
-      root.classList.add(theme)
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      const handleChange = (e: MediaQueryListEvent) => {
+        setSystemTheme(e.matches ? 'dark' : 'light')
+      }
+
+      mediaQuery.addEventListener('change', handleChange)
+
+      return () => mediaQuery.removeEventListener('change', handleChange)
     }
   }, [theme])
 

--- a/packages/views/src/index.ts
+++ b/packages/views/src/index.ts
@@ -108,6 +108,8 @@ export * from './components/settings-user-management-page'
 export * from './components/settings-create-new-user-form'
 export * from './components/user-management/reset-password-dialog'
 
+export * from './components/mode-toggle'
+
 // HOOKS
 export * from './hooks/useCommonFilter'
 


### PR DESCRIPTION
I initially started this PR for fixing the theme issues, but we decided not to do it at the moment.

By the time, I already had the Markdown Preview fix in place. It's a very small change, but an important one, since the UI looked quite distorted in the Light mode before the fix.

<img width="1728" alt="Comparison" src="https://github.com/user-attachments/assets/89c7233a-aa06-4d5f-99d4-8c81564fea08">
