### PR TITLE
fix: Revert changes in Breadcrumbs component

### DIFF
--- a/apps/gitness/src/components-v2/breadcrumbs/breadcrumbs.tsx
+++ b/apps/gitness/src/components-v2/breadcrumbs/breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { Link, useMatches } from 'react-router-dom'
+import { useMatches } from 'react-router-dom'
 
 import { Breadcrumb, Topbar } from '@harnessio/ui/components'
 
@@ -12,32 +12,24 @@ function Breadcrumbs() {
       <Topbar.Left>
         <Breadcrumb.Root className="select-none">
           <Breadcrumb.List>
-            <nav className="flex items-start gap-1">
-              {matches.map((match, index) => {
-                const { breadcrumb } = (match.handle || {}) as CustomHandle
-                const isFirst = index === 1
-                const isLast = index === matches.length - 1
+            {matches.map((match, index) => {
+              const { breadcrumb } = (match.handle || {}) as CustomHandle
+              const isFirst = index === 1
+              const isLast = index === matches.length - 1
 
-                if (!breadcrumb) return null
+              if (!breadcrumb) return null
 
-                return (
-                  <div key={match.pathname} className="flex items-center">
-                    {!isFirst ? <Breadcrumb.Separator className="mr-1" /> : null}
-                    <Breadcrumb.Item>
-                      <Breadcrumb.Item>
-                        {isLast ? (
-                          <Breadcrumb.Page>{breadcrumb(match.params)}</Breadcrumb.Page>
-                        ) : (
-                          <Breadcrumb.Link asChild>
-                            <Link to={match.pathname}>{breadcrumb(match.params)}</Link>
-                          </Breadcrumb.Link>
-                        )}
-                      </Breadcrumb.Item>
-                    </Breadcrumb.Item>
-                  </div>
-                )
-              })}
-            </nav>
+              return (
+                <Breadcrumb.Item key={index}>
+                  {!isFirst ? <Breadcrumb.Separator /> : null}
+                  {isLast ? (
+                    breadcrumb(match.params)
+                  ) : (
+                    <Breadcrumb.Link href={match.pathname}>{breadcrumb(match.params)}</Breadcrumb.Link>
+                  )}
+                </Breadcrumb.Item>
+              )
+            })}
           </Breadcrumb.List>
         </Breadcrumb.Root>
       </Topbar.Left>

--- a/apps/gitness/src/components-v2/breadcrumbs/breadcrumbs.tsx
+++ b/apps/gitness/src/components-v2/breadcrumbs/breadcrumbs.tsx
@@ -20,10 +20,10 @@ function Breadcrumbs() {
               if (!breadcrumb) return null
 
               return (
-                <Breadcrumb.Item key={index}>
+                <Breadcrumb.Item key={match.pathname}>
                   {!isFirst ? <Breadcrumb.Separator /> : null}
                   {isLast ? (
-                    breadcrumb(match.params)
+                    <Breadcrumb.Page>{breadcrumb(match.params)}</Breadcrumb.Page>
                   ) : (
                     <Breadcrumb.Link href={match.pathname}>{breadcrumb(match.params)}</Breadcrumb.Link>
                   )}

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -51,7 +51,7 @@ import { UserManagementPageContainer } from './pages-v2/user-management/user-man
 import { CreateWebhookContainer } from './pages-v2/webhooks/create-webhook-container'
 import WebhookListPage from './pages-v2/webhooks/webhook-list'
 
-const repoRoutes = [
+const repoRoutes: CustomRouteObject[] = [
   {
     path: 'repos',
     handle: {
@@ -373,7 +373,8 @@ const repoRoutes = [
     element: <ProjectPipelineListPage />,
     handle: {
       breadcrumb: () => <Text>Pipelines</Text>
-    }
+    },
+    children: []
   }
 ]
 


### PR DESCRIPTION
- Undo changes done in Breadcrumbs component done in PR https://github.com/harness/canary/pull/560.
- Project selection in the breadcrumbs doesn't work correctly due to this change.

https://github.com/user-attachments/assets/55acf0a9-9e5e-400d-9833-44ef580d376c

