### PR TITLE
Rerfactor and Add disable drag feature for permanently pinned menu items

### DIFF
--- a/apps/gitness/src/components/RootWrapper.tsx
+++ b/apps/gitness/src/components/RootWrapper.tsx
@@ -11,20 +11,7 @@ const RootWrapper = () => {
   const navigate = useNavigate()
   const { t } = useTranslation()
 
-  const { recent, pinned, setRecent, setPinned, setNavLinks } = useNav()
-
-  return (
-    <SandboxRoot
-      t={t}
-      currentUser={currentUser}
-      pinnedMenu={pinned}
-      recentMenu={recent}
-      setPinned={setPinned}
-      setRecent={setRecent}
-      setNavLinks={setNavLinks}
-      logout={() => navigate('/logout')}
-    />
-  )
+  return <SandboxRoot t={t} currentUser={currentUser} useNav={useNav} logout={() => navigate('/logout')} />
 }
 
 export default RootWrapper

--- a/apps/gitness/src/components/stores/recent-pinned-nav-links.store.ts
+++ b/apps/gitness/src/components/stores/recent-pinned-nav-links.store.ts
@@ -1,48 +1,40 @@
 import { create, StateCreator } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-import { NavbarItemType } from '@harnessio/ui/components'
-
-export interface NavState {
-  recent: NavbarItemType[]
-  pinned: NavbarItemType[]
-  setRecent: (route: NavbarItemType) => void
-  setPinned: (route: NavbarItemType, pin: boolean) => void
-  setNavLinks: (links: Partial<Pick<NavState, 'pinned' | 'recent'>>) => void
-}
+import type { NavState } from '@harnessio/ui/components'
 
 const navStateCreator: StateCreator<NavState> = set => ({
-  recent: [],
-  pinned: [],
+  recentMenu: [],
+  pinnedMenu: [],
 
   setRecent: (route, remove = false) =>
     set(state => {
-      let copyRecent = [...state.recent]
+      let copyRecent = [...state.recentMenu]
 
       if (remove) {
         copyRecent = copyRecent.filter(item => item.id !== route.id)
       } else {
         // Check if the route already exists in the history
-        if (state.recent.find(item => item.id === route.id)) return state
+        if (state.recentMenu.find(item => item.id === route.id)) return state
 
         // Check if the route already exists in the pinned list
-        if (state.pinned.find(item => item.id === route.id)) return state
+        if (state.pinnedMenu.find(item => item.id === route.id)) return state
 
-        copyRecent = [route, ...state.recent.slice(0, 4)]
+        copyRecent = [route, ...state.recentMenu.slice(0, 4)]
       }
 
       // Prepend the route to history, limiting to 5 items
       return {
-        pinned: state.pinned,
-        recent: copyRecent
+        pinnedMenu: state.pinnedMenu,
+        recentMenu: copyRecent
       }
     }),
 
   setPinned: (route, pin) =>
     set(state => {
       // Make shallow copies of the lists
-      let copyPinned = [...state.pinned]
-      let copyRecent = [...state.recent]
+      let copyPinned = [...state.pinnedMenu]
+      let copyRecent = [...state.recentMenu]
 
       if (pin) {
         // Push the route to the pinned list
@@ -56,16 +48,16 @@ const navStateCreator: StateCreator<NavState> = set => ({
       }
 
       return {
-        pinned: copyPinned,
-        recent: copyRecent
+        pinnedMenu: copyPinned,
+        recentMenu: copyRecent
       }
     }),
 
-  setNavLinks: ({ pinned, recent }) =>
+  setNavLinks: ({ pinnedMenu, recentMenu }) =>
     set(state => ({
       // Updates the pinned and recent navigation items in the state
-      pinned: pinned ?? state.pinned,
-      recent: recent ?? state.recent
+      pinnedMenu: pinnedMenu ?? state.pinnedMenu,
+      recentMenu: recentMenu ?? state.recentMenu
     }))
 })
 
@@ -73,6 +65,6 @@ export const useNav = create(
   persist(navStateCreator, {
     // localStorage key
     name: 'nav-items',
-    version: 1.0
+    version: 1.1
   })
 )

--- a/packages/ui/src/components/manage-navigation/draggable-item.tsx
+++ b/packages/ui/src/components/manage-navigation/draggable-item.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { DraggableAttributes } from '@dnd-kit/core'
 import { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities'
 import { useSortable } from '@dnd-kit/sortable'

--- a/packages/ui/src/components/manage-navigation/index.tsx
+++ b/packages/ui/src/components/manage-navigation/index.tsx
@@ -16,7 +16,6 @@ import useDragAndDrop from '@/hooks/use-drag-and-drop'
 import { MenuGroupType, NavbarItemType } from '@components/navbar/types'
 import { closestCenter, DndContext } from '@dnd-kit/core'
 import { SortableContext } from '@dnd-kit/sortable'
-import { cn } from '@utils/cn'
 
 import { DraggableItem } from './draggable-item'
 import { ManageNavigationSearch } from './manage-navigation-search'

--- a/packages/ui/src/components/manage-navigation/index.tsx
+++ b/packages/ui/src/components/manage-navigation/index.tsx
@@ -165,13 +165,7 @@ export const ManageNavigation = ({
                           return (
                             <>
                               <Button
-                                disabled={item.permanentlyPinned}
-                                className={cn(
-                                  'w-full grow cursor-grab gap-x-2.5 rounded p-1 px-3 active:cursor-grabbing',
-                                  {
-                                    'opacity-60': item.permanentlyPinned
-                                  }
-                                )}
+                                className={'w-full grow cursor-grab gap-x-2.5 rounded p-1 px-3 active:cursor-grabbing'}
                                 variant="ghost"
                                 {...attributes}
                                 {...listeners}
@@ -179,16 +173,14 @@ export const ManageNavigation = ({
                                 <Icon className="w-3.5" name="grid-dots" size={14} />
                                 <Text className="w-full text-left text-[inherit]">{item.title}</Text>
                               </Button>
-                              {!item.permanentlyPinned ? (
-                                <Button
-                                  className="text-icons-4 hover:text-icons-2 absolute right-1 top-0.5 z-20"
-                                  size="sm_icon"
-                                  variant="custom"
-                                  onClick={() => removeFromPinnedItems(item)}
-                                >
-                                  <Icon className="w-3.5" name="x-mark" size={14} />
-                                </Button>
-                              ) : null}
+                              <Button
+                                className="text-icons-4 hover:text-icons-2 absolute right-1 top-0.5 z-20"
+                                size="sm_icon"
+                                variant="custom"
+                                onClick={() => removeFromPinnedItems(item)}
+                              >
+                                <Icon className="w-3.5" name="x-mark" size={14} />
+                              </Button>
                             </>
                           )
                         }}

--- a/packages/ui/src/components/manage-navigation/index.tsx
+++ b/packages/ui/src/components/manage-navigation/index.tsx
@@ -115,7 +115,7 @@ export const ManageNavigation = ({
     updatePinnedItems(currentPinnedItems.filter(pinnedItem => pinnedItem.id !== item.id))
   }
 
-  const permanantlyPinnedItems = useMemo(
+  const permanentlyPinnedItems = useMemo(
     () => currentPinnedItems.filter(item => item.permanentlyPinned),
     [currentPinnedItems]
   )
@@ -147,7 +147,7 @@ export const ManageNavigation = ({
               <DndContext onDragEnd={handleDragEnd} collisionDetection={closestCenter}>
                 <SortableContext items={currentPinnedItems.map((_, index) => getItemId(index))}>
                   <ul className="-mx-3 mb-1 mt-3.5 flex flex-col gap-y-0.5">
-                    {permanantlyPinnedItems.map(item => {
+                    {permanentlyPinnedItems.map(item => {
                       return (
                         <div
                           key={item.id}
@@ -159,7 +159,7 @@ export const ManageNavigation = ({
                       )
                     })}
                     {draggablePinnedItems.map((item, index) => (
-                      <DraggableItem id={getItemId(index + permanantlyPinnedItems.length)} tag="li" key={item.title}>
+                      <DraggableItem id={getItemId(index + permanentlyPinnedItems.length)} tag="li" key={item.title}>
                         {({ attributes, listeners }) => {
                           return (
                             <>

--- a/packages/ui/src/components/manage-navigation/index.tsx
+++ b/packages/ui/src/components/manage-navigation/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import {
   AlertDialog,
@@ -16,6 +16,7 @@ import useDragAndDrop from '@/hooks/use-drag-and-drop'
 import { MenuGroupType, NavbarItemType } from '@components/navbar/types'
 import { closestCenter, DndContext } from '@dnd-kit/core'
 import { SortableContext } from '@dnd-kit/sortable'
+import { cn } from '@utils/cn'
 
 import { DraggableItem } from './draggable-item'
 import { ManageNavigationSearch } from './manage-navigation-search'
@@ -115,6 +116,15 @@ export const ManageNavigation = ({
     updatePinnedItems(currentPinnedItems.filter(pinnedItem => pinnedItem.id !== item.id))
   }
 
+  const permanantlyPinnedItems = useMemo(
+    () => currentPinnedItems.filter(item => item.permanentlyPinned),
+    [currentPinnedItems]
+  )
+  const draggablePinnedItems = useMemo(
+    () => currentPinnedItems.filter(item => !item.permanentlyPinned),
+    [currentPinnedItems]
+  )
+
   return (
     <AlertDialog open={showManageNavigation} onOpenChange={handleCancel}>
       <AlertDialogContent className="h-[574px] max-h-[70vh] max-w-[410px]" onOverlayClick={handleCancel}>
@@ -138,31 +148,50 @@ export const ManageNavigation = ({
               <DndContext onDragEnd={handleDragEnd} collisionDetection={closestCenter}>
                 <SortableContext items={currentPinnedItems.map((_, index) => getItemId(index))}>
                   <ul className="-mx-3 mb-1 mt-3.5 flex flex-col gap-y-0.5">
-                    {currentPinnedItems.map((item, index) => (
-                      <DraggableItem id={getItemId(index)} tag="li" key={item.title}>
-                        {({ attributes, listeners }) => (
-                          <>
-                            <Button
-                              className="w-full grow cursor-grab gap-x-2.5 rounded p-1 px-3 active:cursor-grabbing"
-                              variant="ghost"
-                              {...attributes}
-                              {...listeners}
-                            >
-                              <Icon className="w-3.5" name="grid-dots" size={14} />
-                              <Text className="w-full text-left text-[inherit]">{item.title}</Text>
-                            </Button>
-                            {!item.permanentlyPinned ? (
+                    {permanantlyPinnedItems.map(item => {
+                      return (
+                        <div
+                          key={item.id}
+                          className="flex w-full grow cursor-not-allowed items-center gap-x-2.5 rounded p-1 px-3 opacity-55"
+                        >
+                          <Icon className="w-3.5" name="shield-lock" size={14} />
+                          <Text>{item.title}</Text>
+                        </div>
+                      )
+                    })}
+                    {draggablePinnedItems.map((item, index) => (
+                      <DraggableItem id={getItemId(index + permanantlyPinnedItems.length)} tag="li" key={item.title}>
+                        {({ attributes, listeners }) => {
+                          return (
+                            <>
                               <Button
-                                className="absolute right-1 top-0.5 z-20 text-icons-4 hover:text-icons-2"
-                                size="sm_icon"
-                                variant="custom"
-                                onClick={() => removeFromPinnedItems(item)}
+                                disabled={item.permanentlyPinned}
+                                className={cn(
+                                  'w-full grow cursor-grab gap-x-2.5 rounded p-1 px-3 active:cursor-grabbing',
+                                  {
+                                    'opacity-60': item.permanentlyPinned
+                                  }
+                                )}
+                                variant="ghost"
+                                {...attributes}
+                                {...listeners}
                               >
-                                <Icon className="w-3.5" name="x-mark" size={14} />
+                                <Icon className="w-3.5" name="grid-dots" size={14} />
+                                <Text className="w-full text-left text-[inherit]">{item.title}</Text>
                               </Button>
-                            ) : null}
-                          </>
-                        )}
+                              {!item.permanentlyPinned ? (
+                                <Button
+                                  className="text-icons-4 hover:text-icons-2 absolute right-1 top-0.5 z-20"
+                                  size="sm_icon"
+                                  variant="custom"
+                                  onClick={() => removeFromPinnedItems(item)}
+                                >
+                                  <Icon className="w-3.5" name="x-mark" size={14} />
+                                </Button>
+                              ) : null}
+                            </>
+                          )
+                        }}
                       </DraggableItem>
                     ))}
                   </ul>

--- a/packages/ui/src/components/navbar/types.ts
+++ b/packages/ui/src/components/navbar/types.ts
@@ -39,4 +39,12 @@ interface UserMenuItemType {
   isSeparated: boolean
 }
 
-export type { MenuGroupType, NavbarItemType, UserMenuItemType, NavbarItemIdType }
+interface NavState {
+  pinnedMenu: NavbarItemType[]
+  recentMenu: NavbarItemType[]
+  setPinned: (items: NavbarItemType, pin: boolean) => void
+  setRecent: (items: NavbarItemType, remove?: boolean) => void
+  setNavLinks: (links: { pinnedMenu?: NavbarItemType[]; recentMenu?: NavbarItemType[] }) => void
+}
+
+export type { MenuGroupType, NavbarItemType, UserMenuItemType, NavbarItemIdType, NavState }

--- a/packages/ui/src/views/layouts/SandboxRoot.tsx
+++ b/packages/ui/src/views/layouts/SandboxRoot.tsx
@@ -5,7 +5,7 @@ import { ManageNavigation, MoreSubmenu, Navbar, SettingsMenu } from '@/component
 import { getNavbarMenuData } from '@/data/navbar-menu-data'
 import { getPinnedMenuItemsData } from '@/data/pinned-menu-items-data'
 import type { TypesUser } from '@/types'
-import { MenuGroupType, MenuGroupTypes, NavbarItemType } from '@components/navbar/types'
+import { MenuGroupType, MenuGroupTypes, NavbarItemType, NavState } from '@components/navbar/types'
 import { useLocationChange } from '@hooks/use-location-change'
 import { TFunction } from 'i18next'
 
@@ -20,26 +20,14 @@ interface NavLinkStorageInterface {
 
 export interface SandboxRootProps {
   currentUser: TypesUser | undefined
-  pinnedMenu: NavbarItemType[]
-  recentMenu: NavbarItemType[]
   logout?: () => void
-  setPinned: (items: NavbarItemType, pin: boolean) => void
-  setRecent: (items: NavbarItemType, remove?: boolean) => void
-  setNavLinks: (links: { pinned?: NavbarItemType[]; recent?: NavbarItemType[] }) => void
+  useNav: () => NavState
   t: TFunction
 }
 
-export const SandboxRoot = ({
-  currentUser,
-  pinnedMenu,
-  recentMenu,
-  logout,
-  setPinned,
-  setRecent,
-  setNavLinks,
-  t
-}: SandboxRootProps) => {
+export const SandboxRoot = ({ currentUser, useNav, t, logout }: SandboxRootProps) => {
   const location = useLocation()
+  const { pinnedMenu, recentMenu, setPinned, setRecent, setNavLinks } = useNav()
 
   const [showMoreMenu, setShowMoreMenu] = useState(false)
   const [showSettingMenu, setShowSettingMenu] = useState(false)
@@ -67,7 +55,7 @@ export const SandboxRoot = ({
       const pinnedItems = pinnedMenu.filter(
         item => !pinnedMenuItemsData.some(staticPinned => staticPinned.id === item.id)
       )
-      setNavLinks({ pinned: [...pinnedMenuItemsData, ...pinnedItems] })
+      setNavLinks({ pinnedMenu: [...pinnedMenuItemsData, ...pinnedItems] })
     }
   }, [])
 
@@ -139,12 +127,9 @@ export const SandboxRoot = ({
    * Handle save recent and pinned items
    */
   const handleSave = (nextRecentItems: NavbarItemType[], nextPinnedItems: NavbarItemType[]) => {
-    console.log('nextRecentItems', nextRecentItems)
-    console.log('nextPinnedItems', nextPinnedItems)
-
     setNavLinks({
-      pinned: nextPinnedItems,
-      recent: nextRecentItems
+      pinnedMenu: nextPinnedItems,
+      recentMenu: nextRecentItems
     })
   }
 


### PR DESCRIPTION
### Changes:
1. Passing "useNav" to `SandboxRoot` component.
2. Disabling permanently pinned component from drag and drop.

#### New recent and pinned menu architecture.
<img width="1595" alt="image" src="https://github.com/user-attachments/assets/bfb6a4a4-6683-425f-9fe0-48fa04324e24">

#### Disabled permanently  pinned menu.
<img width="961" alt="image" src="https://github.com/user-attachments/assets/4fcf078f-0d52-4844-aa93-ae0404439129">


