### PR TITLE
Update light-std-std styles.css

### DIFF
--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -433,7 +433,7 @@
     --canary-input-background: 240 5.9% 90%;
     --canary-ring: 240 5.9% 10%;
     --canary-radius: 0.5rem;
-    --canary-success: var(--canary-green);
+    --canary-success: var(--canary-harness-green-600);
     --canary-error: var(--canary-red);
     --canary-warning: var(--canary-orange);
     --canary-emphasis: var(--canary-emphasis);


### PR DESCRIPTION
Update for --canary-success token. Previously, the value for the light theme incorrectly included a dark mode variable.


Before:
![image](https://github.com/user-attachments/assets/21a3b42e-670c-4b0a-a8b7-404a4055d659)


After:
![image](https://github.com/user-attachments/assets/b5ecca03-f345-46bb-8706-ff3dd6f01fb8)


