### PR TITLE
feat: minor styling improvements

### DIFF
--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
       variant: {
         default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
         destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
-        outline: 'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        outline: 'border border-borders-2 bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground',
         secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
         tertiary: 'bg-tertiary text-secondary-foreground shadow-sm hover:bg-tertiary/80',
         ghost: 'hover:bg-background-12 hover:text-accent-foreground',

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -82,7 +82,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'bg-background-2 text-popover-foreground shadow-1 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1',
+        'bg-background-2 text-foreground-8 shadow-1 z-50 min-w-[8rem] overflow-hidden rounded-md border border-borders-1 p-1',
         className
       )}
       {...props}

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -17,7 +17,7 @@ const tabsListVariants = cva('inline-flex items-center text-foreground-4', {
       // 2. Create a unified variant based on branch
       // 3. Update existing components
       tabnav: 'h-[36px] w-full justify-start gap-0',
-      branch: 'flex w-full border-b border-borders-4 px-3'
+      branch: 'flex w-full border-b border-borders-1 px-3'
     }
   },
   defaultVariants: {
@@ -38,7 +38,7 @@ const tabsTriggerVariants = cva(
         tabnav:
           'm-0 h-[36px] items-center gap-2 rounded-t-md bg-background px-4 text-sm font-normal text-tertiary-background duration-150 ease-in-out tabnav-inactive hover:text-foreground-1 data-[state=active]:tabnav-active [&svg]:data-[state=active]:text-icons-2',
         branch:
-          '-mb-px h-[34px] rounded-t-md border-x border-t border-transparent px-3.5 font-normal text-foreground-2 hover:text-foreground-1 data-[state=active]:border-borders-4 data-[state=active]:text-foreground-1'
+          '-mb-px h-[34px] rounded-t-md border-x border-t border-transparent px-3.5 font-normal text-foreground-2 hover:text-foreground-1 data-[state=active]:border-borders-1 data-[state=active]:text-foreground-1'
       }
     },
     defaultVariants: {

--- a/packages/ui/src/views/repo/components/branch-selector/branch-selector-dropdown.tsx
+++ b/packages/ui/src/views/repo/components/branch-selector/branch-selector-dropdown.tsx
@@ -9,8 +9,7 @@ import {
   SearchBox,
   Tabs,
   TabsList,
-  TabsTrigger,
-  Text
+  TabsTrigger
 } from '@/components'
 import { cn } from '@utils/cn'
 import { BranchSelectorListItem } from '@views/repo/repo.types'
@@ -75,9 +74,7 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
   return (
     <DropdownMenuContent className="w-[298px] p-0" align="start">
       <div className="px-3 pt-2">
-        <Text className="leading-none" size={2} weight="medium">
-          Switch branches/tags
-        </Text>
+        <span className="leading-none text-14 font-medium">Switch branches/tags</span>
 
         <SearchBox.Root
           className="mt-[18px] w-full"
@@ -134,9 +131,7 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
       <div className="mt-1">
         {filteredItems.length === 0 && (
           <div className="px-5 py-4 text-center">
-            <Text className="leading-tight text-foreground-2" size={2}>
-              Nothing to show
-            </Text>
+            <span className="leading-tight text-foreground-2 text-14">Nothing to show</span>
           </div>
         )}
 
@@ -157,14 +152,13 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
               >
                 <div className="flex w-full min-w-0 items-center gap-x-2">
                   {isSelected && <Icon name="tick" size={12} className="min-w-[12px] text-foreground-1" />}
-                  <Text
-                    className={cn('text-foreground-2', {
+                  <span
+                    className={cn('text-foreground-2 truncate', {
                       'text-foreground-1': isSelected
                     })}
-                    truncate
                   >
                     {item.name}
-                  </Text>
+                  </span>
                 </div>
 
                 {isDefault && (
@@ -194,11 +188,11 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
         </div>
 
         <DropdownMenuItem className="p-0" asChild>
-          <div className="mt-1 border-t border-borders-4 px-3 py-2">
+          <div className="mt-1 border-t border-borders-1 px-3 py-2">
             <Link to={viewAllUrl}>
-              <Text className="leading-none text-ring transition-colors duration-200 hover:text-foreground-1">
+              <span className="leading-none transition-colors duration-200 hover:text-foreground-1 text-14 font-medium">
                 View all {activeTab === BranchSelectorTab.BRANCHES ? 'branches' : 'tags'}
-              </Text>
+              </span>
             </Link>
           </div>
         </DropdownMenuItem>

--- a/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
@@ -46,31 +46,31 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
   return (
     <div className="flex flex-col">
       <div className="flex items-center justify-between">
-        <Text size={4} weight={'medium'} truncate>
-          {title}
-        </Text>
+        <span className="text-18 font-medium truncate">{title}</span>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm_icon">
-              <Icon name="ellipsis" size={12} className="text-primary" />
+            <Button variant="ghost" size="sm_icon" aria-label="More options">
+              <Icon name="more-dots-fill" size={12} className="text-icons-3" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem className="flex items-center gap-1.5" onClick={onChangeDescription}>
               <Icon name="plus" size={12} className="text-tertiary-background" />
-              <Text>{description?.length ? 'Edit Description' : 'Add description'}</Text>
+              <span>{description?.length ? 'Edit Description' : 'Add description'}</span>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      <Spacer size={2} />
-      {description?.length && !isEditingDescription ? <Text className="line-clamp-3">{description}</Text> : <></>}
+      <Spacer size={3} />
+      {description?.length && !isEditingDescription && (
+        <span className="line-clamp-3 py-3 border-y border-borders-4 text-foreground-2 text-14">{description}</span>
+      )}
       {isEditingDescription && (
         <div>
           <Textarea
-            defaultValue={description}
             className="h-28 text-primary"
             value={newDesc}
+            defaultValue={description}
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
               setNewDesc(e?.target?.value)
             }}
@@ -95,11 +95,7 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
         </div>
       )}
       <Spacer size={2} />
-      {timestamp && (
-        <Text size={1} color={'tertiaryBackground'}>
-          Created {timestamp}
-        </Text>
-      )}
+      {timestamp && <span className="text-foreground-4 text-13">Created {timestamp}</span>}
       <Spacer size={5} />
       <div className="flex flex-col gap-3">
         {details &&


### PR DESCRIPTION
**Description:**
This pull request introduces minor style adjustments for the `Branch Selector`, `Filters` (updated border color), and `Summary Panel` (updated description area: text color and size.) components, as well as a small refactoring of the `Text` component.

**Screenshots:**
Before
<img width="1819" alt="Google Chrome 2024-12-03 01 29 30" src="https://github.com/user-attachments/assets/bbd27e5a-26cc-4bc8-8302-5be1aa0de2d4">


After
<img width="1823" alt="Google Chrome 2024-12-03 01 30 56" src="https://github.com/user-attachments/assets/1e24b31b-f65a-4c40-a633-d5de1f1c9cd2">
