### PR TITLE
chore: [XD-42]: Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+packages/canary @knagurski
+packages/views @knagurski
+packages/ui @knagurski
+apps/design-system @knagurski


### PR DESCRIPTION
This PR adds the initial CODEOWNERS file to protect the `views`, `canary` and `ui` packages, and the `design-system` app.