### PR TITLE
feat: Add theme support to view preview

### DIFF
--- a/apps/design-system/package.json
+++ b/apps/design-system/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@harnessio/ui": "workspace:*",
     "@harnessio/yaml-editor": "workspace:*",
+    "clsx": "^2.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.0"

--- a/apps/design-system/src/pages/view-preview/view-preview.tsx
+++ b/apps/design-system/src/pages/view-preview/view-preview.tsx
@@ -12,7 +12,7 @@ import RepoSummaryViewWrapper from '../../views/repo-summary/repo-summary.tsx'
 import { RepoFilesViewWrapper } from './repo-files-view-wrapper.tsx'
 import RepoViewWrapper from './repo-view-wrapper.tsx'
 import RootViewWrapper from './root-view-wrapper.tsx'
-import ViewSwitcher from './view-switcher/view-switcher.tsx'
+import ViewSettings from './view-settings.tsx'
 
 const views: Record<string, ReactNode> = {
   'repo-summary': (
@@ -70,15 +70,15 @@ const routeKeys = Object.keys(views)
 
 const ViewPreview: FC = () => {
   return (
-    <div className="dark-std-std">
+    <>
       <Routes>
         {routeEntries.map(([route, node]) => {
           return <Route key={route} path={`${route}/*`} element={node} />
         })}
         <Route path="/" element={<Navigate to={routeKeys[0]} />} />
       </Routes>
-      <ViewSwitcher routes={routeKeys} />
-    </div>
+      <ViewSettings routes={routeKeys} />
+    </>
   )
 }
 

--- a/apps/design-system/src/pages/view-preview/view-settings.module.css
+++ b/apps/design-system/src/pages/view-preview/view-settings.module.css
@@ -1,0 +1,20 @@
+.viewSettings {
+  position: fixed;
+  bottom: 0.5rem;
+  right: 0.5rem;
+
+  &[data-show='show'] {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid hsl(var(--canary-border-01));
+    border-radius: 0.25rem;
+    padding: 1rem;
+    width: 20rem;
+    background: hsl(var(--canary-background-01));
+  }
+}
+
+.showHideButton {
+  gap: 0.5rem;
+  align-self: flex-end;
+}

--- a/apps/design-system/src/pages/view-preview/view-settings.tsx
+++ b/apps/design-system/src/pages/view-preview/view-settings.tsx
@@ -1,0 +1,94 @@
+import { FC, useEffect, useMemo, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import { clsx } from 'clsx'
+
+import { Button, Icon, Select, SelectContent, SelectItem, Spacer } from '@harnessio/ui/components'
+
+import css from './view-settings.module.css'
+
+export interface ViewSettingsProps {
+  routes: string[]
+}
+
+enum Themes {
+  DARK = 'dark-std-std',
+  LIGHT = 'light-std-std'
+}
+
+const ViewSettings: FC<ViewSettingsProps> = ({ routes }) => {
+  const [showSettings, setShowSettings] = useState(false)
+  const [currentTheme, setCurrentTheme] = useState<Themes>(() => {
+    const storedTheme = sessionStorage.getItem('view-preview-theme') as Themes
+
+    if (storedTheme && Object.values(Themes).includes(storedTheme)) {
+      return storedTheme
+    }
+
+    return Themes.DARK
+  })
+
+  useEffect(() => {
+    const bodyClass = document.body.classList
+
+    for (const theme of Object.values(Themes)) {
+      bodyClass.remove(theme)
+    }
+
+    bodyClass.add(currentTheme)
+    sessionStorage.setItem('view-preview-theme', currentTheme)
+  }, [currentTheme])
+
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+
+  const currentView = useMemo<string>(
+    () => pathname.match(/view-preview\/([^/]+)/)?.[1] || routes[0],
+    [pathname, routes]
+  )
+
+  return (
+    <aside className={clsx(css.viewSettings, 'shadow-1')} data-show={showSettings ? 'show' : 'hide'}>
+      <Button
+        variant="link_accent"
+        size="icon"
+        onClick={() => setShowSettings(current => !current)}
+        className={css.showHideButton}
+        title={showSettings ? 'Hide view settings' : 'Show view settings'}
+      >
+        <Icon name={showSettings ? 'close' : 'settings-1'} />
+      </Button>
+
+      {showSettings && (
+        <>
+          <Select placeholder="Select view" label="View" value={currentView} onValueChange={navigate}>
+            <SelectContent>
+              {routes.map(route => (
+                <SelectItem key={route} value={route}>
+                  {route}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Spacer size={5} />
+          <Select
+            placeholder="Select theme"
+            label="Theme"
+            value={currentTheme}
+            onValueChange={(newTheme: Themes) => setCurrentTheme(newTheme)}
+          >
+            <SelectContent>
+              {Object.values(Themes).map(theme => (
+                <SelectItem key={theme} value={theme}>
+                  {theme}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </>
+      )}
+    </aside>
+  )
+}
+
+export default ViewSettings

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@harnessio/yaml-editor':
         specifier: workspace:*
         version: link:../../packages/yaml-editor
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
This PR adds initial support for themes in the view preview. The view switcher has also been replaced by a view settings panel.


https://github.com/user-attachments/assets/ed469f68-a47d-441a-b439-30beca3d101a
