### PR TITLE
fix: corrects the spacing between bread crumbs

### DIFF
--- a/packages/ui/src/views/repo-list/repo-list-page.tsx
+++ b/packages/ui/src/views/repo-list/repo-list-page.tsx
@@ -454,7 +454,7 @@ const SandboxRepoListPage: React.FC<RepoListProps> = ({ repositories, totalPages
 
   return (
     <>
-      <SandboxLayout.Main hasLeftPanel>
+      <SandboxLayout.Main hasHeader hasLeftPanel>
         <SandboxLayout.Content>
           <Spacer size={10} />
           <Text size={5} weight={'medium'}>


### PR DESCRIPTION
Before:
<img width="1812" alt="image" src="https://github.com/user-attachments/assets/de909c8e-c887-413d-8d88-bb8110f4c9b1">


After:
<img width="1807" alt="Arc 2024-11-25 16 33 03" src="https://github.com/user-attachments/assets/07e7ad6a-9917-4f18-ac5e-684d7385c3aa">
