### PR TITLE
Removed theme selector from general settings

### DIFF
--- a/apps/gitness/src/pages/profile-settings/profile-settings-general-page.tsx
+++ b/apps/gitness/src/pages/profile-settings/profile-settings-general-page.tsx
@@ -21,7 +21,7 @@ import {
   Text
 } from '@harnessio/canary'
 import { SkeletonList } from '@harnessio/ui/components'
-import { FormFieldSet, getInitials, ModeToggle, SandboxLayout } from '@harnessio/views'
+import { FormFieldSet, getInitials, SandboxLayout } from '@harnessio/views'
 
 import { useTranslationStore } from '../../i18n/stores/i18n-store'
 import { LanguagesEnum } from './types'
@@ -244,11 +244,6 @@ const SettingsAccountGeneralPage: React.FC<SettingsAccountGeneralPageProps> = ({
                   {profileErrors.email.message?.toString()}
                 </FormFieldSet.Message>
               )}
-            </FormFieldSet.ControlGroup>
-
-            <FormFieldSet.ControlGroup>
-              <FormFieldSet.Label>Theme</FormFieldSet.Label>
-              <ModeToggle />
             </FormFieldSet.ControlGroup>
 
             <FormFieldSet.ControlGroup>


### PR DESCRIPTION
Currently, there is a theme selector on the profile settings page which is now obsolete and needs to be removed.
We have a dedicated theme settings page which should be used for theme selection.

We removed the theme selector from profile settings page as part of this PR. Here's how the profile settings page look after removing the theme selector:
<img width="1728" alt="Removed Theme Selector from Profile Settings" src="https://github.com/user-attachments/assets/e56f106e-0b83-4e10-bd63-b967f5721d89">
