### PR TITLE
fix: Ensure App Shell renders for all applicable routes 

### DIFF
--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -56,6 +56,139 @@ export const routes: CustomRouteObject[] = [
         element: <LandingPage />
       },
       {
+        path: 'create',
+        element: <CreateProject />,
+        handle: {
+          breadcrumb: () => <Text>Create project</Text>
+        },
+        children: []
+      },
+      {
+        path: 'repos',
+        element: (
+          <SandboxLayout.Main>
+            <h1>Repo</h1>
+          </SandboxLayout.Main>
+        )
+      },
+      {
+        path: 'pipelines',
+        element: (
+          <SandboxLayout.Main>
+            <h1>pipelines</h1>
+          </SandboxLayout.Main>
+        )
+      },
+      {
+        path: 'executions',
+        element: (
+          <SandboxLayout.Main>
+            <h1>executions</h1>
+          </SandboxLayout.Main>
+        )
+      },
+      {
+        path: 'databases',
+        element: (
+          <SandboxLayout.Main>
+            <h1>databases</h1>
+          </SandboxLayout.Main>
+        )
+      },
+      {
+        path: 'signin',
+        element: <SignIn />
+      },
+      {
+        path: 'signup',
+        element: <SignUp />
+      },
+
+      {
+        path: 'theme',
+        element: <ProfileSettingsThemePage />
+      },
+      {
+        path: 'logout',
+        element: <Logout />
+      },
+      {
+        path: 'chaos',
+        element: <EmptyPage pathName="Chaos Engineering" />
+      },
+      {
+        path: 'artifacts',
+        element: <EmptyPage pathName="Artifacts" />
+      },
+      {
+        path: 'secrets',
+        element: <EmptyPage pathName="Secrets" />
+      },
+      {
+        path: 'connectors',
+        element: <EmptyPage pathName="Connectors" />
+      },
+      {
+        path: 'continuous-delivery-gitops',
+        element: <EmptyPage pathName="Continuous Delivery Gitops" />
+      },
+      {
+        path: 'continuous-integration',
+        element: <EmptyPage pathName="Continuous Integration" />
+      },
+      {
+        path: 'feature-flags',
+        element: <EmptyPage pathName="Feature Flags" />
+      },
+      {
+        path: 'infrastructure-as-code',
+        element: <EmptyPage pathName="Infrastructure as Code" />
+      },
+      {
+        path: 'service-reliability',
+        element: <EmptyPage pathName="Service Reliability" />
+      },
+      {
+        path: 'developer/portal',
+        element: <EmptyPage pathName="Internal Developer Portal" />
+      },
+      {
+        path: 'developer/environments',
+        element: <EmptyPage pathName="Environments" />
+      },
+      {
+        path: 'developer/insights',
+        element: <EmptyPage pathName="Software Engineering Insights" />
+      },
+      {
+        path: 'infrastructure',
+        element: <EmptyPage pathName="Infrastructure as Code" />
+      },
+      {
+        path: 'code-repository',
+        element: <EmptyPage pathName="Code Repository" />
+      },
+      {
+        path: 'supply-chain',
+        element: <EmptyPage pathName="Software Supply Chain Assurance" />
+      },
+      {
+        path: 'security-tests',
+        element: <EmptyPage pathName="Security Testing Orchestration" />
+      },
+      {
+        path: 'cloud-costs',
+        element: <EmptyPage pathName="Cloud Cost Management" />
+      },
+      {
+        path: 'incidents',
+        element: <EmptyPage pathName="Incidents" />
+      },
+      {
+        path: 'dashboards',
+        element: <EmptyPage pathName="Dashboards" />
+      },
+      {
         path: ':spaceId',
         handle: {
           breadcrumb: () => <ProjectDropdown />
@@ -367,138 +500,5 @@ export const routes: CustomRouteObject[] = [
         ]
       }
     ]
-  },
-  {
-    path: 'create',
-    element: <CreateProject />,
-    handle: {
-      breadcrumb: () => <Text>Create project</Text>
-    },
-    children: []
-  },
-  {
-    path: 'repos',
-    element: (
-      <SandboxLayout.Main>
-        <h1>Repo</h1>
-      </SandboxLayout.Main>
-    )
-  },
-  {
-    path: 'pipelines',
-    element: (
-      <SandboxLayout.Main>
-        <h1>pipelines</h1>
-      </SandboxLayout.Main>
-    )
-  },
-  {
-    path: 'executions',
-    element: (
-      <SandboxLayout.Main>
-        <h1>executions</h1>
-      </SandboxLayout.Main>
-    )
-  },
-  {
-    path: 'databases',
-    element: (
-      <SandboxLayout.Main>
-        <h1>databases</h1>
-      </SandboxLayout.Main>
-    )
-  },
-  {
-    path: 'signin',
-    element: <SignIn />
-  },
-  {
-    path: 'signup',
-    element: <SignUp />
-  },
-
-  {
-    path: 'theme',
-    element: <ProfileSettingsThemePage />
-  },
-  {
-    path: 'logout',
-    element: <Logout />
-  },
-  {
-    path: 'chaos',
-    element: <EmptyPage pathName="Chaos Engineering" />
-  },
-  {
-    path: 'artifacts',
-    element: <EmptyPage pathName="Artifacts" />
-  },
-  {
-    path: 'secrets',
-    element: <EmptyPage pathName="Secrets" />
-  },
-  {
-    path: 'connectors',
-    element: <EmptyPage pathName="Connectors" />
-  },
-  {
-    path: 'continuous-delivery-gitops',
-    element: <EmptyPage pathName="Continuous Delivery Gitops" />
-  },
-  {
-    path: 'continuous-integration',
-    element: <EmptyPage pathName="Continuous Integration" />
-  },
-  {
-    path: 'feature-flags',
-    element: <EmptyPage pathName="Feature Flags" />
-  },
-  {
-    path: 'infrastructure-as-code',
-    element: <EmptyPage pathName="Infrastructure as Code" />
-  },
-  {
-    path: 'service-reliability',
-    element: <EmptyPage pathName="Service Reliability" />
-  },
-  {
-    path: 'developer/portal',
-    element: <EmptyPage pathName="Internal Developer Portal" />
-  },
-  {
-    path: 'developer/environments',
-    element: <EmptyPage pathName="Environments" />
-  },
-  {
-    path: 'developer/insights',
-    element: <EmptyPage pathName="Software Engineering Insights" />
-  },
-  {
-    path: 'infrastructure',
-    element: <EmptyPage pathName="Infrastructure as Code" />
-  },
-  {
-    path: 'code-repository',
-    element: <EmptyPage pathName="Code Repository" />
-  },
-  {
-    path: 'supply-chain',
-    element: <EmptyPage pathName="Software Supply Chain Assurance" />
-  },
-  {
-    path: 'security-tests',
-    element: <EmptyPage pathName="Security Testing Orchestration" />
-  },
-  {
-    path: 'cloud-costs',
-    element: <EmptyPage pathName="Cloud Cost Management" />
-  },
-  {
-    path: 'incidents',
-    element: <EmptyPage pathName="Incidents" />
-  },
-  {
-    path: 'dashboards',
-    element: <EmptyPage pathName="Dashboards" />
   }
 ]

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -67,33 +67,45 @@ export const routes: CustomRouteObject[] = [
         path: 'repos',
         element: (
           <SandboxLayout.Main>
-            <h1>Repo</h1>
+            <h1>Repositories</h1>
           </SandboxLayout.Main>
-        )
+        ),
+        handle: {
+          breadcrumb: () => <Text>Repositories</Text>
+        }
       },
       {
         path: 'pipelines',
         element: (
           <SandboxLayout.Main>
-            <h1>pipelines</h1>
+            <h1>Pipelines</h1>
           </SandboxLayout.Main>
-        )
+        ),
+        handle: {
+          breadcrumb: () => <Text>Pipelines</Text>
+        }
       },
       {
         path: 'executions',
         element: (
           <SandboxLayout.Main>
-            <h1>executions</h1>
+            <h1>Executions</h1>
           </SandboxLayout.Main>
-        )
+        ),
+        handle: {
+          breadcrumb: () => <Text>Executions</Text>
+        }
       },
       {
         path: 'databases',
         element: (
           <SandboxLayout.Main>
-            <h1>databases</h1>
+            <h1>Databases</h1>
           </SandboxLayout.Main>
-        )
+        ),
+        handle: {
+          breadcrumb: () => <Text>Databases</Text>
+        }
       },
       {
         path: 'signin',

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -108,21 +108,8 @@ export const routes: CustomRouteObject[] = [
         }
       },
       {
-        path: 'signin',
-        element: <SignIn />
-      },
-      {
-        path: 'signup',
-        element: <SignUp />
-      },
-
-      {
         path: 'theme',
         element: <ProfileSettingsThemePage />
-      },
-      {
-        path: 'logout',
-        element: <Logout />
       },
       {
         path: 'chaos',
@@ -464,7 +451,6 @@ export const routes: CustomRouteObject[] = [
           }
         ]
       },
-
       {
         path: 'admin/default-settings',
         element: <UserManagementPageContainer />,
@@ -512,5 +498,17 @@ export const routes: CustomRouteObject[] = [
         ]
       }
     ]
+  },
+  {
+    path: 'signin',
+    element: <SignIn />
+  },
+  {
+    path: 'signup',
+    element: <SignUp />
+  },
+  {
+    path: 'logout',
+    element: <Logout />
   }
 ]


### PR DESCRIPTION
Currently, routes which are sibling of `/` do not render with App shell, which includes side nav and breadcrumbs. This PR fixes it.

**Sample**:

**Before**:

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/b84e7aea-e88a-4058-851b-fa135116435e" />

**After**:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/f2da906a-dca9-4f40-b4c3-682f7fdc7469" />
