### PR TITLE
step name should be considered as precedence in step display name

### DIFF
--- a/packages/unified-pipeline/src/utils/ParserUtils.tsx
+++ b/packages/unified-pipeline/src/utils/ParserUtils.tsx
@@ -146,7 +146,7 @@ const getChildNodes = (stage: Record<string, any>): Node[] => {
 
 function getIconAndDisplayName(step: Record<string, any>, stepIndex: number, _?: boolean) {
   return {
-    name: getNameBasedOnStep(step, stepIndex),
+    name: step?.name || getNameBasedOnStep(step, stepIndex),
     icon: (
       <div className="node-icon">
         <Icon name={getIconBasedOnStep(step)} />


### PR DESCRIPTION
Currently we are showing step script in the step display name in pipeline studio. This change to show step name as display name, if not fallback to current approach.