### PR TITLE
Added breadcrumbs to repo list page

### DIFF
--- a/apps/gitness/src/pages-v2/repo/repo-list.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-list.tsx
@@ -70,7 +70,7 @@ export default function ReposListPage() {
 
   return (
     <>
-      <div className="fixed top-0 z-50 ml-56 w-full bg-background-1">
+      <div className="fixed top-0 z-30 ml-56 w-full bg-background-1">
         <Breadcrumbs />
       </div>
       <SandboxRepoListPage

--- a/apps/gitness/src/pages-v2/repo/repo-list.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-list.tsx
@@ -5,6 +5,7 @@ import { parseAsInteger, useQueryState } from 'nuqs'
 import { ListReposOkResponse, useListReposQuery } from '@harnessio/code-service-client'
 import { SandboxRepoListPage } from '@harnessio/ui/views'
 
+import Breadcrumbs from '../../components/breadcrumbs/breadcrumbs'
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
 import useSpaceSSE from '../../framework/hooks/useSpaceSSE'
 import { useTranslationStore } from '../../i18n/stores/i18n-store'
@@ -68,14 +69,19 @@ export default function ReposListPage() {
   })
 
   return (
-    <SandboxRepoListPage
-      useRepoStore={useRepoStore}
-      useTranslationStore={useTranslationStore}
-      isLoading={isFetching}
-      isError={isError}
-      errorMessage={error?.message}
-      searchQuery={query}
-      setSearchQuery={setQuery}
-    />
+    <>
+      <div className="fixed top-0 z-50 ml-56 w-full bg-background-1">
+        <Breadcrumbs />
+      </div>
+      <SandboxRepoListPage
+        useRepoStore={useRepoStore}
+        useTranslationStore={useTranslationStore}
+        isLoading={isFetching}
+        isError={isError}
+        errorMessage={error?.message}
+        searchQuery={query}
+        setSearchQuery={setQuery}
+      />
+    </>
   )
 }


### PR DESCRIPTION
The dropdown for switching between spaces was not present previously on the Repo List page.

By adding Breadcrumbs to the page, the user shall now be able to switch between spaces using the dropdown in breadcrumbs.


https://github.com/user-attachments/assets/62556789-5e4d-494f-a3a8-2cec750b418c

