### PR TITLE
feat: add BranchInfoBar and RecentPushInfoBar components

### DIFF
--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -17,27 +17,27 @@ enum BadgesHoverStates {
 }
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-md border transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center border transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {
         default: 'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
         secondary: 'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        tertiary: 'border-transparent bg-background-8 text-foreground-8',
         destructive: 'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
         outline: 'text-foreground'
       },
       size: {
         default: 'px-2.5 py-0.5 text-xs font-semibold',
+        xl: 'h-[18px] px-2 text-12',
         lg: 'px-3 py-1 text-xs font-normal',
+        md: 'h-6 px-2.5',
         sm: 'h-5 px-1 text-12',
-        xs: 'px-1.5 py-0 text-11 font-light',
-        // TODO: Consider switching size variants to numeric values
-        // Numeric size variants (like '18') provide clearer context about actual dimensions
-        // compared to abstract sizes (xs, sm, lg).
-        '18': 'h-[18px] px-2 text-12'
+        xs: 'px-1.5 py-0 text-11 font-light'
       },
       borderRadius: {
-        default: '',
+        default: 'rounded-md',
+        base: 'rounded',
         full: 'rounded-full'
       },
       hover: {

--- a/packages/ui/src/components/filters/filters-bar/actions/variants/checkbox.tsx
+++ b/packages/ui/src/components/filters/filters-bar/actions/variants/checkbox.tsx
@@ -17,8 +17,8 @@ const Checkbox = ({ filter, filterOption, onUpdateFilter, searchQueries, handleS
   return (
     <>
       {filter.condition !== 'is_empty' && (
-        <div className="border-b border-borders-1 px-3 pb-2.5">
-          <div className="border-border-2 flex min-h-8 justify-between gap-x-1 rounded border px-1 py-[3px] outline-none transition-colors duration-200 focus-within:border focus-within:border-borders-3">
+        <div className="border-borders-1 border-b px-3 pb-2.5">
+          <div className="border-borders-2 focus-within:border-borders-3 flex min-h-8 justify-between gap-x-1 rounded border px-1 py-[3px] outline-none transition-colors duration-200 focus-within:border">
             <div className="flex flex-1 flex-wrap items-center gap-1">
               {!!filter.selectedValues.length &&
                 filter.selectedValues.map(value => {

--- a/packages/ui/src/views/repo/components/branch-info-bar.tsx
+++ b/packages/ui/src/views/repo/components/branch-info-bar.tsx
@@ -1,0 +1,95 @@
+import { FC } from 'react'
+import { Link } from 'react-router-dom'
+
+import { Badge, Button, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, Icon, StyledLink } from '@/components'
+
+interface BranchInfoBarProps {
+  defaultBranchName?: string
+  spaceId: string
+  repoId: string
+  currentBranch: {
+    behindAhead: {
+      ahead: number
+      behind: number
+    }
+  }
+}
+
+export const BranchInfoBar: FC<BranchInfoBarProps> = ({
+  defaultBranchName = 'main',
+  spaceId,
+  repoId,
+  currentBranch
+}) => {
+  const { behindAhead } = currentBranch
+  const hasBehind = behindAhead.behind > 0
+  const hasAhead = behindAhead.ahead > 0
+
+  return (
+    <div className="bg-background-2 pl-4 pr-1.5 h-11 border border-borders-1 rounded-md flex justify-between items-center">
+      <div className="flex items-center gap-x-1.5">
+        <span className="text-foreground-1 text-14 leading-tight">
+          This branch is{' '}
+          {hasAhead && (
+            <>
+              <StyledLink to={`/${spaceId}/repos/${repoId}/pull-requests/compare/`}>
+                <span className="text-foreground-accent">{behindAhead.ahead} commits ahead of</span>
+              </StyledLink>
+              {hasBehind && ', '}
+            </>
+          )}
+          {hasBehind && (
+            <StyledLink to={`/${spaceId}/repos/${repoId}/pull-requests/compare/`}>
+              <span className="text-foreground-accent">{behindAhead.behind} commits behind</span>
+            </StyledLink>
+          )}
+        </span>
+        <Badge className="gap-x-1" variant="tertiary" borderRadius="base" size="md">
+          <Icon className="text-icons-9" name="branch" size={14} />
+          <span className="text-foreground-8">{defaultBranchName}</span>
+        </Badge>
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            className="gap-x-2 data-[state=open]:border-borders-8 [&_svg]:data-[state=open]:text-foreground-1 px-2.5"
+            variant="outline"
+          >
+            <Icon name="merged" size={14} />
+            <span>Contribute</span>
+            <Icon className="text-icons-7 chevron-down" name="chevron-down" size={12} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-60 p-4" align="end">
+          <div className="flex gap-x-2">
+            <div className="flex-shrink-0 border border-borders-4 rounded-full flex items-center justify-center h-6 w-6">
+              <Icon name="merged" size={12} />
+            </div>
+            <div>
+              <span className="text-foreground-1 text-14 leading-snug">
+                This branch is {behindAhead.ahead} commits ahead of{' '}
+              </span>
+              <Badge className="gap-x-1" variant="tertiary" borderRadius="base" size="sm">
+                <Icon className="text-icons-9" name="branch" size={14} />
+                <span className="text-foreground-8">{defaultBranchName}</span>
+              </Badge>
+              .
+              <p className="mt-2.5 text-foreground-4 text-14 leading-tight">
+                Open a pull request to contribute your changes upstream.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-col gap-y-2.5 mt-4">
+            <Button className="w-full" variant="outline" asChild>
+              <Link to={`/${spaceId}/repos/${repoId}/pull-requests/compare/`}>Compare</Link>
+            </Button>
+
+            <Button className="w-full" asChild>
+              <Link to={`/${spaceId}/repos/${repoId}/pull-requests/compare/`}>Open pull request</Link>
+            </Button>
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/packages/ui/src/views/repo/components/branch-selector/branch-selector-dropdown.tsx
+++ b/packages/ui/src/views/repo/components/branch-selector/branch-selector-dropdown.tsx
@@ -158,7 +158,7 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
                     // 5. After theme update, remove overriding classes (text-primary-muted, bg-transparent, -tracking, font-medium)
                     //    as they should be part of the theme definition
                     theme="muted"
-                    size="18"
+                    size="xl"
                     borderRadius="full"
                     disableHover
                   >

--- a/packages/ui/src/views/repo/components/index.ts
+++ b/packages/ui/src/views/repo/components/index.ts
@@ -1,4 +1,5 @@
 export * from './branch-selector'
+export * from './branch-info-bar'
 export * from './summary/summary'
 export * from './file-last-change-bar'
 export * from './commit-selector'

--- a/packages/ui/src/views/repo/repo-summary/components/recent-push-info-bar.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/recent-push-info-bar.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react'
+import { Link } from 'react-router-dom'
+
+import { Button, Icon } from '@/components'
+
+interface RecentPush {
+  branchName: string
+  // Formatted string representing time since push (e.g. "5 minutes ago")
+  timeAgo: string
+}
+
+interface RecentPushInfoBarProps {
+  recentPushes: RecentPush[]
+  spaceId: string
+  repoId: string
+}
+
+export const RecentPushInfoBar: FC<RecentPushInfoBarProps> = ({ recentPushes, spaceId, repoId }) => (
+  <div className="bg-background-success border border-borders-success rounded-md px-4">
+    {recentPushes.map(({ branchName, timeAgo }, index) => (
+      <div className="flex items-center justify-between py-5 last:border-t last:border-borders-8/10" key={index}>
+        <div className="flex items-center gap-x-1.5">
+          <Icon className="text-icons-success" name="branch" size={14} />
+          <span className="text-14 text-foreground-2">
+            <span className="font-medium text-foreground-1">{branchName}</span> had recent pushes {timeAgo}
+          </span>
+        </div>
+
+        <Button asChild>
+          <Link to={`/${spaceId}/repos/${repoId}/pull-requests/new?source=${branchName}`}>Compare & pull request</Link>
+        </Button>
+      </div>
+    ))}
+  </div>
+)

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -23,7 +23,7 @@ import { BranchSelectorListItem, IBranchSelectorStore, RepoFile, SandboxLayout, 
 import { BranchInfoBar, BranchSelector, BranchSelectorTab, Summary } from '@/views/repo/components'
 import { formatDate } from '@utils/utils'
 
-import { RecentPushInfoBar } from './components/recent-push-info-bar'
+// import { RecentPushInfoBar } from './components/recent-push-info-bar'
 import SummaryPanel from './components/summary-panel'
 
 export interface RepoSummaryViewProps {
@@ -65,39 +65,6 @@ export interface RepoSummaryViewProps {
   useTranslationStore: () => TranslationStore
   isEditDialogOpen: boolean
   setEditDialogOpen: (value: boolean) => void
-}
-
-/**
- * TODO: This is a temporary implementation.
- * The actual implementation should:
- * 1. Use backend-provided timestamps and timezone information
- * 2. Support i18n for different languages
- * 3. Handle edge cases:
- *    - Invalid dates
- *    - Different timezones
- * 4. Support more precise time formatting:
- *    - "just now" for very recent changes
- *    - "about 1 hour ago"
- *    - "X minutes ago"
- *
- * Note: This function is specifically for RecentPushBar component,
- * which only shows pushes within last 24 hours (or less, depending on backend configuration)
- */
-export function timeAgoFromISOTime(isoTime: string): string {
-  const date = new Date(isoTime)
-  const seconds = Math.floor((new Date().getTime() - date.getTime()) / 1000)
-
-  if (seconds < 60) {
-    return `${seconds} seconds ago`
-  }
-
-  if (seconds < 3600) {
-    const minutes = Math.floor(seconds / 60)
-    return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
-  }
-
-  const hours = Math.floor(seconds / 3600)
-  return `${hours} hour${hours === 1 ? '' : 's'} ago`
 }
 
 export function RepoSummaryView({
@@ -169,22 +136,24 @@ export function RepoSummaryView({
                   * No PR has been created from this branch yet
                 - Format timestamps using timeAgoFromISOTime
                 - Remove mock data below
+         
+                Example:
+                {selectedBranchTag.name !== repository?.default_branch && (
+                  <>
+                    <RecentPushInfoBar
+                      recentPushes={[
+                        {
+                          branchName: 'new-branch',
+                          timeAgo: timeAgoFromISOTime(new Date(Date.now() - 1000 * 60 * 5).toISOString())
+                        }
+                      ]}
+                      spaceId={spaceId}
+                      repoId={repoId}
+                    />
+                    <Spacer size={6} />
+                  </>
+                )}
             */}
-            {selectedBranchTag.name !== repository?.default_branch && (
-              <>
-                <RecentPushInfoBar
-                  recentPushes={[
-                    {
-                      branchName: 'new-branch',
-                      timeAgo: timeAgoFromISOTime(new Date(Date.now() - 1000 * 60 * 5).toISOString())
-                    }
-                  ]}
-                  spaceId={spaceId}
-                  repoId={repoId}
-                />
-                <Spacer size={6} />
-              </>
-            )}
             <ListActions.Root>
               <ListActions.Left>
                 <ButtonGroup>


### PR DESCRIPTION
**Description:**
This pull request adds information about the currently selected branch, as well as information about new branches that have recently appeared

**:warning: Note**
At the moment it uses test data which is not related to the real data.

**Screenshots:**
`BranchInfoBar`
<img width="1810" alt="Arc 2024-12-11 21 18 40" src="https://github.com/user-attachments/assets/ad6b261c-b5c0-4d1f-aaf9-43800f8510ec" />


`RecentPushInfoBar`
<img width="1810" alt="Arc 2024-12-11 21 15 51" src="https://github.com/user-attachments/assets/0287630c-9326-4e0a-b507-bdf5ffeff54c" />
<img width="1810" alt="Arc 2024-12-11 21 14 31" src="https://github.com/user-attachments/assets/01b313bf-5036-4e31-9610-82819f937388" />

