### PR TITLE
chore: ui lib v0.0.1-alpha.0

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harnessio/ui",
   "description": "Harness Canary UI component library",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
This PR bumps the version of the UI library to `0.0.1-alpha.0`

fixes #744