### PR TITLE
fix: styles for the Create Rule page

### DIFF
--- a/packages/ui/src/components/button-with-options.tsx
+++ b/packages/ui/src/components/button-with-options.tsx
@@ -47,6 +47,7 @@ export interface ButtonWithOptionsProps<T extends string> {
   options: ButtonWithOptionsOptionType<T>[]
   handleOptionChange: (val: T) => void
   className?: string
+  buttonClassName?: string
   size?: ButtonWithOptionsSizes
   theme?: ButtonWithOptionsTheme
   disabled?: boolean
@@ -67,6 +68,7 @@ export const ButtonWithOptions = <T extends string>({
   options,
   handleOptionChange,
   className,
+  buttonClassName,
   size = 'default',
   theme = 'primary',
   disabled = false,
@@ -76,7 +78,12 @@ export const ButtonWithOptions = <T extends string>({
   return (
     <div className={cn('flex', className)}>
       <Button
-        className={cn('rounded-r-none', theme !== 'primary' && 'border-y border-l', buttonPaddings[size])}
+        className={cn(
+          'rounded-r-none',
+          theme !== 'primary' && 'border-y border-l',
+          buttonPaddings[size],
+          buttonClassName
+        )}
         theme={theme}
         size={size}
         onClick={handleButtonClick}
@@ -90,7 +97,7 @@ export const ButtonWithOptions = <T extends string>({
         <DropdownMenuTrigger
           className={cn(
             buttonVariants({ theme }),
-            'relative h-[inherit] w-8 p-0 rounded-l-none after:absolute after:inset-y-0 after:left-0 after:my-auto after:h-3.5 after:w-px',
+            'relative h-[inherit] w-8 p-0 flex-shrink-0 rounded-l-none after:absolute after:inset-y-0 after:left-0 after:my-auto after:h-3.5 after:w-px',
             theme !== 'primary' && 'border-y border-r',
             (!!disabled || !!loading) && 'pointer-events-none',
             separatorThemes[theme || 'default']

--- a/packages/ui/src/views/repo/repo-branch-rules/components/repo-branch-rules-fields.tsx
+++ b/packages/ui/src/views/repo/repo-branch-rules/components/repo-branch-rules-fields.tsx
@@ -27,11 +27,12 @@ import { getInitials } from '@utils/stringUtils'
 import { TFunction } from 'i18next'
 
 export const BranchSettingsRuleToggleField: FC<FieldProps> = ({ register, watch, setValue, t }) => (
-  <StackedList.Root withoutBorder borderBackground>
+  <StackedList.Root className="overflow-hidden" borderBackground>
     <StackedList.Item
-      className="!rounded px-5 py-3.5"
+      className="!rounded px-5 py-3"
       disableHover
       isHeader
+      isLast
       actions={
         <Switch
           {...register!('state')}
@@ -107,7 +108,7 @@ export const BranchSettingsRuleTargetPatternsField: FC<FieldProps> = ({ setValue
         <Label htmlFor="target-patterns" className="mb-2.5" color="secondary">
           {t('views:repos.targetPatterns', 'Target patterns')}
         </Label>
-        <div className="flex items-start gap-x-3.5">
+        <div className="grid grid-cols-[1fr_112px] items-start gap-x-3.5">
           <Input
             id="pattern"
             size="md"
@@ -120,6 +121,7 @@ export const BranchSettingsRuleTargetPatternsField: FC<FieldProps> = ({ setValue
             error={errors?.pattern?.message?.toString()}
           />
           <ButtonWithOptions<PatternsButtonType>
+            buttonClassName="px-0 w-full"
             id="patterns-type"
             size="md"
             handleButtonClick={handleAddPattern}
@@ -307,7 +309,9 @@ export const BranchSettingsRuleListField: FC<{
 
   return (
     <ControlGroup className="max-w-[476px]">
-      <Label className="mb-6">{t('views:repos.rulesTitle', 'Rules: select all that apply')}</Label>
+      <Label className="mb-6" color="secondary">
+        {t('views:repos.rulesTitle', 'Rules: select all that apply')}
+      </Label>
       <Fieldset className="gap-y-5">
         {branchRules.map((rule, index) => {
           const isChecked = rules[index]?.checked ?? false

--- a/packages/ui/src/views/repo/repo-branch-rules/repo-branch-settings-rules-page.tsx
+++ b/packages/ui/src/views/repo/repo-branch-rules/repo-branch-settings-rules-page.tsx
@@ -116,42 +116,43 @@ export const RepoBranchSettingsRulesPage: FC<RepoBranchSettingsRulesPageProps> =
         {presetRuleData ? t('views:repos.updateRule', 'Update rule') : t('views:repos.CreateRule', 'Create a rule')}
       </h1>
 
-      <FormWrapper onSubmit={handleSubmit(onSubmit)}>
+      <FormWrapper className="gap-y-7" onSubmit={handleSubmit(onSubmit)}>
         <BranchSettingsRuleToggleField register={register} setValue={setValue} watch={watch} t={t} />
 
         <BranchSettingsRuleNameField register={register} errors={errors} disabled={!!presetRuleData} t={t} />
 
         <BranchSettingsRuleDescriptionField register={register} errors={errors} t={t} />
 
-        <BranchSettingsRuleTargetPatternsField
-          watch={watch}
-          setValue={setValue}
-          register={register}
-          errors={errors}
-          t={t}
-        />
+        <div className="flex flex-col gap-y-11">
+          <BranchSettingsRuleTargetPatternsField
+            watch={watch}
+            setValue={setValue}
+            register={register}
+            errors={errors}
+            t={t}
+          />
 
-        <BranchSettingsRuleBypassListField
-          register={register}
-          errors={errors}
-          setValue={setValue}
-          watch={watch}
-          bypassOptions={principals}
-          t={t}
-          setPrincipalsSearchQuery={setPrincipalsSearchQuery}
-          principalsSearchQuery={principalsSearchQuery}
-        />
+          <BranchSettingsRuleBypassListField
+            register={register}
+            errors={errors}
+            setValue={setValue}
+            watch={watch}
+            bypassOptions={principals}
+            t={t}
+            setPrincipalsSearchQuery={setPrincipalsSearchQuery}
+            principalsSearchQuery={principalsSearchQuery}
+          />
 
-        <BranchSettingsRuleListField
-          rules={rules}
-          recentStatusChecks={recentStatusChecks}
-          handleCheckboxChange={handleCheckboxChange}
-          handleSubmenuChange={handleSubmenuChange}
-          handleSelectChangeForRule={handleSelectChangeForRule}
-          handleInputChange={handleInputChange}
-          t={t}
-        />
-
+          <BranchSettingsRuleListField
+            rules={rules}
+            recentStatusChecks={recentStatusChecks}
+            handleCheckboxChange={handleCheckboxChange}
+            handleSubmenuChange={handleSubmenuChange}
+            handleSelectChangeForRule={handleSelectChangeForRule}
+            handleInputChange={handleInputChange}
+            t={t}
+          />
+        </div>
         <Fieldset className="mt-5">
           <ControlGroup>
             <ButtonGroup>

--- a/packages/ui/src/views/repo/repo-branch-rules/repo-branch-settings-rules-page.tsx
+++ b/packages/ui/src/views/repo/repo-branch-rules/repo-branch-settings-rules-page.tsx
@@ -116,7 +116,7 @@ export const RepoBranchSettingsRulesPage: FC<RepoBranchSettingsRulesPageProps> =
         {presetRuleData ? t('views:repos.updateRule', 'Update rule') : t('views:repos.CreateRule', 'Create a rule')}
       </h1>
 
-      <FormWrapper className="gap-y-7" onSubmit={handleSubmit(onSubmit)}>
+      <FormWrapper onSubmit={handleSubmit(onSubmit)}>
         <BranchSettingsRuleToggleField register={register} setValue={setValue} watch={watch} t={t} />
 
         <BranchSettingsRuleNameField register={register} errors={errors} disabled={!!presetRuleData} t={t} />


### PR DESCRIPTION
**Description:**
This pull request make minor adjustments to the styles for the `Create Rule` page after review by the design team

**Before:**
<img width="618" alt="image" src="https://github.com/user-attachments/assets/7a5921dc-c45c-4f11-bd20-394d15683e6d" />

**After**
<img width="629" alt="image" src="https://github.com/user-attachments/assets/4cebd661-5e0f-4d82-8b27-f1ab54bb6282" />

**Before:**

https://github.com/user-attachments/assets/55d886dd-e515-434f-a11d-9b47c472a549



**After:**

https://github.com/user-attachments/assets/c5a48e42-0312-4289-8811-27388dd113dc

**Before:**
<img width="663" alt="image" src="https://github.com/user-attachments/assets/a7c69675-52ac-4e24-b85b-9888282bf11e" />

**After:**
<img width="633" alt="image" src="https://github.com/user-attachments/assets/dbf1ada9-2bee-4b4b-ae43-33ec18754fce" />

**Before:**
<img width="634" alt="image" src="https://github.com/user-attachments/assets/51beb8ae-5d28-4ed7-b471-af6009f6ad78" />

**After:**
<img width="649" alt="image" src="https://github.com/user-attachments/assets/83d18423-205d-4745-9d43-e13f90d2d6c5" />
