### PR TITLE
fix: Ensure that UI lib styles have precedence in portal app

### DIFF
--- a/apps/portal/astro.config.ts
+++ b/apps/portal/astro.config.ts
@@ -37,8 +37,8 @@ export default defineConfig({
       ],
       customCss: [
         "./src/tailwind.css",
-        "@harnessio/ui/styles.css",
         "./src/styles.css",
+        "@harnessio/ui/styles.css",
       ],
       components: {
         PageFrame: "./src/components/layout/PageFrame.astro",

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 body {
   @apply text-foreground-3 text-base overscroll-none;
 }


### PR DESCRIPTION
The PR removes unneeded inclusions of tailwind utilities and moves `@harnessio/ui/styles.css` to have precedence over portal app styles.

fixes #740