### PR TITLE
fix: remove file tree from commit details page

### DIFF
--- a/apps/gitness/src/pages-v2/repo/repo-commit-details-diff.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-commit-details-diff.tsx
@@ -26,7 +26,7 @@ import { useCommitDetailsStore } from './stores/commit-details-store.ts'
  * TODO: For now, file-tree is static and contains all files.
  * Needs to filter files for current commit and add opportunity to navigate to diff for each file from file-tree
  */
-export const CommitDiffContainer = () => {
+export const CommitDiffContainer = ({ showSidebar = true }: { showSidebar?: boolean }) => {
   const repoRef = useGetRepoRef()
   const { commitSHA } = useParams<PathParams>()
   const { fullGitRef } = useCodePathDetails()
@@ -99,9 +99,12 @@ export const CommitDiffContainer = () => {
 
   return (
     <>
-      <CommitSidebar useTranslationStore={useTranslationStore} navigateToFile={() => {}} filesList={filesList}>
-        {!!repoDetails?.body?.content?.entries?.length && <Explorer repoDetails={repoDetails?.body} />}
-      </CommitSidebar>
+      {showSidebar && (
+        <CommitSidebar useTranslationStore={useTranslationStore} navigateToFile={() => {}} filesList={filesList}>
+          {!!repoDetails?.body?.content?.entries?.length && <Explorer repoDetails={repoDetails?.body} />}
+        </CommitSidebar>
+      )}
+
       <CommitDiff useCommitDetailsStore={useCommitDetailsStore} useTranslationStore={useTranslationStore} />
     </>
   )

--- a/apps/gitness/src/pages-v2/repo/repo-commit-details.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-commit-details.tsx
@@ -9,7 +9,7 @@ import { useTranslationStore } from '../../i18n/stores/i18n-store'
 import { PathParams } from '../../RouteDefinitions'
 import { useCommitDetailsStore } from './stores/commit-details-store'
 
-export default function RepoCommitDetailsPage() {
+export default function RepoCommitDetailsPage({ showSidebar = true }: { showSidebar?: boolean }) {
   const repoRef = useGetRepoRef()
   const { commitSHA } = useParams<PathParams>()
   const { setCommitData } = useCommitDetailsStore()
@@ -26,6 +26,10 @@ export default function RepoCommitDetailsPage() {
   }, [commitData, setCommitData])
 
   return (
-    <RepoCommitDetailsView useCommitDetailsStore={useCommitDetailsStore} useTranslationStore={useTranslationStore} />
+    <RepoCommitDetailsView
+      useCommitDetailsStore={useCommitDetailsStore}
+      useTranslationStore={useTranslationStore}
+      showSidebar={showSidebar}
+    />
   )
 }

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -106,7 +106,7 @@ const repoRoutes: CustomRouteObject[] = [
               },
               {
                 path: ':commitSHA',
-                element: <RepoCommitDetailsPage />,
+                element: <RepoCommitDetailsPage showSidebar={false} />,
                 handle: {
                   breadcrumb: ({ commitSHA }: { commitSHA: string }) => (
                     <>
@@ -119,7 +119,7 @@ const repoRoutes: CustomRouteObject[] = [
                     index: true,
                     element: (
                       <ExplorerPathsProvider>
-                        <CommitDiffContainer />
+                        <CommitDiffContainer showSidebar={false} />
                       </ExplorerPathsProvider>
                     )
                   }

--- a/packages/ui/src/views/repo/repo-commit-details/components/commit-diff.tsx
+++ b/packages/ui/src/views/repo/repo-commit-details/components/commit-diff.tsx
@@ -17,7 +17,7 @@ export const CommitDiff: React.FC<CommitDiffsViewProps> = ({ useCommitDetailsSto
         {t('views:commits.commitDetailsDiffShowing', 'Showing')}{' '}
         <span className="text-foreground-accent">
           {diffStats?.files_changed || 0} {t('views:commits.commitDetailsDiffChangedFiles', 'changed files')}
-        </span>{' '}
+        </span>
         {t('views:commits.commitDetailsDiffWith', 'with')} {diffStats?.additions || 0}{' '}
         {t('views:commits.commitDetailsDiffAdditionsAnd', 'additions and')} {diffStats?.deletions || 0}{' '}
         {t('views:commits.commitDetailsDiffDeletions', 'deletions')}

--- a/packages/ui/src/views/repo/repo-commit-details/repo-commit-details-view.tsx
+++ b/packages/ui/src/views/repo/repo-commit-details/repo-commit-details-view.tsx
@@ -9,11 +9,13 @@ import { timeAgo } from '@utils/utils'
 export interface RepoCommitDetailsViewProps {
   useCommitDetailsStore: () => ICommitDetailsStore
   useTranslationStore: () => TranslationStore
+  showSidebar?: boolean
 }
 
 export const RepoCommitDetailsView: FC<RepoCommitDetailsViewProps> = ({
   useCommitDetailsStore,
-  useTranslationStore
+  useTranslationStore,
+  showSidebar = true
 }) => {
   const { t } = useTranslationStore()
   const { commitData, isVerified } = useCommitDetailsStore()
@@ -63,10 +65,13 @@ export const RepoCommitDetailsView: FC<RepoCommitDetailsViewProps> = ({
             <CommitCopyActions sha={commitData?.sha || ''} />
           </div>
         </div>
+        {!showSidebar && <Outlet />}
       </SandboxLayout.Content>
-      <SandboxLayout.Content className="mt-5 grid grid-cols-[auto_1fr] border-t border-borders-4 py-0 pl-0 pr-5">
-        <Outlet />
-      </SandboxLayout.Content>
+      {showSidebar && (
+        <SandboxLayout.Content className="mt-5 grid grid-cols-[auto_1fr] border-t border-borders-4 py-0 pl-0 pr-5">
+          <Outlet />
+        </SandboxLayout.Content>
+      )}
     </SandboxLayout.Main>
   )
 }


### PR DESCRIPTION
- Removes `file-tree` from commit details in `gitness`. 
- Still visible in the `design-system`. 

<img width="1728" alt="Screenshot 2025-01-17 at 4 13 46 PM" src="https://github.com/user-attachments/assets/04c4aeb0-2bcf-4185-98a4-3c25e4014b33" />
<img width="1728" alt="Screenshot 2025-01-17 at 4 13 55 PM" src="https://github.com/user-attachments/assets/52939289-14b3-45ad-8aa2-05febd541df3" />
