### PR TITLE
fix: repo list no data state

### DIFF
--- a/apps/gitness/src/components-v2/file-content-viewer.tsx
+++ b/apps/gitness/src/components-v2/file-content-viewer.tsx
@@ -103,7 +103,7 @@ export default function FileContentViewer({ repoContent, defaultBranch }: FileCo
             navigate(`/${spaceId}/repos/${repoId}/pull-requests/compare/${defaultBranch}...${newBranchName}`)
           }
         }}
-        defaultBranch={defaultBranch}
+        currentBranch={fullGitRef || repoMetadata?.default_branch || ''}
         isNew={false}
       />
       <FileViewerControlBar

--- a/apps/gitness/src/components-v2/file-content-viewer.tsx
+++ b/apps/gitness/src/components-v2/file-content-viewer.tsx
@@ -10,6 +10,7 @@ import GitBlame from '../components/GitBlame'
 import { useDownloadRawFile } from '../framework/hooks/useDownloadRawFile'
 import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
 import useCodePathDetails from '../hooks/useCodePathDetails'
+import { useRepoBranchesStore } from '../pages-v2/repo/stores/repo-branches-store'
 import { themes } from '../pages/pipeline-edit/theme/monaco-theme'
 import { PathParams } from '../RouteDefinitions'
 import { decodeGitContent, FILE_SEPERATOR, filenameToLanguage, formatBytes, GitCommitAction } from '../utils/git-utils'
@@ -22,13 +23,12 @@ const getDefaultView = (language?: string): ViewTypeValue => {
 
 interface FileContentViewerProps {
   repoContent?: OpenapiGetContentOutput
-  defaultBranch: string
 }
 
 /**
  * TODO: This code was migrated from V2 and needs to be refactored.
  */
-export default function FileContentViewer({ repoContent, defaultBranch }: FileContentViewerProps) {
+export default function FileContentViewer({ repoContent }: FileContentViewerProps) {
   const { spaceId, repoId } = useParams<PathParams>()
   const fileName = repoContent?.name || ''
   const language = filenameToLanguage(fileName) || ''
@@ -41,6 +41,7 @@ export default function FileContentViewer({ repoContent, defaultBranch }: FileCo
   const rawURL = `/api/v1/repos/${repoRef}/raw/${fullResourcePath}?git_ref=${fullGitRef}`
   const [view, setView] = useState<ViewTypeValue>(getDefaultView(language))
   const [isDeleteFileDialogOpen, setIsDeleteFileDialogOpen] = useState(false)
+  const { selectedBranchTag } = useRepoBranchesStore()
 
   /**
    * Toggle delete dialog open state
@@ -100,10 +101,10 @@ export default function FileContentViewer({ repoContent, defaultBranch }: FileCo
           if (!isNewBranch) {
             navigate(`/${spaceId}/repos/${repoId}/code${parentPath ? `/~/${parentPath}` : ''}`)
           } else {
-            navigate(`/${spaceId}/repos/${repoId}/pull-requests/compare/${defaultBranch}...${newBranchName}`)
+            navigate(`/${spaceId}/repos/${repoId}/pull-requests/compare/${selectedBranchTag.name}...${newBranchName}`)
           }
         }}
-        currentBranch={fullGitRef || repoMetadata?.default_branch || ''}
+        currentBranch={fullGitRef || selectedBranchTag?.name || ''}
         isNew={false}
       />
       <FileViewerControlBar

--- a/apps/gitness/src/components-v2/file-content-viewer.tsx
+++ b/apps/gitness/src/components-v2/file-content-viewer.tsx
@@ -11,8 +11,8 @@ import { useDownloadRawFile } from '../framework/hooks/useDownloadRawFile'
 import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
 import useCodePathDetails from '../hooks/useCodePathDetails'
 import { themes } from '../pages/pipeline-edit/theme/monaco-theme'
-import { PathParams } from '../RouteDefinitions.ts'
-import { decodeGitContent, filenameToLanguage, formatBytes, GitCommitAction } from '../utils/git-utils'
+import { PathParams } from '../RouteDefinitions'
+import { decodeGitContent, FILE_SEPERATOR, filenameToLanguage, formatBytes, GitCommitAction } from '../utils/git-utils'
 
 const getIsMarkdown = (language?: string) => language === 'markdown'
 
@@ -35,6 +35,7 @@ export default function FileContentViewer({ repoContent, defaultBranch }: FileCo
   const fileContent = decodeGitContent(repoContent?.content?.data)
   const repoRef = useGetRepoRef()
   const { fullGitRef, fullResourcePath } = useCodePathDetails()
+  const parentPath = fullResourcePath?.split(FILE_SEPERATOR).slice(0, -1).join(FILE_SEPERATOR)
   const downloadFile = useDownloadRawFile()
   const navigate = useNavigate()
   const rawURL = `/api/v1/repos/${repoRef}/raw/${fullResourcePath}?git_ref=${fullGitRef}`
@@ -97,7 +98,7 @@ export default function FileContentViewer({ repoContent, defaultBranch }: FileCo
         resourcePath={fullResourcePath || ''}
         onSuccess={(_commitInfo, isNewBranch, newBranchName) => {
           if (!isNewBranch) {
-            navigate(`/${spaceId}/repos/${repoId}/code`)
+            navigate(`/${spaceId}/repos/${repoId}/code${parentPath ? `/~/${parentPath}` : ''}`)
           } else {
             navigate(`/${spaceId}/repos/${repoId}/pull-requests/compare/${defaultBranch}...${newBranchName}`)
           }

--- a/apps/gitness/src/components-v2/file-editor.tsx
+++ b/apps/gitness/src/components-v2/file-editor.tsx
@@ -10,11 +10,11 @@ import GitCommitDialog from '../components-v2/git-commit-dialog'
 import { useExitConfirm } from '../framework/hooks/useExitConfirm'
 import useCodePathDetails from '../hooks/useCodePathDetails'
 import { useTranslationStore } from '../i18n/stores/i18n-store'
+import { useRepoBranchesStore } from '../pages-v2/repo/stores/repo-branches-store'
 import { themes } from '../pages/pipeline-edit/theme/monaco-theme'
 import { PathParams } from '../RouteDefinitions'
 import { decodeGitContent, FILE_SEPERATOR, filenameToLanguage, GitCommitAction, PLAIN_TEXT } from '../utils/git-utils'
 import { splitPathWithParents } from '../utils/path-utils'
-import { useRepoBranchesStore } from '../pages-v2/repo/stores/repo-branches-store'
 
 export interface FileEditorProps {
   repoDetails?: OpenapiGetContentOutput

--- a/apps/gitness/src/components-v2/file-editor.tsx
+++ b/apps/gitness/src/components-v2/file-editor.tsx
@@ -14,6 +14,7 @@ import { themes } from '../pages/pipeline-edit/theme/monaco-theme'
 import { PathParams } from '../RouteDefinitions'
 import { decodeGitContent, FILE_SEPERATOR, filenameToLanguage, GitCommitAction, PLAIN_TEXT } from '../utils/git-utils'
 import { splitPathWithParents } from '../utils/path-utils'
+import { useRepoBranchesStore } from '../pages-v2/repo/stores/repo-branches-store'
 
 export interface FileEditorProps {
   repoDetails?: OpenapiGetContentOutput
@@ -37,6 +38,7 @@ export const FileEditor = ({ repoDetails, defaultBranch }: FileEditorProps) => {
   const [view, setView] = useState<EditViewTypeValue>('edit')
   const [dirty, setDirty] = useState(false)
   const [isCommitDialogOpen, setIsCommitDialogOpen] = useState(false)
+  const { selectedBranchTag } = useRepoBranchesStore()
 
   const themeConfig = useMemo(
     () => ({
@@ -157,7 +159,7 @@ export const FileEditor = ({ repoDetails, defaultBranch }: FileEditorProps) => {
             navigate(`/${spaceId}/repos/${repoId}/pull-requests/compare/${defaultBranch}...${newBranchName}`)
           }
         }}
-        defaultBranch={defaultBranch}
+        currentBranch={fullGitRef || selectedBranchTag?.name}
         isNew={!!isNew}
       />
 

--- a/apps/gitness/src/components-v2/git-commit-dialog.tsx
+++ b/apps/gitness/src/components-v2/git-commit-dialog.tsx
@@ -35,7 +35,7 @@ interface CommitDialogProps {
   resourcePath: string
   payload?: string
   onSuccess: CommitDialogOnSuccess
-  defaultBranch: string
+  currentBranch: string
   isNew: boolean
 }
 
@@ -52,7 +52,7 @@ export default function GitCommitDialog({
   payload,
   sha,
   onSuccess,
-  defaultBranch,
+  currentBranch,
   isNew
 }: CommitDialogProps) {
   const repoRef = useGetRepoRef()
@@ -176,7 +176,7 @@ export default function GitCommitDialog({
       dryRun={dryRun}
       violation={violation}
       bypassable={bypassable}
-      defaultBranch={defaultBranch || 'Master'}
+      currentBranch={currentBranch || 'Master'}
       isFileNameRequired={isNew && resourcePath?.length < 1}
       setAllStates={setAllStates}
       // TODO: Add a loading state for submission

--- a/apps/gitness/src/components/FileContentViewer.tsx
+++ b/apps/gitness/src/components/FileContentViewer.tsx
@@ -165,7 +165,7 @@ export default function FileContentViewer({ repoContent }: FileContentViewerProp
             )
           }
         }}
-        defaultBranch={repoMetadata?.default_branch || ''}
+        currentBranch={gitRef || repoMetadata?.default_branch || ''}
         isNew={false}
       />
       <StackedList.Root>

--- a/apps/gitness/src/components/FileEditor.tsx
+++ b/apps/gitness/src/components/FileEditor.tsx
@@ -162,9 +162,7 @@ export const FileEditor: React.FC = () => {
         sha={repoDetails?.sha}
         onSuccess={(_commitInfo, isNewBranch, newBranchName) => {
           if (!isNewBranch) {
-            navigate(
-              `/${spaceId}/repos/${repoId}/code/${fullGitRef}/~/${fileResourcePath}`
-            )
+            navigate(`/${spaceId}/repos/${repoId}/code/${fullGitRef}/~/${fileResourcePath}`)
           } else {
             navigate(
               `/${spaceId}/repos/${repoId}/pull-requests/compare/${repoMetadata?.default_branch}...${newBranchName}`

--- a/apps/gitness/src/components/FileEditor.tsx
+++ b/apps/gitness/src/components/FileEditor.tsx
@@ -160,10 +160,10 @@ export const FileEditor: React.FC = () => {
         resourcePath={fileResourcePath || ''}
         payload={content}
         sha={repoDetails?.sha}
-        onSuccess={(_commitInfo, isNewBranch, newBranchName, fileName) => {
+        onSuccess={(_commitInfo, isNewBranch, newBranchName) => {
           if (!isNewBranch) {
             navigate(
-              `/${spaceId}/repos/${repoId}/code/${fullGitRef}/~/${isNew ? fileResourcePath + fileName : fileResourcePath}`
+              `/${spaceId}/repos/${repoId}/code/${fullGitRef}/~/${fileResourcePath}`
             )
           } else {
             navigate(

--- a/apps/gitness/src/components/FileEditor.tsx
+++ b/apps/gitness/src/components/FileEditor.tsx
@@ -169,7 +169,7 @@ export const FileEditor: React.FC = () => {
             )
           }
         }}
-        defaultBranch={repoMetadata?.default_branch || ''}
+        currentBranch={fullGitRef || repoMetadata?.default_branch || ''}
         isNew={!!isNew}
       />
       <ExitConfirmDialog onCancel={onExitCancel} onConfirm={onExitConfirm} open={isExitConfirmOpen} />

--- a/apps/gitness/src/components/GitCommitDialog.tsx
+++ b/apps/gitness/src/components/GitCommitDialog.tsx
@@ -31,7 +31,7 @@ interface CommitDialogProps {
     newBranchName: string,
     fileName?: string
   ) => void
-  defaultBranch: string
+  currentBranch: string
   isNew: boolean
 }
 
@@ -48,7 +48,7 @@ export default function GitCommitDialog({
   payload,
   sha,
   onSuccess,
-  defaultBranch,
+  currentBranch,
   isNew
 }: CommitDialogProps) {
   const repoRef = useGetRepoRef()
@@ -178,7 +178,7 @@ export default function GitCommitDialog({
             dryRun={dryRun}
             violation={violation}
             bypassable={bypassable}
-            defaultBranch={defaultBranch || 'Master'}
+            currentBranch={currentBranch}
             isFileNameRequired={isNew && resourcePath?.length < 1}
           />
         </DialogDescription>

--- a/apps/gitness/src/components/GitCommitForm.tsx
+++ b/apps/gitness/src/components/GitCommitForm.tsx
@@ -33,7 +33,7 @@ interface GitCommitFormProps {
   dryRun: (commitToGitRef: CommitToGitRefOption, fileName?: string) => void
   violation: boolean
   bypassable: boolean
-  defaultBranch?: string
+  currentBranch?: string
   isFileNameRequired: boolean
 }
 
@@ -81,7 +81,7 @@ export function GitCommitForm({
   dryRun,
   violation,
   bypassable,
-  defaultBranch,
+  currentBranch,
   isFileNameRequired
 }: GitCommitFormProps) {
   const { setAllStates } = useRuleViolationCheck()
@@ -161,7 +161,7 @@ export function GitCommitForm({
                 <FormFieldSet.Option
                   control={<RadioGroupItem value={CommitToGitRefOption.DIRECTLY} id="directly" />}
                   id="directly"
-                  label={`Commit to ${defaultBranch} directly`}
+                  label={`Commit to ${currentBranch} directly`}
                   description=""
                 />
                 {violation && form.getValues().commitToGitRef === CommitToGitRefOption.DIRECTLY && (

--- a/apps/gitness/src/pages-v2/repo/repo-code.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-code.tsx
@@ -149,7 +149,7 @@ export const RepoCode = () => {
    */
   const renderCodeView = useMemo(() => {
     if (codeMode === CodeModes.VIEW && !!repoDetails?.type && repoDetails.type !== 'dir') {
-      return <FileContentViewer repoContent={repoDetails} defaultBranch={repository?.default_branch || ''} />
+      return <FileContentViewer repoContent={repoDetails} />
     }
 
     if (codeMode !== CodeModes.VIEW) {

--- a/apps/gitness/src/pages-v2/repo/repo-list.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-list.tsx
@@ -39,6 +39,8 @@ export default function ReposListPage() {
   useEffect(() => {
     if (repoData) {
       setRepositories(repoData, headers)
+    } else {
+      setRepositories([], headers)
     }
   }, [repoData, headers, setRepositories])
 

--- a/apps/gitness/src/pages-v2/repo/repo-sidebar.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-sidebar.tsx
@@ -29,6 +29,7 @@ export const RepoSidebar = () => {
     setBranchList,
     setTagList,
     selectedBranchTag,
+    setDefaultBranch,
     setSelectedBranchTag,
     setSelectedBranchType,
     setSpaceIdAndRepoId
@@ -66,9 +67,12 @@ export const RepoSidebar = () => {
         branches.map(item => ({
           name: item?.name || '',
           sha: item?.sha || '',
-          default: item?.name === repository?.default_branch
+          is_default: item?.name === repository?.default_branch
         }))
       )
+    }
+    if (repository?.default_branch) {
+      setDefaultBranch(repository)
     }
   }, [branches, repository?.default_branch])
 

--- a/apps/gitness/src/pages-v2/repo/repo-summary.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-summary.tsx
@@ -45,6 +45,7 @@ export default function RepoSummaryPage() {
     setBranchList,
     setTagList,
     setSpaceIdAndRepoId,
+    setDefaultBranch,
     selectedBranchTag,
     setSelectedBranchTag,
     setSelectedBranchType
@@ -102,9 +103,12 @@ export default function RepoSummaryPage() {
         branches.map(item => ({
           name: item?.name || '',
           sha: item?.sha || '',
-          default: item?.name === repository?.default_branch
+          is_default: item?.name === repository?.default_branch
         }))
       )
+    }
+    if (repository?.default_branch) {
+      setDefaultBranch(repository)
     }
   }, [branches, repository?.default_branch])
 
@@ -260,7 +264,6 @@ export default function RepoSummaryPage() {
 
   useEffect(() => {
     const defaultBranch = branchList.find(branch => branch.default)
-
     setSelectedBranchTag({
       name: defaultBranch?.name || '',
       sha: defaultBranch?.sha || '',

--- a/packages/ui/locales/en/views.json
+++ b/packages/ui/locales/en/views.json
@@ -57,21 +57,24 @@
     "noProjects": "No projects available",
     "createProject": "Create Project"
   },
+  "noData": {
+    "noResults": "No search results",
+    "checkSpelling": "Check your spelling and filter options,",
+    "changeSearch": "or search for a different keyword.",
+    "clearSearch": "Clear search",
+    "clearFilters": "Clear filters",
+    "noPullRequests": "There are no pull requests in this project yet.",
+    "createNewPullRequest": "Create a new pull request.",
+    "noBranches": "No branches yet",
+    "createBranchDescription": "Your branches will appear here once they're created.",
+    "startBranchDescription": "Start branching to see your work organized.",
+    "createBranch": "Create branch"
+  },
   "forms": {
     "enterBranchName": "Enter branch name",
     "createBranchError": "Branch name is required",
     "select": "Select",
     "baseBranch": "Base Branch",
     "selectBranchError": "Base branch is required"
-  },
-  "noData": {
-    "noResults": "No search results",
-    "checkSpelling": "Check your spelling and filter options,",
-    "changeSearch": "or search for a different keyword.",
-    "clearSearch": "Clear search",
-    "noBranches": "No branches yet",
-    "createBranchDescription": "Your branches will appear here once they're created.",
-    "startBranchDescription": "Start branching to see your work organized.",
-    "createBranch": "Create branch"
   }
 }

--- a/packages/ui/locales/es/views.json
+++ b/packages/ui/locales/es/views.json
@@ -57,21 +57,24 @@
     "noProjects": "No projects available",
     "createProject": "Create Project"
   },
+  "noData": {
+    "noResults": "No search results",
+    "checkSpelling": "Check your spelling and filter options,",
+    "changeSearch": "or search for a different keyword.",
+    "clearSearch": "Clear search",
+    "clearFilters": "Clear filters",
+    "noPullRequests": "There are no pull requests in this project yet.",
+    "createNewPullRequest": "Create a new pull request.",
+    "noBranches": "No branches yet",
+    "createBranchDescription": "Your branches will appear here once they're created.",
+    "startBranchDescription": "Start branching to see your work organized.",
+    "createBranch": "Create branch"
+  },
   "forms": {
     "enterBranchName": "Enter branch name",
     "createBranchError": "",
     "select": "Select",
     "baseBranch": "Base Branch",
     "selectBranchError": ""
-  },
-  "noData": {
-    "noResults": "No search results",
-    "checkSpelling": "Check your spelling and filter options,",
-    "changeSearch": "or search for a different keyword.",
-    "clearSearch": "Clear search",
-    "noBranches": "No branches yet",
-    "createBranchDescription": "Your branches will appear here once they're created.",
-    "startBranchDescription": "Start branching to see your work organized.",
-    "createBranch": "Create branch"
   }
 }

--- a/packages/ui/locales/fr/views.json
+++ b/packages/ui/locales/fr/views.json
@@ -57,21 +57,24 @@
     "noProjects": "Aucun projet disponible",
     "createProject": "Créer un projet"
   },
+  "noData": {
+    "noResults": "Aucun résultat de recherche",
+    "checkSpelling": "Vérifiez votre orthographe et vos options de filtre,",
+    "changeSearch": "ou recherchez un autre mot-clé.",
+    "clearSearch": "Effacer la recherche",
+    "clearFilters": "Clear filters",
+    "noPullRequests": "There are no pull requests in this project yet.",
+    "createNewPullRequest": "Create a new pull request.",
+    "noBranches": "Pas encore de branches",
+    "createBranchDescription": "Vos branches apparaîtront ici une fois créées.",
+    "startBranchDescription": "Commencez à créer des branches pour voir votre travail organisé.",
+    "createBranch": "Créer une branche"
+  },
   "forms": {
     "enterBranchName": "Enter branch name",
     "createBranchError": "Le nom de la branche est requis",
     "select": "Select",
     "baseBranch": "Base Branch",
     "selectBranchError": "La branche de base est requise"
-  },
-  "noData": {
-    "noResults": "Aucun résultat de recherche",
-    "checkSpelling": "Vérifiez votre orthographe et vos options de filtre,",
-    "changeSearch": "ou recherchez un autre mot-clé.",
-    "clearSearch": "Effacer la recherche",
-    "noBranches": "Pas encore de branches",
-    "createBranchDescription": "Vos branches apparaîtront ici une fois créées.",
-    "startBranchDescription": "Commencez à créer des branches pour voir votre travail organisé.",
-    "createBranch": "Créer une branche"
   }
 }

--- a/packages/ui/src/components/commit-copy-actions.tsx
+++ b/packages/ui/src/components/commit-copy-actions.tsx
@@ -22,7 +22,7 @@ export const CommitCopyActions = ({ sha }: { sha: string }) => {
     <ShaBadge.Root>
       <ShaBadge.Content>
         <Link to="#">
-          <Text size={2} className="text-foreground-3">
+          <Text size={2} className="font-mono text-foreground-3">
             {sha.substring(0, 7)}
           </Text>
         </Link>

--- a/packages/ui/src/components/git-commit-dialog/git-commit-dialog.tsx
+++ b/packages/ui/src/components/git-commit-dialog/git-commit-dialog.tsx
@@ -59,7 +59,7 @@ export interface GitCommitDialogProps {
   isOpen: boolean
   isFileNameRequired?: boolean
   commitTitlePlaceHolder?: string
-  defaultBranch: string
+  currentBranch: string
   violation: boolean
   bypassable: boolean
   disableCTA: boolean
@@ -79,7 +79,7 @@ export const GitCommitDialog = ({
   onFormSubmit,
   commitTitlePlaceHolder,
   dryRun,
-  defaultBranch,
+  currentBranch,
   violation,
   bypassable,
   setAllStates,
@@ -189,7 +189,7 @@ export const GitCommitDialog = ({
                       "
                     >
                       <Icon className="translate-y-0.5 text-icons-9" name="branch" size={14} />
-                      {defaultBranch}
+                      {currentBranch}
                     </span>
                     branch
                   </span>

--- a/packages/ui/src/views/repo/pull-request/pull-request-list-page.tsx
+++ b/packages/ui/src/views/repo/pull-request/pull-request-list-page.tsx
@@ -1,7 +1,16 @@
 import { ChangeEvent, FC, useCallback, useState } from 'react'
 import { Link } from 'react-router-dom'
 
-import { Button, ListActions, NoData, PaginationComponent, SearchBox, SkeletonList, Spacer } from '@/components'
+import {
+  Button,
+  ListActions,
+  NoData,
+  PaginationComponent,
+  SearchBox,
+  SkeletonList,
+  Spacer,
+  StackedList
+} from '@/components'
 import { SandboxLayout, TranslationStore } from '@/views'
 import {
   Filters,
@@ -139,6 +148,9 @@ const PullRequestList: FC<PullRequestPageProps> = ({
     filterHandlers.handleResetFilters()
   }
 
+  const showTopBar =
+    !noData || filterHandlers.activeFilters.length > 0 || filterHandlers.activeSorts.length > 0 || searchQuery?.length
+
   const renderListContent = () => {
     if (isLoading) {
       return <SkeletonList />
@@ -146,29 +158,35 @@ const PullRequestList: FC<PullRequestPageProps> = ({
 
     if (noData) {
       return filterHandlers.activeFilters.length > 0 || searchQuery ? (
-        <NoData
-          iconName="no-search-magnifying-glass"
-          title="No search results"
-          description={['Check your spelling and filter options,', 'or search for a different keyword.']}
-          primaryButton={{
-            label: 'Clear search',
-            onClick: handleResetQuery
-          }}
-          secondaryButton={{
-            label: 'Clear filters',
-            onClick: filterHandlers.handleResetFilters
-          }}
-        />
+        <StackedList.Root>
+          <div className="flex min-h-[50vh] items-center justify-center py-20">
+            <NoData
+              iconName="no-search-magnifying-glass"
+              title="No search results"
+              description={['Check your spelling and filter options,', 'or search for a different keyword.']}
+              primaryButton={{
+                label: 'Clear search',
+                onClick: handleResetQuery
+              }}
+              secondaryButton={{
+                label: 'Clear filters',
+                onClick: filterHandlers.handleResetFilters
+              }}
+            />
+          </div>
+        </StackedList.Root>
       ) : (
-        <NoData
-          iconName="no-data-folder"
-          title="No pull requests yet"
-          description={['There are no pull requests in this project yet.', 'Create a new pull request.']}
-          primaryButton={{
-            label: 'Create pull request',
-            to: `/${spaceId}/repos/${repoId}/pulls/compare/`
-          }}
-        />
+        <div className="flex min-h-[70vh] items-center justify-center py-20">
+          <NoData
+            iconName="no-data-folder"
+            title="No pull requests yet"
+            description={['There are no pull requests in this project yet.', 'Create a new pull request.']}
+            primaryButton={{
+              label: 'Create pull request',
+              to: `/${spaceId}/repos/${repoId}/pulls/compare/`
+            }}
+          />
+        </div>
       )
     }
     return (
@@ -186,44 +204,48 @@ const PullRequestList: FC<PullRequestPageProps> = ({
   return (
     <SandboxLayout.Main hasHeader hasSubHeader hasLeftPanel>
       <SandboxLayout.Content>
-        <Spacer size={2} />
-        <p className="text-24 font-medium leading-snug tracking-tight text-foreground-1">Pull Requests</p>
-        <Spacer size={6} />
-        <ListActions.Root>
-          <ListActions.Left>
-            <SearchBox.Root
-              width="full"
-              className="max-w-96"
-              value={searchInput || ''}
-              handleChange={handleInputChange}
-              placeholder={t('views:repos.search')}
-            />
-          </ListActions.Left>
-          <ListActions.Right>
-            <Filters
+        {showTopBar ? (
+          <>
+            <Spacer size={2} />
+            <p className="text-24 font-medium leading-snug tracking-tight text-foreground-1">Pull Requests</p>
+            <Spacer size={6} />
+            <ListActions.Root>
+              <ListActions.Left>
+                <SearchBox.Root
+                  width="full"
+                  className="max-w-96"
+                  value={searchInput || ''}
+                  handleChange={handleInputChange}
+                  placeholder={t('views:repos.search')}
+                />
+              </ListActions.Left>
+              <ListActions.Right>
+                <Filters
+                  t={t}
+                  showView={false}
+                  filterOptions={FILTER_OPTIONS}
+                  sortOptions={SORT_OPTIONS}
+                  filterHandlers={filterHandlers}
+                  viewManagement={viewManagement}
+                />
+                <Button variant="default" asChild>
+                  <Link to={`/${spaceId}/repos/${repoId}/pulls/compare/`}>New pull request</Link>
+                </Button>
+              </ListActions.Right>
+            </ListActions.Root>
+            {(filterHandlers.activeFilters.length > 0 || filterHandlers.activeSorts.length > 0) && <Spacer size={2} />}
+            <FiltersBar
               t={t}
-              showView={false}
               filterOptions={FILTER_OPTIONS}
               sortOptions={SORT_OPTIONS}
+              sortDirections={SORT_DIRECTIONS}
               filterHandlers={filterHandlers}
               viewManagement={viewManagement}
             />
-            <Button variant="default" asChild>
-              <Link to={`/${spaceId}/repos/${repoId}/pulls/compare/`}>New pull request</Link>
-            </Button>
-          </ListActions.Right>
-        </ListActions.Root>
-        {(filterHandlers.activeFilters.length > 0 || filterHandlers.activeSorts.length > 0) && <Spacer size={2} />}
-        <FiltersBar
-          t={t}
-          filterOptions={FILTER_OPTIONS}
-          sortOptions={SORT_OPTIONS}
-          sortDirections={SORT_DIRECTIONS}
-          filterHandlers={filterHandlers}
-          viewManagement={viewManagement}
-        />
 
-        <Spacer size={5} />
+            <Spacer size={5} />
+          </>
+        ) : null}
         {renderListContent()}
         <Spacer size={6} />
         <PaginationComponent totalPages={totalPages} currentPage={page} goToPage={setPage} t={t} />

--- a/packages/ui/src/views/repo/pull-request/pull-request-list-page.tsx
+++ b/packages/ui/src/views/repo/pull-request/pull-request-list-page.tsx
@@ -162,14 +162,17 @@ const PullRequestList: FC<PullRequestPageProps> = ({
           <div className="flex min-h-[50vh] items-center justify-center py-20">
             <NoData
               iconName="no-search-magnifying-glass"
-              title="No search results"
-              description={['Check your spelling and filter options,', 'or search for a different keyword.']}
+              title={t('views:noData.noResults', 'No search results')}
+              description={[
+                t('views:noData.checkSpelling', 'Check your spelling and filter options,'),
+                t('views:noData.changeSearch', 'or search for a different keyword.')
+              ]}
               primaryButton={{
-                label: 'Clear search',
+                label: t('views:noData.clearSearch', 'Clear search'),
                 onClick: handleResetQuery
               }}
               secondaryButton={{
-                label: 'Clear filters',
+                label: t('views:noData.clearFilters', 'Clear filters'),
                 onClick: filterHandlers.handleResetFilters
               }}
             />
@@ -180,7 +183,10 @@ const PullRequestList: FC<PullRequestPageProps> = ({
           <NoData
             iconName="no-data-folder"
             title="No pull requests yet"
-            description={['There are no pull requests in this project yet.', 'Create a new pull request.']}
+            description={[
+              t('views:noData.noPullRequests', 'There are no pull requests in this project yet.'),
+              t('views:noData.createNewPullRequest', 'Create a new pull request.')
+            ]}
             primaryButton={{
               label: 'Create pull request',
               to: `/${spaceId}/repos/${repoId}/pulls/compare/`

--- a/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
@@ -78,7 +78,7 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
     )
 
   const noData = !(reposWithFormattedDates && reposWithFormattedDates.length > 0)
-  const showFilterBar = !noData || filterHandlers.activeFilters.length > 0 || searchQuery?.length
+  const showTopBar = !noData || filterHandlers.activeFilters.length > 0 || searchQuery?.length
 
   return (
     <SandboxLayout.Main hasHeader hasLeftPanel>
@@ -91,7 +91,7 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
             {t('views:repos.repositories')}
           </Title>
         */}
-        {showFilterBar ? (
+        {showTopBar ? (
           <>
             <Spacer size={10} />
             <div className="flex items-end">

--- a/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
@@ -111,7 +111,6 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
                 <SearchBox.Root
                   width="full"
                   className="max-w-96"
-                  // defaultValue={searchQuery || ''}
                   value={searchInput || ''}
                   handleChange={handleInputChange}
                   placeholder={t('views:repos.search')}

--- a/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
@@ -77,10 +77,12 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
       </>
     )
 
+  const noData = !(reposWithFormattedDates && reposWithFormattedDates.length > 0)
+  const showFilterBar = !noData || filterHandlers.activeFilters.length > 0 || searchQuery?.length
+
   return (
     <SandboxLayout.Main hasHeader hasLeftPanel>
       <SandboxLayout.Content>
-        <Spacer size={10} />
         {/* 
           TODO: Replace the Text component with a Title component in the future.
           Consider using a Title component that supports a prefix prop for displaying the selected saved filter name.
@@ -89,54 +91,59 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
             {t('views:repos.repositories')}
           </Title>
         */}
-        <div className="flex items-end">
-          <Text className="leading-none" size={5} weight={'medium'}>
-            {t('views:repos.repositories')}
-          </Text>
-          {viewManagement.currentView && (
-            <>
-              <span className="mx-2.5 inline-flex h-[18px] w-px bg-borders-1" />
-              <span className="text-14 text-foreground-3">{viewManagement.currentView.name}</span>
-            </>
-          )}
-        </div>
-        <Spacer size={6} />
-        <ListActions.Root>
-          <ListActions.Left>
-            <SearchBox.Root
-              width="full"
-              className="max-w-96"
-              // defaultValue={searchQuery || ''}
-              value={searchInput || ''}
-              handleChange={handleInputChange}
-              placeholder={t('views:repos.search')}
-            />
-          </ListActions.Left>
-          <ListActions.Right>
-            <Filters
+        {showFilterBar ? (
+          <>
+            <Spacer size={10} />
+            <div className="flex items-end">
+              <Text className="leading-none" size={5} weight={'medium'}>
+                {t('views:repos.repositories')}
+              </Text>
+              {viewManagement.currentView && (
+                <>
+                  <span className="mx-2.5 inline-flex h-[18px] w-px bg-borders-1" />
+                  <span className="text-14 text-foreground-3">{viewManagement.currentView.name}</span>
+                </>
+              )}
+            </div>
+            <Spacer size={6} />
+            <ListActions.Root>
+              <ListActions.Left>
+                <SearchBox.Root
+                  width="full"
+                  className="max-w-96"
+                  // defaultValue={searchQuery || ''}
+                  value={searchInput || ''}
+                  handleChange={handleInputChange}
+                  placeholder={t('views:repos.search')}
+                />
+              </ListActions.Left>
+              <ListActions.Right>
+                <Filters
+                  filterOptions={FILTER_OPTIONS}
+                  sortOptions={SORT_OPTIONS}
+                  filterHandlers={filterHandlers}
+                  viewManagement={viewManagement}
+                  layoutOptions={LAYOUT_OPTIONS}
+                  currentLayout={currentLayout}
+                  onLayoutChange={setCurrentLayout}
+                  t={t}
+                />
+                <Button variant="default" asChild>
+                  <Link to={`create`}>{t('views:repos.create-repository')}</Link>
+                </Button>
+              </ListActions.Right>
+            </ListActions.Root>
+            {(filterHandlers.activeFilters.length > 0 || filterHandlers.activeSorts.length > 0) && <Spacer size={2} />}
+            <FiltersBar
               filterOptions={FILTER_OPTIONS}
               sortOptions={SORT_OPTIONS}
+              sortDirections={SORT_DIRECTIONS}
               filterHandlers={filterHandlers}
               viewManagement={viewManagement}
-              layoutOptions={LAYOUT_OPTIONS}
-              currentLayout={currentLayout}
-              onLayoutChange={setCurrentLayout}
               t={t}
             />
-            <Button variant="default" asChild>
-              <Link to={`create`}>{t('views:repos.create-repository')}</Link>
-            </Button>
-          </ListActions.Right>
-        </ListActions.Root>
-        {(filterHandlers.activeFilters.length > 0 || filterHandlers.activeSorts.length > 0) && <Spacer size={2} />}
-        <FiltersBar
-          filterOptions={FILTER_OPTIONS}
-          sortOptions={SORT_OPTIONS}
-          sortDirections={SORT_DIRECTIONS}
-          filterHandlers={filterHandlers}
-          viewManagement={viewManagement}
-          t={t}
-        />
+          </>
+        ) : null}
         <Spacer size={5} />
         <RepoList
           repos={reposWithFormattedDates}

--- a/packages/ui/src/views/repo/repo-list/repo-list.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list.tsx
@@ -61,9 +61,12 @@ export function RepoList({
           <NoData
             iconName="no-search-magnifying-glass"
             title="No search results"
-            description={['Check your spelling and filter options,', 'or search for a different keyword.']}
+            description={[
+              t('views:noData.checkSpelling', 'Check your spelling and filter options,'),
+              t('views:noData.changeSearch', 'or search for a different keyword.')
+            ]}
             primaryButton={{
-              label: 'Clear search',
+              label: t('views:noData.clearSearch', 'Clear search'),
               onClick: handleResetQuery
             }}
             secondaryButton={{

--- a/packages/ui/src/views/repo/repo-list/repo-list.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list.tsx
@@ -55,41 +55,41 @@ export function RepoList({
   }
 
   if (noData) {
-    return (
+    return hasActiveFilters || query ? (
       <StackedList.Root>
         <div className="flex min-h-[50vh] items-center justify-center py-20">
-          {hasActiveFilters || query ? (
-            <NoData
-              iconName="no-search-magnifying-glass"
-              title="No search results"
-              description={['Check your spelling and filter options,', 'or search for a different keyword.']}
-              primaryButton={{
-                label: 'Clear search',
-                onClick: handleResetQuery
-              }}
-              secondaryButton={{
-                label: 'Clear filters',
-                onClick: handleResetFilters
-              }}
-            />
-          ) : (
-            <NoData
-              iconName="no-data-folder"
-              title="No repositories yet"
-              description={[
-                'There are no repositories in this project yet.',
-                'Create new or import an existing repository.'
-              ]}
-              primaryButton={{
-                label: 'Create repository',
-                onClick: () => {
-                  /* TODO: add create handler */
-                }
-              }}
-            />
-          )}
+          <NoData
+            iconName="no-search-magnifying-glass"
+            title="No search results"
+            description={['Check your spelling and filter options,', 'or search for a different keyword.']}
+            primaryButton={{
+              label: 'Clear search',
+              onClick: handleResetQuery
+            }}
+            secondaryButton={{
+              label: 'Clear filters',
+              onClick: handleResetFilters
+            }}
+          />
         </div>
       </StackedList.Root>
+    ) : (
+      <div className="flex min-h-[70vh] items-center justify-center py-20">
+        <NoData
+          iconName="no-data-folder"
+          title="No repositories yet"
+          description={[
+            'There are no repositories in this project yet.',
+            'Create new or import an existing repository.'
+          ]}
+          primaryButton={{
+            label: 'Create repository',
+            onClick: () => {
+              /* TODO: add create handler */
+            }
+          }}
+        />
+      </div>
     )
   }
 


### PR DESCRIPTION
fixes : 
1. **commit changes onSuccess navigation**
2. **default branch for repo summary/files**
3. **commit changes to current branch**

4. **repo list no data state**
<img width="1700" alt="Screenshot 2024-12-11 at 11 34 37 AM" src="https://github.com/user-attachments/assets/6f9f7de1-bd41-41fb-ba5c-cbf96dcf02fd">

<img width="1700" alt="Screenshot 2024-12-11 at 11 34 49 AM" src="https://github.com/user-attachments/assets/7704b4a2-f9b1-495b-93ad-c6582d99b86b">

<img width="1700" alt="Screenshot 2024-12-11 at 11 34 57 AM" src="https://github.com/user-attachments/assets/71aa21df-cd6e-4883-a061-416a7f787a90">

5. **PR list no data state**
<img width="1700" alt="Screenshot 2024-12-11 at 3 26 39 PM" src="https://github.com/user-attachments/assets/884fa48e-99dd-4226-8936-d3ed049adba1">

<img width="1700" alt="Screenshot 2024-12-11 at 3 26 55 PM" src="https://github.com/user-attachments/assets/111a58ee-875e-4b38-bd0e-1b288ba57bfb">

6. **Monospace font for Commit Sha's across the pages**
<img width="1709" alt="Screenshot 2024-12-11 at 10 49 21 PM" src="https://github.com/user-attachments/assets/aedb24b9-2a17-46a8-b617-76443f1f44ef" />

<img width="1709" alt="Screenshot 2024-12-11 at 10 49 28 PM" src="https://github.com/user-attachments/assets/4c05026e-248a-41ab-9a3b-2cabc994ef20" />

<img width="1709" alt="Screenshot 2024-12-11 at 10 49 38 PM" src="https://github.com/user-attachments/assets/dd4b6dc0-17c2-4cba-b409-ee6818885556" />

<img width="1447" alt="Screenshot 2024-12-11 at 10 49 15 PM" src="https://github.com/user-attachments/assets/8995de52-e48a-4e7c-b3b9-fd9cbfae4fb6" />


