### PR TITLE
feat: update color theme for monaco-editor

### DIFF
--- a/apps/gitness/src/components/FileEditor.tsx
+++ b/apps/gitness/src/components/FileEditor.tsx
@@ -260,17 +260,17 @@ export const FileEditor: React.FC = () => {
               value={view}
               type="single"
               unselectable="on"
-              className="rounded-lg border border-primary/10 bg-primary-foreground p-0.5"
+              className="border-primary/10 bg-primary-foreground rounded-lg border p-0.5"
             >
               <ToggleGroupItem
                 value="contents"
-                className="h-7 rounded-md border border-transparent text-xs font-medium disabled:opacity-100 data-[state=on]:border-primary/10"
+                className="data-[state=on]:border-primary/10 h-7 rounded-md border border-transparent text-xs font-medium disabled:opacity-100"
               >
                 Contents
               </ToggleGroupItem>
               <ToggleGroupItem
                 value="changes"
-                className="h-7 rounded-md border border-transparent text-xs font-medium disabled:opacity-100 data-[state=on]:border-primary/10"
+                className="data-[state=on]:border-primary/10 h-7 rounded-md border border-transparent text-xs font-medium disabled:opacity-100"
               >
                 Changes
               </ToggleGroupItem>

--- a/apps/gitness/src/pages/pipeline-edit/theme/monaco-theme.ts
+++ b/apps/gitness/src/pages/pipeline-edit/theme/monaco-theme.ts
@@ -9,47 +9,257 @@ const harnessLightTheme = {
   colors: {}
 }
 
-const getHarnessDarkTheme = (options?: { isBlame?: boolean }) => ({
+const harnessDarkTheme = {
   base: 'vs-dark' as editor.BuiltinTheme,
   inherit: true,
   rules: [
     {
-      background: '#0F0F11', // minimap background
+      background: '000000',
       token: ''
     },
     {
-      foreground: '#5F97ED', // property name
-      token: 'type'
+      foreground: '969896',
+      token: 'comment'
     },
     {
-      foreground: '#E29B36', // strings value
+      foreground: 'eeeeee',
+      token: 'keyword.operator.class'
+    },
+    {
+      foreground: 'eeeeee',
+      token: 'constant.other'
+    },
+    {
+      foreground: 'eeeeee',
+      token: 'source.php.embedded.line'
+    },
+    {
+      foreground: 'd54e53',
+      token: 'variable'
+    },
+    {
+      foreground: 'd54e53',
+      token: 'support.other.variable'
+    },
+    {
+      foreground: 'd54e53',
+      token: 'string.other.link'
+    },
+    {
+      foreground: 'd54e53',
+      token: 'string.regexp'
+    },
+    {
+      foreground: 'd54e53',
+      token: 'entity.name.tag'
+    },
+    {
+      foreground: 'd54e53',
+      token: 'entity.other.attribute-name'
+    },
+    {
+      foreground: 'd54e53',
+      token: 'meta.tag'
+    },
+    {
+      foreground: 'd54e53',
+      token: 'declaration.tag'
+    },
+    {
+      foreground: 'd54e53',
+      token: 'markup.deleted.git_gutter'
+    },
+    {
+      foreground: 'e78c45',
+      token: 'constant.numeric'
+    },
+    {
+      foreground: 'e78c45',
+      token: 'constant.language'
+    },
+    {
+      foreground: 'e78c45',
+      token: 'support.constant'
+    },
+    {
+      foreground: 'e78c45',
+      token: 'constant.character'
+    },
+    {
+      foreground: 'e78c45',
+      token: 'variable.parameter'
+    },
+    {
+      foreground: 'e78c45',
+      token: 'punctuation.section.embedded'
+    },
+    {
+      foreground: 'e78c45',
+      token: 'keyword.other.unit'
+    },
+    {
+      foreground: 'e7c547',
+      token: 'entity.name.class'
+    },
+    {
+      foreground: 'e7c547',
+      token: 'entity.name.type.class'
+    },
+    {
+      foreground: 'e7c547',
+      token: 'support.type'
+    },
+    {
+      foreground: 'e7c547',
+      token: 'support.class'
+    },
+    {
+      foreground: 'b9ca4a',
       token: 'string'
     },
     {
-      foreground: '#E29B36', // number value
-      token: 'number'
+      foreground: 'b9ca4a',
+      token: 'constant.other.symbol'
+    },
+    {
+      foreground: 'b9ca4a',
+      token: 'entity.other.inherited-class'
+    },
+    {
+      foreground: 'b9ca4a',
+      token: 'markup.heading'
+    },
+    {
+      foreground: 'b9ca4a',
+      token: 'markup.inserted.git_gutter'
+    },
+    {
+      foreground: '70c0b1',
+      token: 'keyword.operator'
+    },
+    {
+      foreground: '70c0b1',
+      token: 'constant.other.color'
+    },
+    {
+      foreground: '7aa6da',
+      token: 'entity.name.function'
+    },
+    {
+      foreground: '7aa6da',
+      token: 'meta.function-call'
+    },
+    {
+      foreground: '7aa6da',
+      token: 'support.function'
+    },
+    {
+      foreground: '7aa6da',
+      token: 'keyword.other.special-method'
+    },
+    {
+      foreground: '7aa6da',
+      token: 'meta.block-level'
+    },
+    {
+      foreground: '7aa6da',
+      token: 'markup.changed.git_gutter'
+    },
+    {
+      foreground: 'c397d8',
+      token: 'keyword'
+    },
+    {
+      foreground: 'c397d8',
+      token: 'storage'
+    },
+    {
+      foreground: 'c397d8',
+      token: 'storage.type'
+    },
+    {
+      foreground: 'c397d8',
+      token: 'entity.name.tag.css'
+    },
+    {
+      foreground: 'ced2cf',
+      background: 'df5f5f',
+      token: 'invalid'
+    },
+    {
+      foreground: 'ced2cf',
+      background: '82a3bf',
+      token: 'meta.separator'
+    },
+    {
+      foreground: 'ced2cf',
+      background: 'b798bf',
+      token: 'invalid.deprecated'
+    },
+    {
+      foreground: 'ffffff',
+      token: 'markup.inserted.diff'
+    },
+    {
+      foreground: 'ffffff',
+      token: 'markup.deleted.diff'
+    },
+    {
+      foreground: 'ffffff',
+      token: 'meta.diff.header.to-file'
+    },
+    {
+      foreground: 'ffffff',
+      token: 'meta.diff.header.from-file'
+    },
+    {
+      foreground: '718c00',
+      token: 'markup.inserted.diff'
+    },
+    {
+      foreground: '718c00',
+      token: 'meta.diff.header.to-file'
+    },
+    {
+      foreground: 'c82829',
+      token: 'markup.deleted.diff'
+    },
+    {
+      foreground: 'c82829',
+      token: 'meta.diff.header.from-file'
+    },
+    {
+      foreground: 'ffffff',
+      background: '4271ae',
+      token: 'meta.diff.header.from-file'
+    },
+    {
+      foreground: 'ffffff',
+      background: '4271ae',
+      token: 'meta.diff.header.to-file'
+    },
+    {
+      foreground: '3e999f',
+      fontStyle: 'italic',
+      token: 'meta.diff.range'
     }
   ],
   colors: {
-    'editor.foreground': '#5F97ED', // in yaml this is applied to -, :
-    'editor.background': '#0F0F11', /// background
-    //"editor.selectionBackground": "", // selection background
-    //"editor.lineHighlightBackground": "", // current line highlight bg
-    //"editorCursor.foreground": "", // cursor color
-    'editorBracketHighlight.foreground1': '#E29B36', // square brackets
-    'editorLineNumber.foreground': options?.isBlame ? '#787885' : '#303036', // line number color
-    'editorLineNumber.activeForeground': '#CCCCCC' //active line number color
-    // 'editorIndentGuide.background': '#439911', // WARN: this does not work
-    // 'editorIndentGuide.activeBackground': '#129912' // WARN: this does not work
+    'editor.foreground': '#DEDEDE',
+    'editor.background': '#0F0F11',
+    'editor.selectionBackground': '#424242',
+    'editor.lineHighlightBackground': '#2A2A2A',
+    'editorCursor.foreground': '#9F9F9F',
+    'editorWhitespace.foreground': '#343434'
   }
-})
+}
 
 export const themes: ThemeDefinition[] = [
-  { themeName: 'dark', themeData: getHarnessDarkTheme() },
+  { themeName: 'dark', themeData: harnessDarkTheme },
   { themeName: 'light', themeData: harnessLightTheme }
 ]
 
 export const themesForBlame: ThemeDefinition[] = [
-  { themeName: 'dark', themeData: getHarnessDarkTheme({ isBlame: true }) },
+  { themeName: 'dark', themeData: harnessDarkTheme },
   { themeName: 'light', themeData: harnessLightTheme }
 ]


### PR DESCRIPTION
This pull request brings new color scheme for code blocks

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/fc847f0f-3d00-47a8-8fda-983a03b293cf" />
