### PR TITLE
chore: [XD-44]: Allow root imports with @components and @views alias

### DIFF
--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { buttonVariants } from '@/components/button'
+import { buttonVariants } from '@components/button'
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 import { cn } from '@utils/cn'
 

--- a/packages/ui/src/components/calendar.tsx
+++ b/packages/ui/src/components/calendar.tsx
@@ -57,6 +57,7 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
     />
   )
 }
+
 Calendar.displayName = 'Calendar'
 
 export { Calendar }

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { Dialog, DialogContent, ScrollArea } from '@/components'
+import { Dialog, DialogContent, ScrollArea } from '@components'
 import { type DialogProps } from '@radix-ui/react-dialog'
 import { MagnifyingGlassIcon } from '@radix-ui/react-icons'
 import { cn } from '@utils/cn'
@@ -22,7 +22,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:size-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:size-5">
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:size-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:size-5">
           {children}
         </Command>
       </DialogContent>
@@ -66,7 +66,7 @@ CommandList.displayName = CommandPrimitive.List.displayName
 const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => <CommandPrimitive.Empty ref={ref} className="px-2 py-4 text-sm text-foreground-5" {...props} />)
+>((props, ref) => <CommandPrimitive.Empty ref={ref} className="text-foreground-5 px-2 py-4 text-sm" {...props} />)
 
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName
 

--- a/packages/ui/src/components/commit-copy-actions.tsx
+++ b/packages/ui/src/components/commit-copy-actions.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
-import { Icon, ShaBadge, Text } from '@/components'
+import { Icon, ShaBadge, Text } from '@components'
 import copy from 'clipboard-copy'
 
 export const CommitCopyActions = ({ sha }: { sha: string }) => {

--- a/packages/ui/src/components/file-explorer.tsx
+++ b/packages/ui/src/components/file-explorer.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Icon, Text } from '@/components'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Icon, Text } from '@components'
 import { cn } from '@utils/cn'
 
 interface FolderItemProps {
@@ -36,7 +36,7 @@ function FolderItem({ children, value = '', isActive, content, chevronClassName,
         >
           <div className="flex w-full items-center gap-1.5 py-1.5">
             <Icon
-              className="min-w-4 text-icons-7 duration-100 ease-in-out group-hover:text-icons-2 group-data-[state=open]:text-icons-2"
+              className="text-icons-7 group-hover:text-icons-2 group-data-[state=open]:text-icons-2 min-w-4 duration-100 ease-in-out"
               name="folder"
               size={16}
             />
@@ -74,7 +74,7 @@ function FileItem({ children, isActive, link }: FileItemProps) {
         }
       )}
     >
-      <Icon className="min-w-4 text-icons-7 duration-100 ease-in-out group-hover:text-icons-2" name="file" size={16} />
+      <Icon className="text-icons-7 group-hover:text-icons-2 min-w-4 duration-100 ease-in-out" name="file" size={16} />
       <Text className="duration-100 ease-in-out" size={2} color="inherit" weight="medium" truncate>
         {children}
       </Text>

--- a/packages/ui/src/components/manage-navigation/index.tsx
+++ b/packages/ui/src/components/manage-navigation/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 
+import useDragAndDrop from '@/hooks/use-drag-and-drop'
 import {
   AlertDialog,
   AlertDialogContent,
@@ -11,8 +12,7 @@ import {
   Icon,
   ScrollArea,
   Text
-} from '@/components'
-import useDragAndDrop from '@/hooks/use-drag-and-drop'
+} from '@components'
 import { MenuGroupType, NavbarItemType } from '@components/navbar/types'
 import { closestCenter, DndContext } from '@dnd-kit/core'
 import { SortableContext } from '@dnd-kit/sortable'

--- a/packages/ui/src/components/manage-navigation/manage-navigation-search.tsx
+++ b/packages/ui/src/components/manage-navigation/manage-navigation-search.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react'
 
-import { Button, Popover, PopoverContent, PopoverTrigger, ScrollArea, SearchBox, Text } from '@/components'
+import { Button, Popover, PopoverContent, PopoverTrigger, ScrollArea, SearchBox, Text } from '@components'
 import { MenuGroupType, NavbarItemType } from '@components/navbar/types'
 import { cn } from '@utils/cn'
 import { debounce } from 'lodash-es'

--- a/packages/ui/src/components/more-submenu.tsx
+++ b/packages/ui/src/components/more-submenu.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from 'react-router-dom'
 
-import { Icon, ScrollArea, Sheet, SheetContent, SheetTitle, Spacer } from '@/components'
-import NavbarSkeleton from '@/components/navbar/navbar-skeleton'
+import { Icon, ScrollArea, Sheet, SheetContent, SheetTitle, Spacer } from '@components'
+import NavbarSkeleton from '@components/navbar/navbar-skeleton'
 import { MenuGroupType } from '@components/navbar/types'
 
 interface MoreSubmenuProps {

--- a/packages/ui/src/components/navbar/index.tsx
+++ b/packages/ui/src/components/navbar/index.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
-import { Button, Icon, NavbarProjectChooser, ScrollArea, Spacer } from '@/components'
 import { TypesUser } from '@/types'
+import { Button, Icon, NavbarProjectChooser, ScrollArea, Spacer } from '@components'
 import { TFunction } from 'i18next'
 import { isEmpty } from 'lodash-es'
 
@@ -59,7 +59,7 @@ export const Navbar = ({
           logo={
             <Link className="flex items-center gap-1.5" to="/">
               <Icon name="harness" size={18} className="text-foreground-1" />
-              <Icon name="harness-logo-text" width={65} height={15} className="mb-0.5 text-foreground-1" />
+              <Icon name="harness-logo-text" width={65} height={15} className="text-foreground-1 mb-0.5" />
             </Link>
           }
         />

--- a/packages/ui/src/components/navbar/navbar-ai/index.tsx
+++ b/packages/ui/src/components/navbar/navbar-ai/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Text } from '@/components'
+import { Button, Icon, Text } from '@components'
 
 export const NavbarAi = () => {
   return (

--- a/packages/ui/src/components/navbar/navbar-item/index.tsx
+++ b/packages/ui/src/components/navbar/navbar-item/index.tsx
@@ -9,7 +9,7 @@ import {
   Icon,
   IconProps,
   Text
-} from '@/components'
+} from '@components'
 import { TFunction } from 'i18next'
 
 import NavbarSkeleton from '../navbar-skeleton'
@@ -80,7 +80,7 @@ export const NavbarItem = ({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
-            className="absolute -right-[0.8125rem] top-0 text-icons-4 opacity-0 hover:text-icons-2 focus:opacity-100 focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+            className="text-icons-4 hover:text-icons-2 absolute -right-[0.8125rem] top-0 opacity-0 focus:opacity-100 focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
             size="sm_icon"
             variant="custom"
           >

--- a/packages/ui/src/components/navbar/navbar-skeleton/index.tsx
+++ b/packages/ui/src/components/navbar/navbar-skeleton/index.tsx
@@ -1,4 +1,4 @@
-import { Icon, Text } from '@/components'
+import { Icon, Text } from '@components'
 import { cn } from '@utils/cn'
 import { isSafari } from '@utils/isSafari'
 
@@ -123,9 +123,9 @@ function Item({ icon, text, description, active, submenuItem, className }: ItemP
         />
         <div className="z-10 col-start-1 row-span-full mt-px flex items-center">
           {icon ? (
-            <div className="sub-menu-icon-bg relative flex size-8 place-content-center place-items-center rounded border border-borders-1 bg-background-2">
+            <div className="sub-menu-icon-bg border-borders-1 bg-background-2 relative flex size-8 place-content-center place-items-center rounded border">
               <Icon
-                className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-foreground-3"
+                className="text-foreground-3 absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
                 name="sub-menu-ellipse"
                 size={18}
               />
@@ -147,7 +147,7 @@ function Item({ icon, text, description, active, submenuItem, className }: ItemP
             {text}
           </Text>
           {!!description && (
-            <Text className="z-10 w-full truncate leading-4 text-foreground-4 duration-0 ease-in-out" size={1} truncate>
+            <Text className="text-foreground-4 z-10 w-full truncate leading-4 duration-0 ease-in-out" size={1} truncate>
               {description}
             </Text>
           )}
@@ -192,7 +192,7 @@ function Item({ icon, text, description, active, submenuItem, className }: ItemP
 
 function Footer({ children }: { children: React.ReactNode }) {
   return (
-    <div className="sticky bottom-0 z-20 grid h-[72px] items-center border-t border-borders-5 px-4">{children}</div>
+    <div className="border-borders-5 sticky bottom-0 z-20 grid h-[72px] items-center border-t px-4">{children}</div>
   )
 }
 

--- a/packages/ui/src/components/navbar/navbar-user/index.tsx
+++ b/packages/ui/src/components/navbar/navbar-user/index.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 
+import { TypesUser } from '@/types'
 import {
   Avatar,
   AvatarFallback,
@@ -12,8 +13,7 @@ import {
   DropdownMenuTrigger,
   Icon,
   Text
-} from '@/components'
-import { TypesUser } from '@/types'
+} from '@components'
 import { cn } from '@utils/cn'
 import { getInitials } from '@utils/stringUtils'
 import { TFunction } from 'i18next'
@@ -40,7 +40,7 @@ const UserBlock = ({ username, email, url, isButton = false, className }: UserBl
       )}
     >
       {isButton && (
-        <div className="absolute -inset-2 rounded duration-100 ease-in-out group-hover:bg-background-4 group-data-[state=open]:bg-background-4" />
+        <div className="group-hover:bg-background-4 group-data-[state=open]:bg-background-4 absolute -inset-2 rounded duration-100 ease-in-out" />
       )}
       <div className="col-start-1 row-span-2">
         <Avatar className="overflow-hidden rounded-md" size="8">
@@ -48,9 +48,9 @@ const UserBlock = ({ username, email, url, isButton = false, className }: UserBl
           <AvatarFallback>{getInitials(username)}</AvatarFallback>
         </Avatar>
       </div>
-      <p className="col-start-2 row-start-1 truncate text-13 font-medium leading-tight text-foreground-1">{username}</p>
+      <p className="text-13 text-foreground-1 col-start-2 row-start-1 truncate font-medium leading-tight">{username}</p>
       {!!email && (
-        <p className="col-start-2 row-start-2 truncate text-13 font-normal leading-tight text-foreground-4">{email}</p>
+        <p className="text-13 text-foreground-4 col-start-2 row-start-2 truncate font-normal leading-tight">{email}</p>
       )}
     </Tag>
   )
@@ -119,7 +119,7 @@ export const NavbarUser = ({ currentUser, handleCustomNav, handleLogOut, t }: Na
 
       {menuItems && (
         <DropdownMenuContent
-          className="ml-3 w-[230px] bg-background-1"
+          className="bg-background-1 ml-3 w-[230px]"
           align="start"
           sideOffset={-40}
           alignOffset={187}

--- a/packages/ui/src/components/navbar/types.ts
+++ b/packages/ui/src/components/navbar/types.ts
@@ -1,4 +1,4 @@
-import { IconProps } from '@/components'
+import { IconProps } from '@components'
 
 export enum MenuGroupTypes {
   GENERAL = 'general',

--- a/packages/ui/src/components/path-breadcrumbs.tsx
+++ b/packages/ui/src/components/path-breadcrumbs.tsx
@@ -7,7 +7,7 @@ import {
   BreadcrumbList,
   BreadcrumbPage,
   BreadcrumbSeparator
-} from '@/components'
+} from '@components'
 
 interface PathParts {
   path: string

--- a/packages/ui/src/components/search-box.tsx
+++ b/packages/ui/src/components/search-box.tsx
@@ -7,7 +7,7 @@ import React, {
   type InputHTMLAttributes
 } from 'react'
 
-import { Icon, Input, Text } from '@/components'
+import { Icon, Input, Text } from '@components'
 import { cn } from '@utils/cn'
 import { noop } from 'lodash-es'
 
@@ -112,10 +112,10 @@ const Root = forwardRef<HTMLInputElement, SearchBoxProps>(
     return (
       <div className={cn('relative', width === 'full' ? 'w-full' : 'w-96', className)}>
         {hasSearchIcon && (
-          <Icon name="search" size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-icons-1" />
+          <Icon name="search" size={12} className="text-icons-1 absolute left-2.5 top-1/2 -translate-y-1/2" />
         )}
         {hasShortcut && !!shortcutLetter && (
-          <div className="absolute right-1.5 top-1/2 flex h-5 -translate-y-1/2 cursor-pointer items-center gap-0.5 rounded-sm border bg-background-3 px-1 text-foreground-2 duration-100 ease-in-out">
+          <div className="bg-background-3 text-foreground-2 absolute right-1.5 top-1/2 flex h-5 -translate-y-1/2 cursor-pointer items-center gap-0.5 rounded-sm border px-1 duration-100 ease-in-out">
             <Icon name="apple-shortcut" size={12} />
             <Text size={0} className="text-inherit">
               {shortcutLetter}

--- a/packages/ui/src/components/search-files.tsx
+++ b/packages/ui/src/components/search-files.tsx
@@ -11,8 +11,8 @@ import {
   PopoverContent,
   SearchBox,
   Text
-} from '@/components'
-import { TranslationStore } from '@/views'
+} from '@components'
+import { TranslationStore } from '@views'
 import { debounce } from 'lodash-es'
 
 const markedFileClassName = 'w-full text-foreground-8'

--- a/packages/ui/src/components/settings-menu.tsx
+++ b/packages/ui/src/components/settings-menu.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from 'react-router-dom'
 
-import { Icon, ScrollArea, Sheet, SheetContent, SheetTitle, Spacer } from '@/components'
-import NavbarSkeleton from '@/components/navbar/navbar-skeleton'
+import { Icon, ScrollArea, Sheet, SheetContent, SheetTitle, Spacer } from '@components'
+import NavbarSkeleton from '@components/navbar/navbar-skeleton'
 import { MenuGroupType } from '@components/navbar/types'
 
 interface SystemAdminMenuProps {

--- a/packages/ui/src/components/sha-badge.tsx
+++ b/packages/ui/src/components/sha-badge.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { Button, Text } from '@/components'
+import { Button, Text } from '@components'
 
 interface RootProps {
   children: ReactNode
@@ -28,7 +28,7 @@ function Content({ ...props }: ContentProps) {
   const { children } = props
 
   return (
-    <div className="flex items-center rounded-l px-2.5 py-[3px] hover:bg-background-3">
+    <div className="hover:bg-background-3 flex items-center rounded-l px-2.5 py-[3px]">
       <Text size={2} className="text-foreground-3">
         {children}
       </Text>
@@ -45,7 +45,7 @@ function Icon({ ...props }: IconProps) {
 
   return (
     <Button
-      className="flex h-full items-center rounded-r border-l px-1.5 py-0.5 hover:bg-background-3"
+      className="hover:bg-background-3 flex h-full items-center rounded-r border-l px-1.5 py-0.5"
       tabIndex={0}
       onClick={() => handleClick()}
       variant="custom"

--- a/packages/ui/src/components/skeleton-list.tsx
+++ b/packages/ui/src/components/skeleton-list.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { Skeleton, StackedList } from '@/components'
+import { Skeleton, StackedList } from '@components'
 import { cn } from '@utils/cn'
 
 // Helper function to generate random percentage width within a range
@@ -54,7 +54,7 @@ export const SkeletonList = ({ className }: SkeletonListProps) => {
           </StackedList.Item>
         ))}
       </StackedList.Root>
-      <div className="absolute bottom-0 z-10 size-full bg-gradient-to-b from-transparent to-background" />
+      <div className="to-background absolute bottom-0 z-10 size-full bg-gradient-to-b from-transparent" />
     </div>
   )
 }

--- a/packages/ui/src/views/auth/components/agreements.tsx
+++ b/packages/ui/src/views/auth/components/agreements.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 
-import { Text } from '@/components'
+import { Text } from '@components'
 
 export function Agreements() {
   return (

--- a/packages/ui/src/views/auth/components/animated-harness-logo.tsx
+++ b/packages/ui/src/views/auth/components/animated-harness-logo.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@/components'
+import { Icon } from '@components'
 import { cn } from '@utils/cn'
 
 interface AnimatedHarnessLogoProps {

--- a/packages/ui/src/views/auth/forgot-password-page.tsx
+++ b/packages/ui/src/views/auth/forgot-password-page.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { Link } from 'react-router-dom'
 
-import { Button, Card, CardContent, CardHeader, CardTitle, ErrorMessageTheme, Input, Spacer, Text } from '@/components'
+import { Button, Card, CardContent, CardHeader, CardTitle, ErrorMessageTheme, Input, Spacer, Text } from '@components'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 

--- a/packages/ui/src/views/auth/new-password-page.tsx
+++ b/packages/ui/src/views/auth/new-password-page.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 
-import { Button, Card, CardContent, CardHeader, CardTitle, ErrorMessageTheme, Input, Text } from '@/components'
+import { Button, Card, CardContent, CardHeader, CardTitle, ErrorMessageTheme, Input, Text } from '@components'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 

--- a/packages/ui/src/views/auth/otp-page.tsx
+++ b/packages/ui/src/views/auth/otp-page.tsx
@@ -13,7 +13,7 @@ import {
   InputOTPSlot,
   Spacer,
   Text
-} from '@/components'
+} from '@components'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 

--- a/packages/ui/src/views/auth/signin-page.tsx
+++ b/packages/ui/src/views/auth/signin-page.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Link } from 'react-router-dom'
 
-import { Button, Card, CardContent, CardHeader, CardTitle, ErrorMessageTheme, Input, Spacer, Text } from '@/components'
+import { Button, Card, CardContent, CardHeader, CardTitle, ErrorMessageTheme, Input, Spacer, Text } from '@components'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 

--- a/packages/ui/src/views/auth/signup-page.tsx
+++ b/packages/ui/src/views/auth/signup-page.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Link } from 'react-router-dom'
 
-import { Button, Card, CardContent, CardHeader, CardTitle, ErrorMessageTheme, Input, Spacer, Text } from '@/components'
+import { Button, Card, CardContent, CardHeader, CardTitle, ErrorMessageTheme, Input, Spacer, Text } from '@components'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 

--- a/packages/ui/src/views/layouts/SandboxRoot.tsx
+++ b/packages/ui/src/views/layouts/SandboxRoot.tsx
@@ -1,15 +1,14 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
 
-import { ManageNavigation, MoreSubmenu, Navbar, SettingsMenu } from '@/components'
 import { getNavbarMenuData } from '@/data/navbar-menu-data'
 import { getPinnedMenuItemsData } from '@/data/pinned-menu-items-data'
 import type { TypesUser } from '@/types'
+import { ManageNavigation, MoreSubmenu, Navbar, SettingsMenu } from '@components'
 import { MenuGroupType, MenuGroupTypes, NavbarItemIdType, NavbarItemType } from '@components/navbar/types'
 import { useLocationChange } from '@hooks/useLocationChange'
+import { SandboxLayout } from '@views'
 import { TFunction } from 'i18next'
-
-import { SandboxLayout } from '../index'
 
 /**
  * Returns the complete menu model based on an array of IDs,

--- a/packages/ui/src/views/repo/components/branch-selector/branch-selector-dropdown.tsx
+++ b/packages/ui/src/views/repo/components/branch-selector/branch-selector-dropdown.tsx
@@ -1,18 +1,9 @@
 import { FC, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 
-import {
-  Badge,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  Icon,
-  SearchBox,
-  Tabs,
-  TabsList,
-  TabsTrigger
-} from '@/components'
-import { TranslationStore } from '@/views'
+import { Badge, DropdownMenuContent, DropdownMenuItem, Icon, SearchBox, Tabs, TabsList, TabsTrigger } from '@components'
 import { cn } from '@utils/cn'
+import { TranslationStore } from '@views'
 import { BranchSelectorListItem } from '@views/repo/repo.types'
 import { TFunction } from 'i18next'
 
@@ -80,7 +71,7 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
   return (
     <DropdownMenuContent className="w-[298px] p-0" align="start">
       <div className="px-3 pt-2">
-        <span className="leading-none text-14 font-medium">Switch branches/tags</span>
+        <span className="text-14 font-medium leading-none">Switch branches/tags</span>
 
         <SearchBox.Root
           className="mt-[18px] w-full"
@@ -137,7 +128,7 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
       <div className="mt-1">
         {filteredItems.length === 0 && (
           <div className="px-5 py-4 text-center">
-            <span className="leading-tight text-foreground-2 text-14">Nothing to show</span>
+            <span className="text-foreground-2 text-14 leading-tight">Nothing to show</span>
           </div>
         )}
 
@@ -157,7 +148,7 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
                 key={item.name}
               >
                 <div className="flex w-full min-w-0 items-center gap-x-2">
-                  {isSelected && <Icon name="tick" size={12} className="min-w-[12px] text-foreground-1" />}
+                  {isSelected && <Icon name="tick" size={12} className="text-foreground-1 min-w-[12px]" />}
                   <span
                     className={cn('text-foreground-2 truncate', {
                       'text-foreground-1': isSelected
@@ -169,7 +160,7 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
 
                 {isDefault && (
                   <Badge
-                    className="bg-transparent font-medium text-foreground-3"
+                    className="text-foreground-3 bg-transparent font-medium"
                     variant="outline"
                     // TODO: Review and update 'muted' theme implementation
                     // Current 'muted' theme styles don't fully match the design requirements
@@ -194,9 +185,9 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
         </div>
 
         <DropdownMenuItem className="p-0" asChild>
-          <div className="mt-1 border-t border-borders-1 px-3 py-2">
+          <div className="border-borders-1 mt-1 border-t px-3 py-2">
             <Link to={viewAllUrl}>
-              <span className="leading-none transition-colors duration-200 hover:text-foreground-1 text-14 font-medium">
+              <span className="hover:text-foreground-1 text-14 font-medium leading-none transition-colors duration-200">
                 {t('views:repos.viewAll', 'View all {{type}}', {
                   type: activeTab === BranchSelectorTab.BRANCHES ? t('views:repos.branches') : t('views:repos.tags')
                 })}

--- a/packages/ui/src/views/repo/components/branch-selector/branch-selector.tsx
+++ b/packages/ui/src/views/repo/components/branch-selector/branch-selector.tsx
@@ -1,8 +1,8 @@
 import { FC } from 'react'
 
-import { Button, DropdownMenu, DropdownMenuTrigger, Icon, Text } from '@/components'
-import { TranslationStore } from '@/views'
+import { Button, DropdownMenu, DropdownMenuTrigger, Icon, Text } from '@components'
 import { cn } from '@utils/cn'
+import { TranslationStore } from '@views'
 
 import { BranchSelectorDropdown, type BranchSelectorDropdownProps } from './branch-selector-dropdown'
 
@@ -39,9 +39,9 @@ export const BranchSelector: FC<BranchSelectorProps> = ({
           size={size}
         >
           {!prefix && (
-            <Icon className="shrink-0 fill-transparent text-icons-9" name={isTag ? 'tag' : 'branch'} size={12} />
+            <Icon className="text-icons-9 shrink-0 fill-transparent" name={isTag ? 'tag' : 'branch'} size={12} />
           )}
-          <Text className="w-full text-foreground-8" truncate align="left">
+          <Text className="text-foreground-8 w-full" truncate align="left">
             {prefix ? `${prefix}: ${selectedBranch.name}` : selectedBranch.name}
           </Text>
           <Icon className="chevron-down text-icons-2" name="chevron-down" size={10} />

--- a/packages/ui/src/views/repo/components/summary/summary.tsx
+++ b/packages/ui/src/views/repo/components/summary/summary.tsx
@@ -15,9 +15,9 @@ import {
   TableHeader,
   TableRow,
   Text
-} from '@/components'
-import { LatestFileTypes, RepoFile, SummaryItemType, TranslationStore } from '@/views'
+} from '@components'
 import { getInitials } from '@utils/stringUtils'
+import { LatestFileTypes, RepoFile, SummaryItemType, TranslationStore } from '@views'
 
 interface SummaryProps {
   latestFile: LatestFileTypes

--- a/packages/ui/src/views/repo/repo-files/index.tsx
+++ b/packages/ui/src/views/repo/repo-files/index.tsx
@@ -1,8 +1,8 @@
 import { ReactNode, useMemo } from 'react'
 
-import { NoData, PathBreadcrumbs, PathParts, SkeletonList } from '@/components'
-import { LatestFileTypes, RepoFile, SandboxLayout, TranslationStore } from '@/views'
-import { Summary } from '@/views/repo/components'
+import { NoData, PathBreadcrumbs, PathParts, SkeletonList } from '@components'
+import { LatestFileTypes, RepoFile, SandboxLayout, TranslationStore } from '@views'
+import { Summary } from '@views/repo/components'
 
 interface RepoFilesProps {
   pathParts: PathParts[]

--- a/packages/ui/src/views/repo/repo-layout/index.tsx
+++ b/packages/ui/src/views/repo/repo-layout/index.tsx
@@ -1,7 +1,7 @@
 import { NavLink, Outlet, useLocation } from 'react-router-dom'
 
-import { Tabs, TabsList, TabsTrigger } from '@/components'
-import { SandboxLayout, TranslationStore } from '@/views'
+import { Tabs, TabsList, TabsTrigger } from '@components'
+import { SandboxLayout, TranslationStore } from '@views'
 
 export const RepoLayout = ({ useTranslationStore }: { useTranslationStore: () => TranslationStore }) => {
   const location = useLocation()

--- a/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FC, ReactNode, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
-import { Button, ListActions, PaginationComponent, SearchBox, SkeletonList, Spacer, Text } from '@/components'
+import { Button, ListActions, PaginationComponent, SearchBox, SkeletonList, Spacer, Text } from '@components'
 import { Filters, FiltersBar, type FilterValue, type SortValue } from '@components/filters'
 import useFilters from '@components/filters/use-filters'
 import { useCommonFilter } from '@hooks/useCommonFilter'

--- a/packages/ui/src/views/repo/repo-list/repo-list.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list.tsx
@@ -1,10 +1,12 @@
-import { Badge, Icon, NoData, StackedList } from '@/components'
+import { ComponentType, ReactNode } from 'react'
+
+import { Badge, Icon, NoData, StackedList } from '@components'
 
 import { RepositoryType } from './types'
 
 export interface PageProps {
   repos?: RepositoryType[]
-  LinkComponent: React.ComponentType<{ to: string; children: React.ReactNode }>
+  LinkComponent: ComponentType<{ to: string; children: ReactNode }>
   handleResetFilters?: () => void
   hasActiveFilters?: boolean
   query?: string

--- a/packages/ui/src/views/repo/repo-sidebar/index.tsx
+++ b/packages/ui/src/views/repo/repo-sidebar/index.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 
-import { Button, ButtonGroup, Icon, ScrollArea, SearchFiles, Spacer } from '@/components'
-import { SandboxLayout, TranslationStore } from '@/views'
+import { Button, ButtonGroup, Icon, ScrollArea, SearchFiles, Spacer } from '@components'
+import { SandboxLayout, TranslationStore } from '@views'
 import { BranchSelectorListItem } from '@views/repo'
 import { BranchSelector } from '@views/repo/components'
 
@@ -54,9 +54,9 @@ export const RepoSidebar = ({
                 useTranslationStore={useTranslationStore}
               />
             )}
-            <ButtonGroup.Root spacing="0" className="h-full overflow-hidden rounded shadow-as-border shadow-borders-2">
+            <ButtonGroup.Root spacing="0" className="shadow-as-border shadow-borders-2 h-full overflow-hidden rounded">
               <Button
-                className="rounded-none border-l border-borders-2 p-0"
+                className="border-borders-2 rounded-none border-l p-0"
                 size="icon"
                 variant="ghost"
                 aria-label="Create new folder"
@@ -65,7 +65,7 @@ export const RepoSidebar = ({
                 <Icon size={16} name="add-folder" className="text-icons-3" />
               </Button>
               <Button
-                className="rounded-none border-l border-borders-2 p-0"
+                className="border-borders-2 rounded-none border-l p-0"
                 size="icon"
                 variant="ghost"
                 aria-label="Create new file"

--- a/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
@@ -12,7 +12,7 @@ import {
   Spacer,
   Text,
   Textarea
-} from '@/components'
+} from '@components'
 
 interface DetailItem {
   id: string
@@ -46,7 +46,7 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
   return (
     <div className="flex flex-col">
       <div className="flex items-center justify-between">
-        <span className="text-18 font-medium truncate">{title}</span>
+        <span className="text-18 truncate font-medium">{title}</span>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" size="sm_icon" aria-label="More options">
@@ -63,12 +63,12 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
       </div>
       <Spacer size={3} />
       {description?.length && !isEditingDescription && (
-        <span className="line-clamp-3 py-3 border-y border-borders-4 text-foreground-2 text-14">{description}</span>
+        <span className="border-borders-4 text-foreground-2 text-14 line-clamp-3 border-y py-3">{description}</span>
       )}
       {isEditingDescription && (
         <div>
           <Textarea
-            className="h-28 text-primary"
+            className="text-primary h-28"
             value={newDesc}
             defaultValue={description}
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -17,9 +17,9 @@ import {
   Spacer,
   StackedList,
   Text
-} from '@/components'
-import { BranchSelectorListItem, RepoFile, SandboxLayout, TranslationStore } from '@/views'
-import { BranchSelector, Summary } from '@/views/repo/components'
+} from '@components'
+import { BranchSelectorListItem, RepoFile, SandboxLayout, TranslationStore } from '@views'
+import { BranchSelector, Summary } from '@views/repo/components'
 
 import SummaryPanel from './components/summary-panel'
 

--- a/packages/ui/src/views/webhooks/webhook-list/repo-webhook-list.tsx
+++ b/packages/ui/src/views/webhooks/webhook-list/repo-webhook-list.tsx
@@ -1,4 +1,4 @@
-import { Badge, NoData, Spacer, StackedList, Text } from '@/components'
+import { Badge, NoData, Spacer, StackedList, Text } from '@components'
 
 import { WebhookType } from './types'
 

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -12,7 +12,9 @@
     "skipLibCheck": true,
     "paths": {
       "@utils/*": ["src/utils/*"],
+      "@components": ["src/components"],
       "@components/*": ["src/components/*"],
+      "@views": ["src/views"],
       "@views/*": ["src/views/*"],
       "@hooks/*": ["src/hooks/*"],
       "@/*": ["src/*"]


### PR DESCRIPTION
This PR allows the import of components and views internally in the `ui` package using `@components` and `@views` respectively.

This allows devs to use:

```typescript
import { Button } from '@components'
```

Instead of:
```typescript
import { Button } from '@components/index'
// or
import { Button } from '@/components'
```

Other changes are the result of ESLint and Prettier fixes.