### PR TITLE
chore: Redirect the root of the design system app to  temporarily

### DIFF
--- a/apps/design-system/src/App.tsx
+++ b/apps/design-system/src/App.tsx
@@ -1,9 +1,12 @@
 import { FC } from 'react'
-import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 
 import ViewPreview from './pages/view-preview/view-preview.tsx'
 
-const router = createBrowserRouter([{ path: '/view-preview/*', element: <ViewPreview /> }])
+const router = createBrowserRouter([
+  { path: '/view-preview/*', element: <ViewPreview /> },
+  { path: '/*', element: <Navigate to="/view-preview" /> } // temp redirect to view preview
+])
 
 const App: FC = () => {
   return <RouterProvider router={router} />


### PR DESCRIPTION
This PR redirects requests to the root of the design system app to the view-preview route. This is a temporary measure until the component aspect of the design system app is ready.