### PR TITLE
feat: Restore open/close animation to Dialog component

### DIFF
--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -53,7 +53,7 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
         <DialogPrimitive.Content
           ref={ref}
           className={cn(
-            'bg-background-1 shadow-1 fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col overflow-hidden rounded-10 border duration-200',
+            'bg-background-1 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] shadow-1 fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col overflow-hidden rounded-10 border duration-200',
             className
           )}
           {...props}


### PR DESCRIPTION
This PR restores the open/close animation to the `Dialog` component.

|Before|After|
|------|------|
|![Before](https://github.com/user-attachments/assets/d544ec84-9947-4d51-a9a2-bd00ee20c643)|![After](https://github.com/user-attachments/assets/06d40743-cc56-41ff-a7b6-be7d8f182af3)|

fixed #779