### PR TITLE
feat: enhance PR layout with tab nav and UI improvements

### DIFF
--- a/apps/gitness/src/pages-v2/pull-request/pull-request-conversation.tsx
+++ b/apps/gitness/src/pages-v2/pull-request/pull-request-conversation.tsx
@@ -405,10 +405,13 @@ export default function PullRequestConversationPage() {
   if (prPanelData?.PRStateLoading || changesLoading) {
     return <SkeletonList />
   }
+
+  // TODO: we only need to plug in one component from @harnessio/ui/views
+  // for the PullRequestConversationView example and pass it the required props
   return (
     <SandboxLayout.Columns columnWidths="1fr 220px">
       <SandboxLayout.Column>
-        <SandboxLayout.Content className="pl-0">
+        <SandboxLayout.Content className="pl-0 pt-0">
           {/* TODO: fix handleaction for comment section in panel */}
           <PullRequestPanel
             spaceId={spaceId}
@@ -457,7 +460,7 @@ export default function PullRequestConversationPage() {
             showRestoreBranchButton={showRestoreBranchButton}
             headerMsg={errorMsg}
           />
-          <Spacer size={9} />
+          <Spacer size={12} />
           <PullRequestFilters
             activityFilters={activityFilters}
             dateFilters={dateFilters}
@@ -516,7 +519,7 @@ export default function PullRequestConversationPage() {
         </SandboxLayout.Content>
       </SandboxLayout.Column>
       <SandboxLayout.Column>
-        <SandboxLayout.Content className="px-0">
+        <SandboxLayout.Content className="px-0 pt-0">
           <PullRequestSideBar
             addReviewers={handleAddReviewer}
             usersList={principals?.map(user => ({ id: user.id, display_name: user.display_name, uid: user.uid }))}

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -24,6 +24,7 @@ const badgeVariants = cva(
         default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
         secondary: 'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
         tertiary: 'border-transparent bg-background-8 text-foreground-8',
+        quaternary: 'border-borders-1 bg-background-2 text-foreground-5',
         destructive: 'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
         outline: 'text-foreground'
       },

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
-import { ChevronRightIcon, DotFilledIcon } from '@radix-ui/react-icons'
+import { ChevronRightIcon } from '@radix-ui/react-icons'
 import { cn } from '@utils/cn'
 
 import { Icon } from './icon'
@@ -148,9 +148,9 @@ const DropdownMenuRadioItem = React.forwardRef<
     )}
     {...props}
   >
-    <span className="absolute left-2 flex size-3.5 items-center justify-center">
+    <span className="absolute left-2 flex size-4 items-center justify-center rounded-full border border-icons-1">
       <DropdownMenuPrimitive.ItemIndicator>
-        <DotFilledIcon className="size-4 fill-current" />
+        <span className="size-2 bg-icons-2 rounded-full block" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -10,14 +10,8 @@ const tabsListVariants = cva('inline-flex items-center text-foreground-4', {
       default: 'h-9 justify-center rounded-lg bg-muted p-1',
       underline: 'h-11 justify-center gap-4',
       navigation: 'h-[44px] w-full justify-start gap-6 border-b border-borders-5 px-6',
-      // TODO: Refactor - merge tabnav and branch variants
-      // tabnav is used in existing components and has conflicting styles
-      // Future steps:
-      // 1. Analyze all tabnav usage locations
-      // 2. Create a unified variant based on branch
-      // 3. Update existing components
-      tabnav: 'h-[36px] w-full justify-start gap-0',
-      branch: 'flex w-full border-b border-borders-1 px-3'
+      tabnav:
+        'relative flex w-full before:absolute before:left-0 before:h-px before:w-full before:bg-borders-1 before:bottom-0'
     }
   },
   defaultVariants: {
@@ -36,9 +30,7 @@ const tabsTriggerVariants = cva(
         navigation:
           'm-0 -mb-px h-[44px] border-b border-solid border-b-transparent px-0 text-xs font-normal text-foreground-2 duration-150 ease-in-out hover:text-foreground-1 data-[state=active]:border-borders-9',
         tabnav:
-          'm-0 h-[36px] items-center gap-2 rounded-t-md bg-background px-4 text-sm font-normal text-tertiary-background duration-150 ease-in-out tabnav-inactive hover:text-foreground-1 data-[state=active]:tabnav-active [&svg]:data-[state=active]:text-icons-2',
-        branch:
-          '-mb-px h-[34px] rounded-t-md border-x border-t border-transparent px-3.5 font-normal text-foreground-2 hover:text-foreground-1 data-[state=active]:border-borders-1 data-[state=active]:text-foreground-1'
+          'h-[36px] rounded-t-md border-x border-t border-transparent px-3.5 font-normal text-foreground-2 hover:text-foreground-1 data-[state=active]:border-borders-1 data-[state=active]:text-foreground-1 data-[state=active]:bg-background-1'
       }
     },
     defaultVariants: {
@@ -55,8 +47,7 @@ const tabsContentVariants = cva(
         default: '',
         underline: '',
         navigation: '',
-        tabnav: '',
-        branch: ''
+        tabnav: ''
       }
     },
     defaultVariants: {
@@ -76,18 +67,7 @@ interface TabsProps
 const Tabs = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Root>, TabsProps>(
   ({ children, variant, ...props }, ref) => (
     <TabsPrimitive.Root ref={ref} {...props}>
-      <TabsContext.Provider value={{ variant }}>
-        {variant === 'tabnav' ? (
-          <div className="relative grid w-full grid-flow-col grid-cols-[auto_1fr] items-end">
-            {children}
-            <div className="h-[36px] border-b border-border-background" />
-            <div className="absolute right-full h-[36px] w-[9999px] border-b border-border-background" />
-            <div className="absolute left-full h-[36px] w-[9999px] border-b border-border-background" />
-          </div>
-        ) : (
-          children
-        )}
-      </TabsContext.Provider>
+      <TabsContext.Provider value={{ variant }}>{children}</TabsContext.Provider>
     </TabsPrimitive.Root>
   )
 )

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -8,6 +8,7 @@ export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
   caption?: ReactNode
   error?: string
   optional?: boolean
+  resizable?: boolean
 }
 
 /**
@@ -16,7 +17,7 @@ export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
  * <Textarea name="textarea" label="Textarea" placeholder="Enter text here" />
  */
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ id, disabled, label, caption, error, optional, className, ...props }, ref) => {
+  ({ id, disabled, label, caption, error, optional, className, resizable = false, ...props }, ref) => {
     return (
       <ControlGroup>
         {label && (
@@ -26,7 +27,8 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         )}
         <textarea
           className={cn(
-            'placeholder:text-foreground-4 flex min-h-[74px] w-full rounded border bg-transparent px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:rounded disabled:cursor-not-allowed resize-none',
+            'placeholder:text-foreground-4 flex min-h-[74px] w-full rounded border bg-transparent px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:rounded disabled:cursor-not-allowed',
+            resizable ? 'resize-y [field-sizing:content] whitespace-pre-wrap [word-break:break-word]' : 'resize-none',
             className,
             error
               ? 'border-borders-danger'

--- a/packages/ui/src/views/layouts/PullRequestLayout.tsx
+++ b/packages/ui/src/views/layouts/PullRequestLayout.tsx
@@ -1,6 +1,6 @@
 import { NavLink, Outlet } from 'react-router-dom'
 
-import { Badge, Icon, Spacer } from '@components/index'
+import { Badge, Icon, Spacer, Tabs, TabsList, TabsTrigger } from '@components/index'
 import { TranslationStore } from '@views/repo'
 import { PullRequestHeader } from '@views/repo/pull-request/components/pull-request-header'
 import { IPullRequestStore } from '@views/repo/pull-request/pull-request.types'
@@ -14,6 +14,12 @@ interface PullRequestLayoutProps {
   useTranslationStore: () => TranslationStore
 }
 
+enum PullRequestTabsKeys {
+  CONVERSATION = 'conversation',
+  COMMITS = 'commits',
+  CHANGES = 'changes'
+}
+
 const PullRequestLayout: React.FC<PullRequestLayoutProps> = ({
   usePullRequestStore,
   useTranslationStore,
@@ -23,63 +29,81 @@ const PullRequestLayout: React.FC<PullRequestLayoutProps> = ({
   const { pullRequest } = usePullRequestStore()
   const { t } = useTranslationStore()
 
-  const baseClasses =
-    'inline-flex items-center justify-center px-3 py-1 px-4 items-center gap-2 bg-background hover:text-primary h-[36px] rounded-tl-md rounded-tr-md m-0'
-  const getLinkClasses = (isActive: boolean) => {
-    return `${baseClasses} ${isActive ? 'text-primary [&svg]:text-primary tabnav-active' : 'tabnav-inactive'}`
-  }
   return (
     <>
       <SandboxLayout.Main fullWidth>
-        <SandboxLayout.Content className="px-6" maxWidth="4xl">
-          <Spacer size={8} />
+        <SandboxLayout.Content className="px-6 pt-7" maxWidth="4xl">
           {pullRequest && (
-            <PullRequestHeader
-              data={{
-                title: pullRequest?.title,
-                number: pullRequest?.number,
-                merged: pullRequest?.merged,
-                author: pullRequest?.author,
-                stats: { commits: pullRequest?.stats?.commits },
-                target_branch: pullRequest?.target_branch,
-                source_branch: pullRequest?.source_branch,
-                created: pullRequest?.created,
-                is_draft: pullRequest?.is_draft,
-                state: pullRequest?.state,
-                spaceId,
-                repoId
-              }}
-            />
+            <>
+              <PullRequestHeader
+                data={{
+                  title: pullRequest?.title,
+                  number: pullRequest?.number,
+                  merged: pullRequest?.merged,
+                  author: pullRequest?.author,
+                  stats: { commits: pullRequest?.stats?.commits },
+                  target_branch: pullRequest?.target_branch,
+                  source_branch: pullRequest?.source_branch,
+                  created: pullRequest?.created,
+                  is_draft: pullRequest?.is_draft,
+                  state: pullRequest?.state,
+                  spaceId,
+                  repoId
+                }}
+              />
+              <Spacer size={10} />
+            </>
           )}
-          <div className="relative grid w-full grid-flow-col grid-cols-[auto_1fr] items-end">
-            <div className="inline-flex h-[36px] w-full items-center justify-start gap-0 text-muted-foreground">
-              <NavLink to={`conversation`} className={({ isActive }) => getLinkClasses(isActive)}>
-                <Icon size={16} name="comments" />
-                {t('views:pullRequests.conversation')}
-                <Badge variant="outline" size="xs">
-                  {pullRequest?.stats?.conversations || 0}
-                </Badge>
+          <Tabs variant="tabnav">
+            <TabsList className="left-1/2 w-[calc(100%+48px)] -translate-x-1/2 px-6">
+              <NavLink to={PullRequestTabsKeys.CONVERSATION}>
+                {({ isActive }) => (
+                  <TabsTrigger
+                    className="gap-x-1"
+                    value={PullRequestTabsKeys.CONVERSATION}
+                    data-state={isActive ? 'active' : 'inactive'}
+                  >
+                    <Icon size={14} name="comments" />
+                    {t('views:pullRequests.conversation')}
+                    <Badge variant="outline" size="xs">
+                      {pullRequest?.stats?.conversations || 0}
+                    </Badge>
+                  </TabsTrigger>
+                )}
               </NavLink>
-              <NavLink to={`commits`} className={({ isActive }) => getLinkClasses(isActive)}>
-                <Icon size={16} name="tube-sign" />
-                {t('views:repos.commits')}
-                <Badge variant="outline" size="xs">
-                  {pullRequest?.stats?.commits}
-                </Badge>
+              <NavLink to={PullRequestTabsKeys.COMMITS}>
+                {({ isActive }) => (
+                  <TabsTrigger
+                    className="gap-x-1"
+                    value={PullRequestTabsKeys.COMMITS}
+                    data-state={isActive ? 'active' : 'inactive'}
+                  >
+                    <Icon size={14} name="tube-sign" />
+                    {t('views:repos.commits')}
+                    <Badge variant="outline" size="xs">
+                      {pullRequest?.stats?.commits}
+                    </Badge>
+                  </TabsTrigger>
+                )}
               </NavLink>
-              <NavLink to={`changes`} className={({ isActive }) => getLinkClasses(isActive)}>
-                <Icon size={14} name="changes" />
-                {t('views:pullRequests.changes')}
-                <Badge variant="outline" size="xs">
-                  {pullRequest?.stats?.files_changed}
-                </Badge>
+              <NavLink to={PullRequestTabsKeys.CHANGES}>
+                {({ isActive }) => (
+                  <TabsTrigger
+                    className="gap-x-1"
+                    value={PullRequestTabsKeys.CHANGES}
+                    data-state={isActive ? 'active' : 'inactive'}
+                  >
+                    <Icon size={14} name="changes" />
+                    {t('views:pullRequests.changes')}
+                    <Badge variant="outline" size="xs">
+                      {pullRequest?.stats?.files_changed}
+                    </Badge>
+                  </TabsTrigger>
+                )}
               </NavLink>
-            </div>
-            <div className="h-[36px] border-b border-border-background" />
-            <div className="absolute right-full h-[36px] w-0 border-b border-border-background" />
-            <div className="absolute left-full h-[36px] w-0 border-b border-border-background" />
-          </div>
-          <Spacer size={8} />
+            </TabsList>
+          </Tabs>
+          <Spacer size={7} />
           <Outlet />
         </SandboxLayout.Content>
       </SandboxLayout.Main>

--- a/packages/ui/src/views/repo/components/branch-selector/branch-selector-dropdown.tsx
+++ b/packages/ui/src/views/repo/components/branch-selector/branch-selector-dropdown.tsx
@@ -66,14 +66,14 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
       {!isBranchOnly && (
         <Tabs
           className="mt-2"
-          variant="branch"
+          variant="tabnav"
           value={activeTab}
           onValueChange={value => {
             setActiveTab(value as BranchSelectorTab)
             setSearchQuery('')
           }}
         >
-          <TabsList>
+          <TabsList className="px-3">
             <DropdownMenuItem
               className="rounded-t-md p-0"
               onSelect={e => {

--- a/packages/ui/src/views/repo/pull-request/compare/pull-request-compare-page.tsx
+++ b/packages/ui/src/views/repo/pull-request/compare/pull-request-compare-page.tsx
@@ -300,7 +300,7 @@ export const PullRequestComparePage: FC<PullRequestComparePageProps> = ({
         )}
         {isBranchSelected ? (
           <Layout.Vertical className="mt-10">
-            <Tabs variant="branch" defaultValue={!prBranchCombinationExists ? 'overview' : 'commits'}>
+            <Tabs variant="tabnav" defaultValue={!prBranchCombinationExists ? 'overview' : 'commits'}>
               <TabsList className="relative left-1/2 w-[calc(100%+160px)] -translate-x-1/2 px-20">
                 {!prBranchCombinationExists && (
                   <TabTriggerItem

--- a/packages/ui/src/views/repo/pull-request/components/pull-request-header.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/pull-request-header.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 
-import { Badge, Button, Icon, Layout, Text } from '@components/index'
+import { Badge, Icon } from '@components/index'
 import { timeAgo } from '@utils/utils'
 
 import { IconType } from '../pull-request.types'
@@ -48,58 +48,42 @@ export const PullRequestHeader: React.FC<PullRequestTitleProps> = ({
 
   const stateObject = getPrState(is_draft, merged, state)
   return (
-    <div className="flex flex-col gap-2 pb-8">
-      <div className="flex items-center py-1">
-        <Text size={5} weight={'medium'} className="text-primary">
+    <div className="flex flex-col gap-y-4">
+      <div className="flex items-center">
+        <h1 className="text-foreground-1 font-medium text-24 flex gap-x-2.5">
           {original}
-          &nbsp;&nbsp;
-          <span className="font-normal text-tertiary-background">#{number}</span>
-        </Text>
+          <span className="font-normal text-foreground-4">#{number}</span>
+        </h1>
       </div>
-      <div className="">
-        <div className="flex space-x-2 text-tertiary-background">
-          <div className="flex items-center gap-2.5 text-center align-middle">
-            <Badge
-              disableHover
-              borderRadius="full"
-              className={`select-none justify-center`}
-              theme={stateObject.theme as ThemeType}
-            >
-              <Layout.Horizontal gap="space-x-1" className="flex items-center align-middle">
-                <Icon name={stateObject.icon as IconType} size={13} />
-                &nbsp;{stateObject.text}
-              </Layout.Horizontal>
-            </Badge>
-            <div className="flex gap-2">
-              <Text
-                size={2}
-                className="inline-flex flex-wrap items-center gap-1 text-tertiary-background"
-                weight="normal"
-              >
-                <span className="text-primary">{author?.display_name || author?.email || ''}</span>
-                <span>{merged ? 'merged' : ' wants to merge'}</span>
-                <span className="text-primary">
-                  {stats?.commits} {stats?.commits === 1 ? 'commit' : 'commits'}
-                </span>
-                <span>into</span>
-                <Button variant="secondary" size="xs" asChild>
-                  <Link to={`/${spaceId}/repos/${repoId}/code/${target_branch}`}>
-                    <Icon name="branch" size={12} className="mr-1 text-tertiary-background" />
-                    {target_branch}
-                  </Link>
-                </Button>
-                <span>from</span>
-                <Button asChild variant="secondary" size="xs">
-                  <Link to={`/${spaceId}/repos/${repoId}/code/${source_branch}`}>
-                    <Icon name="branch" size={12} className="mr-1 text-tertiary-background" />
-                    {source_branch}
-                  </Link>
-                </Button>
-                <span>&nbsp;|&nbsp;</span>
-                <span className="time">{formattedTime}</span>
-              </Text>
-            </div>
-          </div>
+
+      <div className="flex items-center gap-x-3">
+        <Badge className="gap-x-1 font-normal" disableHover borderRadius="full" theme={stateObject.theme as ThemeType}>
+          <Icon name={stateObject.icon as IconType} size={13} />
+          {stateObject.text}
+        </Badge>
+
+        <div className="inline-flex flex-wrap items-center gap-1 text-foreground-4">
+          <span className="text-foreground-1">{author?.display_name || author?.email || ''}</span>
+          <span>{merged ? 'merged' : ' wants to merge'}</span>
+          <span className="text-foreground-1">
+            {stats?.commits} {stats?.commits === 1 ? 'commit' : 'commits'}
+          </span>
+          <span>into</span>
+          <Badge variant="tertiary" size="md" borderRadius="base">
+            <Link className="flex items-center gap-x-1" to={`/${spaceId}/repos/${repoId}/code/${target_branch}`}>
+              <Icon name="branch" size={12} className="text-icons-9" />
+              {target_branch}
+            </Link>
+          </Badge>
+          <span>from</span>
+          <Badge variant="tertiary" size="md" borderRadius="base">
+            <Link className="flex items-center gap-x-1" to={`/${spaceId}/repos/${repoId}/code/${source_branch}`}>
+              <Icon name="branch" size={12} className="text-icons-9" />
+              {source_branch}
+            </Link>
+          </Badge>
+          <span className="w-px h-4 mx-1.5 bg-borders-2" />
+          <span className="text-foreground-4">{formattedTime}</span>
         </div>
       </div>
     </div>

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-comment-box.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-comment-box.tsx
@@ -4,14 +4,12 @@ import {
   Avatar,
   AvatarFallback,
   Button,
-  Layout,
   MarkdownViewer,
-  Spacer,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
-  Text
+  Textarea
 } from '@components/index'
 import { cn } from '@utils/cn'
 import { getInitials } from '@utils/stringUtils'
@@ -24,7 +22,6 @@ import { getInitials } from '@utils/stringUtils'
 //   title?: string
 //   size?: number
 // }
-
 interface PullRequestCommentBoxProps {
   onSaveComment: (comment: string) => void
   comment: string
@@ -41,7 +38,6 @@ interface PullRequestCommentBoxProps {
 }
 
 //  TODO: will have to eventually implement a commenting and reply system similiar to gitness
-
 const PullRequestCommentBox = ({
   onSaveComment,
   currentUser,
@@ -57,105 +53,96 @@ const PullRequestCommentBox = ({
       setComment('') // Clear the comment box after saving
     }
   }
+
   const avatar = useMemo(() => {
     return (
       <Avatar size="6">
         {/* <AvatarImage src={AvatarUrl} /> */}
         <AvatarFallback>
-          <Text size={0} color="tertiaryBackground">
-            {getInitials(currentUser || '')}
-          </Text>
+          <span className="text-12 text-foreground-3">{getInitials(currentUser || '')}</span>
         </AvatarFallback>
       </Avatar>
     )
   }, [currentUser])
+
   // TODO: add back when functionality is added
   // const toolbar: ToolbarItem[] = useMemo(() => {
-  //   const initial: ToolbarItem[] = []
-  //   return [
-  //     ...initial,
-
-  //     { icon: 'header', action: ToolbarAction.HEADER },
-  //     { icon: 'bold', action: ToolbarAction.BOLD },
-  //     { icon: 'italicize', action: ToolbarAction.ITALIC },
-  //     { icon: 'attachment', action: ToolbarAction.UPLOAD },
-  //     { icon: 'list', action: ToolbarAction.UNORDER_LIST },
-  //     { icon: 'checklist', action: ToolbarAction.CHECK_LIST },
-  //     { icon: 'code', action: ToolbarAction.CODE_BLOCK }
-  //   ]
+  //  const initial: ToolbarItem[] = []
+  //  return [
+  //    ...initial,
+  //    { icon: 'header', action: ToolbarAction.HEADER },
+  //    { icon: 'bold', action: ToolbarAction.BOLD },
+  //    { icon: 'italicize', action: ToolbarAction.ITALIC },
+  //    { icon: 'attachment', action: ToolbarAction.UPLOAD },
+  //    { icon: 'list', action: ToolbarAction.UNORDER_LIST },
+  //    { icon: 'checklist', action: ToolbarAction.CHECK_LIST },
+  //    { icon: 'code', action: ToolbarAction.CODE_BLOCK }
+  //  ]
   // }, [])
+
   return (
     <div className="flex items-start space-x-4">
       {!inReplyMode && avatar}
       <div
-        className={cn('min-w-0 flex-1  px-3 pb-3 pt-2', {
+        className={cn('min-w-0 flex-1 px-4 pb-5 pt-1.5', {
           'border rounded-md': !inReplyMode || isEditMode,
           'border-t ': inReplyMode
         })}
       >
-        <Tabs variant="navigation" defaultValue="write">
-          <TabsList className="px-0">
-            <TabsTrigger value={'write'}>
-              <Text size={2}>{'Write'}</Text>
-            </TabsTrigger>
-            <TabsTrigger value={'preview'}>
-              <Text size={2}>{'Preview'}</Text>
-            </TabsTrigger>
+        <Tabs variant="tabnav" defaultValue="write">
+          <TabsList className="relative left-1/2 w-[calc(100%+32px)] -translate-x-1/2 px-4">
+            <TabsTrigger value="write">Write</TabsTrigger>
+            <TabsTrigger value="preview">Preview</TabsTrigger>
           </TabsList>
 
-          <TabsContent value="write">
-            <Spacer size={2} />
-            <textarea
-              autoFocus={inReplyMode}
-              className="focus!:outline-none w-full resize-none bg-transparent p-2 focus-visible:outline-1  focus-visible:outline-white"
-              placeholder="Add your comment here"
-              value={comment}
-              onChange={e => setComment(e.target.value)}
-            />
+          <TabsContent className="mt-4" value="write">
+            <div className="relative">
+              <Textarea
+                className="min-h-24 p-3 pb-10"
+                autoFocus={inReplyMode}
+                placeholder="Add your comment here"
+                value={comment}
+                onChange={e => setComment(e.target.value)}
+                resizable
+              />
+
+              {/* TODO: add back when functionality is implemented */}
+              {/* <div className="absolute pb-2 pt-1 px-1 bottom-px bg-background-1 left-1/2 w-[calc(100%-2px)] -translate-x-1/2 rounded">
+                {toolbar.map((item, index) => {
+                  return (
+                    <Button key={`${comment}-${index}`} size="icon" variant="ghost">
+                      <Icon name={item.icon} />
+                    </Button>
+                  )
+                })}
+              </div> */}
+            </div>
           </TabsContent>
-          <TabsContent value="preview">
-            <Spacer size={2} />
-            <div className="min-h-4">
-              <MarkdownViewer source={comment || ''} />
+          <TabsContent className="mt-4" value="preview">
+            <div className="min-h-24">
+              {comment ? <MarkdownViewer source={comment} /> : <span>Nothing to preview</span>}
             </div>
           </TabsContent>
         </Tabs>
-        <div className="mt-2 flex items-center justify-between space-x-2">
-          {/* TODO : add back when functionality is implemented
-          <Layout.Horizontal>
-            {toolbar.map((item, index) => {
-              return (
-                <Button key={`${comment}-${index}`} size="icon" variant="ghost">
-                  <Icon name={item.icon} />
-                </Button>
-              )
-            })}
-          </Layout.Horizontal> */}
-          {!inReplyMode && (
-            <Button variant={'default'} className="float-right" onClick={handleSaveComment}>
-              Comment
-            </Button>
-          )}
-        </div>
-        {inReplyMode && (
-          <Layout.Horizontal className="pl-2 pt-2">
-            {isEditMode ? (
-              <Button variant={'default'} className="float-right" onClick={handleSaveComment}>
-                Save
-              </Button>
-            ) : (
-              <Button variant={'default'} className="float-right" onClick={handleSaveComment}>
-                Reply
-              </Button>
-            )}
-            {/* <Button variant={'outline'} onClick={handleSaveComment}>
+        <div className="mt-4 flex items-center gap-x-3">
+          {!inReplyMode && <Button onClick={handleSaveComment}>Comment</Button>}
+
+          {inReplyMode && (
+            <>
+              {isEditMode ? (
+                <Button onClick={handleSaveComment}>Save</Button>
+              ) : (
+                <Button onClick={handleSaveComment}>Reply</Button>
+              )}
+              {/* <Button variant={'outline'} onClick={handleSaveComment}>
               Reply & Resolve
             </Button> */}
-            <Button variant={'outline'} onClick={onCancelClick}>
-              Cancel
-            </Button>
-          </Layout.Horizontal>
-        )}
+              <Button variant="outline" onClick={onCancelClick}>
+                Cancel
+              </Button>
+            </>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-panel.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-panel.tsx
@@ -2,17 +2,17 @@ import { useEffect, useMemo, useState } from 'react'
 
 import {
   Accordion,
+  Badge,
   Button,
   Checkbox,
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
   Icon,
   Layout,
-  StackedList,
-  Text
+  StackedList
 } from '@components/index'
 import { cn } from '@utils/cn'
 import { timeAgo } from '@utils/utils'
@@ -86,19 +86,19 @@ const HeaderTitle = ({ ...props }: HeaderProps) => {
     return (
       <>
         <div className="inline-flex w-full items-center justify-between gap-2">
-          <Text className="flex items-center gap-2 space-x-2" weight="medium">
-            <Text>{`${props?.pullReqMetadata?.merger?.display_name} merged branch`}</Text>
-            <Button variant="secondary" size="xs">
+          <div className="flex items-center gap-2 font-medium">
+            <span>{`${props?.pullReqMetadata?.merger?.display_name} merged branch`}</span>
+            <Badge variant="secondary" size="xs">
               <Icon name="branch" size={12} className="mr-1 text-tertiary-background" />
               {props?.pullReqMetadata?.source_branch}
-            </Button>
-            <Text>{'into'}</Text>
-            <Button variant="secondary" size="xs">
+            </Badge>
+            <span>into</span>
+            <Badge variant="secondary" size="xs">
               <Icon name="branch" size={12} className="mr-1 text-tertiary-background" />
               {props?.pullReqMetadata?.target_branch}
-            </Button>
-            <Text>{formattedTime}</Text>
-          </Text>
+            </Badge>
+            <span>{formattedTime}</span>
+          </div>
           {props.showRestoreBranchButton ? (
             <Button variant="secondary" size="sm" onClick={props.onRestoreBranch}>
               Restore Branch
@@ -111,9 +111,7 @@ const HeaderTitle = ({ ...props }: HeaderProps) => {
         </div>
         {props.headerMsg && (
           <div className="flex w-full justify-end">
-            <Text size={1} className="text-destructive">
-              {props.headerMsg}
-            </Text>
+            <span className="text-destructive text-12">{props.headerMsg}</span>
           </div>
         )}
       </>
@@ -121,7 +119,7 @@ const HeaderTitle = ({ ...props }: HeaderProps) => {
   }
   return (
     <div className="inline-flex items-center gap-2">
-      <Text weight="medium">
+      <h2 className="font-medium text-foreground-1">
         {props.isDraft
           ? 'This pull request is still a work in progress'
           : props.isClosed
@@ -133,7 +131,7 @@ const HeaderTitle = ({ ...props }: HeaderProps) => {
                 : props.ruleViolation
                   ? 'Cannot merge pull request'
                   : `Pull request can be merged`}
-      </Text>
+      </h2>
     </div>
   )
 }
@@ -193,9 +191,10 @@ const PullRequestPanel = ({
       setNotBypassable(checkIfBypassAllowed)
     }
   }, [ruleViolationArr])
+
   return (
     <StackedList.Root>
-      <StackedList.Item className="items-center" isHeader disableHover>
+      <StackedList.Item className="items-center py-2.5" disableHover>
         <StackedList.Field
           className={cn({ 'w-full': !pullReqMetadata?.merged })}
           title={
@@ -232,14 +231,12 @@ const PullRequestPanel = ({
                           }
                         }}
                       />
-                      <Text size={1} className="text-primary">
-                        Bypass and merge anyway
-                      </Text>
+                      <span className="text-primary text-12">Bypass and merge anyway</span>
                     </Layout.Horizontal>
                   )}
                   <Button
-                    variant="split"
-                    size="xs_split"
+                    variant={actions ? 'split' : 'default'}
+                    size={actions ? 'xs_split' : 'xs'}
                     theme={
                       mergeable && !ruleViolation
                         ? 'success'
@@ -250,26 +247,33 @@ const PullRequestPanel = ({
                     disabled={!checkboxBypass && ruleViolation}
                     onClick={actions[0]?.action}
                     dropdown={
-                      <DropdownMenu>
-                        <DropdownMenuTrigger insideSplitButton>
-                          <Icon name="chevron-down" size={11} className="chevron-down" />
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="mt-1">
-                          <DropdownMenuGroup>
-                            {actions &&
-                              actions.map((action, action_idx) => {
+                      actions && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger insideSplitButton>
+                            <Icon name="chevron-down" size={11} className="chevron-down" />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent className="mt-1 max-w-80" align="end">
+                            {/* TODO: it is required to add the state by which the current active action will be determined */}
+                            <DropdownMenuRadioGroup value={actions[0]?.id}>
+                              {actions.map((action, action_idx) => {
                                 return (
-                                  <DropdownMenuItem onClick={action.action} key={action_idx}>
+                                  <DropdownMenuRadioItem
+                                    className="items-start"
+                                    value={action.id}
+                                    onClick={action.action}
+                                    key={action_idx}
+                                  >
                                     <div className="flex flex-col">
-                                      <Text color="primary">{action.title}</Text>
-                                      <Text color="tertiaryBackground">{action.description}</Text>
+                                      <span className="text-foreground-8 leading-none">{action.title}</span>
+                                      <span className="text-foreground-4 mt-1.5">{action.description}</span>
                                     </div>
-                                  </DropdownMenuItem>
+                                  </DropdownMenuRadioItem>
                                 )
                               })}
-                          </DropdownMenuGroup>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
+                            </DropdownMenuRadioGroup>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )
                     }
                   >
                     Squash and merge

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-timeline-item.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-timeline-item.tsx
@@ -271,7 +271,8 @@ const PullRequestTimelineItem: React.FC<TimelineItemProps> = ({
                       ) : null}
                       <Input
                         value={comment}
-                        placeholder={'Reply here'}
+                        placeholder="Reply here"
+                        size="md"
                         onClick={() => {
                           setHideReplyBox?.(true)
                         }}
@@ -279,15 +280,6 @@ const PullRequestTimelineItem: React.FC<TimelineItemProps> = ({
                           setComment(e.target.value)
                         }}
                       />
-                      <Button
-                        disabled={!comment.trim()}
-                        onClick={() => {
-                          handleSaveComment?.(comment, parentCommentId)
-                          setComment('')
-                        }}
-                      >
-                        Reply
-                      </Button>
                     </div>
                   )}
                 </>

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/sections/pull-request-changes-section.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/sections/pull-request-changes-section.tsx
@@ -4,9 +4,9 @@ import {
   AccordionTrigger,
   Avatar,
   AvatarFallback,
+  Badge,
   Icon,
-  StackedList,
-  Text
+  StackedList
 } from '@components/index'
 import { cn } from '@utils/cn'
 import { getInitials } from '@utils/stringUtils'
@@ -67,11 +67,7 @@ interface HeaderItemProps {
   header: string
 }
 const HeaderItem: React.FC<HeaderItemProps> = ({ header }: HeaderItemProps) => {
-  return (
-    <Text size={0} color="tertiaryBackground">
-      {header}
-    </Text>
-  )
+  return <span className="text-foreground-3 text-12">{header}</span>
 }
 
 const AvatarItem: React.FC<AvatarItemProps> = ({ evaluations }: AvatarItemProps) => {
@@ -84,18 +80,18 @@ const AvatarItem: React.FC<AvatarItemProps> = ({ evaluations }: AvatarItemProps)
             evaluations.map(({ owner }, idx) => {
               if (idx < 2) {
                 return (
-                  <Avatar key={owner?.id} className={cn('h-6 w-6 rounded-full')}>
+                  <Avatar key={owner?.id} className="size-6 rounded-full">
                     <AvatarFallback>
-                      <Text size={1} color="tertiaryBackground">
+                      <span className="text-12 text-foreground-4">
                         {owner?.display_name && getInitials(owner?.display_name)}
-                      </Text>
+                      </span>
                     </AvatarFallback>
                   </Avatar>
                 )
               }
               if (idx === 2 && evaluations.length && evaluations.length > 2) {
                 // TODO: do popover with all the names
-                return <Text key={owner?.id} size={0}>{`+${evaluations.length - 2}`}</Text>
+                return <span key={owner?.id} className="text-12">{`+${evaluations.length - 2}`}</span>
               }
               return null
             })}
@@ -138,21 +134,23 @@ const PullRequestChangesSection = ({
         return <Icon name="success" className="text-success" />
     }
   }
+
+  // TODO: refactoring of icon styles is required
   function renderCodeOwnerStatus() {
     if (codeOwnerPendingEntries && codeOwnerPendingEntries?.length > 0 && reqCodeOwnerLatestApproval) {
       return (
-        <div className="flex pl-2">
+        <div className="flex items-center">
           <Icon name="circle" className="text-warning" />
-          <Text className="pl-2 text-xs">{'Waiting on code owner reviews of latest changes'}</Text>
+          <span className="text-14 text-foreground-1">Waiting on code owner reviews of latest changes</span>
         </div>
       )
     }
 
     if (codeOwnerPendingEntries && codeOwnerPendingEntries?.length > 0 && reqCodeOwnerApproval) {
       return (
-        <div className="flex pl-2">
+        <div className="flex items-center">
           <Icon name="circle" className="text-warning" />
-          <Text className="pl-2 text-xs">{`Changes are pending approval from code owners`}</Text>
+          <span className="text-14 text-foreground-1">Changes are pending approval from code owners</span>
         </div>
       )
     }
@@ -164,26 +162,26 @@ const PullRequestChangesSection = ({
       codeOwnerPendingEntries?.length > 0
     ) {
       return (
-        <div className="flex pl-2">
+        <div className="flex items-center">
           <Icon name="circle" className="text-tertiary-background" />
-          <Text className="pl-2 text-xs">{`Some changes were approved by code owners`}</Text>
+          <span className="text-14 text-foreground-1">Some changes were approved by code owners</span>
         </div>
       )
     }
     if (latestCodeOwnerApprovalArr && latestCodeOwnerApprovalArr?.length > 0 && reqCodeOwnerLatestApproval) {
       return (
-        <Text className="ml-2 flex">
+        <div className="flex items-center">
           <Icon name="success" className="text-success" />
-          <Text className="pl-2 text-xs">{`Latest changes were approved by code owners`}</Text>
-        </Text>
+          <span className="text-14 text-foreground-1">Latest changes were approved by code owners</span>
+        </div>
       )
     }
     if (codeOwnerApprovalEntries && codeOwnerApprovalEntries?.length > 0 && reqCodeOwnerApproval) {
       return (
-        <Text className="ml-2 flex">
+        <div className="flex items-center">
           <Icon name="success" className="text-success" />
-          <Text className="pl-2 text-xs">{`Changes were approved by code owners`}</Text>
-        </Text>
+          <span className="text-14 text-foreground-1">Changes were approved by code owners</span>
+        </div>
       )
     }
     if (codeOwnerApprovalEntries && codeOwnerApprovalEntries?.length > 0) {
@@ -194,42 +192,40 @@ const PullRequestChangesSection = ({
         latestCodeOwnerApprovalArr.length < minReqLatestApproval
       ) {
         return (
-          <div className="flex pl-2">
+          <div className="flex items-center">
             <Icon name="pending-clock" className="text-warning" />
-            <Text className="pl-2 text-xs">{`Latest changes are pending approval from required reviewers`}</Text>
+            <span className="text-14 text-foreground-1">
+              Latest changes are pending approval from required reviewers
+            </span>
           </div>
         )
       }
       return (
-        <div className="flex pl-2">
+        <div className="flex items-center">
           <Icon name="circle" className="text-warning" />
-          <Text className="pl-2 text-xs">{`Changes were approved by code owners`}</Text>
+          <span className="text-14 text-foreground-1">Changes were approved by code owners</span>
         </div>
       )
     }
 
     return (
-      <div className="flex pl-2">
+      <div className="flex items-center">
         <Icon name="circle" className="text-tertiary-background" />
-
-        <Text className="pl-2 text-xs">{`No codeowner reviews`}</Text>
+        <span className="text-14 text-foreground-1">No codeowner reviews</span>
       </div>
     )
   }
 
   const viewBtn =
-    (minApproval && minReqLatestApproval && minApproval > minReqLatestApproval) ||
-    (!isEmpty(approvedEvaluations) && minReqLatestApproval === 0) ||
-    (minApproval && minApproval > 0 && minReqLatestApproval === undefined) ||
-    (minReqLatestApproval && minReqLatestApproval > 0) ||
+    (minApproval && minApproval > 0 && !isEmpty(approvedEvaluations)) ||
+    (minReqLatestApproval && minReqLatestApproval > 0 && !isEmpty(latestApprovalArr)) ||
     !isEmpty(changeReqEvaluations) ||
-    !isEmpty(codeOwners) ||
-    false
+    (!isEmpty(codeOwners) && !isEmpty(codeOwners?.evaluation_entries))
   return (
     <AccordionItem value="item-1">
       <AccordionTrigger
-        hideChevron={!viewBtn}
         className="text-left"
+        hideChevron={!viewBtn}
         onClick={e => {
           if (!viewBtn) e.preventDefault()
         }}
@@ -238,106 +234,102 @@ const PullRequestChangesSection = ({
           title={<LineTitle text={changesInfo.header} icon={getStatusIcon(changesInfo.status)} />}
           description={<LineDescription text={changesInfo.content} />}
         />
-        {viewBtn && <Text className="px-2 py-1.5 text-xs">Show more</Text>}
+        {viewBtn && <span className="px-2 py-1.5 text-14 text-foreground-2">Show more</span>}
       </AccordionTrigger>
+
       <AccordionContent>
-        <div>
+        <>
           {((minApproval ?? 0) > (minReqLatestApproval ?? 0) ||
             (!isEmpty(approvedEvaluations) && minReqLatestApproval === 0 && minApproval && minApproval > 0) ||
             ((minApproval ?? 0) > 0 && minReqLatestApproval === undefined)) && (
-            <div className="ml-4">
-              <div className="ml-2 mt-3 flex items-center justify-between border-t pt-2">
-                {approvedEvaluations && minApproval && minApproval <= approvedEvaluations?.length ? (
-                  <Text className="ml-2 flex">
-                    <Icon name="success" className="text-success" />
-                    <Text className="pl-2 text-xs">
-                      {`Changes were approved by ${approvedEvaluations?.length} ${easyPluralize(approvedEvaluations?.length, 'reviewer', 'reviewers')}`}
-                    </Text>
-                  </Text>
-                ) : (
-                  <div className="ml-2 flex">
-                    <Icon name="circle" className="text-warning" />
-                    <Text className="pl-2 text-xs">
-                      {`${(approvedEvaluations && approvedEvaluations.length) || ''}/${minApproval} approvals completed`}
-                    </Text>
-                  </div>
-                )}
-                <div className="rounded-full border bg-transparent">
-                  <Text className="px-2 py-1.5 text-xs text-tertiary-background">required</Text>
+            <div className="ml-6 flex items-center justify-between">
+              {approvedEvaluations && minApproval && minApproval <= approvedEvaluations?.length ? (
+                <div className="flex gap-x-2 items-center">
+                  <Icon name="success" className="text-icons-success" />
+                  <span className="text-14 text-foreground-1">
+                    {`Changes were approved by ${approvedEvaluations?.length} ${easyPluralize(approvedEvaluations?.length, 'reviewer', 'reviewers')}`}
+                  </span>
                 </div>
-              </div>
+              ) : (
+                <div className="flex gap-x-2 items-center">
+                  <Icon name="circle" className="text-icons-7 fill-transparent" />
+                  <span className="text-14 text-foreground-1">
+                    {`${(approvedEvaluations && approvedEvaluations.length) || ''}/${minApproval} approvals completed`}
+                  </span>
+                </div>
+              )}
+              <Badge variant="quaternary" borderRadius="full" size="xl" disableHover>
+                Required
+              </Badge>
             </div>
           )}
 
           {(minReqLatestApproval ?? 0) > 0 && (
-            <div className="ml-4">
-              <div className="ml-2 mt-3 flex items-center justify-between border-t pt-2">
-                {latestApprovalArr !== undefined &&
-                minReqLatestApproval !== undefined &&
-                minReqLatestApproval <= latestApprovalArr?.length ? (
-                  <Text className="ml-2 flex">
-                    <Icon name="success" className="text-success" />
-                    <Text className="pl-2 text-xs">{`Latest changes were approved by ${latestApprovalArr?.length || minReqLatestApproval || ''} ${easyPluralize(latestApprovalArr?.length || minReqLatestApproval, 'reviewer', 'reviewers')}`}</Text>
-                  </Text>
-                ) : (
-                  <div className="ml-2 flex">
-                    <Icon name="circle" className="text-warning" />
-                    <Text className="pl-2 text-xs">
-                      {`${latestApprovalArr?.length || minReqLatestApproval || ''} ${easyPluralize(latestApprovalArr?.length || minReqLatestApproval || 0, 'approval', 'approvals')} pending on latest changes`}
-                    </Text>
-                  </div>
-                )}
-                <div className="rounded-full border bg-transparent">
-                  <Text className="px-2 py-1.5 text-xs text-tertiary-background">required</Text>
+            <div className="ml-6 flex items-center justify-between">
+              {latestApprovalArr !== undefined &&
+              minReqLatestApproval !== undefined &&
+              minReqLatestApproval <= latestApprovalArr?.length ? (
+                <div className="flex gap-x-2 items-center">
+                  <Icon name="success" className="text-icons-success" />
+                  <span className="text-14 text-foreground-1">{`Latest changes were approved by ${latestApprovalArr?.length || minReqLatestApproval || ''} ${easyPluralize(latestApprovalArr?.length || minReqLatestApproval, 'reviewer', 'reviewers')}`}</span>
                 </div>
-              </div>
+              ) : (
+                <div className="flex gap-x-2 items-center">
+                  <Icon name="circle" className="text-icons-7 fill-transparent" />
+                  <span className="text-14 text-foreground-1">
+                    {`${latestApprovalArr?.length || minReqLatestApproval || ''} ${easyPluralize(latestApprovalArr?.length || minReqLatestApproval || 0, 'approval', 'approvals')} pending on latest changes`}
+                  </span>
+                </div>
+              )}
+              <Badge variant="quaternary" borderRadius="full" size="xl" disableHover>
+                Required
+              </Badge>
             </div>
           )}
 
           {!isEmpty(changeReqEvaluations) && (
-            <div className="ml-4">
-              <div className="ml-2 mt-3 flex items-center justify-between border-t pt-2">
-                <Text className="ml-2 flex">
-                  <Icon
-                    name="triangle-warning"
-                    className={cn('', {
-                      'text-destructive': reqNoChangeReq,
-                      'text-tertiary-background': !reqNoChangeReq
-                    })}
-                  />
-                  <Text className="pl-2 text-xs">{`${changeReqReviewer} requested changes to the pull request`}</Text>
-                </Text>
-                {reqNoChangeReq && (
-                  <div className="rounded-full border bg-transparent">
-                    <Text className="px-2 py-1.5 text-xs text-tertiary-background">required</Text>
-                  </div>
-                )}
+            <div className="ml-6 flex items-center justify-between">
+              <div className="flex gap-x-2 items-center">
+                <Icon
+                  name="triangle-warning"
+                  className={cn({
+                    'text-icons-danger': reqNoChangeReq,
+                    'text-icons-alert': !reqNoChangeReq
+                  })}
+                />
+                <span className="text-14 text-foreground-1">{`${changeReqReviewer} requested changes to the pull request`}</span>
               </div>
+              {reqNoChangeReq && (
+                <Badge variant="quaternary" borderRadius="full" size="xl" disableHover>
+                  Required
+                </Badge>
+              )}
             </div>
           )}
+
           {!isEmpty(codeOwners) && !isEmpty(codeOwners.evaluation_entries) && (
-            <div className="ml-4">
-              <div className="ml-2 mt-3 flex items-center justify-between border-t pt-2">
-                {codeOwnerChangeReqEntries && codeOwnerChangeReqEntries?.length > 0 ? (
-                  <Text className="ml-2 flex">
-                    <Icon
-                      name="triangle-warning"
-                      className={cn('', {
-                        'text-destructive': reqCodeOwnerApproval || reqCodeOwnerLatestApproval,
-                        'text-tertiary-background': !reqCodeOwnerApproval || !reqCodeOwnerLatestApproval
-                      })}
-                    />
-                    <Text className="pl-2 text-xs">{'Code owners requested changes to the pull request'}</Text>
-                  </Text>
-                ) : (
-                  renderCodeOwnerStatus()
-                )}
-                {(reqCodeOwnerApproval || reqCodeOwnerLatestApproval) && (
-                  <div className="rounded-full border bg-transparent">
-                    <Text className="px-2 py-1.5 text-xs text-tertiary-background">required</Text>
-                  </div>
-                )}
-              </div>
+            <div className="ml-6 flex items-center justify-between">
+              {codeOwnerChangeReqEntries && codeOwnerChangeReqEntries?.length > 0 ? (
+                <div className="flex gap-x-2 items-center">
+                  <Icon
+                    name="triangle-warning"
+                    className={cn({
+                      'text-icons-danger': reqCodeOwnerApproval || reqCodeOwnerLatestApproval,
+                      'text-icons-alert': !reqCodeOwnerApproval || !reqCodeOwnerLatestApproval
+                    })}
+                  />
+                  <span className="text-14 text-foreground-1">
+                    {'Code owners requested changes to the pull request'}
+                  </span>
+                </div>
+              ) : (
+                renderCodeOwnerStatus()
+              )}
+              {(reqCodeOwnerApproval || reqCodeOwnerLatestApproval) && (
+                <Badge variant="quaternary" borderRadius="full" size="xl" disableHover>
+                  Required
+                </Badge>
+              )}
             </div>
           )}
           {/* TODO: add codeowners table */}
@@ -374,7 +366,7 @@ const PullRequestChangesSection = ({
               </StackedList.Root>
             </div>
           )}
-        </div>
+        </>
       </AccordionContent>
     </AccordionItem>
   )

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/sections/pull-request-line-title.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/sections/pull-request-line-title.tsx
@@ -1,5 +1,3 @@
-import { Text } from '@components/index'
-
 interface LineTitleProps {
   text?: string
   icon?: React.ReactElement
@@ -13,7 +11,7 @@ export const LineTitle = ({ ...props }: LineTitleProps) => {
   return (
     <div className="inline-flex items-center gap-2">
       {props.icon}
-      <Text weight="medium">{props.text}</Text>
+      <h3 className="font-medium text-14">{props.text}</h3>
     </div>
   )
 }
@@ -21,9 +19,7 @@ export const LineTitle = ({ ...props }: LineTitleProps) => {
 export const LineDescription = ({ ...props }: LineDescriptionProps) => {
   return (
     <div className="ml-6 inline-flex items-center gap-2">
-      <Text size={1} weight="normal" color={'tertiaryBackground'}>
-        {props.text}
-      </Text>
+      <p className="text-foreground-4 text-14 font-normal">{props.text}</p>
     </div>
   )
 }

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/sections/pull-request-merge-section.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/sections/pull-request-merge-section.tsx
@@ -1,4 +1,4 @@
-import { AccordionContent, AccordionItem, AccordionTrigger, Icon, StackedList, Text } from '@components/index'
+import { AccordionContent, AccordionItem, AccordionTrigger, Icon, StackedList } from '@components/index'
 import { isEmpty } from 'lodash-es'
 
 import { LineDescription, LineTitle } from './pull-request-line-title'
@@ -17,11 +17,7 @@ const PullRequestMergeSection = ({
 }: PullRequestMergeSectionProps) => {
   return (
     <AccordionItem value="item-4" isLast>
-      <AccordionTrigger
-        className="text-left"
-        hideChevron
-        // hideChevron={!mergeable || !unchecked}
-      >
+      <AccordionTrigger className="text-left" hideChevron={mergeable || unchecked}>
         <StackedList.Field
           title={
             <LineTitle
@@ -53,7 +49,7 @@ const PullRequestMergeSection = ({
               <LineDescription text={'Checking for ability to merge automatically...'} />
             ) : !mergeable ? (
               <div className="ml-6 inline-flex items-center gap-2">
-                <Text size={1} weight="normal" color={'tertiaryBackground'}>
+                <p className="text-foreground-4 text-14 font-normal">
                   Use the
                   <span
                     // onClick={() => {
@@ -69,39 +65,33 @@ const PullRequestMergeSection = ({
                   </span>
                   to resolve conflicts
                   {/* {getString('pr.useCmdLineToResolveConflicts')} */}
-                </Text>
+                </p>
               </div>
             ) : (
               ''
             )
           }
         />
-        {!mergeable && !unchecked && (
-          <Text className="pr-2" size={1}>
-            Show more
-          </Text>
-        )}
+        {!mergeable && !unchecked && <span className="px-2 py-1.5 text-14 text-foreground-2">Show more</span>}
       </AccordionTrigger>
       {!mergeable && !unchecked && (
         <AccordionContent>
-          <StackedList.Root className="ml-2 border-transparent bg-inherit">
-            <StackedList.Item className="ml-2 px-0.5 pt-0.5">
-              <Text
-                size={1}
-                weight="normal"
-                color={'tertiaryBackground'}
-              >{`Conflicting files (${conflictingFiles?.length || 0})`}</Text>
-            </StackedList.Item>
-            {!isEmpty(conflictingFiles) &&
-              conflictingFiles?.map((file, idx) => (
-                <StackedList.Item className="ml-2 px-2 py-1" key={`${file}-${idx}`}>
-                  <Icon size={14} name="changes" />
-                  <Text size={1} className="pl-1">
-                    {file}
-                  </Text>
-                </StackedList.Item>
-              ))}
-          </StackedList.Root>
+          <div className="ml-6">
+            <span className="text-14 text-foreground-2">
+              Conflicting files <span className="text-foreground-4">{`(${conflictingFiles?.length || 0})`}</span>
+            </span>
+
+            {!isEmpty(conflictingFiles) && (
+              <div className="mt-2">
+                {conflictingFiles?.map((file, idx) => (
+                  <div className="py-1.5 flex items-center gap-x-2" key={`${file}-${idx}`}>
+                    <Icon className="text-icons-1" size={16} name="file" />
+                    <span className="text-14 text-foreground-1">{file}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </AccordionContent>
       )}
     </AccordionItem>

--- a/packages/ui/src/views/repo/repo-summary/components/clone-repo-dialog.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/clone-repo-dialog.tsx
@@ -50,7 +50,7 @@ export const CloneRepoDialog: FC<CloneRepoDialogProps> = ({
         </div>
         <Tabs
           className="mt-4"
-          variant="branch"
+          variant="tabnav"
           value={currentTab}
           onValueChange={val => setCurrentTab(val as CloneRepoTabs)}
         >


### PR DESCRIPTION
**Description**:
This pull request introduces a refactoring of the header components for the detailed `PR` page as well as style adjustments. 

**TODO** (points that need to be finalized and fixed in separate PR's)

- Refactor Page Construction: in `apps/gitness`, revise the way the page is built. Currently, the page is constructed entirely from individual components. Instead, we should use a single component named `PullRequestConversationView` and pass it the required props, similar to the approach used on other pages.
- In the `Overview section` on the `Conversation tab`, the commit history need to be displayed (currently missing), and the components and styles require refactoring.
- A state needs to be added for the dropdown where we select how we plan to merge this PR (currently, it works as static mock data).
- Add functionality to the `form` buttons (on the Write tab) to use and edit md markup (right now they are static), and check the styles for the Preview tab.

**Screenshots**:
Before:
<img width="1811" alt="Arc 2025-01-09 21 17 26" src="https://github.com/user-attachments/assets/ffca6195-59dd-461d-837d-7c5ce7445468" />



After:
<img width="1812" alt="Arc 2025-01-09 21 24 27" src="https://github.com/user-attachments/assets/2b4e2c14-04bf-40e3-903b-b5f76feb4d65" />


