### PR TITLE
Fixed Settings Menu Overlap with Breadcrumbs

### DIFF
--- a/apps/gitness/src/pages-v2/repo/repo-layout.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-layout.tsx
@@ -6,7 +6,7 @@ import { useTranslationStore } from '../../i18n/stores/i18n-store'
 const RepoLayout = () => {
   return (
     <>
-      <div className="fixed top-0 z-50 ml-56 w-full bg-background-1">
+      <div className="fixed top-0 z-30 ml-56 w-full bg-background-1">
         <Breadcrumbs />
       </div>
       <RepoLayoutView useTranslationStore={useTranslationStore} />


### PR DESCRIPTION
Fixed settings menu overlap with Breadcrumbs.

After Fix:

https://github.com/user-attachments/assets/35cac714-c08f-4504-afb1-0adb7f16c8bb

Before Fix:

https://github.com/user-attachments/assets/39bbd434-42b9-4d5d-a50d-74459cc4b50a

