### PR TITLE
chore: set min node version to 18.17.1

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -41,6 +41,9 @@
     "prettier-plugin-astro": "^0.14.1",
     "typescript": "^5.7.3"
   },
+  "engines": {
+    "node": ">=18.17.1"
+  },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,md,mdx}": [
       "astro check",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pre-commit": "pnpm run -r --workspace-concurrency=1 pre-commit"
   },
   "engines": {
-    "node": ">=18.20.4"
+    "node": ">=18.17.1"
   },
   "license": "Apache-2.0",
   "resolutions": {


### PR DESCRIPTION
This PR sets the min Node version 18.17.1.

fixes #691