### PR TITLE
Handled loading, error and no data states in view

### DIFF
--- a/apps/gitness/src/pages-v2/repo/repo-list.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-list.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useMemo } from 'react'
 import { parseAsInteger, useQueryState } from 'nuqs'
 
 import { ListReposOkResponse, useListReposQuery } from '@harnessio/code-service-client'
-import { SkeletonList, Spacer, Text } from '@harnessio/ui/components'
 import { SandboxRepoListPage } from '@harnessio/ui/views'
 
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
@@ -67,17 +66,13 @@ export default function ReposListPage() {
     shouldRun: isRepoStillImporting
   })
 
-  if (isLoading) return <SkeletonList />
-
-  if (isError)
-    return (
-      <>
-        <Spacer size={2} />
-        <Text size={1} className="text-destructive">
-          {error?.message || 'Something went wrong'}
-        </Text>
-      </>
-    )
-
-  return <SandboxRepoListPage useRepoStore={useRepoStore} useTranslationStore={useTranslationStore} />
+  return (
+    <SandboxRepoListPage
+      useRepoStore={useRepoStore}
+      useTranslationStore={useTranslationStore}
+      isLoading={isLoading}
+      isError={isError}
+      errorMessage={error?.message}
+    />
+  )
 }

--- a/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
+import { SkeletonList } from '@/components'
 import { Filters, FiltersBar, type FilterValue, type SortValue } from '@components/filters'
 import useFilters from '@components/filters/use-filters'
 import { Button, ListActions, PaginationComponent, SearchBox, Spacer, Text } from '@components/index'
@@ -14,7 +15,13 @@ import { RepoListProps } from './types'
 
 const LinkComponent = ({ to, children }: { to: string; children: React.ReactNode }) => <Link to={to}>{children}</Link>
 
-const SandboxRepoListPage: React.FC<RepoListProps> = ({ useRepoStore, useTranslationStore }) => {
+const SandboxRepoListPage: React.FC<RepoListProps> = ({
+  useRepoStore,
+  useTranslationStore,
+  isLoading,
+  isError,
+  errorMessage
+}) => {
   const { t } = useTranslationStore()
   const FILTER_OPTIONS = getFilterOptions(t)
   const SORT_OPTIONS = getSortOptions(t)
@@ -365,6 +372,18 @@ const SandboxRepoListPage: React.FC<RepoListProps> = ({ useRepoStore, useTransla
     setValue('')
     handleSearch({ target: { value: '' } } as React.ChangeEvent<HTMLInputElement>)
   }
+
+  if (isLoading) return <SkeletonList />
+
+  if (isError)
+    return (
+      <>
+        <Spacer size={2} />
+        <Text size={1} className="text-destructive">
+          {errorMessage || 'Something went wrong'}
+        </Text>
+      </>
+    )
 
   return (
     <>

--- a/packages/ui/src/views/repo/repo-list/repo-list.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list.tsx
@@ -41,69 +41,73 @@ export function RepoList({
   query,
   handleResetQuery
 }: PageProps) {
+  const noData = !(repos && repos.length > 0)
+
+  if (noData) {
+    return (
+      <StackedList.Root>
+        <div className="flex min-h-[50vh] items-center justify-center py-20">
+          {hasActiveFilters || query ? (
+            <NoData
+              iconName="no-search-magnifying-glass"
+              title="No search results"
+              description={['Check your spelling and filter options,', 'or search for a different keyword.']}
+              primaryButton={{
+                label: 'Clear search',
+                onClick: handleResetQuery
+              }}
+              secondaryButton={{
+                label: 'Clear filters',
+                onClick: handleResetFilters
+              }}
+            />
+          ) : (
+            <NoData
+              iconName="no-data-folder"
+              title="No repositories yet"
+              description={[
+                'There are no repositories in this project yet.',
+                'Create new or import an existing repository.'
+              ]}
+              primaryButton={{
+                label: 'Create repository',
+                onClick: () => {
+                  /* TODO: add create handler */
+                }
+              }}
+            />
+          )}
+        </div>
+      </StackedList.Root>
+    )
+  }
+
   return (
     <>
       <StackedList.Root>
-        {repos && repos.length > 0 ? (
-          <>
-            {repos.map((repo, repo_idx) => (
-              <LinkComponent key={repo_idx} to={repo.name}>
-                <StackedList.Item key={repo.name} isLast={repos.length - 1 === repo_idx}>
-                  <StackedList.Field
-                    primary
-                    description={repo.description}
-                    title={<Title title={repo.name} isPrivate={repo.private} />}
-                    className="gap-1.5 truncate"
-                  />
-                  <StackedList.Field
-                    title={
-                      <>
-                        Updated <em>{repo.timestamp}</em>
-                      </>
-                    }
-                    description={<Stats stars={repo.stars} pulls={repo.pulls} />}
-                    right
-                    label
-                    secondary
-                  />
-                </StackedList.Item>
-              </LinkComponent>
-            ))}
-          </>
-        ) : (
-          <div className="flex min-h-[50vh] items-center justify-center py-20">
-            {hasActiveFilters || query ? (
-              <NoData
-                iconName="no-search-magnifying-glass"
-                title="No search results"
-                description={['Check your spelling and filter options,', 'or search for a different keyword.']}
-                primaryButton={{
-                  label: 'Clear search',
-                  onClick: handleResetQuery
-                }}
-                secondaryButton={{
-                  label: 'Clear filters',
-                  onClick: handleResetFilters
-                }}
+        {repos.map((repo, repo_idx) => (
+          <LinkComponent key={repo_idx} to={repo.name}>
+            <StackedList.Item key={repo.name} isLast={repos.length - 1 === repo_idx}>
+              <StackedList.Field
+                primary
+                description={repo.description}
+                title={<Title title={repo.name} isPrivate={repo.private} />}
+                className="gap-1.5 truncate"
               />
-            ) : (
-              <NoData
-                iconName="no-data-folder"
-                title="No repositories yet"
-                description={[
-                  'There are no repositories in this project yet.',
-                  'Create new or import an existing repository.'
-                ]}
-                primaryButton={{
-                  label: 'Create repository',
-                  onClick: () => {
-                    /* TODO: add create handler */
-                  }
-                }}
+              <StackedList.Field
+                title={
+                  <>
+                    Updated <em>{repo.timestamp}</em>
+                  </>
+                }
+                description={<Stats stars={repo.stars} pulls={repo.pulls} />}
+                right
+                label
+                secondary
               />
-            )}
-          </div>
-        )}
+            </StackedList.Item>
+          </LinkComponent>
+        ))}
       </StackedList.Root>
     </>
   )

--- a/packages/ui/src/views/repo/repo-list/types.ts
+++ b/packages/ui/src/views/repo/repo-list/types.ts
@@ -29,4 +29,7 @@ export interface TranslationStore {
 export interface RepoListProps {
   useRepoStore: () => RepoStore
   useTranslationStore: () => TranslationStore
+  isLoading: boolean
+  isError: boolean
+  errorMessage?: string
 }


### PR DESCRIPTION
The loading and error states are currently handled directly in the repo-list page. Ideally, these states should be passed as props to the view, enabling the view to handle rendering for the Loading, Error, or No Data states in a more modular way.

In several pages/views, multiple ternary operators are being used, which can reduce code readability and maintainability. Let's try using if conditions instead for rendering different data states.

The source of truth for loading, error, and data states should come from the react-query hook and be passed as props from the page to the view.

Refer to the changes in this PR as a reference for effectively managing data states.