### PR TITLE
feat: add Views Management System for Filters

### DIFF
--- a/packages/ui/locales/en/component.json
+++ b/packages/ui/locales/en/component.json
@@ -1,11 +1,10 @@
 {
   "filter": {
+    "add-filter": "Add filter",
+    "reset": "Reset",
     "defaultLabel": "Filter",
     "inputPlaceholder": "Filter by...",
     "buttonLabel": "Reset filters",
-    "add-filter": "Add filter",
-    "reset": "Reset",
-    "save": "Save",
     "is": "is",
     "isNot": "is not",
     "isEmpty": "is empty",
@@ -104,5 +103,9 @@
   "searchFile": {
     "input": "Search files...",
     "noFile": "No file found."
+  },
+  "layout": {
+    "table": "Table",
+    "list": "List"
   }
 }

--- a/packages/ui/locales/en/component_old.json
+++ b/packages/ui/locales/en/component_old.json
@@ -1,5 +1,0 @@
-{
-  "filter": {
-    "save": "Save"
-  }
-}

--- a/packages/ui/locales/en/component_old.json
+++ b/packages/ui/locales/en/component_old.json
@@ -1,0 +1,5 @@
+{
+  "filter": {
+    "save": "Save"
+  }
+}

--- a/packages/ui/locales/es/component.json
+++ b/packages/ui/locales/es/component.json
@@ -1,11 +1,10 @@
 {
   "filter": {
+    "add-filter": "Add filter",
+    "reset": "Reset",
     "defaultLabel": "Filter",
     "inputPlaceholder": "Filter by...",
     "buttonLabel": "Reset filters",
-    "add-filter": "Add filter",
-    "reset": "Reset",
-    "save": "Save",
     "is": "is",
     "isNot": "is not",
     "isEmpty": "is empty",
@@ -104,5 +103,9 @@
   "searchFile": {
     "input": "Search files...",
     "noFile": "No file found."
+  },
+  "layout": {
+    "table": "Table",
+    "list": "List"
   }
 }

--- a/packages/ui/locales/es/component_old.json
+++ b/packages/ui/locales/es/component_old.json
@@ -1,5 +1,0 @@
-{
-  "filter": {
-    "save": "Save"
-  }
-}

--- a/packages/ui/locales/es/component_old.json
+++ b/packages/ui/locales/es/component_old.json
@@ -1,0 +1,5 @@
+{
+  "filter": {
+    "save": "Save"
+  }
+}

--- a/packages/ui/locales/fr/component.json
+++ b/packages/ui/locales/fr/component.json
@@ -1,11 +1,10 @@
 {
   "filter": {
+    "add-filter": "Ajouter un filtre",
+    "reset": "Réinitialiser",
     "defaultLabel": "Filtrer",
     "inputPlaceholder": "Filtrer par...",
     "buttonLabel": "Réinitialiser les filtres",
-    "add-filter": "Ajouter un filtre",
-    "reset": "Réinitialiser",
-    "save": "Enregistrer",
     "is": "est",
     "isNot": "n'est pas",
     "isEmpty": "est vide",
@@ -104,5 +103,9 @@
   "searchFile": {
     "input": "Rechercher des fichiers...",
     "noFile": "Aucun fichier trouvé."
+  },
+  "layout": {
+    "table": "Table",
+    "list": "List"
   }
 }

--- a/packages/ui/locales/fr/component_old.json
+++ b/packages/ui/locales/fr/component_old.json
@@ -1,0 +1,5 @@
+{
+  "filter": {
+    "save": "Enregistrer"
+  }
+}

--- a/packages/ui/locales/fr/component_old.json
+++ b/packages/ui/locales/fr/component_old.json
@@ -1,5 +1,0 @@
-{
-  "filter": {
-    "save": "Enregistrer"
-  }
-}

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -100,10 +100,29 @@ AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
 
 const AlertDialogDescription = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Description ref={ref} className={cn('text-muted-foreground text-sm', className)} {...props} />
-))
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description> & {
+    variant?: 'secondary' | 'quaternary'
+    size?: 'sm'
+  }
+>(({ className, variant = 'quaternary', size = 'sm', ...props }, ref) => {
+  const variants = {
+    variant: {
+      secondary: 'text-foreground-2',
+      quaternary: 'text-foreground-4'
+    },
+    size: {
+      sm: 'text-sm'
+    }
+  }
+
+  return (
+    <AlertDialogPrimitive.Description
+      ref={ref}
+      className={cn(className, variants.variant[variant], variants.size[size])}
+      {...props}
+    />
+  )
+})
 AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName
 
 const AlertDialogAction = React.forwardRef<

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -25,8 +25,8 @@ const buttonVariants = cva(
         custom: ''
       },
       size: {
-        default: 'h-8 px-6 py-2',
-        sm: 'h-7 px-3 py-0 text-sm font-normal',
+        default: 'h-8 px-6',
+        sm: 'h-7 px-3 text-sm font-normal',
         xs: 'h-auto px-1.5 py-0.5 text-xs font-normal',
         md: 'h-9 px-7',
         lg: 'h-10 px-8',

--- a/packages/ui/src/components/filters/filters-bar/actions/filters.tsx
+++ b/packages/ui/src/components/filters/filters-bar/actions/filters.tsx
@@ -1,23 +1,28 @@
 import { useEffect, useState } from 'react'
 
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, Icon } from '@/components'
 import { cn } from '@utils/cn'
 
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../../dropdown-menu'
-import { Icon } from '../../icon'
-import type { CheckboxFilterOption, FilterAction, FilterOption, FilterSearchQueries, FilterValue } from '../types'
-import { UseFiltersReturn } from '../use-filters'
-import { getFilterDisplayValue, getFilteredOptions } from '../utils'
-import Calendar from './filter-variants/calendar'
-import Checkbox from './filter-variants/checkbox'
-import Number from './filter-variants/number'
-import Text from './filter-variants/text'
+import type {
+  CheckboxFilterOption,
+  FilterAction,
+  FilterHandlers,
+  FilterOption,
+  FilterSearchQueries,
+  FilterValue
+} from '../../types'
+import { getFilterDisplayValue, getFilteredOptions } from '../../utils'
+import Calendar from './variants/calendar'
+import Checkbox from './variants/checkbox'
+import Number from './variants/number'
+import Text from './variants/text'
 
 const renderFilterValues = (
   filter: FilterValue,
   filterOption: FilterOption,
-  onUpdateFilter: UseFiltersReturn['handleUpdateFilter'],
+  onUpdateFilter: FilterHandlers['handleUpdateFilter'],
   searchQueries: FilterSearchQueries,
-  handleSearchChange: UseFiltersReturn['handleSearchChange'],
+  handleSearchChange: FilterHandlers['handleSearchChange'],
   filteredOptions?: CheckboxFilterOption['options']
 ) => {
   if (!onUpdateFilter) return null
@@ -50,10 +55,10 @@ const renderFilterValues = (
 interface FiltersProps {
   filter: FilterValue
   filterOptions: FilterOption[]
-  handleUpdateFilter: UseFiltersReturn['handleUpdateFilter']
-  handleRemoveFilter: UseFiltersReturn['handleRemoveFilter']
-  handleUpdateCondition: UseFiltersReturn['handleUpdateCondition']
-  handleSearchChange: UseFiltersReturn['handleSearchChange']
+  handleUpdateFilter: FilterHandlers['handleUpdateFilter']
+  handleRemoveFilter: FilterHandlers['handleRemoveFilter']
+  handleUpdateCondition: FilterHandlers['handleUpdateCondition']
+  handleSearchChange: FilterHandlers['handleSearchChange']
   searchQueries: FilterSearchQueries
   filterToOpen: FilterAction | null
   onOpen?: () => void

--- a/packages/ui/src/components/filters/filters-bar/actions/sorts.tsx
+++ b/packages/ui/src/components/filters/filters-bar/actions/sorts.tsx
@@ -1,3 +1,5 @@
+// TODO: we should rethink the approach and stop using the @dnd-kit library
+
 import { useEffect, useState } from 'react'
 
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, Icon, Input } from '@/components'
@@ -7,16 +9,22 @@ import { CSS } from '@dnd-kit/utilities'
 import useDragAndDrop from '@hooks/use-drag-and-drop'
 import { cn } from '@utils/cn'
 
-import type { FilterAction, FilterSearchQueries, SortDirection, SortOption, SortValue } from '../types'
-import { UseFiltersReturn } from '../use-filters'
-import { getSortTriggerLabel } from '../utils'
+import type {
+  FilterAction,
+  FilterHandlers,
+  FilterSearchQueries,
+  SortDirection,
+  SortOption,
+  SortValue
+} from '../../types'
+import { getSortTriggerLabel } from '../../utils'
 
 interface SortableItemProps {
   id: string
   sort: SortValue
   index: number
-  onUpdateSort: UseFiltersReturn['handleUpdateSort']
-  onRemoveSort: UseFiltersReturn['handleRemoveSort']
+  onUpdateSort: FilterHandlers['handleUpdateSort']
+  onRemoveSort: FilterHandlers['handleRemoveSort']
   sortOptions: SortOption[]
   sortDirections: SortDirection[]
 }
@@ -104,13 +112,13 @@ const SortableItem = ({
 interface SortsProps {
   activeSorts: SortValue[]
   sortOptions: SortOption[]
-  handleUpdateSort: UseFiltersReturn['handleUpdateSort']
-  handleSortChange: UseFiltersReturn['handleSortChange']
-  handleRemoveSort: UseFiltersReturn['handleRemoveSort']
-  handleResetSorts: UseFiltersReturn['handleResetSorts']
-  handleReorderSorts: UseFiltersReturn['handleReorderSorts']
+  handleUpdateSort: FilterHandlers['handleUpdateSort']
+  handleSortChange: FilterHandlers['handleSortChange']
+  handleRemoveSort: FilterHandlers['handleRemoveSort']
+  handleResetSorts: FilterHandlers['handleResetSorts']
+  handleReorderSorts: FilterHandlers['handleReorderSorts']
   searchQueries: FilterSearchQueries
-  handleSearchChange: UseFiltersReturn['handleSearchChange']
+  handleSearchChange: FilterHandlers['handleSearchChange']
   sortDirections: SortDirection[]
   filterToOpen: FilterAction | null
   onOpen?: () => void

--- a/packages/ui/src/components/filters/filters-bar/actions/variants/calendar.tsx
+++ b/packages/ui/src/components/filters/filters-bar/actions/variants/calendar.tsx
@@ -3,12 +3,11 @@ import { useState } from 'react'
 import { Input, Calendar as UICalendar, type CalendarDateRange } from '@/components'
 import { cn } from '@utils/cn'
 
-import { FilterValue } from '../../types'
-import { UseFiltersReturn } from '../../use-filters'
+import { FilterHandlers, FilterValue } from '../../../types'
 
 interface CalendarProps {
   filter: FilterValue
-  onUpdateFilter: UseFiltersReturn['handleUpdateFilter']
+  onUpdateFilter: FilterHandlers['handleUpdateFilter']
 }
 
 interface DateInputState {

--- a/packages/ui/src/components/filters/filters-bar/actions/variants/checkbox.tsx
+++ b/packages/ui/src/components/filters/filters-bar/actions/variants/checkbox.tsx
@@ -1,15 +1,14 @@
 import { DropdownMenuCheckboxItem, Icon, Input } from '@/components'
 
-import { CheckboxFilterOption, FilterValue } from '../../types'
-import { UseFiltersReturn } from '../../use-filters'
-import { getFilteredOptions } from '../../utils'
+import { CheckboxFilterOption, FilterHandlers, FilterValue } from '../../../types'
+import { getFilteredOptions } from '../../../utils'
 
 interface CheckboxFilterProps {
   filter: FilterValue
   filterOption: CheckboxFilterOption
-  onUpdateFilter: UseFiltersReturn['handleUpdateFilter']
-  searchQueries: UseFiltersReturn['searchQueries']
-  handleSearchChange: UseFiltersReturn['handleSearchChange']
+  onUpdateFilter: FilterHandlers['handleUpdateFilter']
+  searchQueries: FilterHandlers['searchQueries']
+  handleSearchChange: FilterHandlers['handleSearchChange']
 }
 
 const Checkbox = ({ filter, filterOption, onUpdateFilter, searchQueries, handleSearchChange }: CheckboxFilterProps) => {
@@ -18,17 +17,17 @@ const Checkbox = ({ filter, filterOption, onUpdateFilter, searchQueries, handleS
   return (
     <>
       {filter.condition !== 'is_empty' && (
-        <div className="border-b border-borders-1 px-3 pb-2.5">
-          <div className="border-border-2 flex min-h-8 justify-between gap-x-1 rounded border px-1 py-[3px] outline-none transition-colors duration-200 focus-within:border focus-within:border-borders-3">
+        <div className="border-borders-1 border-b px-3 pb-2.5">
+          <div className="border-border-2 focus-within:border-borders-3 flex min-h-8 justify-between gap-x-1 rounded border px-1 py-[3px] outline-none transition-colors duration-200 focus-within:border">
             <div className="flex flex-1 flex-wrap items-center gap-1">
               {!!filter.selectedValues.length &&
                 filter.selectedValues.map(value => {
                   const label = filterOption.options?.find(opt => opt.value === value)?.label
                   return (
-                    <div className="flex h-6 items-center gap-x-1.5 rounded bg-background-8 px-2" key={value}>
+                    <div className="bg-background-8 flex h-6 items-center gap-x-1.5 rounded px-2" key={value}>
                       <span className="text-14 text-foreground-8">{label}</span>
                       <button
-                        className="text-icons-1 transition-colors duration-200 hover:text-foreground-1"
+                        className="text-icons-1 hover:text-foreground-1 transition-colors duration-200"
                         onClick={() => {
                           const newValues = filter.selectedValues.filter(v => v !== value)
                           onUpdateFilter(filter.type, newValues)
@@ -54,7 +53,7 @@ const Checkbox = ({ filter, filterOption, onUpdateFilter, searchQueries, handleS
             </div>
             {(!!filter.selectedValues.length || searchQueries.filters[filter.type]) && (
               <button
-                className="flex p-1.5 text-foreground-4 transition-colors duration-200 hover:text-foreground-1"
+                className="text-foreground-4 hover:text-foreground-1 flex p-1.5 transition-colors duration-200"
                 onClick={() => {
                   onUpdateFilter(filter.type, [])
                   handleSearchChange?.(filter.type, '', 'filters')

--- a/packages/ui/src/components/filters/filters-bar/actions/variants/number.tsx
+++ b/packages/ui/src/components/filters/filters-bar/actions/variants/number.tsx
@@ -2,12 +2,11 @@ import { useState } from 'react'
 
 import { Icon, Input } from '@/components'
 
-import { FilterValue } from '../../types'
-import { UseFiltersReturn } from '../../use-filters'
+import { FilterHandlers, FilterValue } from '../../../types'
 
 interface NumberFilterProps {
   filter: FilterValue
-  onUpdateFilter: UseFiltersReturn['handleUpdateFilter']
+  onUpdateFilter: FilterHandlers['handleUpdateFilter']
 }
 
 const Number = ({ filter, onUpdateFilter }: NumberFilterProps) => {

--- a/packages/ui/src/components/filters/filters-bar/actions/variants/text.tsx
+++ b/packages/ui/src/components/filters/filters-bar/actions/variants/text.tsx
@@ -2,12 +2,11 @@ import { useState } from 'react'
 
 import { DropdownMenuItem, Icon, Input } from '@/components'
 
-import { FilterValue } from '../../types'
-import { UseFiltersReturn } from '../../use-filters'
+import { FilterHandlers, FilterValue } from '../../../types'
 
 interface TextFilterProps {
   filter: FilterValue
-  onUpdateFilter: UseFiltersReturn['handleUpdateFilter']
+  onUpdateFilter: FilterHandlers['handleUpdateFilter']
 }
 
 const Text = ({ filter, onUpdateFilter }: TextFilterProps) => {

--- a/packages/ui/src/components/filters/filters-bar/actions/views.tsx
+++ b/packages/ui/src/components/filters/filters-bar/actions/views.tsx
@@ -1,0 +1,272 @@
+import { FC, useEffect, useState } from 'react'
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Icon,
+  Input
+} from '@/components'
+
+import { FilterValue, SavedView, SortValue, ViewManagement } from '../../types'
+
+/**
+ * Views component handles the management of filter views including creation, updating, renaming and deletion.
+ * It provides UI for saving current filter/sort configurations as named views and managing existing ones.
+ */
+interface ViewsProps {
+  currentView: SavedView | null
+  savedViews: SavedView[]
+  viewManagement: ViewManagement & {
+    activeFilters: FilterValue[]
+    activeSorts: SortValue[]
+  }
+  hasChanges: boolean
+}
+
+const Views: FC<ViewsProps> = ({ currentView, viewManagement, hasChanges }) => {
+  /**
+   * Dialog states for creating new view and renaming existing one
+   */
+  const [isNewViewDialogOpen, setIsNewViewDialogOpen] = useState(false)
+  const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false)
+  const [newViewName, setNewViewName] = useState('')
+  const [nameError, setNameError] = useState('')
+
+  /**
+   * Effect handles real-time validation of view names
+   * - For new views: checks if name already exists
+   * - For renaming: checks if new name exists excluding current view
+   * - Skips validation for empty names (handled by button disable state)
+   */
+  useEffect(() => {
+    const trimmedName = newViewName.trim()
+
+    if (!trimmedName) {
+      setNameError('')
+      return
+    }
+
+    if (isRenameDialogOpen && currentView) {
+      if (trimmedName === currentView.name) {
+        setNameError('')
+        return
+      }
+
+      if (viewManagement.checkNameExists(trimmedName, currentView.id)) {
+        setNameError('A view with this name already exists')
+      } else {
+        setNameError('')
+      }
+    } else {
+      if (viewManagement.checkNameExists(trimmedName)) {
+        setNameError('A view with this name already exists')
+      } else {
+        setNameError('')
+      }
+    }
+  }, [newViewName, currentView, isRenameDialogOpen, viewManagement])
+
+  /**
+   * Resets error state when dialogs are opened/closed
+   * to ensure clean state for next interaction
+   */
+  useEffect(() => {
+    setNameError('')
+  }, [isNewViewDialogOpen, isRenameDialogOpen])
+
+  /**
+   * Handles saving a new view with current filters and sorts
+   * Validates name existence before saving
+   * Closes dialog and resets form state after successful save
+   */
+  const handleSaveNewView = () => {
+    const trimmedName = newViewName.trim()
+    if (viewManagement.checkNameExists(trimmedName)) return
+
+    viewManagement.saveView(trimmedName, viewManagement.activeFilters, viewManagement.activeSorts)
+    setNewViewName('')
+    setNameError('')
+    setIsNewViewDialogOpen(false)
+  }
+
+  /**
+   * Handles renaming an existing view
+   * Validates new name doesn't conflict with other views
+   * Updates view name and closes dialog on success
+   */
+  const handleRename = () => {
+    if (!currentView) return
+
+    const trimmedName = newViewName.trim()
+    if (viewManagement.checkNameExists(trimmedName, currentView.id)) return
+
+    viewManagement.renameView(currentView.id, trimmedName)
+    setNewViewName('')
+    setNameError('')
+    setIsRenameDialogOpen(false)
+  }
+
+  /**
+   * Updates current view with latest filter and sort configurations
+   * Used when user modifies filters/sorts and wants to update existing view
+   */
+  const handleUpdateCurrentView = () => {
+    if (!currentView) return
+
+    const updatedView = {
+      ...currentView,
+      filters: viewManagement.activeFilters,
+      sorts: viewManagement.activeSorts
+    }
+    viewManagement.updateView(updatedView)
+  }
+
+  /**
+   * Validation flags for enabling/disabling save buttons
+   * - canSaveNew: checks if new view name is valid and unique
+   * - canRename: checks if new name is valid, different from current, and unique
+   */
+  const canSaveNew = newViewName.trim() !== '' && !viewManagement.checkNameExists(newViewName.trim())
+  const canRename =
+    currentView &&
+    newViewName.trim() !== '' &&
+    newViewName.trim() !== currentView.name &&
+    !viewManagement.checkNameExists(newViewName.trim(), currentView.id)
+
+  return (
+    <>
+      {!currentView ? (
+        <Button
+          className="flex items-center gap-x-1.5 text-14 text-foreground-4 hover:text-foreground-1 transition-colors duration-200 px-0"
+          variant="custom"
+          onClick={() => setIsNewViewDialogOpen(true)}
+        >
+          <Icon name="bookmark-add" size={12} />
+          <span>Save view</span>
+        </Button>
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              className="flex items-center gap-x-1.5 text-14 text-foreground-4 hover:text-foreground-1 transition-colors duration-200 px-0"
+              variant="custom"
+            >
+              <Icon name="bookmark-icon" size={12} />
+              <span>Manage view</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-48" align="end">
+            {hasChanges && (
+              <>
+                <DropdownMenuItem onSelect={handleUpdateCurrentView}>Update current view</DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => setIsNewViewDialogOpen(true)}>Save as new view</DropdownMenuItem>
+              </>
+            )}
+            <DropdownMenuItem
+              onSelect={() => {
+                setNewViewName(currentView.name)
+                setIsRenameDialogOpen(true)
+              }}
+            >
+              Rename
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="text-foreground-danger"
+              onSelect={() => viewManagement.deleteView(currentView.id)}
+            >
+              Delete view
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+
+      <AlertDialog open={isNewViewDialogOpen} onOpenChange={setIsNewViewDialogOpen}>
+        <AlertDialogContent className="max-w-[460px]">
+          <AlertDialogHeader>
+            <AlertDialogTitle>New view</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogDescription variant="secondary">
+            You can save current configuration of the view. Manage and switch them through the{' '}
+            <strong className="text-foreground-1">View</strong> dropdown.
+          </AlertDialogDescription>
+
+          <div className="pt-3 pb-4">
+            <Input
+              label="Name"
+              placeholder="Enter view name"
+              value={newViewName}
+              size="md"
+              error={nameError}
+              onChange={e => {
+                setNewViewName(e.target.value)
+              }}
+            />
+          </div>
+          <AlertDialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setIsNewViewDialogOpen(false)
+                setNameError('')
+                setNewViewName('')
+              }}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleSaveNewView} disabled={!canSaveNew}>
+              Save
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={isRenameDialogOpen} onOpenChange={setIsRenameDialogOpen}>
+        <AlertDialogContent className="max-w-[460px]">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Rename view</AlertDialogTitle>
+          </AlertDialogHeader>
+
+          <div className="py-4">
+            <Input
+              label="Name"
+              placeholder="Enter new name"
+              value={newViewName}
+              size="md"
+              error={nameError}
+              onChange={e => {
+                setNewViewName(e.target.value)
+              }}
+            />
+          </div>
+
+          <AlertDialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setIsRenameDialogOpen(false)
+                setNameError('')
+                setNewViewName('')
+              }}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleRename} disabled={!canRename}>
+              Save
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+export default Views

--- a/packages/ui/src/components/filters/filters.tsx
+++ b/packages/ui/src/components/filters/filters.tsx
@@ -1,31 +1,30 @@
+import { useState } from 'react'
+
 import { TFunction } from 'i18next'
 
-import FilterTrigger from './filter-trigger'
-import { FilterOption, SortOption } from './types'
-import { UseFiltersReturn } from './use-filters'
+import ManageViews from './manage-views'
+import FilterTrigger from './triggers/filter-trigger'
+import ViewTrigger from './triggers/view-trigger'
+import { FilterHandlers, FilterOption, SortOption, ViewLayoutOption, ViewManagement } from './types'
 
 interface FiltersProps {
   showFilter?: boolean
   showSort?: boolean
+  showView?: boolean
   filterOptions: FilterOption[]
   sortOptions: SortOption[]
-  filterHandlers: Pick<
-    UseFiltersReturn,
-    | 'activeFilters'
-    | 'activeSorts'
-    | 'handleFilterChange'
-    | 'handleSortChange'
-    | 'handleResetFilters'
-    | 'handleResetSorts'
-    | 'searchQueries'
-    | 'handleSearchChange'
-  >
+  filterHandlers: FilterHandlers
+  viewManagement: ViewManagement
+  layoutOptions?: ViewLayoutOption[]
+  currentLayout?: string
+  onLayoutChange?: (layout: string) => void
   t: TFunction
 }
 
 const Filters = ({
   showFilter = true,
   showSort = true,
+  showView = true,
   filterOptions,
   sortOptions,
   filterHandlers: {
@@ -38,36 +37,63 @@ const Filters = ({
     handleSortChange,
     handleResetSorts
   },
+  viewManagement,
+  layoutOptions,
+  currentLayout,
+  onLayoutChange,
   t
 }: FiltersProps) => {
-  return (
-    <div className="flex items-center gap-x-5">
-      {showFilter && (
-        <FilterTrigger
-          type="filter"
-          activeFilters={activeFilters}
-          onChange={handleFilterChange}
-          onReset={handleResetFilters}
-          searchQueries={searchQueries}
-          onSearchChange={handleSearchChange}
-          options={filterOptions}
-          t={t}
-        />
-      )}
+  const [isManageDialogOpen, setIsManageDialogOpen] = useState(false)
 
-      {showSort && (
-        <FilterTrigger
-          type="sort"
-          activeFilters={activeSorts}
-          onChange={handleSortChange}
-          onReset={handleResetSorts}
-          searchQueries={searchQueries}
-          onSearchChange={handleSearchChange}
-          options={sortOptions}
-          t={t}
-        />
-      )}
-    </div>
+  return (
+    <>
+      <div className="flex items-center gap-x-5">
+        {showFilter && (
+          <FilterTrigger
+            type="filter"
+            activeFilters={activeFilters}
+            onChange={handleFilterChange}
+            onReset={handleResetFilters}
+            searchQueries={searchQueries}
+            onSearchChange={handleSearchChange}
+            options={filterOptions}
+            t={t}
+          />
+        )}
+
+        {showSort && (
+          <FilterTrigger
+            type="sort"
+            activeFilters={activeSorts}
+            onChange={handleSortChange}
+            onReset={handleResetSorts}
+            searchQueries={searchQueries}
+            onSearchChange={handleSearchChange}
+            options={sortOptions}
+            t={t}
+          />
+        )}
+
+        {showView && (
+          <ViewTrigger
+            savedViews={viewManagement.savedViews}
+            currentView={viewManagement.currentView}
+            layoutOptions={layoutOptions}
+            currentLayout={currentLayout}
+            onLayoutChange={onLayoutChange ?? (() => {})}
+            onManageClick={() => setIsManageDialogOpen(true)}
+            onViewSelect={viewManagement.applyView}
+          />
+        )}
+      </div>
+
+      <ManageViews
+        open={isManageDialogOpen}
+        onOpenChange={setIsManageDialogOpen}
+        views={viewManagement.savedViews}
+        viewManagement={viewManagement}
+      />
+    </>
   )
 }
 

--- a/packages/ui/src/components/filters/index.ts
+++ b/packages/ui/src/components/filters/index.ts
@@ -1,8 +1,15 @@
 import Filters from './filters'
 import FiltersBar from './filters-bar/filters-bar'
-import { FilterCondition, FilterOption, FilterValue, SortDirection, SortOption, SortValue } from './types'
-import useFilters from './use-filters'
+import {
+  FilterCondition,
+  FilterOption,
+  FilterValue,
+  SortDirection,
+  SortOption,
+  SortValue,
+  ViewLayoutOption
+} from './types'
 
-export { Filters, FiltersBar, useFilters }
+export { Filters, FiltersBar }
 
-export type { FilterOption, FilterCondition, SortOption, SortDirection, FilterValue, SortValue }
+export type { FilterOption, FilterCondition, SortOption, SortDirection, FilterValue, SortValue, ViewLayoutOption }

--- a/packages/ui/src/components/filters/manage-views.tsx
+++ b/packages/ui/src/components/filters/manage-views.tsx
@@ -1,0 +1,239 @@
+// TODO: we should rethink the approach and stop using the @dnd-kit library
+
+import { ChangeEvent, FC, memo, useCallback, useEffect, useMemo, useState } from 'react'
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  Icon,
+  Input
+} from '@/components'
+import { DndContext } from '@dnd-kit/core'
+import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+
+import useDragAndDrop from '../../hooks/use-drag-and-drop'
+import { SavedView, ViewManagement } from './types'
+
+/**
+ * Interface for the draggable view item component
+ * @property view - The view object containing id, name, and other properties
+ * @property id - Unique identifier for drag and drop functionality
+ * @property onRename - Callback function for handling view rename
+ * @property onDelete - Callback function for handling view deletion
+ * @property existingNames - Set of existing view names for validation
+ * @property validateViewNameChange - Function to validate view name changes
+ */
+interface SortableItemProps {
+  view: SavedView
+  id: string
+  onRename: (id: string, newName: string) => void
+  onDelete: (id: string) => void
+  existingNames: Set<string>
+  validateViewNameChange: ViewManagement['validateViewNameChange']
+}
+
+/**
+ * SortableItem component represents a draggable view item with rename and delete capabilities
+ * Implements drag and drop functionality using dnd-kit
+ * Handles real-time name validation and error states
+ */
+const SortableItem = memo<SortableItemProps>(
+  ({ view, id, onRename, onDelete, existingNames, validateViewNameChange }) => {
+    const [name, setName] = useState(view.name.trim())
+    const [hasError, setHasError] = useState(false)
+
+    // Initialize drag and drop functionality
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id })
+
+    /**
+     * Handles input changes for view name
+     * Validates the new name in real-time and updates error state
+     * Propagates changes to parent component
+     * @param e - Change event from input
+     */
+    const handleChange = useCallback(
+      (e: ChangeEvent<HTMLInputElement>) => {
+        const newName = e.target.value
+        setName(newName)
+
+        const validation = validateViewNameChange(newName, view.name, existingNames)
+        setHasError(validation.hasError)
+
+        // Always update parent to reflect current state
+        onRename(view.id, newName)
+      },
+      [view.id, view.name, existingNames, onRename, validateViewNameChange]
+    )
+
+    return (
+      <div
+        ref={setNodeRef}
+        style={{ transform: CSS.Transform.toString(transform), transition }}
+        className="flex items-center gap-x-2 p-2 hover:bg-background-4 rounded"
+      >
+        <div className="cursor-move group" {...attributes} {...listeners}>
+          <Icon
+            className="text-icons-4 group-hover:text-icons-2 transition-colors duration-200"
+            name="grid-dots"
+            size={14}
+          />
+        </div>
+
+        <Input
+          theme={hasError ? 'danger' : 'default'}
+          value={name}
+          size="md"
+          placeholder="Enter a name"
+          onChange={handleChange}
+        />
+
+        <button
+          className="text-icons-4 hover:text-icons-danger"
+          onClick={() => onDelete(view.id)}
+          aria-label="Delete view"
+        >
+          <Icon className="rotate-45" name="plus" size={14} />
+        </button>
+      </div>
+    )
+  }
+)
+
+SortableItem.displayName = 'SortableItem'
+
+/**
+ * Interface for the ManageViews component
+ * @property open - Controls dialog visibility
+ * @property onOpenChange - Callback for dialog open state changes
+ * @property views - Array of saved views
+ * @property viewManagement - Object containing view management methods
+ */
+interface ManageViewsProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  views: SavedView[]
+  viewManagement: ViewManagement
+}
+
+/**
+ * ManageViews component provides interface for reordering, renaming and deleting saved views
+ * Features:
+ * - Drag and drop reordering
+ * - Real-time name validation
+ * - Local state management for changes
+ * - Batch updates on save
+ */
+const ManageViews: FC<ManageViewsProps> = memo(({ open, onOpenChange, views, viewManagement }) => {
+  const [localViews, setLocalViews] = useState<SavedView[]>([])
+
+  /**
+   * Syncs local state with props when dialog opens
+   * Ensures fresh start for each editing session
+   */
+  useEffect(() => {
+    if (open) setLocalViews(views)
+  }, [open, views])
+
+  /**
+   * Memoized set of existing view names for validation
+   * Updates when local views change
+   */
+  const existingNames = useMemo(() => viewManagement.getExistingNames(localViews), [localViews])
+
+  /**
+   * Handles local view rename operations
+   * Updates only local state without persisting changes
+   */
+  const handleLocalRename = useCallback((viewId: string, newName: string) => {
+    setLocalViews(prev => prev.map(view => (view.id === viewId ? { ...view, name: newName } : view)))
+  }, [])
+
+  /**
+   * Handles local view deletion
+   * Updates only local state without persisting changes
+   */
+  const handleLocalDelete = useCallback((viewId: string) => {
+    setLocalViews(prev => prev.filter(v => v.id !== viewId))
+  }, [])
+
+  // Initialize drag and drop functionality
+  const { handleDragEnd, getItemId } = useDragAndDrop({
+    items: localViews,
+    onReorder: setLocalViews
+  })
+
+  /**
+   * Determines if save button should be disabled
+   * Checks for changes and validation errors
+   */
+  const isSaveDisabled =
+    !viewManagement.hasViewListChanges(localViews, views) || viewManagement.hasViewErrors(localViews)
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="max-w-[410px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Manage saved filters</AlertDialogTitle>
+        </AlertDialogHeader>
+
+        <div className="-mx-3.5 space-y-0.5 max-h-[320px] overflow-y-auto">
+          <DndContext onDragEnd={handleDragEnd}>
+            <SortableContext
+              items={localViews.map((_, index) => getItemId(index))}
+              strategy={verticalListSortingStrategy}
+            >
+              {localViews.map((view, index) => (
+                <SortableItem
+                  key={`${getItemId(index)}-${view.id}`}
+                  id={getItemId(index)}
+                  view={view}
+                  onRename={handleLocalRename}
+                  onDelete={handleLocalDelete}
+                  existingNames={existingNames}
+                  validateViewNameChange={viewManagement.validateViewNameChange}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
+        </div>
+
+        <AlertDialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setLocalViews(views)
+              onOpenChange(false)
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              // Update views order first
+              viewManagement.updateViewsOrder(viewManagement.prepareViewsForSave(localViews))
+
+              // If all views were deleted, reset current view
+              if (localViews.length === 0) {
+                viewManagement.setCurrentView(null)
+              }
+
+              onOpenChange(false)
+            }}
+            disabled={isSaveDisabled}
+          >
+            Save
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+})
+
+ManageViews.displayName = 'ManageViews'
+
+export default ManageViews

--- a/packages/ui/src/components/filters/triggers/filter-trigger.tsx
+++ b/packages/ui/src/components/filters/triggers/filter-trigger.tsx
@@ -2,8 +2,7 @@ import { Icon, Input } from '@/components'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@components/dropdown-menu'
 import { TFunction } from 'i18next'
 
-import { FilterOption, SortOption } from './types'
-import { UseFiltersReturn } from './use-filters'
+import { FilterHandlers, FilterOption, SortOption } from '../types'
 
 interface BaseFilterTriggerProps {
   type: 'filter' | 'sort'
@@ -16,22 +15,22 @@ interface BaseFilterTriggerProps {
 interface FilterTriggerFilterProps extends BaseFilterTriggerProps {
   type: 'filter'
   options: FilterOption[]
-  activeFilters: UseFiltersReturn['activeFilters']
-  onChange: UseFiltersReturn['handleFilterChange']
-  onReset?: UseFiltersReturn['handleResetFilters']
-  searchQueries: UseFiltersReturn['searchQueries']
-  onSearchChange: UseFiltersReturn['handleSearchChange']
+  activeFilters: FilterHandlers['activeFilters']
+  onChange: FilterHandlers['handleFilterChange']
+  onReset?: FilterHandlers['handleResetFilters']
+  searchQueries: FilterHandlers['searchQueries']
+  onSearchChange: FilterHandlers['handleSearchChange']
   t: TFunction
 }
 
 interface FilterTriggerSortProps extends BaseFilterTriggerProps {
   type: 'sort'
   options: SortOption[]
-  activeFilters: UseFiltersReturn['activeSorts']
-  onChange: UseFiltersReturn['handleSortChange']
-  onReset: UseFiltersReturn['handleResetSorts']
-  searchQueries: UseFiltersReturn['searchQueries']
-  onSearchChange: UseFiltersReturn['handleSearchChange']
+  activeFilters: FilterHandlers['activeSorts']
+  onChange: FilterHandlers['handleSortChange']
+  onReset: FilterHandlers['handleResetSorts']
+  searchQueries: FilterHandlers['searchQueries']
+  onSearchChange: FilterHandlers['handleSearchChange']
   t: TFunction
 }
 

--- a/packages/ui/src/components/filters/triggers/view-trigger.tsx
+++ b/packages/ui/src/components/filters/triggers/view-trigger.tsx
@@ -1,0 +1,90 @@
+import { FC, useState } from 'react'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Icon
+} from '@/components'
+
+import { SavedView, ViewLayoutOption } from '../types'
+
+interface ViewTriggerProps {
+  savedViews: SavedView[]
+  currentView: SavedView | null
+  layoutOptions?: ViewLayoutOption[]
+  currentLayout?: string
+  onLayoutChange?: (layout: string) => void
+  onManageClick: () => void
+  onViewSelect: (view: SavedView) => void
+}
+
+const ViewTrigger: FC<ViewTriggerProps> = ({
+  savedViews,
+  currentView,
+  layoutOptions,
+  currentLayout,
+  onLayoutChange,
+  onManageClick,
+  onViewSelect
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const handleManageClick = () => {
+    setIsOpen(false)
+    onManageClick()
+  }
+
+  return (
+    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+      <DropdownMenuTrigger className="flex items-center gap-x-1.5">
+        <span className="flex items-center gap-x-1 text-14 text-foreground-2 hover:text-foreground-1">
+          View
+          <Icon className="chevron-down text-icons-4" name="chevron-fill-down" size={6} />
+        </span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56 max-h-[358px] overflow-y-auto" align="end">
+        {layoutOptions?.length && (
+          <>
+            <div className="py-2.5 px-2">
+              <span className="text-13 text-foreground-7 leading-none">Layout</span>
+            </div>
+            {layoutOptions.map(option => (
+              <DropdownMenuItem key={option.value} onSelect={() => onLayoutChange?.(option.value)} className="gap-x-2">
+                <span>{option.label}</span>
+                {currentLayout === option.value && <Icon name="tick" size={12} className="ml-auto text-foreground-8" />}
+              </DropdownMenuItem>
+            ))}
+          </>
+        )}
+
+        {savedViews.length > 0 && (
+          <>
+            {layoutOptions?.length && <DropdownMenuSeparator />}
+            <div className="px-2 py-1.5">
+              <div className="flex items-center justify-between">
+                <span className="text-13 text-foreground-7 leading-none">Saved views</span>
+                <button
+                  className="text-foreground-accent hover:text-foreground-1 text-13 transition-colors duration-200"
+                  onClick={handleManageClick}
+                >
+                  Manage
+                </button>
+              </div>
+            </div>
+            {savedViews.map(view => (
+              <DropdownMenuItem key={view.id} className="gap-x-2" onSelect={() => onViewSelect(view)}>
+                <span>{view.name}</span>
+                {currentView?.id === view.id && <Icon name="tick" size={12} className="ml-auto text-foreground-8" />}
+              </DropdownMenuItem>
+            ))}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export default ViewTrigger

--- a/packages/ui/src/components/filters/types.ts
+++ b/packages/ui/src/components/filters/types.ts
@@ -65,6 +65,91 @@ interface FilterSearchQueries {
   menu: Record<string, string>
 }
 
+interface SavedView {
+  id: string
+  name: string
+  filters: FilterValue[]
+  sorts: SortValue[]
+}
+
+interface ViewLayoutOption {
+  label: string
+  value: string
+}
+
+interface ValidationResult {
+  isValid: boolean
+  error?: string
+}
+
+interface ViewManagement {
+  // Validation methods
+  validateViewName: (name: string, currentName?: string) => ValidationResult
+  hasViewErrors: (views: SavedView[]) => boolean
+  hasViewListChanges: (currentViews: SavedView[], originalViews: SavedView[]) => boolean
+  hasActiveViewChanges: (activeFilters: FilterValue[], activeSorts: SortValue[]) => boolean
+  getExistingNames: (views: SavedView[]) => Set<string>
+  checkNameExists: (name: string, excludeId?: string) => boolean
+  validateViewNameChange: (
+    newName: string,
+    currentName: string,
+    existingNames: Set<string>
+  ) => {
+    hasError: boolean
+    errorMessage?: string
+  }
+
+  // Data preparation
+  prepareViewsForSave: (views: SavedView[]) => SavedView[]
+
+  // State management
+  savedViews: SavedView[]
+  currentView: SavedView | null
+  setCurrentView: (view: SavedView | null) => void
+
+  // CRUD operations
+  saveView: (name: string, filters: FilterValue[], sorts: SortValue[]) => void
+  updateView: (view: SavedView) => void
+  deleteView: (viewId: string) => void
+  renameView: (viewId: string, newName: string) => void
+  applyView: (view: SavedView) => void
+  updateViewsOrder: (newViews: SavedView[]) => void
+}
+
+interface FilterHandlers {
+  // State values
+  activeFilters: FilterValue[]
+  activeSorts: SortValue[]
+  setActiveFilters: (filters: FilterValue[]) => void
+  setActiveSorts: (sorts: SortValue[]) => void
+  searchQueries: FilterSearchQueries
+  filterToOpen: FilterAction | null
+
+  // Filter methods
+  handleFilterChange: (newFilter: Omit<FilterValue, 'condition' | 'selectedValues'>, defaultCondition?: string) => void
+  handleUpdateFilter: (type: string, selectedValues: string[]) => void
+  handleUpdateCondition: (type: string, condition: string) => void
+  handleRemoveFilter: (type: string) => void
+  handleResetFilters: () => void
+
+  // Sort methods
+  handleSortChange: (newSort: SortValue) => void
+  handleUpdateSort: (index: number, updatedSort: SortValue) => void
+  handleRemoveSort: (index: number) => void
+  handleReorderSorts: (newSorts: SortValue[]) => void
+  handleResetSorts: () => void
+
+  // Common methods
+  handleResetAll: () => void
+
+  // Search methods
+  handleSearchChange: (type: string, query: string, searchType: keyof FilterSearchQueries) => void
+  clearSearchQuery: (type: string, searchType: keyof FilterSearchQueries) => void
+
+  // Filter opening control
+  clearFilterToOpen: () => void
+}
+
 export type {
   FilterAction,
   FilterOption,
@@ -75,5 +160,10 @@ export type {
   SortOption,
   SortDirection,
   SortValue,
-  FilterSearchQueries
+  FilterSearchQueries,
+  SavedView,
+  ViewLayoutOption,
+  ValidationResult,
+  ViewManagement,
+  FilterHandlers
 }

--- a/packages/ui/src/components/icon.tsx
+++ b/packages/ui/src/components/icon.tsx
@@ -10,6 +10,7 @@ import ArrowLong from '../icons/arrow-long.svg'
 import ArtifactsGradient from '../icons/artifacts-gradient.svg'
 import Artifacts from '../icons/artifacts-icon.svg'
 import BitrisePlugin from '../icons/bitrise-plugin.svg'
+import BookmarkAdd from '../icons/bookmark-add.svg'
 import BookmarkIcon from '../icons/bookmark-icon.svg'
 import BoxCloning from '../icons/box-cloning.svg'
 import BoxGuide from '../icons/box-guide.svg'
@@ -321,7 +322,8 @@ const IconNameMap = {
   'chaos-engineering': ChaosEngineering,
   'dashboards-gradient': DashboardsGradient,
   dashboards: Dashboards,
-  'menu-dots': MenuDots
+  'menu-dots': MenuDots,
+  'bookmark-add': BookmarkAdd
   // fork: Fork
 } satisfies Record<string, React.FunctionComponent<React.SVGProps<SVGSVGElement>>>
 

--- a/packages/ui/src/icons/bookmark-add.svg
+++ b/packages/ui/src/icons/bookmark-add.svg
@@ -1,0 +1,11 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_17758_120682)">
+<path d="M10.0009 1V4V7M7 3.99744H13" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.81354 9.81549V13.166L5.20658 10.2343L0.599609 13.166V2.27682C0.599609 1.35124 1.34929 0.601562 2.27487 0.601562H6.46302" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_17758_120682">
+<rect width="14" height="14" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/ui/src/views/repo/constants/filter-options.ts
+++ b/packages/ui/src/views/repo/constants/filter-options.ts
@@ -1,4 +1,10 @@
-import { type FilterCondition, type FilterOption, type SortDirection, type SortOption } from '@components/filters'
+import {
+  type FilterCondition,
+  type FilterOption,
+  type SortDirection,
+  type SortOption,
+  type ViewLayoutOption
+} from '@components/filters'
 import { TFunction } from 'i18next'
 
 export const getBasicConditions = (t: TFunction): FilterCondition[] => [
@@ -82,4 +88,9 @@ export const getSortOptions = (t: TFunction): SortOption[] => [
 export const getSortDirections = (t: TFunction): SortDirection[] => [
   { label: t('component:filter.ascending', 'Ascending'), value: 'asc' },
   { label: t('component:filter.descending', 'Descending'), value: 'desc' }
+]
+
+export const getLayoutOptions = (t: TFunction): ViewLayoutOption[] => [
+  { label: t('component:layout.table', 'Table'), value: 'table' },
+  { label: t('component:layout.list', 'List'), value: 'list' }
 ]

--- a/packages/ui/src/views/repo/hooks/index.ts
+++ b/packages/ui/src/views/repo/hooks/index.ts
@@ -1,0 +1,4 @@
+import { useFilters } from './use-filters'
+import { useViewManagement } from './use-view-management'
+
+export { useFilters, useViewManagement }

--- a/packages/ui/src/views/repo/hooks/use-filters.tsx
+++ b/packages/ui/src/views/repo/hooks/use-filters.tsx
@@ -1,105 +1,18 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 
-import { FilterAction, FilterSearchQueries, FilterValue, SortValue } from './types'
+import { FilterAction, FilterHandlers, FilterSearchQueries, FilterValue, SortValue } from '@/components/filters/types'
 
-export interface UseFiltersReturn {
-  // State values
-  activeFilters: FilterValue[]
-  activeSorts: SortValue[]
-  searchQueries: FilterSearchQueries
-  filterToOpen: FilterAction | null
-
-  // Filter methods
-  handleFilterChange: (newFilter: Omit<FilterValue, 'condition' | 'selectedValues'>, defaultCondition?: string) => void
-  handleUpdateFilter: (type: string, selectedValues: string[]) => void
-  handleUpdateCondition: (type: string, condition: string) => void
-  handleRemoveFilter: (type: string) => void
-  handleResetFilters: () => void
-
-  // Sort methods
-  handleSortChange: (newSort: SortValue) => void
-  handleUpdateSort: (index: number, updatedSort: SortValue) => void
-  handleRemoveSort: (index: number) => void
-  handleReorderSorts: (newSorts: SortValue[]) => void
-  handleResetSorts: () => void
-
-  // Common methods
-  handleResetAll: () => void
-
-  // Search methods
-  handleSearchChange: (type: string, query: string, searchType: keyof FilterSearchQueries) => void
-  clearSearchQuery: (type: string, searchType: keyof FilterSearchQueries) => void
-
-  // Filter opening control
-  clearFilterToOpen: () => void
-
-  // Save and clear saved filters
-  handleSaveFilters: () => void
-  handleClearSavedFilters: () => void
-  hasUnsavedChanges: boolean
-}
-
-interface UseFiltersProps {
-  /**
-   * Initial state for filters and sorts
-   */
-  initialState?: {
-    filters: FilterValue[]
-    sorts: SortValue[]
-  }
-
-  /**
-   * Callback fired when filters or sorts state changes
-   */
-  onStateChange?: (state: { filters: FilterValue[]; sorts: SortValue[] }) => void
-
-  /**
-   * Controls visibility of save button
-   */
-  hasUnsavedChanges?: boolean
-
-  /**
-   * Callback fired when save button is clicked
-   */
-  onSave?: () => void
-
-  /**
-   * Callback fired when clear button is clicked
-   */
-  onClear?: () => void
-}
-
-const useFilters = ({
-  initialState,
-  onStateChange,
-  hasUnsavedChanges = false,
-  onSave,
-  onClear
-}: UseFiltersProps): UseFiltersReturn => {
+export const useFilters = (): FilterHandlers => {
   // Initialize state with initialState if provided
-  const [activeFilters, setActiveFilters] = useState<FilterValue[]>(() => initialState?.filters || [])
-  const [activeSorts, setActiveSorts] = useState<SortValue[]>(() => initialState?.sorts || [])
+  const [activeFilters, setActiveFilters] = useState<FilterValue[]>([])
+  const [activeSorts, setActiveSorts] = useState<SortValue[]>([])
   const [searchQueries, setSearchQueries] = useState<FilterSearchQueries>({
     filters: {},
     menu: {}
   })
   const [filterToOpen, setFilterToOpen] = useState<FilterAction | null>(null)
 
-  // Update filters and sorts when initialState changes
-  useEffect(() => {
-    if (initialState) {
-      setActiveFilters(initialState.filters)
-      setActiveSorts(initialState.sorts)
-    }
-  }, [initialState])
-
-  // Notify parent component about state changes
-  useEffect(() => {
-    onStateChange?.({
-      filters: activeFilters,
-      sorts: activeSorts
-    })
-  }, [activeFilters, activeSorts, onStateChange])
+  // Load saved views on mount
 
   // FILTERS
   /**
@@ -234,6 +147,7 @@ const useFilters = ({
   const handleResetAll = useCallback(() => {
     setActiveFilters([])
     setActiveSorts([])
+    setSearchQueries({ filters: {}, menu: {} })
   }, [])
 
   // SEARCH
@@ -262,47 +176,29 @@ const useFilters = ({
     setFilterToOpen(null)
   }
 
-  /**
-   * Saves current filter state using provided onSave callback
-   * Parent component is responsible for implementing the actual save logic
-   * (e.g. localStorage, API call, cookies etc.)
-   */
-  const handleSaveFilters = useCallback(() => {
-    onSave?.()
-  }, [onSave])
-
-  /**
-   * Clears saved filter state using provided onClear callback
-   * Parent component is responsible for implementing the actual clear logic
-   * and resetting filters to initial state
-   */
-  const handleClearSavedFilters = useCallback(() => {
-    onClear?.()
-  }, [onClear])
-
   return {
+    // Filters
     activeFilters,
     activeSorts,
+    setActiveFilters,
+    setActiveSorts,
     searchQueries,
     filterToOpen,
     handleFilterChange,
     handleUpdateFilter,
     handleUpdateCondition,
     handleRemoveFilter,
+    handleResetFilters,
+    clearFilterToOpen,
+    // Sorts
     handleSortChange,
     handleUpdateSort,
     handleRemoveSort,
-    handleResetFilters,
-    handleResetSorts,
     handleReorderSorts,
+    handleResetSorts,
     handleResetAll,
+    // Search
     handleSearchChange,
-    clearSearchQuery,
-    clearFilterToOpen,
-    handleSaveFilters,
-    handleClearSavedFilters,
-    hasUnsavedChanges
+    clearSearchQuery
   }
 }
-
-export default useFilters

--- a/packages/ui/src/views/repo/hooks/use-view-management.ts
+++ b/packages/ui/src/views/repo/hooks/use-view-management.ts
@@ -1,0 +1,320 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { FilterValue, SavedView, SortValue, ValidationResult, ViewManagement } from '@components/filters/types'
+
+interface UseViewManagementProps {
+  storageKey: string
+  setActiveFilters: (filters: FilterValue[]) => void
+  setActiveSorts: (sorts: SortValue[]) => void
+}
+
+/**
+ * Compares two arrays for equality in the context of filter and sort states
+ * Used to detect changes in filter/sort configurations and view states
+ *
+ * @param {Array} arr1 - First array (usually current filters/sorts)
+ * @param {Array} arr2 - Second array (usually saved view filters/sorts)
+ * @returns {boolean} Whether the arrays have the same elements regardless of order
+ *
+ * @example
+ * // Used to detect changes in view state
+ * const hasViewChanges = !areArraysEqual(currentView.filters, activeFilters) ||
+ *                       !areArraysEqual(currentView.sorts, activeSorts)
+ */
+export const areArraysEqual = (arr1: any[], arr2: any[]) => {
+  if (!arr1 || !arr2) return false
+  if (arr1.length !== arr2.length) return false
+
+  // Sort arrays to ensure order-independent comparison
+  const sorted1 = [...arr1].sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+  const sorted2 = [...arr2].sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+
+  return JSON.stringify(sorted1) === JSON.stringify(sorted2)
+}
+
+/**
+ * Hook for managing filter views state and operations
+ * Handles saving, loading, updating and validating filter views
+ *
+ * @param storageKey - Unique key for localStorage
+ * @param setActiveFilters - Callback to update active filters
+ * @param setActiveSorts - Callback to update active sorts
+ */
+export const useViewManagement = ({
+  storageKey,
+  setActiveFilters,
+  setActiveSorts
+}: UseViewManagementProps): ViewManagement => {
+  const [savedViews, setSavedViews] = useState<SavedView[]>([])
+  const [currentView, setCurrentView] = useState<SavedView | null>(null)
+
+  /**
+   * Applies a view by updating current filters and sorts
+   * Saves the current view ID to localStorage
+   */
+  const applyView = useCallback(
+    (view: SavedView) => {
+      setCurrentView(view)
+      setActiveFilters(view.filters)
+      setActiveSorts(view.sorts)
+      localStorage.setItem(`${storageKey}-current-view`, view.id)
+    },
+    [storageKey, setActiveFilters, setActiveSorts]
+  )
+
+  /**
+   * Loads saved views from localStorage on mount
+   * Restores the last active view if available
+   */
+  useEffect(() => {
+    try {
+      const savedViewsString = localStorage.getItem(`${storageKey}-views`)
+      const lastViewId = localStorage.getItem(`${storageKey}-current-view`)
+
+      // First update savedViews
+      const views = savedViewsString ? JSON.parse(savedViewsString) : []
+      setSavedViews(views)
+
+      // Check currentView in any case
+      if (lastViewId) {
+        const lastView = views.find((v: SavedView) => v.id === lastViewId)
+        if (lastView) {
+          applyView(lastView)
+        } else {
+          // If view not found - clear it
+          setCurrentView(null)
+          localStorage.removeItem(`${storageKey}-current-view`)
+        }
+      }
+    } catch (error) {
+      console.error('Error loading saved views:', error)
+      // Clear on error as well
+      setCurrentView(null)
+      localStorage.removeItem(`${storageKey}-current-view`)
+    }
+  }, [storageKey, applyView])
+
+  /**
+   * Validates a view name for emptiness and uniqueness
+   * @returns ValidationResult with isValid flag and optional error message
+   */
+  const validateViewName = (name: string, currentName?: string): ValidationResult => {
+    const trimmedName = name.trim()
+
+    if (!trimmedName) {
+      return {
+        isValid: false,
+        error: 'Name cannot be empty'
+      }
+    }
+
+    if (currentName?.trim().toLowerCase() === trimmedName.toLowerCase()) {
+      return { isValid: true }
+    }
+
+    return { isValid: true }
+  }
+
+  /**
+   * Returns a Set of existing view names in lowercase for validation
+   */
+  const getExistingNames = useCallback((views: SavedView[]): Set<string> => {
+    return new Set(views.map(v => v.name.trim().toLowerCase()))
+  }, [])
+
+  /**
+   * Checks for validation errors in views list
+   * Currently checks for duplicate names and empty names
+   */
+  const hasViewErrors = useCallback((views: SavedView[]): boolean => {
+    const duplicatesMap = new Map<string, boolean>()
+
+    return views.some(view => {
+      const trimmedName = view.name.trim().toLowerCase()
+
+      if (!trimmedName) return true
+
+      if (duplicatesMap.has(trimmedName)) {
+        return true
+      }
+
+      duplicatesMap.set(trimmedName, true)
+      return false
+    })
+  }, [])
+
+  /**
+   * Prepares views for saving by trimming names
+   */
+  const prepareViewsForSave = useCallback((views: SavedView[]): SavedView[] => {
+    return views.map(view => ({
+      ...view,
+      name: view.name.trim()
+    }))
+  }, [])
+
+  /**
+   * Creates and saves a new view
+   * Updates localStorage and sets it as current view
+   */
+  const saveView = useCallback(
+    (name: string, filters: FilterValue[], sorts: SortValue[]) => {
+      const newView: SavedView = {
+        id: crypto.randomUUID(),
+        name,
+        filters,
+        sorts
+      }
+
+      setSavedViews(prev => {
+        const updated = [...prev, newView]
+        localStorage.setItem(`${storageKey}-views`, JSON.stringify(updated))
+        return updated
+      })
+
+      setCurrentView(newView)
+      localStorage.setItem(`${storageKey}-current-view`, newView.id)
+    },
+    [storageKey]
+  )
+
+  /**
+   * Updates an existing view
+   * Updates both savedViews and currentView if necessary
+   */
+  const updateView = useCallback(
+    (updatedView: SavedView) => {
+      setSavedViews(prev => {
+        const updatedViews = prev.map(view => (view.id === updatedView.id ? updatedView : view))
+        localStorage.setItem(`${storageKey}-views`, JSON.stringify(updatedViews))
+        return updatedViews
+      })
+      setCurrentView(updatedView)
+      localStorage.setItem(`${storageKey}-current-view`, updatedView.id)
+    },
+    [storageKey]
+  )
+
+  /**
+   * Deletes a view and updates localStorage
+   * Clears currentView if deleted view was active
+   */
+  const deleteView = useCallback(
+    (viewId: string) => {
+      setSavedViews(prev => {
+        const updated = prev.filter(v => v.id !== viewId)
+        localStorage.setItem(`${storageKey}-views`, JSON.stringify(updated))
+        return updated
+      })
+
+      if (currentView?.id === viewId) {
+        setCurrentView(null)
+        localStorage.removeItem(`${storageKey}-current-view`)
+      }
+    },
+    [currentView, storageKey]
+  )
+
+  /**
+   * Renames an existing view
+   * Updates both savedViews and currentView if necessary
+   */
+  const renameView = useCallback(
+    (viewId: string, newName: string) => {
+      setSavedViews(prev => {
+        const updated = prev.map(v => (v.id === viewId ? { ...v, name: newName } : v))
+        localStorage.setItem(`${storageKey}-views`, JSON.stringify(updated))
+        return updated
+      })
+
+      setCurrentView(prev => (prev?.id === viewId ? { ...prev, name: newName } : prev))
+    },
+    [storageKey]
+  )
+
+  /**
+   * Updates the order of views after drag and drop
+   * Persists new order to localStorage
+   */
+  const updateViewsOrder = useCallback(
+    (newViews: SavedView[]) => {
+      setSavedViews(newViews)
+      localStorage.setItem(`${storageKey}-views`, JSON.stringify(newViews))
+    },
+    [storageKey]
+  )
+
+  /**
+   * Checks if a view name already exists
+   * @param excludeId - Optional ID to exclude from check (for renaming)
+   */
+  const checkNameExists = useCallback(
+    (name: string, excludeId?: string) => {
+      return savedViews.some(
+        view => view.name.toLowerCase().trim() === name.toLowerCase().trim() && view.id !== excludeId
+      )
+    },
+    [savedViews]
+  )
+
+  /**
+   * Validates view name changes in real-time
+   * Used for inline editing validation
+   */
+  const validateViewNameChange = useCallback((newName: string, currentName: string, existingNames: Set<string>) => {
+    const trimmedName = newName.trim().toLowerCase()
+    const currentViewName = currentName.trim().toLowerCase()
+
+    const hasError = Boolean(trimmedName && existingNames.has(trimmedName) && trimmedName !== currentViewName)
+
+    return {
+      hasError,
+      errorMessage: hasError ? 'A view with this name already exists' : undefined
+    }
+  }, [])
+
+  /**
+   * Checks if the list of views has been modified
+   * Used in ManageViews to detect changes in view order or names
+   */
+  const hasViewListChanges = useCallback((currentViews: SavedView[], originalViews: SavedView[]): boolean => {
+    if (currentViews.length !== originalViews.length) return true
+
+    return currentViews.some((currentView, index) => {
+      const originalView = originalViews[index]
+      return !originalView || currentView.id !== originalView.id || currentView.name.trim() !== originalView.name.trim()
+    })
+  }, [])
+
+  /**
+   * Checks if current filters/sorts differ from the saved view
+   * Used to detect unsaved changes in current view
+   */
+  const hasActiveViewChanges = useCallback(
+    (activeFilters: FilterValue[], activeSorts: SortValue[]): boolean => {
+      if (!currentView) return false
+      return !areArraysEqual(currentView.filters, activeFilters) || !areArraysEqual(currentView.sorts, activeSorts)
+    },
+    [currentView]
+  )
+
+  return {
+    validateViewName,
+    hasViewErrors,
+    hasViewListChanges,
+    getExistingNames,
+    prepareViewsForSave,
+    saveView,
+    updateView,
+    deleteView,
+    renameView,
+    applyView,
+    updateViewsOrder,
+    savedViews,
+    currentView,
+    setCurrentView,
+    checkNameExists,
+    validateViewNameChange,
+    hasActiveViewChanges
+  }
+}

--- a/packages/ui/src/views/repo/pull-request/pull-request-list-page.tsx
+++ b/packages/ui/src/views/repo/pull-request/pull-request-list-page.tsx
@@ -7,16 +7,16 @@ import {
   FiltersBar,
   type FilterCondition,
   type FilterOption,
-  type FilterValue,
   type SortDirection,
-  type SortOption,
-  type SortValue
+  type SortOption
 } from '@components/filters'
-import useFilters from '@components/filters/use-filters'
 import { useCommonFilter } from '@hooks/use-common-filter'
 import { noop } from 'lodash-es'
 
 import { SandboxLayout, TranslationStore } from '../..'
+import { useFilters, useViewManagement } from '../hooks'
+import { filterPullRequests } from '../utils/filtering/pulls'
+import { sortPullRequests } from '../utils/sorting/pulls'
 import { PullRequestList as PullRequestListContent } from './pull-request-list'
 import { PullRequestStore } from './types'
 
@@ -101,278 +101,18 @@ const PullRequestList: FC<PullRequestListProps> = ({
   const { query, handleSearch } = useCommonFilter()
   const [value, setValue] = useState<string>()
 
-  const [savedState, setSavedState] = useState<{
-    filters: FilterValue[]
-    sorts: SortValue[]
-  } | null>(null)
-  // Controls visibility of the Save button
-  // true when current filters/sorts differ from saved state
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
-
-  /**
-   * Load previously saved filters from localStorage when component mounts
-   * This restores the last saved filter configuration for this page
-   */
-  useEffect(() => {
-    try {
-      const savedFiltersString = localStorage.getItem('pull-req-list-filters')
-      if (savedFiltersString) {
-        const savedFilters = JSON.parse(savedFiltersString)
-        setSavedState(savedFilters)
-      }
-    } catch (error) {
-      console.error('Error loading saved filters:', error)
-    }
-  }, [])
-
   /**
    * Initialize filters hook with handlers for managing filter state
    */
-  const filterHandlers = useFilters({
-    // Pass saved state to initialize filters
-    initialState: savedState ?? undefined,
-    /**
-     * Called whenever filters or sorts change
-     * Determines if current state differs from saved state to show/hide Save button
-     */
-    onStateChange: state => {
-      // If no saved state exists, show Save button if any filters/sorts are active
-      if (!savedState) {
-        setHasUnsavedChanges(state.filters.length > 0 || state.sorts.length > 0)
-        return
-      }
-
-      // Compare current state with saved state
-      // Show Save button only if:
-      // 1. States are different AND
-      // 2. There are actually some filters/sorts active
-      const isChanged =
-        JSON.stringify(state) !== JSON.stringify(savedState) && (state.filters.length > 0 || state.sorts.length > 0)
-
-      setHasUnsavedChanges(isChanged)
-    },
-    // Controls Save button visibility
-    hasUnsavedChanges,
-    /**
-     * Called when Save button is clicked
-     * Saves current filters and sorts to localStorage
-     */
-    onSave: () => {
-      try {
-        // Create state object to save
-        const stateToSave = {
-          filters: filterHandlers.activeFilters,
-          sorts: filterHandlers.activeSorts
-        }
-        // Save to localStorage
-        localStorage.setItem('pull-req-list-filters', JSON.stringify(stateToSave))
-        // Update saved state
-        setSavedState(stateToSave)
-        // Hide Save button
-        setHasUnsavedChanges(false)
-      } catch (error) {
-        console.error('Error saving filters:', error)
-      }
-    },
-    /**
-     * Called when Clear button is clicked
-     * Removes saved filters from localStorage and resets all filters
-     */
-    onClear: () => {
-      try {
-        // Remove saved filters from localStorage
-        localStorage.removeItem('pull-req-list-filters')
-        // Reset saved state
-        setSavedState(null)
-        // Hide Save button
-        setHasUnsavedChanges(false)
-        // Reset all filters
-        filterHandlers.handleResetAll()
-      } catch (error) {
-        console.error('Error clearing saved filters:', error)
-      }
-    }
+  const filterHandlers = useFilters()
+  const viewManagement = useViewManagement({
+    storageKey: 'pull-req-list-filters',
+    setActiveFilters: filterHandlers.setActiveFilters,
+    setActiveSorts: filterHandlers.setActiveSorts
   })
 
-  /**
-   * Filters pull requests based on active filters
-   *
-   * @param pullrequest - Pullrequest object to filter
-   * @returns boolean - Whether the pullrequests matches all active filters
-   *
-   * Filter logic:
-   * - If no active filters, returns all pullrequests
-   * - Applies all active filters (AND condition)
-   * - For type filter:
-   *   - Handles 'private', 'public', and 'fork' types
-   *   - Supports 'is' and 'is not' conditions
-   *   - Ignores empty filters or is_empty/is_not_empty conditions
-   */
-  const filteredPullReqs =
-    pullRequests &&
-    pullRequests.filter(pullRequest => {
-      if (filterHandlers.activeFilters.length === 0) return true
-
-      return filterHandlers.activeFilters.every(filter => {
-        switch (filter.type) {
-          case 'type': {
-            // Skip empty/not empty conditions for type filter
-            if (filter.condition === 'is_empty' || filter.condition === 'is_not_empty') {
-              return true
-            }
-
-            // Skip if no values selected
-            if (filter.selectedValues.length === 0) {
-              return true
-            }
-
-            // Determine pullReq types
-            const isOpen = pullRequest.state === 'open'
-            const isClosed = pullRequest.state === 'closed'
-
-            // Check if pullrquest matches any of the selected type values
-            const matchesType = filter.selectedValues.some(value => {
-              switch (value) {
-                case 'enabled':
-                  return isOpen
-                case 'disabled':
-                  return isClosed
-
-                default:
-                  return false
-              }
-            })
-
-            // Apply condition (is/is not)
-            return filter.condition === 'is' ? matchesType : !matchesType
-          }
-
-          case 'created_time': {
-            // Skip if no values selected
-            if (filter.selectedValues.length === 0) {
-              return true
-            }
-
-            // Handle empty conditions
-            if (filter.condition === 'is_empty') {
-              return !pullRequest.updated
-            }
-            if (filter.condition === 'is_not_empty') {
-              return !!pullRequest.updated
-            }
-
-            const createdDate = new Date(pullRequest.updated)
-            const selectedDate = new Date(filter.selectedValues[0])
-
-            // Reset time parts for date-only comparison
-            createdDate.setHours(0, 0, 0, 0)
-            selectedDate.setHours(0, 0, 0, 0)
-
-            switch (filter.condition) {
-              case 'is':
-                return createdDate.getTime() === selectedDate.getTime()
-
-              case 'is_before':
-                return createdDate.getTime() < selectedDate.getTime()
-
-              case 'is_after':
-                return createdDate.getTime() > selectedDate.getTime()
-
-              case 'is_between': {
-                if (filter.selectedValues.length !== 2) return true
-                const endDate = new Date(filter.selectedValues[1])
-                endDate.setHours(0, 0, 0, 0)
-                return createdDate.getTime() >= selectedDate.getTime() && createdDate.getTime() <= endDate.getTime()
-              }
-
-              default:
-                return true
-            }
-          }
-
-          case 'name': {
-            if (filter.condition === 'is_empty') {
-              return !pullRequest.name
-            }
-            if (filter.condition === 'is_not_empty') {
-              return !!pullRequest.name
-            }
-
-            // Skip if no values selected
-            if (filter.selectedValues.length === 0) {
-              return true
-            }
-
-            const value = filter.selectedValues[0].toLowerCase()
-            const name = pullRequest?.name?.toLowerCase() ?? ''
-
-            switch (filter.condition) {
-              case 'is':
-                return name === value
-              case 'is_not':
-                return name !== value
-              case 'contains':
-                return name.includes(value)
-              case 'does_not_contain':
-                return !name.includes(value)
-              case 'starts_with':
-                return name.startsWith(value)
-              case 'ends_with':
-                return name.endsWith(value)
-              default:
-                return true
-            }
-          }
-
-          default:
-            return true
-        }
-      })
-    })
-
-  /**
-   * Sorts filtered pullrequest based on active sorts
-   *
-   * @param a - First pullrequest to compare
-   * @param b - Second pullrequest to compare
-   * @returns number - Comparison result (-1, 0, 1)
-   *
-   * Sort logic:
-   * - Applies multiple sorts in priority order (first sort has highest priority)
-   * - For equal values, moves to next sort criteria
-   * - Supports following sort types:
-   *   - updated: by timestamp
-   *   - stars: by number of stars
-   *   - forks: by number of forks
-   *   - pulls: by number of pull requests
-   *   - title: alphabetically by name
-   * - Each sort supports ascending/descending direction
-   */
-  const sortedPullReqs = [...(filteredPullReqs ?? [])].sort((a, b) => {
-    // Iterate through sorts in priority order
-    for (const sort of filterHandlers.activeSorts) {
-      const direction = sort.direction === 'asc' ? 1 : -1
-      let comparison = 0
-
-      switch (sort.type) {
-        case 'updated':
-          comparison = (new Date(b.updated).getTime() - new Date(a.updated).getTime()) * direction
-          break
-        case 'title':
-          comparison = a.name!.localeCompare(b.name!) * direction
-          break
-        default:
-          comparison = 0
-      }
-
-      // If items are different by current sort criteria, return result
-      if (comparison !== 0) {
-        return comparison
-      }
-    }
-
-    return 0
-  })
+  const filteredPullReqs = filterPullRequests(pullRequests, filterHandlers.activeFilters)
+  const sortedPullReqs = sortPullRequests(filteredPullReqs, filterHandlers.activeSorts)
 
   useEffect(() => {
     setValue(query || '')
@@ -455,7 +195,13 @@ const PullRequestList: FC<PullRequestListProps> = ({
             />
           </ListActions.Left>
           <ListActions.Right>
-            <Filters t={t} filterOptions={FILTER_OPTIONS} sortOptions={SORT_OPTIONS} filterHandlers={filterHandlers} />
+            <Filters
+              t={t}
+              filterOptions={FILTER_OPTIONS}
+              sortOptions={SORT_OPTIONS}
+              filterHandlers={filterHandlers}
+              viewManagement={viewManagement}
+            />
             <Button variant="default" asChild>
               <Link to={`/${spaceId}/repos/${repoId}/pulls/compare/`}>New pull request</Link>
             </Button>
@@ -468,6 +214,7 @@ const PullRequestList: FC<PullRequestListProps> = ({
           sortOptions={SORT_OPTIONS}
           sortDirections={SORT_DIRECTIONS}
           filterHandlers={filterHandlers}
+          viewManagement={viewManagement}
         />
 
         <Spacer size={5} />

--- a/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
@@ -1,14 +1,16 @@
-import { ChangeEvent, FC, ReactNode, useCallback, useEffect, useState } from 'react'
+import { ChangeEvent, FC, ReactNode, useCallback, useState } from 'react'
 import { Link } from 'react-router-dom'
 
 import { Button, ListActions, PaginationComponent, SearchBox, Spacer, Text } from '@/components'
-import { Filters, FiltersBar, type FilterValue, type SortValue } from '@components/filters'
-import useFilters from '@components/filters/use-filters'
-import { formatDistanceToNow } from 'date-fns'
+import { Filters, FiltersBar } from '@components/filters'
 import { debounce } from 'lodash-es'
 
 import { SandboxLayout } from '../../index'
-import { getFilterOptions, getSortDirections, getSortOptions } from './filter-options'
+import { getFilterOptions, getLayoutOptions, getSortDirections, getSortOptions } from '../constants/filter-options'
+import { useFilters, useViewManagement } from '../hooks'
+import { filterRepositories } from '../utils/filtering/repos'
+import { formatRepositories } from '../utils/formatting/repos'
+import { sortRepositories } from '../utils/sorting/repos'
 import { RepoList } from './repo-list'
 import { RepoListProps } from './types'
 
@@ -24,339 +26,33 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
   setSearchQuery
 }) => {
   const { t } = useTranslationStore()
+
   const FILTER_OPTIONS = getFilterOptions(t)
   const SORT_OPTIONS = getSortOptions(t)
   const SORT_DIRECTIONS = getSortDirections(t)
+  const LAYOUT_OPTIONS = getLayoutOptions(t)
+
   const [searchInput, setSearchInput] = useState(searchQuery)
 
   // State for storing saved filters and sorts
   // null means no saved state exists
   const { repositories, totalPages, page, setPage } = useRepoStore()
 
-  const [savedState, setSavedState] = useState<{
-    filters: FilterValue[]
-    sorts: SortValue[]
-  } | null>(null)
-  // Controls visibility of the Save button
-  // true when current filters/sorts differ from saved state
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
-
-  /**
-   * Load previously saved filters from localStorage when component mounts
-   * This restores the last saved filter configuration for this page
-   */
-  useEffect(() => {
-    try {
-      const savedFiltersString = localStorage.getItem('sandbox-repo-filters')
-      if (savedFiltersString) {
-        const savedFilters = JSON.parse(savedFiltersString)
-        setSavedState(savedFilters)
-      }
-    } catch (error) {
-      console.error('Error loading saved filters:', error)
-    }
-  }, [])
+  const [currentLayout, setCurrentLayout] = useState(LAYOUT_OPTIONS[1].value)
 
   /**
    * Initialize filters hook with handlers for managing filter state
    */
-  const filterHandlers = useFilters({
-    // Pass saved state to initialize filters
-    initialState: savedState ?? undefined,
-    /**
-     * Called whenever filters or sorts change
-     * Determines if current state differs from saved state to show/hide Save button
-     */
-    onStateChange: state => {
-      // If no saved state exists, show Save button if any filters/sorts are active
-      if (!savedState) {
-        setHasUnsavedChanges(state.filters.length > 0 || state.sorts.length > 0)
-        return
-      }
-
-      // Compare current state with saved state
-      // Show Save button only if:
-      // 1. States are different AND
-      // 2. There are actually some filters/sorts active
-      const isChanged =
-        JSON.stringify(state) !== JSON.stringify(savedState) && (state.filters.length > 0 || state.sorts.length > 0)
-
-      setHasUnsavedChanges(isChanged)
-    },
-    // Controls Save button visibility
-    hasUnsavedChanges,
-    /**
-     * Called when Save button is clicked
-     * Saves current filters and sorts to localStorage
-     */
-    onSave: () => {
-      try {
-        // Create state object to save
-        const stateToSave = {
-          filters: filterHandlers.activeFilters,
-          sorts: filterHandlers.activeSorts
-        }
-        // Save to localStorage
-        localStorage.setItem('sandbox-repo-filters', JSON.stringify(stateToSave))
-        // Update saved state
-        setSavedState(stateToSave)
-        // Hide Save button
-        setHasUnsavedChanges(false)
-      } catch (error) {
-        console.error('Error saving filters:', error)
-      }
-    },
-    /**
-     * Called when Clear button is clicked
-     * Removes saved filters from localStorage and resets all filters
-     */
-    onClear: () => {
-      try {
-        // Remove saved filters from localStorage
-        localStorage.removeItem('sandbox-repo-filters')
-        // Reset saved state
-        setSavedState(null)
-        // Hide Save button
-        setHasUnsavedChanges(false)
-        // Reset all filters
-        filterHandlers.handleResetAll()
-      } catch (error) {
-        console.error('Error clearing saved filters:', error)
-      }
-    }
+  const filterHandlers = useFilters()
+  const viewManagement = useViewManagement({
+    storageKey: 'sandbox-repo-filters',
+    setActiveFilters: filterHandlers.setActiveFilters,
+    setActiveSorts: filterHandlers.setActiveSorts
   })
 
-  /**
-   * Filters repositories based on active filters
-   *
-   * @param repo - Repository object to filter
-   * @returns boolean - Whether the repository matches all active filters
-   *
-   * Filter logic:
-   * - If no active filters, returns all repositories
-   * - Applies all active filters (AND condition)
-   * - For type filter:
-   *   - Handles 'private', 'public', and 'fork' types
-   *   - Supports 'is' and 'is not' conditions
-   *   - Ignores empty filters or is_empty/is_not_empty conditions
-   */
-  const filteredRepos =
-    repositories &&
-    repositories.filter(repo => {
-      if (filterHandlers.activeFilters.length === 0) return true
-
-      return filterHandlers.activeFilters.every(filter => {
-        switch (filter.type) {
-          case 'type': {
-            // Skip empty/not empty conditions for type filter
-            if (filter.condition === 'is_empty' || filter.condition === 'is_not_empty') {
-              return true
-            }
-
-            // Skip if no values selected
-            if (filter.selectedValues.length === 0) {
-              return true
-            }
-
-            // Determine repository types
-            const isPrivate = repo.private
-            const isPublic = !repo.private
-            const isFork = repo.forks > 0
-
-            // Check if repo matches any of the selected type values
-            const matchesType = filter.selectedValues.some(value => {
-              switch (value) {
-                case 'private':
-                  return isPrivate
-                case 'public':
-                  return isPublic
-                case 'fork':
-                  return isFork
-                default:
-                  return false
-              }
-            })
-
-            // Apply condition (is/is not)
-            return filter.condition === 'is' ? matchesType : !matchesType
-          }
-
-          case 'created_time': {
-            // Skip if no values selected
-            if (filter.selectedValues.length === 0) {
-              return true
-            }
-
-            // Handle empty conditions
-            if (filter.condition === 'is_empty') {
-              return !repo.createdAt
-            }
-            if (filter.condition === 'is_not_empty') {
-              return !!repo.createdAt
-            }
-
-            const createdDate = new Date(repo.createdAt)
-            const selectedDate = new Date(filter.selectedValues[0])
-
-            // Reset time parts for date-only comparison
-            createdDate.setHours(0, 0, 0, 0)
-            selectedDate.setHours(0, 0, 0, 0)
-
-            switch (filter.condition) {
-              case 'is':
-                return createdDate.getTime() === selectedDate.getTime()
-
-              case 'is_before':
-                return createdDate.getTime() < selectedDate.getTime()
-
-              case 'is_after':
-                return createdDate.getTime() > selectedDate.getTime()
-
-              case 'is_between': {
-                if (filter.selectedValues.length !== 2) return true
-                const endDate = new Date(filter.selectedValues[1])
-                endDate.setHours(0, 0, 0, 0)
-                return createdDate.getTime() >= selectedDate.getTime() && createdDate.getTime() <= endDate.getTime()
-              }
-
-              default:
-                return true
-            }
-          }
-
-          case 'name': {
-            if (filter.condition === 'is_empty') {
-              return !repo.name
-            }
-            if (filter.condition === 'is_not_empty') {
-              return !!repo.name
-            }
-
-            // Skip if no values selected
-            if (filter.selectedValues.length === 0) {
-              return true
-            }
-
-            const value = filter.selectedValues[0].toLowerCase()
-            const name = repo.name.toLowerCase()
-
-            switch (filter.condition) {
-              case 'is':
-                return name === value
-              case 'is_not':
-                return name !== value
-              case 'contains':
-                return name.includes(value)
-              case 'does_not_contain':
-                return !name.includes(value)
-              case 'starts_with':
-                return name.startsWith(value)
-              case 'ends_with':
-                return name.endsWith(value)
-              default:
-                return true
-            }
-          }
-
-          case 'stars': {
-            if (filter.condition === 'is_empty') {
-              return !repo.stars
-            }
-            if (filter.condition === 'is_not_empty') {
-              return !!repo.stars
-            }
-
-            if (filter.selectedValues.length === 0) {
-              return true
-            }
-
-            const filterValue = Number(filter.selectedValues[0])
-            const repoValue = repo.stars || 0
-
-            switch (filter.condition) {
-              case 'equals':
-                return repoValue === filterValue
-              case 'not_equals':
-                return repoValue !== filterValue
-              case 'greater':
-                return repoValue > filterValue
-              case 'less':
-                return repoValue < filterValue
-              case 'greater_equals':
-                return repoValue >= filterValue
-              case 'less_equals':
-                return repoValue <= filterValue
-              default:
-                return true
-            }
-          }
-
-          default:
-            return true
-        }
-      })
-    })
-
-  /**
-   * Sorts filtered repositories based on active sorts
-   *
-   * @param a - First repository to compare
-   * @param b - Second repository to compare
-   * @returns number - Comparison result (-1, 0, 1)
-   *
-   * Sort logic:
-   * - Applies multiple sorts in priority order (first sort has highest priority)
-   * - For equal values, moves to next sort criteria
-   * - Supports following sort types:
-   *   - updated: by timestamp
-   *   - stars: by number of stars
-   *   - forks: by number of forks
-   *   - pulls: by number of pull requests
-   *   - title: alphabetically by name
-   * - Each sort supports ascending/descending direction
-   */
-  const sortedRepos = [...(filteredRepos ?? [])].sort((a, b) => {
-    // Iterate through sorts in priority order
-    for (const sort of filterHandlers.activeSorts) {
-      const direction = sort.direction === 'asc' ? 1 : -1
-      let comparison = 0
-
-      switch (sort.type) {
-        case 'updated':
-          comparison = (new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()) * direction
-          break
-        case 'stars':
-          comparison = (b.stars - a.stars) * direction
-          break
-        case 'forks':
-          comparison = (b.forks - a.forks) * direction
-          break
-        case 'pulls':
-          comparison = (b.pulls - a.pulls) * direction
-          break
-        case 'title':
-          comparison = a.name.localeCompare(b.name) * direction
-          break
-        default:
-          comparison = 0
-      }
-
-      // If items are different by current sort criteria, return result
-      if (comparison !== 0) {
-        return comparison
-      }
-    }
-
-    return 0
-  })
-
-  const reposWithFormattedDates = sortedRepos.map(repo => ({
-    ...repo,
-    timestamp: formatDistanceToNow(new Date(repo.createdAt), {
-      addSuffix: true,
-      includeSeconds: true
-    }).replace('about ', '')
-  }))
+  const filteredRepos = filterRepositories(repositories, filterHandlers.activeFilters)
+  const sortedRepos = sortRepositories(filteredRepos, filterHandlers.activeSorts)
+  const reposWithFormattedDates = formatRepositories(sortedRepos)
 
   const debouncedSetSearchQuery = debounce(searchQuery => {
     setSearchQuery(searchQuery || null)
@@ -382,64 +78,83 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
     )
 
   return (
-    <>
-      <SandboxLayout.Main hasHeader hasLeftPanel>
-        <SandboxLayout.Content>
-          <Spacer size={10} />
-          <Text size={5} weight={'medium'}>
+    <SandboxLayout.Main hasHeader hasLeftPanel>
+      <SandboxLayout.Content>
+        <Spacer size={10} />
+        {/* 
+          TODO: Replace the Text component with a Title component in the future.
+          Consider using a Title component that supports a prefix prop for displaying the selected saved filter name.
+          Example:
+          <Title prefix={filterHandlers.currentView?.name}>
+            {t('views:repos.repositories')}
+          </Title>
+        */}
+        <div className="flex items-end">
+          <Text className="leading-none" size={5} weight={'medium'}>
             {t('views:repos.repositories')}
           </Text>
-          <Spacer size={6} />
-          <ListActions.Root>
-            <ListActions.Left>
-              <SearchBox.Root
-                width="full"
-                className="max-w-96"
-                // defaultValue={searchQuery || ''}
-                value={searchInput || ''}
-                handleChange={handleInputChange}
-                placeholder={t('views:repos.search')}
-              />
-            </ListActions.Left>
-            <ListActions.Right>
-              <Filters
-                filterOptions={FILTER_OPTIONS}
-                sortOptions={SORT_OPTIONS}
-                filterHandlers={filterHandlers}
-                t={t}
-              />
-              <Button variant="default" asChild>
-                <Link to={`create`}>{t('views:repos.create-repository')}</Link>
-              </Button>
-            </ListActions.Right>
-          </ListActions.Root>
-          {(filterHandlers.activeFilters.length > 0 || filterHandlers.activeSorts.length > 0) && <Spacer size={2} />}
-          <FiltersBar
-            filterOptions={FILTER_OPTIONS}
-            sortOptions={SORT_OPTIONS}
-            sortDirections={SORT_DIRECTIONS}
-            filterHandlers={filterHandlers}
-            t={t}
-          />
-          <Spacer size={5} />
-          <RepoList
-            repos={reposWithFormattedDates}
-            LinkComponent={LinkComponent}
-            handleResetFilters={filterHandlers.handleResetFilters}
-            hasActiveFilters={filterHandlers.activeFilters.length > 0}
-            query={searchQuery ?? ''}
-            handleResetQuery={() => {
-              setSearchInput('')
-              setSearchQuery(null)
-            }}
-            useTranslationStore={useTranslationStore}
-            isLoading={isLoading}
-          />
-          <Spacer size={8} />
-          <PaginationComponent totalPages={totalPages} currentPage={page} goToPage={page => setPage(page)} t={t} />
-        </SandboxLayout.Content>
-      </SandboxLayout.Main>
-    </>
+          {viewManagement.currentView && (
+            <>
+              <span className="inline-flex bg-borders-1 mx-2.5 h-[18px] w-px" />
+              <span className="text-foreground-3 text-14">{viewManagement.currentView.name}</span>
+            </>
+          )}
+        </div>
+        <Spacer size={6} />
+        <ListActions.Root>
+          <ListActions.Left>
+            <SearchBox.Root
+              width="full"
+              className="max-w-96"
+              // defaultValue={searchQuery || ''}
+              value={searchInput || ''}
+              handleChange={handleInputChange}
+              placeholder={t('views:repos.search')}
+            />
+          </ListActions.Left>
+          <ListActions.Right>
+            <Filters
+              filterOptions={FILTER_OPTIONS}
+              sortOptions={SORT_OPTIONS}
+              filterHandlers={filterHandlers}
+              viewManagement={viewManagement}
+              layoutOptions={LAYOUT_OPTIONS}
+              currentLayout={currentLayout}
+              onLayoutChange={setCurrentLayout}
+              t={t}
+            />
+            <Button variant="default" asChild>
+              <Link to={`create`}>{t('views:repos.create-repository')}</Link>
+            </Button>
+          </ListActions.Right>
+        </ListActions.Root>
+        {(filterHandlers.activeFilters.length > 0 || filterHandlers.activeSorts.length > 0) && <Spacer size={2} />}
+        <FiltersBar
+          filterOptions={FILTER_OPTIONS}
+          sortOptions={SORT_OPTIONS}
+          sortDirections={SORT_DIRECTIONS}
+          filterHandlers={filterHandlers}
+          viewManagement={viewManagement}
+          t={t}
+        />
+        <Spacer size={5} />
+        <RepoList
+          repos={reposWithFormattedDates}
+          LinkComponent={LinkComponent}
+          handleResetFilters={filterHandlers.handleResetFilters}
+          hasActiveFilters={filterHandlers.activeFilters.length > 0}
+          query={searchQuery ?? ''}
+          handleResetQuery={() => {
+            setSearchInput('')
+            setSearchQuery(null)
+          }}
+          useTranslationStore={useTranslationStore}
+          isLoading={isLoading}
+        />
+        <Spacer size={8} />
+        <PaginationComponent totalPages={totalPages} currentPage={page} goToPage={page => setPage(page)} t={t} />
+      </SandboxLayout.Content>
+    </SandboxLayout.Main>
   )
 }
 

--- a/packages/ui/src/views/repo/repo-list/repo-list.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list.tsx
@@ -1,7 +1,8 @@
 import { Badge, Icon, NoData, SkeletonList, StackedList } from '@/components'
 import { TFunction } from 'i18next'
 
-import { RepositoryType, TranslationStore } from './types'
+import { RepositoryType } from '../repo.types'
+import { TranslationStore } from './types'
 
 export interface PageProps {
   repos?: RepositoryType[]

--- a/packages/ui/src/views/repo/repo-list/types.ts
+++ b/packages/ui/src/views/repo/repo-list/types.ts
@@ -1,17 +1,5 @@
+import { RepositoryType } from '@views/repo/repo.types'
 import i18n, { TFunction } from 'i18next'
-
-export interface RepositoryType {
-  id: number
-  name: string
-  description?: string
-  private: boolean
-  stars: number
-  forks: number
-  pulls: number
-  createdAt: number
-  timestamp: string
-  importing?: boolean
-}
 
 interface RepoStore {
   repositories: RepositoryType[] | null

--- a/packages/ui/src/views/repo/repo.types.ts
+++ b/packages/ui/src/views/repo/repo.types.ts
@@ -48,6 +48,19 @@ export interface RepoFile {
   path: string
 }
 
+export interface RepositoryType {
+  id: number
+  name: string
+  description?: string
+  private: boolean
+  stars: number
+  forks: number
+  pulls: number
+  createdAt: number
+  timestamp: string
+  importing?: boolean
+}
+
 export type LatestFileTypes = Pick<RepoFile, 'user' | 'lastCommitMessage' | 'timestamp' | 'sha'>
 
 export interface IBranchSelectorStore {

--- a/packages/ui/src/views/repo/utils/filtering/pulls.ts
+++ b/packages/ui/src/views/repo/utils/filtering/pulls.ts
@@ -1,0 +1,121 @@
+import { FilterValue } from '@components/filters/types'
+
+import { PullRequestType } from '../../pull-request/types'
+
+export const filterPullRequests = (
+  pullRequests: PullRequestType[] | null,
+  activeFilters: FilterValue[]
+): PullRequestType[] => {
+  if (!pullRequests) return []
+  if (activeFilters.length === 0) return pullRequests
+
+  return pullRequests.filter(pr => activeFilters.every(filter => applyFilter(pr, filter)))
+}
+
+const applyFilter = (pr: PullRequestType, filter: FilterValue): boolean => {
+  switch (filter.type) {
+    case 'type':
+      return applyTypeFilter(pr, filter)
+    case 'created_time':
+      return applyDateFilter(pr, filter)
+    case 'name':
+      return applyNameFilter(pr, filter)
+    default:
+      return true
+  }
+}
+
+const applyTypeFilter = (pr: PullRequestType, filter: FilterValue): boolean => {
+  if (filter.condition === 'is_empty' || filter.condition === 'is_not_empty') {
+    return true
+  }
+
+  if (filter.selectedValues.length === 0) {
+    return true
+  }
+
+  const isOpen = pr.state === 'open'
+  const isClosed = pr.state === 'closed'
+
+  const matchesType = filter.selectedValues.some(value => {
+    switch (value) {
+      case 'enabled':
+        return isOpen
+      case 'disabled':
+        return isClosed
+      default:
+        return false
+    }
+  })
+
+  return filter.condition === 'is' ? matchesType : !matchesType
+}
+
+const applyDateFilter = (pr: PullRequestType, filter: FilterValue): boolean => {
+  if (filter.selectedValues.length === 0) {
+    return true
+  }
+
+  if (filter.condition === 'is_empty') {
+    return !pr.updated
+  }
+  if (filter.condition === 'is_not_empty') {
+    return !!pr.updated
+  }
+
+  const createdDate = new Date(pr.updated)
+  const selectedDate = new Date(filter.selectedValues[0])
+
+  createdDate.setHours(0, 0, 0, 0)
+  selectedDate.setHours(0, 0, 0, 0)
+
+  switch (filter.condition) {
+    case 'is':
+      return createdDate.getTime() === selectedDate.getTime()
+    case 'is_before':
+      return createdDate.getTime() < selectedDate.getTime()
+    case 'is_after':
+      return createdDate.getTime() > selectedDate.getTime()
+    case 'is_between': {
+      if (filter.selectedValues.length !== 2) return true
+      const endDate = new Date(filter.selectedValues[1])
+      endDate.setHours(0, 0, 0, 0)
+      return createdDate.getTime() >= selectedDate.getTime() && createdDate.getTime() <= endDate.getTime()
+    }
+    default:
+      return true
+  }
+}
+
+const applyNameFilter = (pr: PullRequestType, filter: FilterValue): boolean => {
+  if (filter.condition === 'is_empty') {
+    return !pr.name
+  }
+  if (filter.condition === 'is_not_empty') {
+    return !!pr.name
+  }
+
+  if (filter.selectedValues.length === 0) {
+    return true
+  }
+
+  const value = filter.selectedValues[0].toLowerCase()
+  const name = pr.name?.toLowerCase() ?? ''
+
+  switch (filter.condition) {
+    case 'is':
+      return name === value
+    case 'is_not':
+      return name !== value
+    case 'contains':
+      return name.includes(value)
+    case 'does_not_contain':
+      return !name.includes(value)
+    case 'starts_with':
+      return name.startsWith(value)
+    case 'ends_with':
+      return name.endsWith(value)
+    default:
+      return true
+  }
+}

--- a/packages/ui/src/views/repo/utils/filtering/repos.ts
+++ b/packages/ui/src/views/repo/utils/filtering/repos.ts
@@ -1,0 +1,179 @@
+import { FilterValue } from '@components/filters/types'
+import { RepositoryType } from '@views/repo/repo.types'
+
+/**
+ * Filters repositories based on active filters
+ * @param repositories - Array of repositories to filter
+ * @param activeFilters - Array of active filter conditions
+ * @returns Filtered array of repositories
+ */
+export const filterRepositories = (
+  repositories: RepositoryType[] | null,
+  activeFilters: FilterValue[]
+): RepositoryType[] => {
+  if (!repositories) return []
+  if (activeFilters.length === 0) return repositories
+
+  return repositories.filter(repo => activeFilters.every(filter => applyFilter(repo, filter)))
+}
+
+/**
+ * Applies a single filter to a repository
+ */
+const applyFilter = (repo: RepositoryType, filter: FilterValue): boolean => {
+  switch (filter.type) {
+    case 'type':
+      return applyTypeFilter(repo, filter)
+    case 'created_time':
+      return applyDateFilter(repo, filter)
+    case 'name':
+      return applyNameFilter(repo, filter)
+    case 'stars':
+      return applyStarsFilter(repo, filter)
+    default:
+      return true
+  }
+}
+
+/**
+ * Applies type-based filtering (private/public/fork)
+ */
+const applyTypeFilter = (repo: RepositoryType, filter: FilterValue): boolean => {
+  if (filter.condition === 'is_empty' || filter.condition === 'is_not_empty') {
+    return true
+  }
+
+  if (filter.selectedValues.length === 0) {
+    return true
+  }
+
+  const isPrivate = repo.private
+  const isPublic = !repo.private
+  const isFork = repo.forks > 0
+
+  const matchesType = filter.selectedValues.some(value => {
+    switch (value) {
+      case 'private':
+        return isPrivate
+      case 'public':
+        return isPublic
+      case 'fork':
+        return isFork
+      default:
+        return false
+    }
+  })
+
+  return filter.condition === 'is' ? matchesType : !matchesType
+}
+
+/**
+ * Applies date-based filtering
+ */
+const applyDateFilter = (repo: RepositoryType, filter: FilterValue): boolean => {
+  if (filter.selectedValues.length === 0) {
+    return true
+  }
+
+  if (filter.condition === 'is_empty') {
+    return !repo.createdAt
+  }
+  if (filter.condition === 'is_not_empty') {
+    return !!repo.createdAt
+  }
+
+  const createdDate = new Date(repo.createdAt)
+  const selectedDate = new Date(filter.selectedValues[0])
+
+  createdDate.setHours(0, 0, 0, 0)
+  selectedDate.setHours(0, 0, 0, 0)
+
+  switch (filter.condition) {
+    case 'is':
+      return createdDate.getTime() === selectedDate.getTime()
+    case 'is_before':
+      return createdDate.getTime() < selectedDate.getTime()
+    case 'is_after':
+      return createdDate.getTime() > selectedDate.getTime()
+    case 'is_between': {
+      if (filter.selectedValues.length !== 2) return true
+      const endDate = new Date(filter.selectedValues[1])
+      endDate.setHours(0, 0, 0, 0)
+      return createdDate.getTime() >= selectedDate.getTime() && createdDate.getTime() <= endDate.getTime()
+    }
+    default:
+      return true
+  }
+}
+
+/**
+ * Applies name-based filtering
+ */
+const applyNameFilter = (repo: RepositoryType, filter: FilterValue): boolean => {
+  if (filter.condition === 'is_empty') {
+    return !repo.name
+  }
+  if (filter.condition === 'is_not_empty') {
+    return !!repo.name
+  }
+
+  if (filter.selectedValues.length === 0) {
+    return true
+  }
+
+  const value = filter.selectedValues[0].toLowerCase()
+  const name = repo.name.toLowerCase()
+
+  switch (filter.condition) {
+    case 'is':
+      return name === value
+    case 'is_not':
+      return name !== value
+    case 'contains':
+      return name.includes(value)
+    case 'does_not_contain':
+      return !name.includes(value)
+    case 'starts_with':
+      return name.startsWith(value)
+    case 'ends_with':
+      return name.endsWith(value)
+    default:
+      return true
+  }
+}
+
+/**
+ * Applies stars-based filtering
+ */
+const applyStarsFilter = (repo: RepositoryType, filter: FilterValue): boolean => {
+  if (filter.condition === 'is_empty') {
+    return !repo.stars
+  }
+  if (filter.condition === 'is_not_empty') {
+    return !!repo.stars
+  }
+
+  if (filter.selectedValues.length === 0) {
+    return true
+  }
+
+  const filterValue = Number(filter.selectedValues[0])
+  const repoValue = repo.stars || 0
+
+  switch (filter.condition) {
+    case 'equals':
+      return repoValue === filterValue
+    case 'not_equals':
+      return repoValue !== filterValue
+    case 'greater':
+      return repoValue > filterValue
+    case 'less':
+      return repoValue < filterValue
+    case 'greater_equals':
+      return repoValue >= filterValue
+    case 'less_equals':
+      return repoValue <= filterValue
+    default:
+      return true
+  }
+}

--- a/packages/ui/src/views/repo/utils/filtering/webhooks.ts
+++ b/packages/ui/src/views/repo/utils/filtering/webhooks.ts
@@ -1,0 +1,130 @@
+import { FilterValue } from '@components/filters/types'
+
+import { WebhookType } from '../../webhooks/webhook-list/types'
+
+/**
+ * Filters webhooks based on active filters
+ */
+export const filterWebhooks = (webhooks: WebhookType[] | null, activeFilters: FilterValue[]): WebhookType[] => {
+  if (!webhooks) return []
+  if (activeFilters.length === 0) return webhooks
+
+  return webhooks.filter(webhook => activeFilters.every(filter => applyFilter(webhook, filter)))
+}
+
+const applyFilter = (webhook: WebhookType, filter: FilterValue): boolean => {
+  switch (filter.type) {
+    case 'type':
+      return applyTypeFilter(webhook, filter)
+    case 'created_time':
+      return applyDateFilter(webhook, filter)
+    case 'name':
+      return applyNameFilter(webhook, filter)
+    default:
+      return true
+  }
+}
+
+/**
+ * Applies type-based filtering (enabled/disabled)
+ */
+const applyTypeFilter = (webhook: WebhookType, filter: FilterValue): boolean => {
+  if (filter.condition === 'is_empty' || filter.condition === 'is_not_empty') {
+    return true
+  }
+
+  if (filter.selectedValues.length === 0) {
+    return true
+  }
+
+  const isEnabled = webhook.enabled
+  const isDisabled = !webhook.enabled
+
+  const matchesType = filter.selectedValues.some(value => {
+    switch (value) {
+      case 'enabled':
+        return isEnabled
+      case 'disabled':
+        return isDisabled
+      default:
+        return false
+    }
+  })
+
+  return filter.condition === 'is' ? matchesType : !matchesType
+}
+
+/**
+ * Applies date-based filtering
+ */
+const applyDateFilter = (webhook: WebhookType, filter: FilterValue): boolean => {
+  if (filter.selectedValues.length === 0) {
+    return true
+  }
+
+  if (filter.condition === 'is_empty') {
+    return !webhook.updated
+  }
+  if (filter.condition === 'is_not_empty') {
+    return !!webhook.updated
+  }
+
+  const createdDate = new Date(webhook.updated)
+  const selectedDate = new Date(filter.selectedValues[0])
+
+  createdDate.setHours(0, 0, 0, 0)
+  selectedDate.setHours(0, 0, 0, 0)
+
+  switch (filter.condition) {
+    case 'is':
+      return createdDate.getTime() === selectedDate.getTime()
+    case 'is_before':
+      return createdDate.getTime() < selectedDate.getTime()
+    case 'is_after':
+      return createdDate.getTime() > selectedDate.getTime()
+    case 'is_between': {
+      if (filter.selectedValues.length !== 2) return true
+      const endDate = new Date(filter.selectedValues[1])
+      endDate.setHours(0, 0, 0, 0)
+      return createdDate.getTime() >= selectedDate.getTime() && createdDate.getTime() <= endDate.getTime()
+    }
+    default:
+      return true
+  }
+}
+
+/**
+ * Applies name-based filtering
+ */
+const applyNameFilter = (webhook: WebhookType, filter: FilterValue): boolean => {
+  if (filter.condition === 'is_empty') {
+    return !webhook.name
+  }
+  if (filter.condition === 'is_not_empty') {
+    return !!webhook.name
+  }
+
+  if (filter.selectedValues.length === 0) {
+    return true
+  }
+
+  const value = filter.selectedValues[0].toLowerCase()
+  const name = webhook.name.toLowerCase()
+
+  switch (filter.condition) {
+    case 'is':
+      return name === value
+    case 'is_not':
+      return name !== value
+    case 'contains':
+      return name.includes(value)
+    case 'does_not_contain':
+      return !name.includes(value)
+    case 'starts_with':
+      return name.startsWith(value)
+    case 'ends_with':
+      return name.endsWith(value)
+    default:
+      return true
+  }
+}

--- a/packages/ui/src/views/repo/utils/formatting/repos.ts
+++ b/packages/ui/src/views/repo/utils/formatting/repos.ts
@@ -1,0 +1,18 @@
+// TODO: we should rethink the approach and stop using the @date-fns library
+
+import { RepositoryType } from '@views/repo/repo.types'
+import { formatDistanceToNow } from 'date-fns'
+
+/**
+ * Formats repository data for display
+ * Adds formatted timestamps and any other display-specific data
+ */
+export const formatRepositories = (repositories: RepositoryType[]): RepositoryType[] => {
+  return repositories.map(repo => ({
+    ...repo,
+    timestamp: formatDistanceToNow(new Date(repo.createdAt), {
+      addSuffix: true,
+      includeSeconds: true
+    }).replace('about ', '')
+  }))
+}

--- a/packages/ui/src/views/repo/utils/formatting/webhooks.ts
+++ b/packages/ui/src/views/repo/utils/formatting/webhooks.ts
@@ -1,0 +1,16 @@
+import { formatDistanceToNow } from 'date-fns'
+
+import { WebhookType } from '../../webhooks/webhook-list/types'
+
+/**
+ * Formats webhook data for display
+ */
+export const formatWebhooks = (webhooks: WebhookType[]): WebhookType[] => {
+  return webhooks.map(webhook => ({
+    ...webhook,
+    timestamp: formatDistanceToNow(new Date(webhook.updated), {
+      addSuffix: true,
+      includeSeconds: true
+    }).replace('about ', '')
+  }))
+}

--- a/packages/ui/src/views/repo/utils/sorting/pulls.ts
+++ b/packages/ui/src/views/repo/utils/sorting/pulls.ts
@@ -1,0 +1,33 @@
+import { SortValue } from '@components/filters/types'
+
+import { PullRequestType } from '../../pull-request/types'
+
+export const sortPullRequests = (
+  pullRequests: PullRequestType[] | null,
+  activeSorts: SortValue[]
+): PullRequestType[] => {
+  if (!pullRequests) return []
+
+  return [...pullRequests].sort((a, b) => {
+    for (const sort of activeSorts) {
+      const direction = sort.direction === 'asc' ? 1 : -1
+      const comparison = comparePullRequests(a, b, sort.type) * direction
+
+      if (comparison !== 0) {
+        return comparison
+      }
+    }
+    return 0
+  })
+}
+
+const comparePullRequests = (a: PullRequestType, b: PullRequestType, sortType: string): number => {
+  switch (sortType) {
+    case 'updated':
+      return new Date(b.updated).getTime() - new Date(a.updated).getTime()
+    case 'title':
+      return (a.name || '').localeCompare(b.name || '')
+    default:
+      return 0
+  }
+}

--- a/packages/ui/src/views/repo/utils/sorting/repos.ts
+++ b/packages/ui/src/views/repo/utils/sorting/repos.ts
@@ -1,0 +1,39 @@
+import { SortValue } from '@components/filters/types'
+import { RepositoryType } from '@views/repo/repo.types'
+
+/**
+ * Sorts repositories based on active sorts
+ * Applies multiple sorts in priority order
+ */
+export const sortRepositories = (repositories: RepositoryType[] | null, activeSorts: SortValue[]): RepositoryType[] => {
+  if (!repositories) return []
+
+  return [...repositories].sort((a, b) => {
+    for (const sort of activeSorts) {
+      const direction = sort.direction === 'asc' ? 1 : -1
+      const comparison = compareRepositories(a, b, sort.type) * direction
+
+      if (comparison !== 0) {
+        return comparison
+      }
+    }
+    return 0
+  })
+}
+
+const compareRepositories = (a: RepositoryType, b: RepositoryType, sortType: string): number => {
+  switch (sortType) {
+    case 'updated':
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    case 'stars':
+      return b.stars - a.stars
+    case 'forks':
+      return b.forks - a.forks
+    case 'pulls':
+      return b.pulls - a.pulls
+    case 'title':
+      return a.name.localeCompare(b.name)
+    default:
+      return 0
+  }
+}

--- a/packages/ui/src/views/repo/utils/sorting/webhooks.ts
+++ b/packages/ui/src/views/repo/utils/sorting/webhooks.ts
@@ -1,0 +1,33 @@
+import { SortValue } from '@components/filters/types'
+
+import { WebhookType } from '../../webhooks/webhook-list/types'
+
+/**
+ * Sorts webhooks based on active sorts
+ */
+export const sortWebhooks = (webhooks: WebhookType[] | null, activeSorts: SortValue[]): WebhookType[] => {
+  if (!webhooks) return []
+
+  return [...webhooks].sort((a, b) => {
+    for (const sort of activeSorts) {
+      const direction = sort.direction === 'asc' ? 1 : -1
+      const comparison = compareWebhooks(a, b, sort.type) * direction
+
+      if (comparison !== 0) {
+        return comparison
+      }
+    }
+    return 0
+  })
+}
+
+const compareWebhooks = (a: WebhookType, b: WebhookType, sortType: string): number => {
+  switch (sortType) {
+    case 'updated':
+      return new Date(b.updated).getTime() - new Date(a.updated).getTime()
+    case 'title':
+      return a.name.localeCompare(b.name)
+    default:
+      return 0
+  }
+}

--- a/packages/ui/src/views/repo/webhooks/webhook-list/repo-webhook-list-page.tsx
+++ b/packages/ui/src/views/repo/webhooks/webhook-list/repo-webhook-list-page.tsx
@@ -1,379 +1,58 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
-import {
-  Filters,
-  FiltersBar,
-  type FilterCondition,
-  type FilterOption,
-  type FilterValue,
-  type SortDirection,
-  type SortOption,
-  type SortValue
-} from '@components/filters'
-import useFilters from '@components/filters/use-filters'
+import { Filters, FiltersBar } from '@components/filters'
 import { Button, ListActions, PaginationComponent, SearchBox, SkeletonList, Spacer, Text } from '@components/index'
 import { useCommonFilter } from '@hooks/use-common-filter'
-import { formatDistanceToNow } from 'date-fns'
+import {
+  getFilterOptions,
+  getLayoutOptions,
+  getSortDirections,
+  getSortOptions
+} from '@views/repo/constants/filter-options'
+import { useFilters, useViewManagement } from '@views/repo/hooks'
+import { filterWebhooks } from '@views/repo/utils/filtering/webhooks'
+import { formatWebhooks } from '@views/repo/utils/formatting/webhooks'
+import { sortWebhooks } from '@views/repo/utils/sorting/webhooks'
 
 import { SandboxLayout } from '../../../index'
 import { RepoWebhookList } from './repo-webhook-list'
 import { WebhookListProps } from './types'
-
-const BASIC_CONDITIONS: FilterCondition[] = [
-  { label: 'is', value: 'is' },
-  { label: 'is not', value: 'is_not' },
-  { label: 'is empty', value: 'is_empty' },
-  { label: 'is not empty', value: 'is_not_empty' }
-]
-
-const RANGE_CONDITIONS: FilterCondition[] = [
-  { label: 'is', value: 'is' },
-  { label: 'is before', value: 'is_before' },
-  { label: 'is after', value: 'is_after' },
-  { label: 'is between', value: 'is_between' },
-  { label: 'is empty', value: 'is_empty' },
-  { label: 'is not empty', value: 'is_not_empty' }
-]
-
-const TEXT_CONDITIONS: FilterCondition[] = [
-  { label: 'is', value: 'is' },
-  { label: 'is not', value: 'is_not' },
-  { label: 'contains', value: 'contains' },
-  { label: 'does not contain', value: 'does_not_contain' },
-  { label: 'starts with', value: 'starts_with' },
-  { label: 'ends with', value: 'ends_with' },
-  { label: 'is empty', value: 'is_empty' },
-  { label: 'is not empty', value: 'is_not_empty' }
-]
-
-const FILTER_OPTIONS: FilterOption[] = [
-  {
-    label: 'Type',
-    value: 'type',
-    type: 'checkbox',
-    conditions: BASIC_CONDITIONS,
-    options: [
-      { label: 'Enabled', value: 'enabled' },
-      { label: 'Disabled', value: 'disabled' }
-    ]
-  },
-  {
-    label: 'Created time',
-    value: 'created_time',
-    type: 'calendar',
-    conditions: RANGE_CONDITIONS
-  },
-  {
-    label: 'Name',
-    value: 'name',
-    type: 'text',
-    conditions: TEXT_CONDITIONS
-  }
-]
-
-const SORT_OPTIONS: SortOption[] = [
-  { label: 'Last updated', value: 'updated' },
-  { label: 'Title', value: 'title' }
-]
-
-const SORT_DIRECTIONS: SortDirection[] = [
-  { label: 'Ascending', value: 'asc' },
-  { label: 'Descending', value: 'desc' }
-]
 
 const LinkComponent = ({ to, children }: { to: string; children: React.ReactNode }) => <Link to={to}>{children}</Link>
 
 const RepoWebhookListPage: React.FC<WebhookListProps> = ({ useWebhookStore, useTranslationStore }) => {
   const { t } = useTranslationStore()
 
+  const FILTER_OPTIONS = getFilterOptions(t)
+  const SORT_OPTIONS = getSortOptions(t)
+  const SORT_DIRECTIONS = getSortDirections(t)
+  const LAYOUT_OPTIONS = getLayoutOptions(t)
+
+  const [currentLayout, setCurrentLayout] = useState(LAYOUT_OPTIONS[1].value)
+
   // State for storing saved filters and sorts
   // null means no saved state exists
   const navigate = useNavigate()
   const { webhooks, totalPages, page, setPage, webhookLoading, error } = useWebhookStore()
 
-  const [savedState, setSavedState] = useState<{
-    filters: FilterValue[]
-    sorts: SortValue[]
-  } | null>(null)
-  // Controls visibility of the Save button
-  // true when current filters/sorts differ from saved state
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
-
   const handleNavigate = () => {
     navigate('create')
   }
-  /**
-   * Load previously saved filters from localStorage when component mounts
-   * This restores the last saved filter configuration for this page
-   */
-  useEffect(() => {
-    try {
-      const savedFiltersString = localStorage.getItem('sandbox-webhook-filters')
-      if (savedFiltersString) {
-        const savedFilters = JSON.parse(savedFiltersString)
-        setSavedState(savedFilters)
-      }
-    } catch (error) {
-      console.error('Error loading saved filters:', error)
-    }
-  }, [])
 
   /**
    * Initialize filters hook with handlers for managing filter state
    */
-  const filterHandlers = useFilters({
-    // Pass saved state to initialize filters
-    initialState: savedState ?? undefined,
-    /**
-     * Called whenever filters or sorts change
-     * Determines if current state differs from saved state to show/hide Save button
-     */
-    onStateChange: state => {
-      // If no saved state exists, show Save button if any filters/sorts are active
-      if (!savedState) {
-        setHasUnsavedChanges(state.filters.length > 0 || state.sorts.length > 0)
-        return
-      }
-
-      // Compare current state with saved state
-      // Show Save button only if:
-      // 1. States are different AND
-      // 2. There are actually some filters/sorts active
-      const isChanged =
-        JSON.stringify(state) !== JSON.stringify(savedState) && (state.filters.length > 0 || state.sorts.length > 0)
-
-      setHasUnsavedChanges(isChanged)
-    },
-    // Controls Save button visibility
-    hasUnsavedChanges,
-    /**
-     * Called when Save button is clicked
-     * Saves current filters and sorts to localStorage
-     */
-    onSave: () => {
-      try {
-        // Create state object to save
-        const stateToSave = {
-          filters: filterHandlers.activeFilters,
-          sorts: filterHandlers.activeSorts
-        }
-        // Save to localStorage
-        localStorage.setItem('sandbox-webhook-filters', JSON.stringify(stateToSave))
-        // Update saved state
-        setSavedState(stateToSave)
-        // Hide Save button
-        setHasUnsavedChanges(false)
-      } catch (error) {
-        console.error('Error saving filters:', error)
-      }
-    },
-    /**
-     * Called when Clear button is clicked
-     * Removes saved filters from localStorage and resets all filters
-     */
-    onClear: () => {
-      try {
-        // Remove saved filters from localStorage
-        localStorage.removeItem('sandbox-webhook-filters')
-        // Reset saved state
-        setSavedState(null)
-        // Hide Save button
-        setHasUnsavedChanges(false)
-        // Reset all filters
-        filterHandlers.handleResetAll()
-      } catch (error) {
-        console.error('Error clearing saved filters:', error)
-      }
-    }
+  const filterHandlers = useFilters()
+  const viewManagement = useViewManagement({
+    storageKey: 'repo-webhook-list-filters',
+    setActiveFilters: filterHandlers.setActiveFilters,
+    setActiveSorts: filterHandlers.setActiveSorts
   })
 
-  /**
-   * Filters webhooks based on active filters
-   *
-   * @param webhook - Webhook object to filter
-   * @returns boolean - Whether the webhooks matches all active filters
-   *
-   * Filter logic:
-   * - If no active filters, returns all webhooks
-   * - Applies all active filters (AND condition)
-   * - For type filter:
-   *   - Handles 'private', 'public', and 'fork' types
-   *   - Supports 'is' and 'is not' conditions
-   *   - Ignores empty filters or is_empty/is_not_empty conditions
-   */
-  const filteredWebhooks =
-    webhooks &&
-    webhooks.filter(webhook => {
-      if (filterHandlers.activeFilters.length === 0) return true
-
-      return filterHandlers.activeFilters.every(filter => {
-        switch (filter.type) {
-          case 'type': {
-            // Skip empty/not empty conditions for type filter
-            if (filter.condition === 'is_empty' || filter.condition === 'is_not_empty') {
-              return true
-            }
-
-            // Skip if no values selected
-            if (filter.selectedValues.length === 0) {
-              return true
-            }
-
-            // Determine webhook types
-            const isEnabled = webhook.enabled
-            const isDisabled = !webhook.enabled
-
-            // Check if webhook matches any of the selected type values
-            const matchesType = filter.selectedValues.some(value => {
-              switch (value) {
-                case 'enabled':
-                  return isEnabled
-                case 'disabled':
-                  return isDisabled
-
-                default:
-                  return false
-              }
-            })
-
-            // Apply condition (is/is not)
-            return filter.condition === 'is' ? matchesType : !matchesType
-          }
-
-          case 'created_time': {
-            // Skip if no values selected
-            if (filter.selectedValues.length === 0) {
-              return true
-            }
-
-            // Handle empty conditions
-            if (filter.condition === 'is_empty') {
-              return !webhook.updated
-            }
-            if (filter.condition === 'is_not_empty') {
-              return !!webhook.updated
-            }
-
-            const createdDate = new Date(webhook.updated)
-            const selectedDate = new Date(filter.selectedValues[0])
-
-            // Reset time parts for date-only comparison
-            createdDate.setHours(0, 0, 0, 0)
-            selectedDate.setHours(0, 0, 0, 0)
-
-            switch (filter.condition) {
-              case 'is':
-                return createdDate.getTime() === selectedDate.getTime()
-
-              case 'is_before':
-                return createdDate.getTime() < selectedDate.getTime()
-
-              case 'is_after':
-                return createdDate.getTime() > selectedDate.getTime()
-
-              case 'is_between': {
-                if (filter.selectedValues.length !== 2) return true
-                const endDate = new Date(filter.selectedValues[1])
-                endDate.setHours(0, 0, 0, 0)
-                return createdDate.getTime() >= selectedDate.getTime() && createdDate.getTime() <= endDate.getTime()
-              }
-
-              default:
-                return true
-            }
-          }
-
-          case 'name': {
-            if (filter.condition === 'is_empty') {
-              return !webhook.name
-            }
-            if (filter.condition === 'is_not_empty') {
-              return !!webhook.name
-            }
-
-            // Skip if no values selected
-            if (filter.selectedValues.length === 0) {
-              return true
-            }
-
-            const value = filter.selectedValues[0].toLowerCase()
-            const name = webhook.name.toLowerCase()
-
-            switch (filter.condition) {
-              case 'is':
-                return name === value
-              case 'is_not':
-                return name !== value
-              case 'contains':
-                return name.includes(value)
-              case 'does_not_contain':
-                return !name.includes(value)
-              case 'starts_with':
-                return name.startsWith(value)
-              case 'ends_with':
-                return name.endsWith(value)
-              default:
-                return true
-            }
-          }
-
-          default:
-            return true
-        }
-      })
-    })
-
-  /**
-   * Sorts filtered webhooks based on active sorts
-   *
-   * @param a - First webhook to compare
-   * @param b - Second webhook to compare
-   * @returns number - Comparison result (-1, 0, 1)
-   *
-   * Sort logic:
-   * - Applies multiple sorts in priority order (first sort has highest priority)
-   * - For equal values, moves to next sort criteria
-   * - Supports following sort types:
-   *   - updated: by timestamp
-   *   - forks: by number of forks
-   *   - pulls: by number of pull requests
-   *   - title: alphabetically by name
-   * - Each sort supports ascending/descending direction
-   */
-  const sortedWebhooks = [...(filteredWebhooks ?? [])].sort((a, b) => {
-    // Iterate through sorts in priority order
-    for (const sort of filterHandlers.activeSorts) {
-      const direction = sort.direction === 'asc' ? 1 : -1
-      let comparison = 0
-
-      switch (sort.type) {
-        case 'updated':
-          comparison = (new Date(b.updated).getTime() - new Date(a.updated).getTime()) * direction
-          break
-        case 'title':
-          comparison = a.name.localeCompare(b.name) * direction
-          break
-        default:
-          comparison = 0
-      }
-
-      // If items are different by current sort criteria, return result
-      if (comparison !== 0) {
-        return comparison
-      }
-    }
-
-    return 0
-  })
-
-  const webhooksWithFormattedDates = sortedWebhooks.map(webhook => ({
-    ...webhook,
-    timestamp: formatDistanceToNow(new Date(webhook.updated), {
-      addSuffix: true,
-      includeSeconds: true
-    }).replace('about ', '')
-  }))
+  const filteredWebhooks = filterWebhooks(webhooks, filterHandlers.activeFilters)
+  const sortedWebhooks = sortWebhooks(filteredWebhooks, filterHandlers.activeSorts)
+  const webhooksWithFormattedDates = formatWebhooks(sortedWebhooks)
 
   const { query, handleSearch } = useCommonFilter()
   const [value, setValue] = useState<string>()
@@ -432,10 +111,14 @@ const RepoWebhookListPage: React.FC<WebhookListProps> = ({ useWebhookStore, useT
             </ListActions.Left>
             <ListActions.Right>
               <Filters
-                t={t}
                 filterOptions={FILTER_OPTIONS}
                 sortOptions={SORT_OPTIONS}
                 filterHandlers={filterHandlers}
+                layoutOptions={LAYOUT_OPTIONS}
+                currentLayout={currentLayout}
+                onLayoutChange={setCurrentLayout}
+                viewManagement={viewManagement}
+                t={t}
               />
               <Button variant="default" asChild>
                 <Link to="create">New webhook</Link>
@@ -444,11 +127,12 @@ const RepoWebhookListPage: React.FC<WebhookListProps> = ({ useWebhookStore, useT
           </ListActions.Root>
           {(filterHandlers.activeFilters.length > 0 || filterHandlers.activeSorts.length > 0) && <Spacer size={2} />}
           <FiltersBar
-            t={t}
             filterOptions={FILTER_OPTIONS}
             sortOptions={SORT_OPTIONS}
             sortDirections={SORT_DIRECTIONS}
             filterHandlers={filterHandlers}
+            viewManagement={viewManagement}
+            t={t}
           />
           <Spacer size={5} />
           <RepoWebhookList


### PR DESCRIPTION
**Description:**
This pull request implements a new Views system that allows users to save, manage, and reuse filter configurations. This feature enables users to persist their filter setups and switch between different saved views.

**Key Features**
- Save current filter configuration as a named view
- Manage saved views (rename, reorder, delete)
- Update existing views when filter configuration changes
- Automatic validation of view names (prevents duplicates)
- Drag-and-drop reordering of saved views
- Local storage persistence for saved views

**Technical Implementation**
- Integrated with existing filter system using `FiltersBar` component
- Added validation system for view names and filter configurations
- Implemented drag-and-drop functionality using dnd-kit
- Added local storage integration for persistence


https://github.com/user-attachments/assets/45cfe1c3-fb19-47b4-affe-28dffe303ea8


