### PR TITLE
fix: Add "asLink" prop to allow rendering non-link breadcrumbs

### DIFF
--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -7,7 +7,6 @@ import { NuqsAdapter } from 'nuqs/adapters/react-router'
 import { CodeServiceAPIClient } from '@harnessio/code-service-client'
 import { TooltipProvider } from '@harnessio/ui/components'
 
-import { AppProvider } from './framework/context/AppContext'
 import { ExitConfirmProvider } from './framework/context/ExitConfirmContext'
 import { NavigationProvider } from './framework/context/NavigationContext'
 import { ThemeProvider } from './framework/context/ThemeContext'
@@ -34,22 +33,20 @@ export default function AppV1() {
   const router = createBrowserRouter(routes)
 
   return (
-    <AppProvider>
-      <I18nextProvider i18n={i18n}>
-        <ThemeProvider defaultTheme="dark-std-std">
-          <QueryClientProvider client={queryClient}>
-            <TooltipProvider>
-              <ExitConfirmProvider>
-                <NuqsAdapter>
-                  <NavigationProvider routes={routes}>
-                    <RouterProvider router={router} />
-                  </NavigationProvider>
-                </NuqsAdapter>
-              </ExitConfirmProvider>
-            </TooltipProvider>
-          </QueryClientProvider>
-        </ThemeProvider>
-      </I18nextProvider>
-    </AppProvider>
+    <I18nextProvider i18n={i18n}>
+      <ThemeProvider defaultTheme="dark-std-std">
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <ExitConfirmProvider>
+              <NuqsAdapter>
+                <NavigationProvider routes={routes}>
+                  <RouterProvider router={router} />
+                </NavigationProvider>
+              </NuqsAdapter>
+            </ExitConfirmProvider>
+          </TooltipProvider>
+        </QueryClientProvider>
+      </ThemeProvider>
+    </I18nextProvider>
   )
 }

--- a/apps/gitness/src/components-v2/app-shell.tsx
+++ b/apps/gitness/src/components-v2/app-shell.tsx
@@ -15,7 +15,7 @@ import { SandboxLayout } from '@harnessio/ui/views'
 import { useNav } from '../components/stores/recent-pinned-nav-links.store'
 import { getNavbarMenuData } from '../data/navbar-menu-data'
 import { getPinnedMenuItemsData } from '../data/pinned-menu-items-data'
-import { useAppContext } from '../framework/context/AppContext'
+import { AppProvider, useAppContext } from '../framework/context/AppContext'
 import { useRoutes } from '../framework/context/NavigationContext'
 import { useThemeStore } from '../framework/context/ThemeContext'
 import { useLocationChange } from '../framework/hooks/useLocationChange'
@@ -171,40 +171,42 @@ export const AppShell = () => {
   )
 
   return (
-    <SandboxLayout.Root>
-      <SandboxLayout.LeftPanel>
-        <Navbar
-          showMoreMenu={showMoreMenu}
-          showSettingMenu={showSettingMenu}
-          handleMoreMenu={handleMoreMenu}
-          handleSettingsMenu={handleSettingsMenu}
-          currentUser={currentUser}
-          handleCustomNav={handleCustomNav}
-          handleLogOut={handleLogOut}
-          recentMenuItems={recentMenu}
-          pinnedMenuItems={pinnedMenu}
-          handleChangePinnedMenuItem={handleChangePinnedMenuItem}
-          handleRemoveRecentMenuItem={handleRemoveRecentMenuItem}
-          useThemeStore={useThemeStore}
-          useTranslationStore={useTranslationStore}
+    <AppProvider>
+      <SandboxLayout.Root>
+        <SandboxLayout.LeftPanel>
+          <Navbar
+            showMoreMenu={showMoreMenu}
+            showSettingMenu={showSettingMenu}
+            handleMoreMenu={handleMoreMenu}
+            handleSettingsMenu={handleSettingsMenu}
+            currentUser={currentUser}
+            handleCustomNav={handleCustomNav}
+            handleLogOut={handleLogOut}
+            recentMenuItems={recentMenu}
+            pinnedMenuItems={pinnedMenu}
+            handleChangePinnedMenuItem={handleChangePinnedMenuItem}
+            handleRemoveRecentMenuItem={handleRemoveRecentMenuItem}
+            useThemeStore={useThemeStore}
+            useTranslationStore={useTranslationStore}
+          />
+        </SandboxLayout.LeftPanel>
+
+        <BreadcrumbsAndOutlet />
+
+        <MoreSubmenu showMoreMenu={showMoreMenu} handleMoreMenu={handleMoreMenu} items={moreMenu} />
+        <SettingsMenu showSettingMenu={showSettingMenu} handleSettingsMenu={handleSettingsMenu} items={settingsMenu} />
+        <ManageNavigation
+          pinnedItems={pinnedMenu}
+          recentItems={recentMenu}
+          navbarMenuData={getNavbarMenuData({ t, routes, spaceId: spaceIdPathParam, repoId })}
+          showManageNavigation={showCustomNav}
+          isSubmitting={false}
+          submitted={false}
+          onSave={handleSave}
+          onClose={handleCustomNav}
         />
-      </SandboxLayout.LeftPanel>
-
-      <BreadcrumbsAndOutlet />
-
-      <MoreSubmenu showMoreMenu={showMoreMenu} handleMoreMenu={handleMoreMenu} items={moreMenu} />
-      <SettingsMenu showSettingMenu={showSettingMenu} handleSettingsMenu={handleSettingsMenu} items={settingsMenu} />
-      <ManageNavigation
-        pinnedItems={pinnedMenu}
-        recentItems={recentMenu}
-        navbarMenuData={getNavbarMenuData({ t, routes, spaceId: spaceIdPathParam, repoId })}
-        showManageNavigation={showCustomNav}
-        isSubmitting={false}
-        submitted={false}
-        onSave={handleSave}
-        onClose={handleCustomNav}
-      />
-    </SandboxLayout.Root>
+      </SandboxLayout.Root>
+    </AppProvider>
   )
 }
 

--- a/apps/gitness/src/components-v2/app-shell.tsx
+++ b/apps/gitness/src/components-v2/app-shell.tsx
@@ -15,7 +15,7 @@ import { SandboxLayout } from '@harnessio/ui/views'
 import { useNav } from '../components/stores/recent-pinned-nav-links.store'
 import { getNavbarMenuData } from '../data/navbar-menu-data'
 import { getPinnedMenuItemsData } from '../data/pinned-menu-items-data'
-import { AppProvider, useAppContext } from '../framework/context/AppContext'
+import { useAppContext } from '../framework/context/AppContext'
 import { useRoutes } from '../framework/context/NavigationContext'
 import { useThemeStore } from '../framework/context/ThemeContext'
 import { useLocationChange } from '../framework/hooks/useLocationChange'
@@ -171,42 +171,40 @@ export const AppShell = () => {
   )
 
   return (
-    <AppProvider>
-      <SandboxLayout.Root>
-        <SandboxLayout.LeftPanel>
-          <Navbar
-            showMoreMenu={showMoreMenu}
-            showSettingMenu={showSettingMenu}
-            handleMoreMenu={handleMoreMenu}
-            handleSettingsMenu={handleSettingsMenu}
-            currentUser={currentUser}
-            handleCustomNav={handleCustomNav}
-            handleLogOut={handleLogOut}
-            recentMenuItems={recentMenu}
-            pinnedMenuItems={pinnedMenu}
-            handleChangePinnedMenuItem={handleChangePinnedMenuItem}
-            handleRemoveRecentMenuItem={handleRemoveRecentMenuItem}
-            useThemeStore={useThemeStore}
-            useTranslationStore={useTranslationStore}
-          />
-        </SandboxLayout.LeftPanel>
-
-        <BreadcrumbsAndOutlet />
-
-        <MoreSubmenu showMoreMenu={showMoreMenu} handleMoreMenu={handleMoreMenu} items={moreMenu} />
-        <SettingsMenu showSettingMenu={showSettingMenu} handleSettingsMenu={handleSettingsMenu} items={settingsMenu} />
-        <ManageNavigation
-          pinnedItems={pinnedMenu}
-          recentItems={recentMenu}
-          navbarMenuData={getNavbarMenuData({ t, routes, spaceId: spaceIdPathParam, repoId })}
-          showManageNavigation={showCustomNav}
-          isSubmitting={false}
-          submitted={false}
-          onSave={handleSave}
-          onClose={handleCustomNav}
+    <SandboxLayout.Root>
+      <SandboxLayout.LeftPanel>
+        <Navbar
+          showMoreMenu={showMoreMenu}
+          showSettingMenu={showSettingMenu}
+          handleMoreMenu={handleMoreMenu}
+          handleSettingsMenu={handleSettingsMenu}
+          currentUser={currentUser}
+          handleCustomNav={handleCustomNav}
+          handleLogOut={handleLogOut}
+          recentMenuItems={recentMenu}
+          pinnedMenuItems={pinnedMenu}
+          handleChangePinnedMenuItem={handleChangePinnedMenuItem}
+          handleRemoveRecentMenuItem={handleRemoveRecentMenuItem}
+          useThemeStore={useThemeStore}
+          useTranslationStore={useTranslationStore}
         />
-      </SandboxLayout.Root>
-    </AppProvider>
+      </SandboxLayout.LeftPanel>
+
+      <BreadcrumbsAndOutlet />
+
+      <MoreSubmenu showMoreMenu={showMoreMenu} handleMoreMenu={handleMoreMenu} items={moreMenu} />
+      <SettingsMenu showSettingMenu={showSettingMenu} handleSettingsMenu={handleSettingsMenu} items={settingsMenu} />
+      <ManageNavigation
+        pinnedItems={pinnedMenu}
+        recentItems={recentMenu}
+        navbarMenuData={getNavbarMenuData({ t, routes, spaceId: spaceIdPathParam, repoId })}
+        showManageNavigation={showCustomNav}
+        isSubmitting={false}
+        submitted={false}
+        onSave={handleSave}
+        onClose={handleCustomNav}
+      />
+    </SandboxLayout.Root>
   )
 }
 

--- a/apps/gitness/src/components-v2/breadcrumbs/breadcrumbs.tsx
+++ b/apps/gitness/src/components-v2/breadcrumbs/breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { useMatches } from 'react-router-dom'
+import { Link, useMatches } from 'react-router-dom'
 
 import { Breadcrumb, Topbar } from '@harnessio/ui/components'
 
@@ -13,19 +13,22 @@ function Breadcrumbs() {
         <Breadcrumb.Root className="select-none">
           <Breadcrumb.List>
             {matches.map((match, index) => {
-              const { breadcrumb } = (match.handle || {}) as CustomHandle
+              const { breadcrumb, asLink = true } = (match.handle || {}) as CustomHandle
+              if (!breadcrumb) return null
+
               const isFirst = index === 1
               const isLast = index === matches.length - 1
-
-              if (!breadcrumb) return null
+              const breadcrumbContent = breadcrumb(match.params)
 
               return (
                 <Breadcrumb.Item key={match.pathname}>
                   {!isFirst ? <Breadcrumb.Separator /> : null}
-                  {isLast ? (
-                    <Breadcrumb.Page>{breadcrumb(match.params)}</Breadcrumb.Page>
+                  {isLast || !asLink ? (
+                    <Breadcrumb.Page>{breadcrumbContent}</Breadcrumb.Page>
                   ) : (
-                    <Breadcrumb.Link href={match.pathname}>{breadcrumb(match.params)}</Breadcrumb.Link>
+                    <Breadcrumb.Link asChild>
+                      <Link to={match.pathname}>{breadcrumbContent}</Link>
+                    </Breadcrumb.Link>
                   )}
                 </Breadcrumb.Item>
               )

--- a/apps/gitness/src/components-v2/breadcrumbs/project-dropdown.tsx
+++ b/apps/gitness/src/components-v2/breadcrumbs/project-dropdown.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
+import { membershipSpaces, TypesSpace } from '@harnessio/code-service-client'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -17,7 +19,24 @@ function ProjectDropdown(): JSX.Element {
   const routes = useRoutes()
   const { spaceId } = useParams<PathParams>()
   const navigate = useNavigate()
-  const { spaces } = useAppContext()
+  const { spaces, setSpaces } = useAppContext()
+
+  useEffect(() => {
+    if (!spaces?.length) {
+      membershipSpaces({
+        queryParams: { page: 1, limit: 100, sort: 'identifier', order: 'asc' }
+      })
+        .then(({ body: memberships }) => {
+          const spaceList = memberships.filter(item => item?.space).map(item => item.space as TypesSpace)
+          setSpaces(spaceList)
+        })
+        .catch(() => {
+          // Optionally handle error or show toast
+          navigate(routes.toSignIn())
+        })
+    }
+  }, [spaces, membershipSpaces, navigate])
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className="flex items-center gap-x-1.5">

--- a/apps/gitness/src/components-v2/breadcrumbs/project-dropdown.tsx
+++ b/apps/gitness/src/components-v2/breadcrumbs/project-dropdown.tsx
@@ -1,7 +1,5 @@
-import { useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
-import { membershipSpaces, TypesSpace } from '@harnessio/code-service-client'
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/apps/gitness/src/components-v2/breadcrumbs/project-dropdown.tsx
+++ b/apps/gitness/src/components-v2/breadcrumbs/project-dropdown.tsx
@@ -19,27 +19,11 @@ function ProjectDropdown(): JSX.Element {
   const routes = useRoutes()
   const { spaceId } = useParams<PathParams>()
   const navigate = useNavigate()
-  const { spaces, setSpaces } = useAppContext()
-
-  useEffect(() => {
-    if (!spaces?.length) {
-      membershipSpaces({
-        queryParams: { page: 1, limit: 100, sort: 'identifier', order: 'asc' }
-      })
-        .then(({ body: memberships }) => {
-          const spaceList = memberships.filter(item => item?.space).map(item => item.space as TypesSpace)
-          setSpaces(spaceList)
-        })
-        .catch(() => {
-          // Optionally handle error or show toast
-          navigate(routes.toSignIn())
-        })
-    }
-  }, [spaces, membershipSpaces, navigate])
+  const { spaces } = useAppContext()
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="flex items-center gap-x-1.5">
+      <DropdownMenuTrigger className="flex items-center gap-x-1.5" disabled={!spaces.length}>
         {spaceId ?? 'Select project'}
         <Icon className="chevron-down text-icons-4" name="chevron-fill-down" size={6} />
       </DropdownMenuTrigger>

--- a/apps/gitness/src/framework/context/AppContext.tsx
+++ b/apps/gitness/src/framework/context/AppContext.tsx
@@ -27,18 +27,16 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   const [currentUser, setCurrentUser] = useLocalStorage<TypesUser>('currentUser', {})
 
   useEffect(() => {
-    if (!spaces?.length) {
-      membershipSpaces({
-        queryParams: { page: 1, limit: 100, sort: 'identifier', order: 'asc' }
+    membershipSpaces({
+      queryParams: { page: 1, limit: 100, sort: 'identifier', order: 'asc' }
+    })
+      .then(({ body: memberships }) => {
+        const spaceList = memberships.filter(item => item?.space).map(item => item.space as TypesSpace)
+        setSpaces(spaceList)
       })
-        .then(({ body: memberships }) => {
-          const spaceList = memberships.filter(item => item?.space).map(item => item.space as TypesSpace)
-          setSpaces(spaceList)
-        })
-        .catch(() => {
-          // Optionally handle error or show toast
-        })
-    }
+      .catch(() => {
+        // Optionally handle error or show toast
+      })
   }, [])
 
   const addSpaces = (newSpaces: TypesSpace[]): void => {

--- a/apps/gitness/src/framework/context/AppContext.tsx
+++ b/apps/gitness/src/framework/context/AppContext.tsx
@@ -1,8 +1,8 @@
-import { createContext, ReactNode, useContext, useState } from 'react'
+import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
 
 import { noop } from 'lodash-es'
 
-import { TypesSpace, TypesUser } from '@harnessio/code-service-client'
+import { membershipSpaces, TypesSpace, TypesUser } from '@harnessio/code-service-client'
 
 import useLocalStorage from '../hooks/useLocalStorage'
 
@@ -25,6 +25,21 @@ const AppContext = createContext<AppContextType>({
 export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [spaces, setSpaces] = useState<TypesSpace[]>([])
   const [currentUser, setCurrentUser] = useLocalStorage<TypesUser>('currentUser', {})
+
+  useEffect(() => {
+    if (!spaces?.length) {
+      membershipSpaces({
+        queryParams: { page: 1, limit: 100, sort: 'identifier', order: 'asc' }
+      })
+        .then(({ body: memberships }) => {
+          const spaceList = memberships.filter(item => item?.space).map(item => item.space as TypesSpace)
+          setSpaces(spaceList)
+        })
+        .catch(() => {
+          // Optionally handle error or show toast
+        })
+    }
+  }, [])
 
   const addSpaces = (newSpaces: TypesSpace[]): void => {
     setSpaces([...spaces, ...newSpaces])

--- a/apps/gitness/src/framework/routing/types.ts
+++ b/apps/gitness/src/framework/routing/types.ts
@@ -83,7 +83,19 @@ export type RouteFunctionMap = Record<keyof typeof RouteConstants, (params?: Par
 
 // Custom handle with the breadcrumb property
 export interface CustomHandle {
+  /**
+   * Defines the breadcrumb text or label using route parameters.
+   */
   breadcrumb?: (params: Params<string>) => string
+
+  /**
+   * Renders the breadcrumb as a custom React component instead of a link.
+   */
+  asLink?: boolean
+
+  /**
+   * Associated route name for the breadcrumb.
+   */
   routeName?: string
 }
 

--- a/apps/gitness/src/pages-v2/landing-page-container.tsx
+++ b/apps/gitness/src/pages-v2/landing-page-container.tsx
@@ -1,33 +1,10 @@
-import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
-
-import { membershipSpaces, TypesSpace } from '@harnessio/code-service-client'
 import { LandingPageView } from '@harnessio/ui/views'
 
 import { useAppContext } from '../framework/context/AppContext'
-import { useRoutes } from '../framework/context/NavigationContext'
 import { useTranslationStore } from '../i18n/stores/i18n-store'
 
 export const LandingPage = () => {
-  const routes = useRoutes()
-  const navigate = useNavigate()
-  const { spaces, setSpaces } = useAppContext()
-
-  useEffect(() => {
-    if (spaces.length === 0) {
-      membershipSpaces({
-        queryParams: { page: 1, limit: 100, sort: 'identifier', order: 'asc' }
-      })
-        .then(({ body: memberships }) => {
-          const spaceList = memberships.filter(item => item?.space).map(item => item.space as TypesSpace)
-          setSpaces(spaceList)
-        })
-        .catch(_e => {
-          // Ignore/toast error
-          navigate(routes.toSignIn())
-        })
-    }
-  }, [])
+  const { spaces } = useAppContext()
 
   return <LandingPageView spaces={spaces} useTranslationStore={useTranslationStore} />
 }

--- a/apps/gitness/src/pages-v2/signin.tsx
+++ b/apps/gitness/src/pages-v2/signin.tsx
@@ -1,16 +1,14 @@
 import { FC } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { getUser, useOnLoginMutation } from '@harnessio/code-service-client'
+import { useOnLoginMutation } from '@harnessio/code-service-client'
 import { SignInData, SignInPage } from '@harnessio/ui/views'
 
-import { useAppContext } from '../framework/context/AppContext'
 import { useRoutes } from '../framework/context/NavigationContext'
 
 export const SignIn: FC = () => {
   const routes = useRoutes()
   const navigate = useNavigate()
-  const { setCurrentUser } = useAppContext()
   const {
     mutate: login,
     isLoading,
@@ -18,16 +16,7 @@ export const SignIn: FC = () => {
   } = useOnLoginMutation(
     { queryParams: { include_cookie: true } },
     {
-      onSuccess: () => {
-        getUser({})
-          .then(response => {
-            setCurrentUser(response.body)
-          })
-          .catch(_e => {
-            // Ignore/toast error
-          })
-        navigate(routes.toHome()) // Redirect to Home page
-      }
+      onSuccess: () => navigate(routes.toHome()) // Redirect to Home page
     }
   )
 

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -6,6 +6,7 @@ import { EmptyPage, RepoSettingsLayout, SandboxLayout } from '@harnessio/ui/view
 
 import { AppShell, AppShellMFE } from './components-v2/app-shell'
 import { ProjectDropdown } from './components-v2/breadcrumbs/project-dropdown'
+import { AppProvider } from './framework/context/AppContext'
 import { ExplorerPathsProvider } from './framework/context/ExplorerPathsContext'
 import { CustomRouteObject, RouteConstants } from './framework/routing/types'
 import { useTranslationStore } from './i18n/stores/i18n-store'
@@ -408,7 +409,11 @@ const repoRoutes: CustomRouteObject[] = [
 export const routes: CustomRouteObject[] = [
   {
     path: '/',
-    element: <AppShell />,
+    element: (
+      <AppProvider>
+        <AppShell />
+      </AppProvider>
+    ),
     handle: { routeName: 'toHome' },
     children: [
       {

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -705,7 +705,8 @@ export const routes: CustomRouteObject[] = [
       {
         path: ':spaceId',
         handle: {
-          breadcrumb: () => <ProjectDropdown />
+          breadcrumb: () => <ProjectDropdown />,
+          asLink: false
         },
         children: repoRoutes
       },


### PR DESCRIPTION
- This PR adds support for `asLink` prop that handles rendering of non-link elements in Breadcrumbs, for e.g. Project Selector.
- Also fixes the flow where list of spaces if fetched if not available in App context while rendering the Project selector. Additionally, also removes duplicate api calls from Landing page.
- `<AppProvider /` now wraps around `<AppShell />` instead, since few routes outside of the App shell, such as `/signin` etc., do not need access to App context.