### PR TITLE
fix: repo description in a dialog

### DIFF
--- a/apps/gitness/src/pages-v2/repo/repo-summary.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-summary.tsx
@@ -7,6 +7,7 @@ import {
   OpenapiGetContentOutput,
   pathDetails,
   RepoPathsDetailsOutput,
+  UpdateRepositoryErrorResponse,
   useCreateTokenMutation,
   useFindRepositoryQuery,
   useGetContentQuery,
@@ -56,28 +57,43 @@ export default function RepoSummaryPage() {
     setSpaceIdAndRepoId(spaceId || '', repoId || '')
   }, [spaceId, repoId])
 
-  const { mutate: updateDescription } = useUpdateRepositoryMutation(
+  const [updateError, setUpdateError] = useState<string>("")
+
+  const updateDescription = useUpdateRepositoryMutation(
     { repo_ref: repoRef },
     {
       onSuccess: () => {
+        setUpdateError('')
         refetchRepo()
+      },
+      onError: (error: UpdateRepositoryErrorResponse) => {
+        const errormsg = error?.message || 'An unknown error occurred.'
+        setUpdateError(errormsg)
       }
     }
   )
-  const [isEditingDescription, setIsEditingDescription] = useState<boolean>(false)
-
-  const onChangeDescription = () => {
-    setIsEditingDescription(true)
-  }
 
   const saveDescription = (description: string) => {
-    updateDescription({
+    updateDescription.mutate({
       body: {
         description: description
       }
     })
-    setIsEditingDescription(false)
   }
+  const [submitted, setSubmitted] = useState(false)
+
+  useEffect(() => {
+    if (updateDescription.isSuccess) {
+      setSubmitted(true)
+
+      // After 1 second, reset the submitted state and make the button clickable again
+      const timer = setTimeout(() => {
+        setSubmitted(false)
+      }, 1000)
+
+      return () => clearTimeout(timer)
+    }
+  }, [updateDescription.isSuccess])
 
   const [createdTokenData, setCreatedTokenData] = useState<(TokenFormType & { token: string }) | null>(null)
   const [successTokenDialog, setSuccessTokenDialog] = useState(false)
@@ -299,11 +315,11 @@ export default function RepoSummaryPage() {
         summaryDetails={summaryDetails}
         gitRef={gitRef}
         latestCommitInfo={latestCommitInfo}
-        onChangeDescription={onChangeDescription}
-        isEditingDescription={isEditingDescription}
-        setIsEditingDescription={setIsEditingDescription}
         saveDescription={saveDescription}
         useRepoBranchesStore={useRepoBranchesStore}
+        updateRepoError={updateError}
+        isSubmitting={updateDescription.isLoading}
+        isSubmitted={submitted}
         useTranslationStore={useTranslationStore}
       />
       {createdTokenData && (

--- a/apps/gitness/src/pages-v2/repo/repo-summary.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-summary.tsx
@@ -57,7 +57,7 @@ export default function RepoSummaryPage() {
     setSpaceIdAndRepoId(spaceId || '', repoId || '')
   }, [spaceId, repoId])
 
-  const [updateError, setUpdateError] = useState<string>("")
+  const [updateError, setUpdateError] = useState<string>('')
 
   const updateDescription = useUpdateRepositoryMutation(
     { repo_ref: repoRef },

--- a/apps/gitness/src/pages-v2/repo/repo-summary.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-summary.tsx
@@ -59,12 +59,14 @@ export default function RepoSummaryPage() {
 
   const [updateError, setUpdateError] = useState<string>('')
 
+  const [isEditDialogOpen, setEditDialogOpen] = useState(false)
+
   const updateDescription = useUpdateRepositoryMutation(
     { repo_ref: repoRef },
     {
       onSuccess: () => {
-        setUpdateError('')
         refetchRepo()
+        setEditDialogOpen(false)
       },
       onError: (error: UpdateRepositoryErrorResponse) => {
         const errormsg = error?.message || 'An unknown error occurred.'
@@ -80,20 +82,10 @@ export default function RepoSummaryPage() {
       }
     })
   }
-  const [submitted, setSubmitted] = useState(false)
 
   useEffect(() => {
-    if (updateDescription.isSuccess) {
-      setSubmitted(true)
-
-      // After 1 second, reset the submitted state and make the button clickable again
-      const timer = setTimeout(() => {
-        setSubmitted(false)
-      }, 1000)
-
-      return () => clearTimeout(timer)
-    }
-  }, [updateDescription.isSuccess])
+    setUpdateError('')
+  }, [isEditDialogOpen])
 
   const [createdTokenData, setCreatedTokenData] = useState<(TokenFormType & { token: string }) | null>(null)
   const [successTokenDialog, setSuccessTokenDialog] = useState(false)
@@ -318,8 +310,8 @@ export default function RepoSummaryPage() {
         saveDescription={saveDescription}
         useRepoBranchesStore={useRepoBranchesStore}
         updateRepoError={updateError}
-        isSubmitting={updateDescription.isLoading}
-        isSubmitted={submitted}
+        isEditDialogOpen={isEditDialogOpen}
+        setEditDialogOpen={setEditDialogOpen}
         useTranslationStore={useTranslationStore}
       />
       {createdTokenData && (

--- a/packages/ui/src/views/repo/repo-list/repo-list.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list.tsx
@@ -102,7 +102,7 @@ export function RepoList({
                 primary
                 description={repo.description}
                 title={<Title title={repo.name} isPrivate={repo.private} t={t} />}
-                className="gap-1.5 truncate"
+                className="gap-1.5 line-clamp-1 text-wrap"
               />
               <StackedList.Field
                 title={

--- a/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
@@ -39,7 +39,7 @@ export const EditRepoDetails = ({
         <AlertDialogHeader>
           <AlertDialogTitle className="mb-4">Repository Description</AlertDialogTitle>
         </AlertDialogHeader>
-        <Text className="inline-block leading-none text-foreground-7" size={1}>
+        <Text className="inline-block leading-none text-foreground-2" size={1}>
           Description
         </Text>
         <Textarea

--- a/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from 'react'
+import { ChangeEvent, useEffect, useState } from 'react'
 
 import {
   AlertDialog,
@@ -8,12 +8,13 @@ import {
   AlertDialogTitle,
   Button,
   ButtonGroup,
+  Icon,
   Textarea
 } from '@/components'
 
 interface EditRepoDetailsDialog {
   showEditRepoDetails: boolean
-  description?: string
+  description: string
   onSave: (desc: string) => void
   onClose: () => void
   updateRepoError?: string
@@ -26,16 +27,30 @@ export const EditRepoDetails = ({
   onClose,
   updateRepoError
 }: EditRepoDetailsDialog) => {
-  const [newDesc, setNewDesc] = useState<string>(description || '')
+  const [newDesc, setNewDesc] = useState<string>(description)
   const handleClose = () => {
     setNewDesc(description || '')
     onClose()
   }
+  useEffect(() => {
+    setNewDesc(description)
+  }, [description])
   return (
     <AlertDialog open={showEditRepoDetails} onOpenChange={onClose}>
-      <AlertDialogContent className="h-80 max-h-[70vh] max-w-[460px]" onOverlayClick={handleClose}>
+      <AlertDialogContent className="h-80 max-h-[70vh] w-[460px] !rounded" onOverlayClick={handleClose}>
         <AlertDialogHeader>
-          <AlertDialogTitle className="mb-4">Repository Description</AlertDialogTitle>
+          <AlertDialogTitle className="mb-4">
+            Repository Description
+            <Button
+              className="absolute right-1 top-1 text-icons-4 hover:text-icons-2"
+              variant="custom"
+              size="icon"
+              onClick={handleClose}
+            >
+              <Icon name="close" size={16} />
+              <span className="sr-only">Close</span>
+            </Button>
+          </AlertDialogTitle>
         </AlertDialogHeader>
         <Textarea
           label="Description"

--- a/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
@@ -8,9 +8,9 @@ import {
   AlertDialogTitle,
   Button,
   ButtonGroup,
-  Textarea,
+  Icon,
   Text,
-  Icon
+  Textarea
 } from '@/components'
 
 interface EditRepoDetailsDialog {
@@ -23,7 +23,15 @@ interface EditRepoDetailsDialog {
   isSubmitted: boolean
 }
 
-export const EditRepoDetails = ({ showEditRepoDetails, description, onSave, onClose, updateRepoError, isSubmitting, isSubmitted }: EditRepoDetailsDialog) => {
+export const EditRepoDetails = ({
+  showEditRepoDetails,
+  description,
+  onSave,
+  onClose,
+  updateRepoError,
+  isSubmitting,
+  isSubmitted
+}: EditRepoDetailsDialog) => {
   const [newDesc, setNewDesc] = useState<string>(description || '')
   return (
     <AlertDialog open={showEditRepoDetails} onOpenChange={onClose}>
@@ -43,17 +51,13 @@ export const EditRepoDetails = ({ showEditRepoDetails, description, onSave, onCl
           }}
           placeholder="Enter repository description here"
         />
-        {
-          updateRepoError?.length ?
-            <Text
-              className="leading-none tracking-tight text-foreground-danger"
-              align="center"
-              size={1}
-              as="p"
-            >
-              {updateRepoError}
-            </Text> : <></>
-        }
+        {updateRepoError?.length ? (
+          <Text className="leading-none tracking-tight text-foreground-danger" align="center" size={1} as="p">
+            {updateRepoError}
+          </Text>
+        ) : (
+          <></>
+        )}
         <AlertDialogFooter>
           <ButtonGroup>
             {!isSubmitted ? (

--- a/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
@@ -1,0 +1,86 @@
+import { ChangeEvent, useState } from 'react'
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  ButtonGroup,
+  Textarea,
+  Text,
+  Icon
+} from '@/components'
+
+interface EditRepoDetailsDialog {
+  showEditRepoDetails: boolean
+  description?: string
+  onSave: (desc: string) => void
+  onClose: () => void
+  updateRepoError?: string
+  isSubmitting: boolean
+  isSubmitted: boolean
+}
+
+export const EditRepoDetails = ({ showEditRepoDetails, description, onSave, onClose, updateRepoError, isSubmitting, isSubmitted }: EditRepoDetailsDialog) => {
+  const [newDesc, setNewDesc] = useState<string>(description || '')
+  return (
+    <AlertDialog open={showEditRepoDetails} onOpenChange={onClose}>
+      <AlertDialogContent className="h-80 max-h-[70vh] max-w-[460px]" onOverlayClick={onClose}>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="mb-4">Repository Description</AlertDialogTitle>
+        </AlertDialogHeader>
+        <Text className="inline-block leading-none text-foreground-7" size={1}>
+          Description
+        </Text>
+        <Textarea
+          className="h-24 text-primary"
+          value={newDesc}
+          defaultValue={description}
+          onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
+            setNewDesc(e?.target?.value)
+          }}
+          placeholder="Enter repository description here"
+        />
+        {
+          updateRepoError?.length ?
+            <Text
+              className="leading-none tracking-tight text-foreground-danger"
+              align="center"
+              size={1}
+              as="p"
+            >
+              {updateRepoError}
+            </Text> : <></>
+        }
+        <AlertDialogFooter>
+          <ButtonGroup>
+            {!isSubmitted ? (
+              <>
+                <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+                  Cancel
+                </Button>
+                <Button type="button" theme="primary" onClick={() => onSave(newDesc)} disabled={isSubmitting}>
+                  {isSubmitting ? 'Saving...' : 'Save'}
+                </Button>
+              </>
+            ) : (
+              <Button
+                variant="ghost"
+                type="button"
+                size="sm"
+                theme="success"
+                className="pointer-events-none flex gap-2"
+                disabled={isSubmitted}
+              >
+                Saved
+                <Icon name="tick" size={14} />
+              </Button>
+            )}
+          </ButtonGroup>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
@@ -8,8 +8,6 @@ import {
   AlertDialogTitle,
   Button,
   ButtonGroup,
-  Icon,
-  Text,
   Textarea
 } from '@/components'
 
@@ -19,8 +17,6 @@ interface EditRepoDetailsDialog {
   onSave: (desc: string) => void
   onClose: () => void
   updateRepoError?: string
-  isSubmitting: boolean
-  isSubmitted: boolean
 }
 
 export const EditRepoDetails = ({
@@ -28,20 +24,20 @@ export const EditRepoDetails = ({
   description,
   onSave,
   onClose,
-  updateRepoError,
-  isSubmitting,
-  isSubmitted
+  updateRepoError
 }: EditRepoDetailsDialog) => {
   const [newDesc, setNewDesc] = useState<string>(description || '')
+  const handleClose = () => {
+    setNewDesc(description || '')
+    onClose()
+  }
   return (
     <AlertDialog open={showEditRepoDetails} onOpenChange={onClose}>
-      <AlertDialogContent className="h-80 max-h-[70vh] max-w-[460px]" onOverlayClick={onClose}>
+      <AlertDialogContent className="h-80 max-h-[70vh] max-w-[460px]" onOverlayClick={handleClose}>
         <AlertDialogHeader>
           <AlertDialogTitle className="mb-4">Repository Description</AlertDialogTitle>
         </AlertDialogHeader>
-        <Text className="inline-block leading-none text-foreground-2" size={1}>
-          Description
-        </Text>
+        <span className="inline-block leading-none text-foreground-7 text-14">Description</span>
         <Textarea
           className="h-24 text-primary"
           value={newDesc}
@@ -50,38 +46,16 @@ export const EditRepoDetails = ({
             setNewDesc(e?.target?.value)
           }}
           placeholder="Enter repository description here"
+          error={updateRepoError?.length ? updateRepoError : undefined}
         />
-        {updateRepoError?.length ? (
-          <Text className="leading-none tracking-tight text-foreground-danger" align="center" size={1} as="p">
-            {updateRepoError}
-          </Text>
-        ) : (
-          <></>
-        )}
         <AlertDialogFooter>
           <ButtonGroup>
-            {!isSubmitted ? (
-              <>
-                <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
-                  Cancel
-                </Button>
-                <Button type="button" theme="primary" onClick={() => onSave(newDesc)} disabled={isSubmitting}>
-                  {isSubmitting ? 'Saving...' : 'Save'}
-                </Button>
-              </>
-            ) : (
-              <Button
-                variant="ghost"
-                type="button"
-                size="sm"
-                theme="success"
-                className="pointer-events-none flex gap-2"
-                disabled={isSubmitted}
-              >
-                Saved
-                <Icon name="tick" size={14} />
-              </Button>
-            )}
+            <Button variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="button" theme="primary" onClick={() => onSave(newDesc)}>
+              Save
+            </Button>
           </ButtonGroup>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
@@ -37,7 +37,7 @@ export const EditRepoDetails = ({
         <AlertDialogHeader>
           <AlertDialogTitle className="mb-4">Repository Description</AlertDialogTitle>
         </AlertDialogHeader>
-        <span className="inline-block leading-none text-foreground-7 text-14">Description</span>
+        <span className="inline-block leading-none text-foreground-2 text-14">Description</span>
         <Textarea
           className="h-24 text-primary"
           value={newDesc}

--- a/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/edit-repo-details-dialog.tsx
@@ -37,8 +37,8 @@ export const EditRepoDetails = ({
         <AlertDialogHeader>
           <AlertDialogTitle className="mb-4">Repository Description</AlertDialogTitle>
         </AlertDialogHeader>
-        <span className="inline-block leading-none text-foreground-2 text-14">Description</span>
         <Textarea
+          label="Description"
           className="h-24 text-primary"
           value={newDesc}
           defaultValue={description}

--- a/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, useState } from 'react'
+import { ChangeEvent, FC, useEffect, useState } from 'react'
 
 import {
   Badge,
@@ -13,6 +13,7 @@ import {
   Text,
   Textarea
 } from '@/components'
+import { EditRepoDetails } from './edit-repo-details-dialog'
 
 interface DetailItem {
   id: string
@@ -26,10 +27,10 @@ interface SummaryPanelProps {
   details: DetailItem[]
   timestamp?: string
   description?: string
-  onChangeDescription?: () => void
-  isEditingDescription?: boolean
-  setIsEditingDescription: (value: boolean) => void
   saveDescription: (description: string) => void
+  updateRepoError?: string
+  isSubmitting: boolean
+  isSubmitted: boolean
 }
 
 const SummaryPanel: FC<SummaryPanelProps> = ({
@@ -37,79 +38,68 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
   details,
   timestamp,
   description,
-  onChangeDescription,
-  isEditingDescription,
-  setIsEditingDescription,
-  saveDescription
+  saveDescription,
+  updateRepoError,
+  isSubmitting,
+  isSubmitted
 }) => {
-  const [newDesc, setNewDesc] = useState(description)
+  const [isEditDialogOpen, setEditDialogOpen] = useState(false)
+  const onClose = () => {
+    setEditDialogOpen(false)
+  }
   return (
-    <div className="flex flex-col">
-      <div className="flex items-center justify-between">
-        <span className="truncate text-18 font-medium">{title}</span>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm_icon" aria-label="More options">
-              <Icon name="more-dots-fill" size={12} className="text-icons-3" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem className="flex items-center gap-1.5" onClick={onChangeDescription}>
-              <Icon name="plus" size={12} className="text-tertiary-background" />
-              <span>{description?.length ? 'Edit Description' : 'Add description'}</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-      <Spacer size={3} />
-      {description?.length && !isEditingDescription && (
-        <span className="line-clamp-3 border-y border-borders-4 py-3 text-14 text-foreground-2">{description}</span>
-      )}
-      {isEditingDescription && (
-        <div>
-          <Textarea
-            className="h-28 text-primary"
-            value={newDesc}
-            defaultValue={description}
-            onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
-              setNewDesc(e?.target?.value)
-            }}
-          />
-          <div className="flex justify-end gap-3 pt-3">
-            <Button
-              type="button"
-              onClick={() => setIsEditingDescription(false)}
-              className="text-primary"
-              variant="outline"
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={() => {
-                saveDescription(newDesc || '')
-              }}
-            >
-              Save
-            </Button>
-          </div>
+    <>
+      <div className="flex flex-col">
+        <div className="flex items-center justify-between">
+          <span className="truncate text-18 font-medium">{title}</span>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm_icon" aria-label="More options">
+                <Icon name="more-dots-fill" size={12} className="text-icons-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem className="flex items-center gap-1.5" onClick={() => setEditDialogOpen(true)}>
+                <Icon name="plus" size={12} className="text-tertiary-background" />
+                <span>{description?.length ? 'Edit Description' : 'Add description'}</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
-      )}
-      <Spacer size={2} />
-      {timestamp && <span className="text-13 text-foreground-4">Created {timestamp}</span>}
-      <Spacer size={5} />
-      <div className="flex flex-col gap-3">
-        {details &&
-          details.map(item => (
-            <div key={item.id} className="flex items-center gap-1.5">
-              <Icon name={item.iconName} size={14} className="text-tertiary-background" />
-              <Text>{item.name}</Text>
-              <Badge variant="outline" size="sm">
-                {item.count}
-              </Badge>
-            </div>
-          ))}
+        {description?.length ? (
+          <>
+            <Spacer size={3} />
+            <span className="line-clamp-3 border-y border-borders-4 py-3 text-14 text-foreground-2">{description}</span>
+          </>
+        ) : (
+          <></>
+        )}
+        <Spacer size={2} />
+        {timestamp && <span className="text-13 text-foreground-4">Created {timestamp}</span>}
+        <Spacer size={5} />
+        <div className="flex flex-col gap-3">
+          {details &&
+            details.map(item => (
+              <div key={item.id} className="flex items-center gap-1.5">
+                <Icon name={item.iconName} size={14} className="text-tertiary-background" />
+                <Text>{item.name}</Text>
+                <Badge variant="outline" size="sm">
+                  {item.count}
+                </Badge>
+              </div>
+            ))}
+        </div>
       </div>
-    </div>
+      <EditRepoDetails
+        showEditRepoDetails={isEditDialogOpen}
+        description={description}
+        onSave={saveDescription}
+        onClose={onClose}
+        updateRepoError={updateRepoError}
+        isSubmitting={isSubmitting}
+        isSubmitted={isSubmitted}
+      />
+    </>
   )
 }
 

--- a/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
@@ -29,8 +29,8 @@ interface SummaryPanelProps {
   description?: string
   saveDescription: (description: string) => void
   updateRepoError?: string
-  isSubmitting: boolean
-  isSubmitted: boolean
+  isEditDialogOpen: boolean
+  setEditDialogOpen: (value: boolean) => void
 }
 
 const SummaryPanel: FC<SummaryPanelProps> = ({
@@ -40,12 +40,14 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
   description,
   saveDescription,
   updateRepoError,
-  isSubmitting,
-  isSubmitted
+  isEditDialogOpen,
+  setEditDialogOpen
 }) => {
-  const [isEditDialogOpen, setEditDialogOpen] = useState(false)
   const onClose = () => {
     setEditDialogOpen(false)
+  }
+  const onSave = (description: string) => {
+    saveDescription(description)
   }
   return (
     <>
@@ -66,16 +68,22 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
-        {description?.length ? (
+        {timestamp?.length ? (
           <>
-            <Spacer size={3} />
-            <span className="line-clamp-3 border-y border-borders-4 py-3 text-14 text-foreground-2">{description}</span>
+            <Spacer size={2} />
+            <span className="text-13 text-foreground-4">Created {timestamp}</span>
           </>
         ) : (
           <></>
         )}
-        <Spacer size={2} />
-        {timestamp && <span className="text-13 text-foreground-4">Created {timestamp}</span>}
+        {description?.length ? (
+          <>
+            <Spacer size={3} />
+            <span className="border-y border-borders-4 py-3 text-14 text-foreground-2">{description}</span>
+          </>
+        ) : (
+          <></>
+        )}
         <Spacer size={5} />
         <div className="flex flex-col gap-3">
           {details &&
@@ -93,11 +101,9 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
       <EditRepoDetails
         showEditRepoDetails={isEditDialogOpen}
         description={description}
-        onSave={saveDescription}
+        onSave={onSave}
         onClose={onClose}
         updateRepoError={updateRepoError}
-        isSubmitting={isSubmitting}
-        isSubmitted={isSubmitted}
       />
     </>
   )

--- a/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, useEffect, useState } from 'react'
+import { FC, useState } from 'react'
 
 import {
   Badge,
@@ -10,9 +10,9 @@ import {
   Icon,
   IconProps,
   Spacer,
-  Text,
-  Textarea
+  Text
 } from '@/components'
+
 import { EditRepoDetails } from './edit-repo-details-dialog'
 
 interface DetailItem {

--- a/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
@@ -37,7 +37,7 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
   title,
   details,
   timestamp,
-  description,
+  description = '',
   saveDescription,
   updateRepoError,
   isEditDialogOpen,
@@ -77,7 +77,9 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
         {!!description?.length && (
           <>
             <Spacer size={3} />
-            <span className="border-y border-borders-4 py-3 text-14 text-foreground-2">{description}</span>
+            <span className="border-y border-borders-4 py-1 text-14 text-foreground-2 line-clamp-6">
+              {description}
+            </span>
           </>
         )}
         <Spacer size={5} />

--- a/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
@@ -77,9 +77,7 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
         {!!description?.length && (
           <>
             <Spacer size={3} />
-            <span className="border-y border-borders-4 py-1 text-14 text-foreground-2 line-clamp-6">
-              {description}
-            </span>
+            <span className="border-y border-borders-4 py-1 text-14 text-foreground-2 line-clamp-6">{description}</span>
           </>
         )}
         <Spacer size={5} />

--- a/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
@@ -68,21 +68,17 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
-        {timestamp?.length ? (
+        {!!timestamp?.length && (
           <>
             <Spacer size={2} />
             <span className="text-13 text-foreground-4">Created {timestamp}</span>
           </>
-        ) : (
-          <></>
         )}
-        {description?.length ? (
+        {!!description?.length && (
           <>
             <Spacer size={3} />
             <span className="border-y border-borders-4 py-3 text-14 text-foreground-2">{description}</span>
           </>
-        ) : (
-          <></>
         )}
         <Spacer size={5} />
         <div className="flex flex-col gap-3">

--- a/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC } from 'react'
 
 import {
   Badge,

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -100,8 +100,8 @@ export function RepoSummaryView({
   }
 
   return (
-    <SandboxLayout.Main hasLeftPanel hasHeader hasSubHeader>
-      <SandboxLayout.Columns columnWidths="1fr 220px">
+    <SandboxLayout.Main hasLeftPanel hasHeader hasSubHeader fullWidth>
+      <SandboxLayout.Columns columnWidths="1fr 255px">
         <SandboxLayout.Column>
           <SandboxLayout.Content>
             <ListActions.Root>

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -53,11 +53,11 @@ export interface RepoSummaryViewProps {
     timestamp: string
     sha: string | null
   }
-  onChangeDescription?: () => void
-  isEditingDescription?: boolean
-  setIsEditingDescription: (value: boolean) => void
   saveDescription: (description: string) => void
   useRepoBranchesStore: () => IBranchSelectorStore
+  updateRepoError?: string
+  isSubmitting: boolean
+  isSubmitted: boolean
   useTranslationStore: () => TranslationStore
 }
 
@@ -71,12 +71,12 @@ export function RepoSummaryView({
   summaryDetails: { default_branch_commit_count = 0, branch_count = 0, tag_count = 0, pull_req_summary },
   gitRef,
   latestCommitInfo,
-  onChangeDescription,
-  isEditingDescription,
-  setIsEditingDescription,
   saveDescription,
-  useTranslationStore,
-  useRepoBranchesStore
+  useRepoBranchesStore,
+  updateRepoError,
+  isSubmitting,
+  isSubmitted,
+  useTranslationStore
 }: RepoSummaryViewProps) {
   const navigate = useNavigate()
   const { t } = useTranslationStore()
@@ -207,10 +207,10 @@ export function RepoSummaryView({
                 }
               ]}
               description={repository?.description}
-              onChangeDescription={onChangeDescription}
-              isEditingDescription={isEditingDescription}
-              setIsEditingDescription={setIsEditingDescription}
               saveDescription={saveDescription}
+              updateRepoError={updateRepoError}
+              isSubmitting={isSubmitting}
+              isSubmitted={isSubmitted}
             />
           </SandboxLayout.Content>
         </SandboxLayout.Column>

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -208,7 +208,7 @@ export function RepoSummaryView({
                   iconName: 'open-pr'
                 }
               ]}
-              timestamp={formatDate(repository?.created!)}
+              timestamp={formatDate(repository?.created || '')}
               description={repository?.description}
               saveDescription={saveDescription}
               updateRepoError={updateRepoError}

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -18,8 +18,9 @@ import {
   StackedList,
   Text
 } from '@/components'
-import { IBranchSelectorStore, RepoFile, SandboxLayout, TranslationStore } from '@/views'
-import { BranchSelector, Summary } from '@/views/repo/components'
+import { BranchSelectorListItem, IBranchSelectorStore, RepoFile, SandboxLayout, TranslationStore } from '@/views'
+import { BranchSelector, BranchSelectorTab, Summary } from '@/views/repo/components'
+import { formatDate } from '@utils/utils'
 
 import SummaryPanel from './components/summary-panel'
 
@@ -32,6 +33,7 @@ export interface RepoSummaryViewProps {
         git_ssh_url?: string
         git_url?: string
         description?: string
+        created?: number
       }
     | undefined
   handleCreateToken: () => void
@@ -56,9 +58,9 @@ export interface RepoSummaryViewProps {
   saveDescription: (description: string) => void
   useRepoBranchesStore: () => IBranchSelectorStore
   updateRepoError?: string
-  isSubmitting: boolean
-  isSubmitted: boolean
   useTranslationStore: () => TranslationStore
+  isEditDialogOpen: boolean
+  setEditDialogOpen: (value: boolean) => void
 }
 
 export function RepoSummaryView({
@@ -74,8 +76,8 @@ export function RepoSummaryView({
   saveDescription,
   useRepoBranchesStore,
   updateRepoError,
-  isSubmitting,
-  isSubmitted,
+  isEditDialogOpen,
+  setEditDialogOpen,
   useTranslationStore
 }: RepoSummaryViewProps) {
   const navigate = useNavigate()
@@ -206,11 +208,12 @@ export function RepoSummaryView({
                   iconName: 'open-pr'
                 }
               ]}
+              timestamp={formatDate(repository?.created!)}
               description={repository?.description}
               saveDescription={saveDescription}
               updateRepoError={updateRepoError}
-              isSubmitting={isSubmitting}
-              isSubmitted={isSubmitted}
+              isEditDialogOpen={isEditDialogOpen}
+              setEditDialogOpen={setEditDialogOpen}
             />
           </SandboxLayout.Content>
         </SandboxLayout.Column>


### PR DESCRIPTION
repo description in a dialog as per new figma design

also added full width for summary page acc to figma - https://www.figma.com/design/Lu5QJyq9tQEjHMeQmQhbAd/Gitness-Product-Design---Stage-2?node-id=5318-41915&node-type=canvas&t=kwQAdKoUWXZT5HPm-0

<img width="1728" alt="Screenshot 2024-12-06 at 12 23 28 AM" src="https://github.com/user-attachments/assets/7bfd1bcd-0e40-4c31-8ea2-d91f95253215">
<img width="1728" alt="Screenshot 2024-12-06 at 12 23 50 AM" src="https://github.com/user-attachments/assets/f17df566-8f58-4f5b-96db-5c451b80640e">
<img width="1728" alt="Screenshot 2024-12-06 at 12 24 08 AM" src="https://github.com/user-attachments/assets/209fdbf1-e280-487c-b008-b01ef4a86473">
<img width="1728" alt="Screenshot 2024-12-06 at 12 24 18 AM" src="https://github.com/user-attachments/assets/0d2ab4e2-52fb-46ff-a117-ad243ed66c17">


