### PR TITLE
feat: updating the Summary page display and fixing filtering issues

### DIFF
--- a/packages/ui/src/components/filters/filters-bar/actions/views.tsx
+++ b/packages/ui/src/components/filters/filters-bar/actions/views.tsx
@@ -25,14 +25,9 @@ import { FilterValue, SavedView, SortValue, ViewManagement } from '../../types'
 interface ViewsProps {
   currentView: SavedView | null
   savedViews: SavedView[]
-  viewManagement: {
+  viewManagement: Pick<ViewManagement, 'checkNameExists' | 'saveView' | 'updateView' | 'deleteView' | 'renameView'> & {
     activeFilters: FilterValue[]
     activeSorts: SortValue[]
-    checkNameExists: ViewManagement['checkNameExists']
-    saveView: ViewManagement['saveView']
-    updateView: ViewManagement['updateView']
-    deleteView: ViewManagement['deleteView']
-    renameView: ViewManagement['renameView']
   }
   hasChanges: boolean
 }

--- a/packages/ui/src/components/filters/filters-bar/actions/views.tsx
+++ b/packages/ui/src/components/filters/filters-bar/actions/views.tsx
@@ -25,9 +25,14 @@ import { FilterValue, SavedView, SortValue, ViewManagement } from '../../types'
 interface ViewsProps {
   currentView: SavedView | null
   savedViews: SavedView[]
-  viewManagement: ViewManagement & {
+  viewManagement: {
     activeFilters: FilterValue[]
     activeSorts: SortValue[]
+    checkNameExists: ViewManagement['checkNameExists']
+    saveView: ViewManagement['saveView']
+    updateView: ViewManagement['updateView']
+    deleteView: ViewManagement['deleteView']
+    renameView: ViewManagement['renameView']
   }
   hasChanges: boolean
 }

--- a/packages/ui/src/components/filters/filters-bar/filters-bar.tsx
+++ b/packages/ui/src/components/filters/filters-bar/filters-bar.tsx
@@ -12,10 +12,57 @@ interface FiltersBarProps {
   sortOptions: SortOption[]
   sortDirections: SortDirection[]
   t: TFunction
-  filterHandlers: FilterHandlers
-  viewManagement: ViewManagement
+  filterHandlers: {
+    activeFilters: FilterHandlers['activeFilters']
+    activeSorts: FilterHandlers['activeSorts']
+    handleUpdateFilter: FilterHandlers['handleUpdateFilter']
+    handleRemoveFilter: FilterHandlers['handleRemoveFilter']
+    handleFilterChange: FilterHandlers['handleFilterChange']
+    handleUpdateCondition: FilterHandlers['handleUpdateCondition']
+    handleUpdateSort: FilterHandlers['handleUpdateSort']
+    handleRemoveSort: FilterHandlers['handleRemoveSort']
+    handleSortChange: FilterHandlers['handleSortChange']
+    handleResetSorts: FilterHandlers['handleResetSorts']
+    handleReorderSorts: FilterHandlers['handleReorderSorts']
+    handleResetAll: FilterHandlers['handleResetAll']
+    searchQueries: FilterHandlers['searchQueries']
+    handleSearchChange: FilterHandlers['handleSearchChange']
+    filterToOpen: FilterHandlers['filterToOpen']
+    clearFilterToOpen: FilterHandlers['clearFilterToOpen']
+  }
+  /**
+   * Optional view management configuration.
+   * If provided, enables saving and managing filter views
+   */
+  viewManagement?: {
+    savedViews: ViewManagement['savedViews']
+    currentView: ViewManagement['currentView']
+    hasActiveViewChanges: ViewManagement['hasActiveViewChanges']
+    checkNameExists: ViewManagement['checkNameExists']
+    saveView: ViewManagement['saveView']
+    updateView: ViewManagement['updateView']
+    deleteView: ViewManagement['deleteView']
+    renameView: ViewManagement['renameView']
+  }
 }
 
+/**
+ * FiltersBar component displays active filters and sorts with the ability to manage them.
+ * Shows up only when there are active filters or sorts.
+ *
+ * @example
+ * ```tsx
+ * <FiltersBar
+ *   filterOptions={[{ id: 'status', label: 'Status', options: ['Active', 'Inactive'] }]}
+ *   sortOptions={[{ id: 'name', label: 'Name' }]}
+ *   sortDirections={['asc', 'desc']}
+ *   filterHandlers={filterHandlers}
+ *   t={t}
+ *   // Optional: Enable view management
+ *   viewManagement={viewManagement}
+ * />
+ * ```
+ */
 const FiltersBar = ({
   filterOptions,
   sortOptions,
@@ -45,7 +92,7 @@ const FiltersBar = ({
 
   const hasActiveFilters = !!activeFilters.length || !!activeSorts.length
 
-  const hasViewChanges = viewManagement.hasActiveViewChanges(activeFilters, activeSorts)
+  const hasViewChanges = viewManagement?.hasActiveViewChanges(activeFilters, activeSorts)
 
   if (!hasActiveFilters) return null
 
@@ -114,17 +161,19 @@ const FiltersBar = ({
             </button>
           </div>
 
-          <Views
-            currentView={viewManagement.currentView}
-            savedViews={viewManagement.savedViews}
-            viewManagement={{
-              ...viewManagement,
-              activeFilters,
-              activeSorts,
-              saveView: (name: string) => viewManagement.saveView(name, activeFilters, activeSorts)
-            }}
-            hasChanges={!!hasViewChanges}
-          />
+          {viewManagement && (
+            <Views
+              currentView={viewManagement.currentView}
+              savedViews={viewManagement.savedViews}
+              viewManagement={{
+                ...viewManagement,
+                activeFilters,
+                activeSorts,
+                saveView: (name: string) => viewManagement.saveView(name, activeFilters, activeSorts)
+              }}
+              hasChanges={!!hasViewChanges}
+            />
+          )}
         </div>
       )}
     </div>

--- a/packages/ui/src/components/filters/filters-bar/filters-bar.tsx
+++ b/packages/ui/src/components/filters/filters-bar/filters-bar.tsx
@@ -12,38 +12,40 @@ interface FiltersBarProps {
   sortOptions: SortOption[]
   sortDirections: SortDirection[]
   t: TFunction
-  filterHandlers: {
-    activeFilters: FilterHandlers['activeFilters']
-    activeSorts: FilterHandlers['activeSorts']
-    handleUpdateFilter: FilterHandlers['handleUpdateFilter']
-    handleRemoveFilter: FilterHandlers['handleRemoveFilter']
-    handleFilterChange: FilterHandlers['handleFilterChange']
-    handleUpdateCondition: FilterHandlers['handleUpdateCondition']
-    handleUpdateSort: FilterHandlers['handleUpdateSort']
-    handleRemoveSort: FilterHandlers['handleRemoveSort']
-    handleSortChange: FilterHandlers['handleSortChange']
-    handleResetSorts: FilterHandlers['handleResetSorts']
-    handleReorderSorts: FilterHandlers['handleReorderSorts']
-    handleResetAll: FilterHandlers['handleResetAll']
-    searchQueries: FilterHandlers['searchQueries']
-    handleSearchChange: FilterHandlers['handleSearchChange']
-    filterToOpen: FilterHandlers['filterToOpen']
-    clearFilterToOpen: FilterHandlers['clearFilterToOpen']
-  }
+  filterHandlers: Pick<
+    FilterHandlers,
+    | 'activeFilters'
+    | 'activeSorts'
+    | 'handleUpdateFilter'
+    | 'handleRemoveFilter'
+    | 'handleFilterChange'
+    | 'handleUpdateCondition'
+    | 'handleUpdateSort'
+    | 'handleRemoveSort'
+    | 'handleSortChange'
+    | 'handleResetSorts'
+    | 'handleReorderSorts'
+    | 'handleResetAll'
+    | 'searchQueries'
+    | 'handleSearchChange'
+    | 'filterToOpen'
+    | 'clearFilterToOpen'
+  >
   /**
    * Optional view management configuration.
    * If provided, enables saving and managing filter views
    */
-  viewManagement?: {
-    savedViews: ViewManagement['savedViews']
-    currentView: ViewManagement['currentView']
-    hasActiveViewChanges: ViewManagement['hasActiveViewChanges']
-    checkNameExists: ViewManagement['checkNameExists']
-    saveView: ViewManagement['saveView']
-    updateView: ViewManagement['updateView']
-    deleteView: ViewManagement['deleteView']
-    renameView: ViewManagement['renameView']
-  }
+  viewManagement?: Pick<
+    ViewManagement,
+    | 'savedViews'
+    | 'currentView'
+    | 'hasActiveViewChanges'
+    | 'checkNameExists'
+    | 'saveView'
+    | 'updateView'
+    | 'deleteView'
+    | 'renameView'
+  >
 }
 
 /**
@@ -91,8 +93,6 @@ const FiltersBar = ({
   } = filterHandlers
 
   const hasActiveFilters = !!activeFilters.length || !!activeSorts.length
-
-  const hasViewChanges = viewManagement?.hasActiveViewChanges(activeFilters, activeSorts)
 
   if (!hasActiveFilters) return null
 
@@ -171,7 +171,7 @@ const FiltersBar = ({
                 activeSorts,
                 saveView: (name: string) => viewManagement.saveView(name, activeFilters, activeSorts)
               }}
-              hasChanges={!!hasViewChanges}
+              hasChanges={!!viewManagement.hasActiveViewChanges(activeFilters, activeSorts)}
             />
           )}
         </div>

--- a/packages/ui/src/components/filters/filters.tsx
+++ b/packages/ui/src/components/filters/filters.tsx
@@ -12,35 +12,37 @@ interface FiltersProps {
   showSort?: boolean
   filterOptions: FilterOption[]
   sortOptions: SortOption[]
-  filterHandlers: {
-    activeFilters: FilterHandlers['activeFilters']
-    activeSorts: FilterHandlers['activeSorts']
-    handleFilterChange: FilterHandlers['handleFilterChange']
-    handleResetFilters: FilterHandlers['handleResetFilters']
-    searchQueries: FilterHandlers['searchQueries']
-    handleSearchChange: FilterHandlers['handleSearchChange']
-    handleSortChange: FilterHandlers['handleSortChange']
-    handleResetSorts: FilterHandlers['handleResetSorts']
-  }
+  filterHandlers: Pick<
+    FilterHandlers,
+    | 'activeFilters'
+    | 'activeSorts'
+    | 'handleFilterChange'
+    | 'handleResetFilters'
+    | 'searchQueries'
+    | 'handleSearchChange'
+    | 'handleSortChange'
+    | 'handleResetSorts'
+  >
   /**
    * Optional view management configuration.
    * If provided, enables saving and managing filter views
    */
-  viewManagement?: {
-    savedViews: ViewManagement['savedViews']
-    currentView: ViewManagement['currentView']
-    hasActiveViewChanges: ViewManagement['hasActiveViewChanges']
-    checkNameExists: ViewManagement['checkNameExists']
-    validateViewName: ViewManagement['validateViewName']
-    hasViewErrors: ViewManagement['hasViewErrors']
-    hasViewListChanges: ViewManagement['hasViewListChanges']
-    applyView: ViewManagement['applyView']
-    setCurrentView: ViewManagement['setCurrentView']
-    updateViewsOrder: ViewManagement['updateViewsOrder']
-    prepareViewsForSave: ViewManagement['prepareViewsForSave']
-    getExistingNames: ViewManagement['getExistingNames']
-    validateViewNameChange: ViewManagement['validateViewNameChange']
-  }
+  viewManagement?: Pick<
+    ViewManagement,
+    | 'savedViews'
+    | 'currentView'
+    | 'hasActiveViewChanges'
+    | 'checkNameExists'
+    | 'validateViewName'
+    | 'hasViewErrors'
+    | 'hasViewListChanges'
+    | 'applyView'
+    | 'setCurrentView'
+    | 'updateViewsOrder'
+    | 'prepareViewsForSave'
+    | 'getExistingNames'
+    | 'validateViewNameChange'
+  >
   layoutOptions?: ViewLayoutOption[]
   currentLayout?: string
   onLayoutChange?: (layout: string) => void

--- a/packages/ui/src/components/filters/filters.tsx
+++ b/packages/ui/src/components/filters/filters.tsx
@@ -10,21 +10,66 @@ import { FilterHandlers, FilterOption, SortOption, ViewLayoutOption, ViewManagem
 interface FiltersProps {
   showFilter?: boolean
   showSort?: boolean
-  showView?: boolean
   filterOptions: FilterOption[]
   sortOptions: SortOption[]
-  filterHandlers: FilterHandlers
-  viewManagement: ViewManagement
+  filterHandlers: {
+    activeFilters: FilterHandlers['activeFilters']
+    activeSorts: FilterHandlers['activeSorts']
+    handleFilterChange: FilterHandlers['handleFilterChange']
+    handleResetFilters: FilterHandlers['handleResetFilters']
+    searchQueries: FilterHandlers['searchQueries']
+    handleSearchChange: FilterHandlers['handleSearchChange']
+    handleSortChange: FilterHandlers['handleSortChange']
+    handleResetSorts: FilterHandlers['handleResetSorts']
+  }
+  /**
+   * Optional view management configuration.
+   * If provided, enables saving and managing filter views
+   */
+  viewManagement?: {
+    savedViews: ViewManagement['savedViews']
+    currentView: ViewManagement['currentView']
+    hasActiveViewChanges: ViewManagement['hasActiveViewChanges']
+    checkNameExists: ViewManagement['checkNameExists']
+    validateViewName: ViewManagement['validateViewName']
+    hasViewErrors: ViewManagement['hasViewErrors']
+    hasViewListChanges: ViewManagement['hasViewListChanges']
+    applyView: ViewManagement['applyView']
+    setCurrentView: ViewManagement['setCurrentView']
+    updateViewsOrder: ViewManagement['updateViewsOrder']
+    prepareViewsForSave: ViewManagement['prepareViewsForSave']
+    getExistingNames: ViewManagement['getExistingNames']
+    validateViewNameChange: ViewManagement['validateViewNameChange']
+  }
   layoutOptions?: ViewLayoutOption[]
   currentLayout?: string
   onLayoutChange?: (layout: string) => void
   t: TFunction
 }
 
+/**
+ * Filters component for handling filtering, sorting, and view management
+ * @example
+ * ```tsx
+ * <Filters
+ *   filterOptions={[
+ *     { id: 'status', label: 'Status', options: ['Active', 'Inactive'] },
+ *     { id: 'type', label: 'Type', options: ['Public', 'Private'] }
+ *   ]}
+ *   sortOptions={[
+ *     { id: 'name', label: 'Name' },
+ *     { id: 'date', label: 'Date' }
+ *   ]}
+ *   filterHandlers={filterHandlers}
+ *   // Optional: Enable view management
+ *   viewManagement={viewManagement}
+ *   t={t}
+ * />
+ * ```
+ */
 const Filters = ({
   showFilter = true,
   showSort = true,
-  showView = true,
   filterOptions,
   sortOptions,
   filterHandlers: {
@@ -74,7 +119,7 @@ const Filters = ({
           />
         )}
 
-        {showView && (
+        {viewManagement && (!!viewManagement.savedViews.length || !!layoutOptions?.length) && (
           <ViewTrigger
             savedViews={viewManagement.savedViews}
             currentView={viewManagement.currentView}
@@ -87,12 +132,14 @@ const Filters = ({
         )}
       </div>
 
-      <ManageViews
-        open={isManageDialogOpen}
-        onOpenChange={setIsManageDialogOpen}
-        views={viewManagement.savedViews}
-        viewManagement={viewManagement}
-      />
+      {viewManagement && (
+        <ManageViews
+          open={isManageDialogOpen}
+          onOpenChange={setIsManageDialogOpen}
+          views={viewManagement.savedViews}
+          viewManagement={viewManagement}
+        />
+      )}
     </>
   )
 }

--- a/packages/ui/src/components/filters/manage-views.tsx
+++ b/packages/ui/src/components/filters/manage-views.tsx
@@ -117,15 +117,16 @@ interface ManageViewsProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   views: SavedView[]
-  viewManagement: {
-    setCurrentView: ViewManagement['setCurrentView']
-    updateViewsOrder: ViewManagement['updateViewsOrder']
-    prepareViewsForSave: ViewManagement['prepareViewsForSave']
-    getExistingNames: ViewManagement['getExistingNames']
-    hasViewListChanges: ViewManagement['hasViewListChanges']
-    hasViewErrors: ViewManagement['hasViewErrors']
-    validateViewNameChange: ViewManagement['validateViewNameChange']
-  }
+  viewManagement: Pick<
+    ViewManagement,
+    | 'setCurrentView'
+    | 'updateViewsOrder'
+    | 'prepareViewsForSave'
+    | 'getExistingNames'
+    | 'hasViewListChanges'
+    | 'hasViewErrors'
+    | 'validateViewNameChange'
+  >
 }
 
 /**

--- a/packages/ui/src/components/filters/manage-views.tsx
+++ b/packages/ui/src/components/filters/manage-views.tsx
@@ -117,7 +117,15 @@ interface ManageViewsProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   views: SavedView[]
-  viewManagement: ViewManagement
+  viewManagement: {
+    setCurrentView: ViewManagement['setCurrentView']
+    updateViewsOrder: ViewManagement['updateViewsOrder']
+    prepareViewsForSave: ViewManagement['prepareViewsForSave']
+    getExistingNames: ViewManagement['getExistingNames']
+    hasViewListChanges: ViewManagement['hasViewListChanges']
+    hasViewErrors: ViewManagement['hasViewErrors']
+    validateViewNameChange: ViewManagement['validateViewNameChange']
+  }
 }
 
 /**

--- a/packages/ui/src/components/filters/triggers/view-trigger.tsx
+++ b/packages/ui/src/components/filters/triggers/view-trigger.tsx
@@ -46,7 +46,7 @@ const ViewTrigger: FC<ViewTriggerProps> = ({
         </span>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="max-h-[358px] w-56 overflow-y-auto" align="end">
-        {layoutOptions?.length && (
+        {!!layoutOptions?.length && (
           <>
             <div className="px-2 py-2.5">
               <span className="text-13 leading-none text-foreground-7">Layout</span>
@@ -62,7 +62,7 @@ const ViewTrigger: FC<ViewTriggerProps> = ({
 
         {savedViews.length > 0 && (
           <>
-            {layoutOptions?.length && <DropdownMenuSeparator />}
+            {!!layoutOptions?.length && <DropdownMenuSeparator />}
             <div className="px-2 py-1.5">
               <div className="flex items-center justify-between">
                 <span className="text-13 leading-none text-foreground-7">Saved views</span>

--- a/packages/ui/src/components/stacked-list.tsx
+++ b/packages/ui/src/components/stacked-list.tsx
@@ -50,9 +50,17 @@ interface ListFieldProps extends Omit<React.ComponentProps<'div'>, 'title'>, Var
 interface ListProps extends React.ComponentProps<'div'> {
   onlyTopRounded?: boolean
   borderBackground?: boolean
+  withoutBorder?: boolean
 }
 
-const List: React.FC<ListProps> = ({ className, children, onlyTopRounded, borderBackground, ...props }) => (
+const List: React.FC<ListProps> = ({
+  className,
+  children,
+  onlyTopRounded,
+  borderBackground,
+  withoutBorder = false,
+  ...props
+}) => (
   <div
     className={cn(
       'w-full',
@@ -63,6 +71,7 @@ const List: React.FC<ListProps> = ({ className, children, onlyTopRounded, border
           !onlyTopRounded
       },
       onlyTopRounded ? 'rounded-t-md' : 'rounded-md',
+      withoutBorder ? 'border-none' : '',
       borderBackground ? 'border-borders-1' : '',
       className
     )}

--- a/packages/ui/src/views/repo/components/file-last-change-bar.tsx
+++ b/packages/ui/src/views/repo/components/file-last-change-bar.tsx
@@ -38,13 +38,20 @@ const TopDetails: FC<LatestFileTypes> = ({ sha, timestamp }) => {
 
 export interface FileLastChangeBarProps extends LatestFileTypes {
   useTranslationStore: () => TranslationStore
+  onlyTopRounded?: boolean
+  withoutBorder?: boolean
 }
 
-export const FileLastChangeBar: FC<FileLastChangeBarProps> = ({ useTranslationStore, ...props }) => {
+export const FileLastChangeBar: FC<FileLastChangeBarProps> = ({
+  useTranslationStore,
+  onlyTopRounded = false,
+  withoutBorder = false,
+  ...props
+}) => {
   const { t } = useTranslationStore()
 
   return (
-    <StackedList.Root className="mb-4">
+    <StackedList.Root withoutBorder={withoutBorder} onlyTopRounded={onlyTopRounded}>
       <StackedList.Item disableHover isHeader className="px-3 py-2">
         {props ? (
           <>

--- a/packages/ui/src/views/repo/components/summary/summary.tsx
+++ b/packages/ui/src/views/repo/components/summary/summary.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 
-import { Icon, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Text } from '@/components'
+import { Icon, Spacer, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Text } from '@/components'
 import { LatestFileTypes, RepoFile, SummaryItemType, TranslationStore } from '@/views'
 import { FileLastChangeBar } from '@views/repo/components'
 
@@ -8,24 +8,45 @@ interface SummaryProps {
   latestFile: LatestFileTypes
   files: RepoFile[]
   useTranslationStore: () => TranslationStore
+  hideHeader?: boolean
 }
 
-export const Summary = ({ latestFile, files, useTranslationStore }: SummaryProps) => {
+export const Summary = ({ latestFile, files, useTranslationStore, hideHeader = false }: SummaryProps) => {
   const navigate = useNavigate()
   const { t } = useTranslationStore()
 
   return (
     <>
-      <FileLastChangeBar useTranslationStore={useTranslationStore} {...latestFile} />
+      {!hideHeader && (
+        <>
+          <FileLastChangeBar useTranslationStore={useTranslationStore} {...latestFile} />
+          <Spacer size={4} />
+        </>
+      )}
+
       <Table variant="asStackedList">
-        <TableHeader>
-          <TableRow>
-            <TableHead>{t('views:repos.name', 'Name')}</TableHead>
-            <TableHead>{t('views:repos.lastCommit', 'Last commit message')}</TableHead>
-            <TableHead className="text-right">{t('views:repos.date', 'Date')}</TableHead>
-          </TableRow>
-        </TableHeader>
+        {!hideHeader && (
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t('views:repos.name', 'Name')}</TableHead>
+              <TableHead>{t('views:repos.lastCommit', 'Last commit message')}</TableHead>
+              <TableHead className="text-right">{t('views:repos.date', 'Date')}</TableHead>
+            </TableRow>
+          </TableHeader>
+        )}
         <TableBody>
+          {hideHeader && (
+            <TableRow>
+              <TableCell className="!p-0" colSpan={3}>
+                <FileLastChangeBar
+                  onlyTopRounded
+                  withoutBorder
+                  useTranslationStore={useTranslationStore}
+                  {...latestFile}
+                />
+              </TableCell>
+            </TableRow>
+          )}
           {files.map(file => (
             <TableRow key={file.id} onClick={() => navigate(file.path)}>
               <TableCell>

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -5,10 +5,6 @@ import { Link, useNavigate } from 'react-router-dom'
 import {
   Button,
   ButtonGroup,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   Icon,
   ListActions,
   MarkdownViewer,
@@ -224,6 +220,7 @@ export function RepoSummaryView({
               }}
               files={files}
               useTranslationStore={useTranslationStore}
+              hideHeader
             />
             <Spacer size={5} />
             <StackedList.Root>


### PR DESCRIPTION
**Description:**
This pull request updates the `Repo Summary` page, specifically the `FileLastChangeBar` component, and fixes type and validation issues in the `Filters` component.

- [Repo Summary Preview](https://deploy-preview-590--harness-xd-review.netlify.app/view-preview/repo-summary)
- [Pull Request List Preview](https://deploy-preview-590--harness-xd-review.netlify.app/view-preview/pull-request-list)

**Screenshots:**
Before: **Repo Summary**
<img width="1585" alt="Arc 2024-12-13 21 01 43" src="https://github.com/user-attachments/assets/658e0767-e137-4efd-ae73-5bcc62461d7e" />


After: **Repo Summary**
<img width="1589" alt="Arc 2024-12-13 21 02 40" src="https://github.com/user-attachments/assets/62b350ce-d7e4-4fca-a17c-f9acbc755b42" />

**Filters**

fixed bug when views logic is disabled from filtering but the save button is still displayed
<img width="1585" alt="Arc 2024-12-13 21 11 07" src="https://github.com/user-attachments/assets/b283385b-7f17-4f72-bcf6-c2aba580fa75" />

corrected data display and their check if for some reason they are missing - in this case Views is not displayed
<img width="1584" alt="Arc 2024-12-13 20 24 20" src="https://github.com/user-attachments/assets/338be1f2-dd4c-4b56-a04c-f229a60f65cf" />

corrected types for easy checking when passing parameters and also added examples
<img width="888" alt="Cursor 2024-12-13 20 59 56" src="https://github.com/user-attachments/assets/5e2675ca-1b1a-45b3-8271-4348674ae2f5" />
