### PR TITLE
fix: Remove exploratory code

### DIFF
--- a/apps/portal/src/content/docs/components/accordion.mdx
+++ b/apps/portal/src/content/docs/components/accordion.mdx
@@ -13,7 +13,7 @@ import { DocsPage } from "@/components/docs-page";
 <h5>Single non-collapsible</h5>
 <Accordion.Root type="single" defaultValue="item1">
   <Accordion.Item value="item1">
-    <Accordion.Trigger chevronClassName="size-5" className="text-foreground">Item 1</Accordion.Trigger>
+    <Accordion.Trigger className="text-foreground">Item 1</Accordion.Trigger>
     <Accordion.Content>
       <p>This is the content of item 1</p>
     </Accordion.Content>


### PR DESCRIPTION
This PR removes exploratory code that was added in the initial version of the `Accordion` docs.

refs #694