### PR TITLE
fix: fix gradients at navbar and tabs

### DIFF
--- a/packages/ui/src/components/navbar-skeleton/item.tsx
+++ b/packages/ui/src/components/navbar-skeleton/item.tsx
@@ -74,13 +74,7 @@ export function Item({ icon, text, description, active, submenuItem, className }
           )}
         >
           {active && (
-            <span
-              className="absolute left-1/2 top-1/2 z-[-1] size-7 -translate-x-1/2 -translate-y-1/2"
-              style={{
-                background:
-                  'radial-gradient(50% 50% at 50% 50%, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.11) 17.63%, rgba(255, 255, 255, 0.07) 40.23%, rgba(255, 255, 255, 0.03) 61.54%, rgba(255, 255, 255, 0.01) 80%, rgba(255, 255, 255, 0.00) 100%)'
-              }}
-            />
+            <span className="absolute left-1/2 top-1/2 z-[-1] size-7 -translate-x-1/2 -translate-y-1/2 bg-navbar-item-gradient" />
           )}
           {icon}
         </div>

--- a/packages/ui/src/components/navbar-skeleton/root.tsx
+++ b/packages/ui/src/components/navbar-skeleton/root.tsx
@@ -14,41 +14,20 @@ export function Root({ className, children, isSubMenu = false }: RootProps) {
   return (
     <div
       className={cn(
-        'border-borders-5 bg-background-7 grid h-screen w-[220px] select-none grid-rows-[auto_1fr_auto] overflow-y-auto border-r',
+        'relative border-borders-5 bg-background-7 grid h-screen w-[220px] select-none grid-rows-[auto_1fr_auto] overflow-y-auto border-r',
         { 'bg-background-7/70 backdrop-blur-[20px]': isSubMenu },
         className
       )}
     >
       {!isSubMenu && (
         <>
-          <div
-            className="absolute left-1/2 top-[-82px] z-[-1] h-[164px] w-[392px] -translate-x-1/2 rounded-[392px]"
-            // style={{
-            //   background: 'radial-gradient(50% 50% at 50% 50%, rgba(48, 48, 54, 0.4) 0%, rgba(48, 48, 54, 0) 100%)'
-            // }}
-          />
-          <div
-            className="absolute left-[-132px] top-[-51px] z-[-1] h-[325px] w-[263px] rounded-[325px]"
-            // style={{
-            //   background:
-            //     'radial-gradient(50% 50% at 50% 50%, rgba(73, 73, 73, 0.25) 0%, rgba(73, 73, 73, 0.15) 44.95%, rgba(73, 73, 73, 0) 100%)'
-            // }}
-          />
-          <div
-            className="absolute right-[-93px] top-[22%] z-[-1] h-[333px] w-[186px] rounded-[333px]"
-            // style={{
-            //   background: 'radial-gradient(50% 50% at 50% 50%, rgba(58, 58, 58, 0.2) 0%, rgba(58, 58, 58, 0) 100%)'
-            // }}
-          />
-          <div
-            className="absolute bottom-[161px] left-[-139px] z-[-1] h-[362px] w-[297px] rounded-[362px]"
-            // style={{
-            //   background: 'radial-gradient(50% 50% at 50% 50%, rgba(73, 73, 73, 0.2) 0%, rgba(73, 73, 73, 0) 100%)'
-            // }}
-          />
+          <div className="pointer-events-none absolute left-1/2 top-[-82px] h-[164px] w-[392px] -translate-x-1/2 rounded-[392px] bg-navbar-gradient-1" />
+          <div className="pointer-events-none absolute left-[-132px] top-[-51px] h-[325px] w-[263px] rounded-[325px] bg-navbar-gradient-2" />
+          <div className="pointer-events-none absolute right-[-93px] top-[22%] h-[333px] w-[186px] rounded-[333px] bg-navbar-gradient-3" />
+          <div className="pointer-events-none absolute bottom-[161px] left-[-139px] h-[362px] w-[297px] rounded-[362px] bg-navbar-gradient-4" />
           <div
             className={cn(
-              `absolute left-0 top-0 z-[-1] size-full bg-repeat opacity-20 mix-blend-overlay`,
+              `absolute left-0 top-0 size-full bg-repeat opacity-20 mix-blend-overlay pointer-events-none`,
               isSafari() ? 'opacity-5' : 'opacity-20'
             )}
             style={{ backgroundImage: `url(${noiseBg})` }}

--- a/packages/ui/src/components/navbar/navbar.tsx
+++ b/packages/ui/src/components/navbar/navbar.tsx
@@ -48,6 +48,7 @@ export const Navbar = ({
   const navigate = useNavigate()
   const { t } = useTranslationStore()
   const adminMenuItem = getAdminMenuItem(t)
+
   const showNavbar = useMemo(() => {
     return !hideNavbarPaths.includes(location.pathname)
   }, [location.pathname])
@@ -114,7 +115,7 @@ export const Navbar = ({
         </ScrollArea>
 
         {/*<NavbarAi />*/}
-        {currentUser?.admin && (
+        {!!currentUser?.admin && (
           <NavbarSkeleton.Group>
             <Link to="/admin/default-settings">
               <NavbarSkeleton.Item text="User Management" icon={<Icon name="account" size={12} />} />

--- a/packages/ui/src/shared-style-variables.css
+++ b/packages/ui/src/shared-style-variables.css
@@ -7,6 +7,8 @@
   --canary-grey-12: 240 5% 11%;
   --canary-grey-15: 240 6% 15%;
   --canary-grey-20: 240 6% 20%;
+  --canary-grey-23: 0 0% 23%;
+  --canary-grey-29: 0 0% 29%;
   --canary-grey-30: 240 6% 30%;
   --canary-grey-40: 240 6% 40%;
   --canary-grey-50: 240 6% 50%;
@@ -467,25 +469,33 @@
     --canary-button-background-disabled-01: var(--canary-harness-grey-400) / 0.15;
     --canary-button-border-disabled-01: var(--canary-harness-grey-400) / 0.2;
 
-    /* 🚨 Need these colors for other themes */
+    /* Box shadow colors */
+    --canary-box-shadow-1: var(--canary-harness-grey-400) / 0.1;
+    --canary-box-shadow-2: var(--canary-harness-grey-400) / 0.1;
+    --canary-box-shadow-pagination: var(--canary-harness-grey-400) / 0.1;
+
+    /* Navigation gradients */
+    --canary-nav-gradient-1-1: var(--canary-harness-grey-0) / 0.4;
+    --canary-nav-gradient-1-2: var(--canary-harness-grey-0) / 0;
+    --canary-nav-gradient-2-1: var(--canary-harness-grey-200) / 0.25;
+    --canary-nav-gradient-2-2: var(--canary-harness-grey-200) / 0.15;
+    --canary-nav-gradient-2-3: var(--canary-harness-grey-200) / 0;
+    --canary-nav-gradient-3-1: var(--canary-harness-grey-200) / 0.2;
+    --canary-nav-gradient-3-2: var(--canary-harness-grey-200) / 0;
+    --canary-nav-gradient-4-1: var(--canary-harness-grey-200) / 0.2;
+    --canary-nav-gradient-4-2: var(--canary-harness-grey-200) / 0;
+    --canary-nav-item-gradient-1: var(--canary-harness-grey-0) / 0.12;
+    --canary-nav-item-gradient-2: var(--canary-harness-grey-0) / 0.11;
+    --canary-nav-item-gradient-3: var(--canary-harness-grey-0) / 0.07;
+    --canary-nav-item-gradient-4: var(--canary-harness-grey-0) / 0.03;
+    --canary-nav-item-gradient-5: var(--canary-harness-grey-0) / 0.01;
+    --canary-nav-item-gradient-6: var(--canary-harness-grey-0) / 0;
+
     /* Selected tab bg element*/
     --canary-tab-item-gradient-from: var(--canary-harness-grey-400) / 15%;
     --canary-tab-item-gradient-to: var(--canary-harness-grey-400) / 0%;
     --canary-tab-item-gradient-stops: hsla(var(--canary-tab-item-gradient-from)),
       hsla(var(--canary-tab-item-gradient-to));
-    /* Navigation vertical element gradients*/
-    --canary-nav-gradient-item-y-from: var(--canary-harness-grey-200);
-    --canary-nav-gradient-item-y-to: var(--canary-harness-grey-200) / 0;
-    --canary-tab-gradient-item-y-stops: var(--canary-nav-gradient-item-y-from), var(--canary-nav-gradient-item-y-to);
-    /* Navigation horizontal element gradients*/
-    --canary-nav-gradient-item-x-from: var(--canary-harness-grey-0);
-    --canary-nav-gradient-item-x-to: var(--canary-harness-grey-0) / 0;
-    --canary-tab-gradient-item-x-stops: var(--canary-nav-gradient-item-x-from), var(--canary-nav-gradient-item-x-to);
-
-    /* Box shadow colors */
-    --canary-box-shadow-1: var(--canary-harness-grey-400) / 0.1;
-    --canary-box-shadow-2: var(--canary-harness-grey-400) / 0.1;
-    --canary-box-shadow-pagination: var(--canary-harness-grey-400) / 0.1;
   }
   .dark,
   .dark-std-std {
@@ -653,5 +663,28 @@
     --canary-box-shadow-1: var(--canary-solid-black) / 0.3;
     --canary-box-shadow-2: var(--canary-solid-black) / 0.6;
     --canary-box-shadow-pagination: var(--canary-solid-black) / 0.5;
+
+    /* Navigation gradients */
+    --canary-nav-gradient-1-1: var(--canary-grey-20) / 0.4;
+    --canary-nav-gradient-1-2: var(--canary-grey-20) / 0;
+    --canary-nav-gradient-2-1: var(--canary-grey-29) / 0.25;
+    --canary-nav-gradient-2-2: var(--canary-grey-29) / 0.15;
+    --canary-nav-gradient-2-3: var(--canary-grey-29) / 0;
+    --canary-nav-gradient-3-1: var(--canary-grey-23) / 0.2;
+    --canary-nav-gradient-3-2: var(--canary-grey-23) / 0;
+    --canary-nav-gradient-4-1: var(--canary-grey-29) / 0.2;
+    --canary-nav-gradient-4-2: var(--canary-grey-29) / 0;
+    --canary-nav-item-gradient-1: var(--canary-white) / 0.12;
+    --canary-nav-item-gradient-2: var(--canary-white) / 0.11;
+    --canary-nav-item-gradient-3: var(--canary-white) / 0.07;
+    --canary-nav-item-gradient-4: var(--canary-white) / 0.03;
+    --canary-nav-item-gradient-5: var(--canary-white) / 0.01;
+    --canary-nav-item-gradient-6: var(--canary-white) / 0;
+
+    /* Selected tab bg element*/
+    --canary-tab-item-gradient-from: var(--canary-grey-20) / 0.3;
+    --canary-tab-item-gradient-to: var(--canary-grey-20) / 0;
+    --canary-tab-item-gradient-stops: hsla(var(--canary-tab-item-gradient-from)),
+      hsla(var(--canary-tab-item-gradient-to));
   }
 }

--- a/packages/ui/src/views/repo/webhooks/webhook-list/repo-webhook-list-page.tsx
+++ b/packages/ui/src/views/repo/webhooks/webhook-list/repo-webhook-list-page.tsx
@@ -76,7 +76,7 @@ const RepoWebhookListPage: FC<RepoWebhookListPageProps> = ({
       <Spacer size={6} />
 
       {error ? (
-        <span className="text-destructive text-xs">{error || 'Something went wrong'}</span>
+        <span className="text-xs text-destructive">{error || 'Something went wrong'}</span>
       ) : (
         <>
           {(!!webhooksWithFormattedDates.length || (!webhooksWithFormattedDates.length && isDirtyList)) && (

--- a/packages/ui/tailwind.ts
+++ b/packages/ui/tailwind.ts
@@ -296,7 +296,17 @@ export default {
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--canary-tw-gradient-stops))',
         'ai-button':
-          'linear-gradient(to right, hsl(var(--canary-ai-button-stop-1)), hsl(var(--canary-ai-button-stop-2)), hsl(var(--canary-ai-button-stop-3)), hsl(var(--canary-ai-button-stop-4)))'
+          'linear-gradient(to right, hsl(var(--canary-ai-button-stop-1)), hsl(var(--canary-ai-button-stop-2)), hsl(var(--canary-ai-button-stop-3)), hsl(var(--canary-ai-button-stop-4)))',
+        'navbar-gradient-1':
+            'radial-gradient(50% 50% at 50% 50%, hsla(var(--canary-nav-gradient-1-1)) 0%, hsla(var(--canary-nav-gradient-1-2)) 100%)',
+        'navbar-gradient-2':
+            'radial-gradient(50% 50% at 50% 50%, hsla(var(--canary-nav-gradient-2-1)) 0%, hsla(var(--canary-nav-gradient-2-2)) 44.95%, hsla(var(--canary-nav-gradient-2-3)) 100%)',
+        'navbar-gradient-3':
+            'radial-gradient(50% 50% at 50% 50%, hsla(var(--canary-nav-gradient-3-1)) 0%, hsla(var(--canary-nav-gradient-3-2)) 100%)',
+        'navbar-gradient-4':
+            'radial-gradient(50% 50% at 50% 50%, hsla(var(--canary-nav-gradient-4-1)) 0%, hsla(var(--canary-nav-gradient-4-2)) 100%)',
+        'navbar-item-gradient':
+            'radial-gradient(50% 50% at 50% 50%, hsla(var(--canary-nav-item-gradient-1)) 0%, hsla(var(--canary-nav-item-gradient-2)) 17.63%, hsla(var(--canary-nav-item-gradient-3)) 40.23%, hsla(var(--canary-nav-item-gradient-4)) 61.54%, hsla(var(--canary-nav-item-gradient-5)) 80%, hsla(var(--canary-nav-item-gradient-6)) 100%)'
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
- Restored the pattern and gradients in Navigation, moved the colors to variables
- Converted the glow gradient of the active item in Navigation into variables
- Restored the gradient on the active Tab

![image](https://github.com/user-attachments/assets/3f16682b-cd89-4955-9a81-2839e8fe7023)
![image](https://github.com/user-attachments/assets/b64a3522-b301-40bd-8ad9-1f787af8797a)
