### PR TITLE
feat: add preview pages

### DIFF
--- a/apps/design-system/src/pages/view-preview/root-view-wrapper-store.tsx
+++ b/apps/design-system/src/pages/view-preview/root-view-wrapper-store.tsx
@@ -1,0 +1,344 @@
+import { MenuGroupType, MenuGroupTypes } from '@harnessio/ui/components'
+
+export const useRootViewWrapperStore = () => {
+  const moreMenu = [
+    {
+      groupId: 0,
+      title: 'Devops',
+      type: MenuGroupTypes.GENERAL,
+      items: [
+        {
+          id: 0,
+          iconName: 'repositories-gradient',
+          title: 'Repositories',
+          description: 'Integrated & familiar git experience.',
+          to: '/iatopilskii/repos'
+        },
+        {
+          id: 1,
+          iconName: 'pipelines-gradient',
+          title: 'Pipelines',
+          description: 'Up to 4X faster than other solutions.',
+          to: '/pipelines'
+        },
+        {
+          id: 2,
+          iconName: 'execution-gradient',
+          title: 'Executions',
+          description: 'Optimize feature rollout velocity.',
+          to: '/:spaceId/repos/:repoId/pipelines/:pipelineId/executions'
+        },
+        {
+          id: 3,
+          iconName: 'database-gradient',
+          title: 'Databases',
+          description: 'Manage all your infrastructure.',
+          to: '/databases'
+        },
+        {
+          id: 4,
+          iconName: 'artifacts-gradient',
+          title: 'Artifacts',
+          description: 'Validate service resilience.',
+          to: '/artifacts'
+        },
+        {
+          id: 5,
+          iconName: 'infrastructure-gradient',
+          title: 'Infrastructure',
+          description: 'Manage all your infrastructure.',
+          to: '/infrastructure-as-code'
+        },
+        {
+          id: 6,
+          iconName: 'flag-gradient',
+          title: 'Feature Flags',
+          description: 'Optimize feature rollout velocity.',
+          to: '/feature-flags'
+        }
+      ]
+    },
+    {
+      groupId: 1,
+      title: 'Devex',
+      type: MenuGroupTypes.GENERAL,
+      items: [
+        {
+          id: 7,
+          iconName: 'dev-portal-gradient',
+          title: 'Developer Portal',
+          description: 'Built for developers, onboard in minutes.',
+          to: '/developer/portal'
+        },
+        {
+          id: 8,
+          iconName: 'dev-envs-gradient',
+          title: 'Developer Environments',
+          description: 'Integrated & familiar git experience.',
+          to: '/developer/environments'
+        },
+        {
+          id: 9,
+          iconName: 'dev-insights-gradient',
+          title: 'Developer Insights',
+          description: 'Actionable insights on SDLC.',
+          to: '/developer/insights'
+        }
+      ]
+    },
+    {
+      groupId: 2,
+      title: 'Secops',
+      type: MenuGroupTypes.GENERAL,
+      items: [
+        {
+          id: 10,
+          iconName: 'security-tests-gradient',
+          title: 'Security Tests',
+          description: 'Shift left security testing.',
+          to: '/security-tests'
+        },
+        {
+          id: 11,
+          iconName: 'supply-chain-gradient',
+          title: 'Supply Chain',
+          description: 'Artifact integrity and governance.',
+          to: '/supply-chain'
+        }
+      ]
+    },
+    {
+      groupId: 3,
+      title: 'Finops',
+      type: MenuGroupTypes.GENERAL,
+      items: [
+        {
+          id: 12,
+          iconName: 'cloud-costs-gradient',
+          title: 'Cloud Costs',
+          description: 'Intelligent cost management.',
+          to: '/cloud-costs'
+        }
+      ]
+    },
+    {
+      groupId: 4,
+      title: 'Reliability',
+      type: MenuGroupTypes.GENERAL,
+      items: [
+        {
+          id: 13,
+          iconName: 'incidents-gradient',
+          title: 'Incidents',
+          description: 'Shift left security testing.',
+          to: '/incidents'
+        },
+        {
+          id: 14,
+          iconName: 'chaos-engineering-gradient',
+          title: 'Chaos Engineering',
+          description: 'Validate service resilience.',
+          to: '/chaos'
+        }
+      ]
+    },
+    {
+      groupId: 5,
+      title: 'Platform',
+      type: MenuGroupTypes.GENERAL,
+      items: [
+        {
+          id: 15,
+          iconName: 'dashboards-gradient',
+          title: 'Dashboard',
+          description: 'Intelligent cost management.',
+          to: '/cloud-costs'
+        }
+      ]
+    }
+  ] as MenuGroupType[]
+
+  const settingsMenu = [
+    {
+      groupId: 6,
+      title: 'General',
+      type: MenuGroupTypes.SETTINGS,
+      items: [
+        {
+          id: 16,
+          iconName: 'settings-2',
+          title: 'Settings',
+          to: '/iatopilskii/settings/general'
+        },
+        {
+          id: 17,
+          iconName: 'notification',
+          title: 'Notifications',
+          to: '/notifications'
+        }
+      ]
+    },
+    {
+      groupId: 7,
+      title: 'Resources',
+      type: MenuGroupTypes.SETTINGS,
+      items: [
+        {
+          id: 18,
+          iconName: 'wrench',
+          title: 'Services',
+          to: '/service-reliability'
+        },
+        {
+          id: 19,
+          iconName: 'environment',
+          title: 'Environments',
+          to: '/environments'
+        },
+        {
+          id: 20,
+          iconName: 'connectors',
+          title: 'Connectors',
+          to: '/connectors'
+        },
+        {
+          id: 21,
+          iconName: 'hierarchy',
+          title: 'Delegeates',
+          to: '/file-store'
+        },
+        {
+          id: 22,
+          iconName: 'key',
+          title: 'Secrets',
+          to: '/secrets'
+        },
+        {
+          id: 23,
+          iconName: 'file-icon',
+          title: 'File Store',
+          to: '/delegates'
+        },
+        {
+          id: 24,
+          iconName: 'sidebar-icon',
+          title: 'Templates',
+          to: '/templates'
+        },
+        {
+          id: 25,
+          iconName: 'variable',
+          title: 'Variables',
+          to: '/variables'
+        },
+        {
+          id: 26,
+          iconName: 'clock-icon',
+          title: 'SLO Downtime',
+          to: '/slo-downtime'
+        },
+        {
+          id: 27,
+          iconName: 'search',
+          title: 'Discovery',
+          to: '/discovery'
+        },
+        {
+          id: 28,
+          iconName: 'eye',
+          title: 'Monitored Services',
+          to: '/monitored-services'
+        },
+        {
+          id: 29,
+          iconName: 'stack',
+          title: 'Overrides',
+          to: '/overrides'
+        },
+        {
+          id: 30,
+          iconName: 'bookmark-icon',
+          title: 'Certificates',
+          to: '/certificates'
+        },
+        {
+          id: 31,
+          iconName: 'webhook',
+          title: 'Webhooks',
+          to: '/iatopilskii/repos/:repoId/settings/webhooks'
+        }
+      ]
+    },
+    {
+      groupId: 8,
+      title: 'Acces Control',
+      type: MenuGroupTypes.SETTINGS,
+      items: [
+        {
+          id: 32,
+          iconName: 'user',
+          title: 'Users',
+          to: '/admin/default-settings'
+        },
+        {
+          id: 33,
+          iconName: 'users',
+          title: 'User Groups',
+          to: '/admin/user-groups'
+        },
+        {
+          id: 34,
+          iconName: 'account-icon',
+          title: 'Service Accounts',
+          to: '/admin/service-accounts'
+        },
+        {
+          id: 35,
+          iconName: 'folder-icon',
+          title: 'Resource Groups',
+          to: '/admin/resource-groups'
+        },
+        {
+          id: 36,
+          iconName: 'briefcase',
+          title: 'Roles',
+          to: '/admin/roles'
+        }
+      ]
+    },
+    {
+      groupId: 9,
+      title: 'Security and Governance',
+      type: MenuGroupTypes.SETTINGS,
+      items: [
+        {
+          id: 37,
+          iconName: 'shield',
+          title: 'Policies',
+          to: '/policies'
+        },
+        {
+          id: 38,
+          iconName: 'snow',
+          title: 'Freeze Windows',
+          to: '/freeze-windows'
+        }
+      ]
+    },
+    {
+      groupId: 10,
+      title: 'External Tickets',
+      type: MenuGroupTypes.SETTINGS,
+      items: [
+        {
+          id: 39,
+          iconName: 'ticket',
+          title: 'External Tickets',
+          to: '/external-tickets'
+        }
+      ]
+    }
+  ] as MenuGroupType[]
+
+  return { moreMenu, settingsMenu }
+}

--- a/apps/design-system/src/pages/view-preview/root-view-wrapper.tsx
+++ b/apps/design-system/src/pages/view-preview/root-view-wrapper.tsx
@@ -3,14 +3,17 @@ import { Outlet, Route, Routes } from 'react-router-dom'
 
 import { noop, useThemeStore, useTranslationsStore } from '@utils/viewUtils'
 
-import { Breadcrumb, Navbar, NavbarItemType, Topbar } from '@harnessio/ui/components'
+import { Breadcrumb, MoreSubmenu, Navbar, NavbarItemType, SettingsMenu, Topbar } from '@harnessio/ui/components'
 import { SandboxLayout } from '@harnessio/ui/views'
+
+import { useRootViewWrapperStore } from './root-view-wrapper-store'
 
 const RootViewWrapper: FC<PropsWithChildren<{ asChild?: boolean }>> = ({ children, asChild = false }) => {
   const [showMoreMenu, setShowMoreMenu] = useState(false)
   const [showSettingsMenu, setShowSettingsMenu] = useState(false)
   const [pinnedMenu, setPinnedMenu] = useState<NavbarItemType[]>([])
   const [recentMenu] = useState<NavbarItemType[]>([])
+  const { moreMenu, settingsMenu } = useRootViewWrapperStore()
 
   const setPinned = useCallback((item: NavbarItemType, pin: boolean) => {
     setPinnedMenu(current => (pin ? [...current, item] : current.filter(pinnedItem => pinnedItem !== item)))
@@ -18,6 +21,7 @@ const RootViewWrapper: FC<PropsWithChildren<{ asChild?: boolean }>> = ({ childre
 
   const onToggleMoreMenu = useCallback(() => {
     setShowSettingsMenu(false)
+    console.log('open more menu')
     setShowMoreMenu(current => !current)
   }, [])
 
@@ -47,6 +51,12 @@ const RootViewWrapper: FC<PropsWithChildren<{ asChild?: boolean }>> = ({ childre
                 handleRemoveRecentMenuItem={noop}
                 useThemeStore={useThemeStore}
                 useTranslationStore={useTranslationsStore}
+              />
+              <MoreSubmenu showMoreMenu={showMoreMenu} handleMoreMenu={onToggleMoreMenu} items={moreMenu} />
+              <SettingsMenu
+                showSettingMenu={showSettingsMenu}
+                handleSettingsMenu={onToggleSettingsMenu}
+                items={settingsMenu}
               />
             </SandboxLayout.LeftPanel>
             <div className="flex flex-col">

--- a/apps/design-system/src/pages/view-preview/view-preview.tsx
+++ b/apps/design-system/src/pages/view-preview/view-preview.tsx
@@ -16,16 +16,20 @@ import PullRequestConversation from '@subjects/views/pull-request-conversation/p
 import PullRequestListWrapper from '@subjects/views/pull-request-list/pull-request-list'
 import { RepoBranchesView } from '@subjects/views/repo-branches'
 import { RepoCommitsView } from '@subjects/views/repo-commits'
+import { CreateRepoView } from '@subjects/views/repo-create'
 import { RepoCreateRule } from '@subjects/views/repo-create-rule'
 import { RepoFilesEditView } from '@subjects/views/repo-files/repo-files-edit-view'
 import { RepoFilesJsonView } from '@subjects/views/repo-files/repo-files-json-view'
 import { RepoFilesList } from '@subjects/views/repo-files/repo-files-list'
 import { RepoFilesMarkdownView } from '@subjects/views/repo-files/repo-files-markdown-view'
 import { RepoGeneralSettings } from '@subjects/views/repo-general-settings/repo-general-settings'
+import { ImportRepoView } from '@subjects/views/repo-import'
 import RepoListWrapper from '@subjects/views/repo-list/repo-list'
 import RepoSummaryViewWrapper from '@subjects/views/repo-summary/repo-summary'
 import { RepoWebhooksCreate } from '@subjects/views/repo-webhooks-create/repo-webhooks-list'
 import { RepoWebhooksList } from '@subjects/views/repo-webhooks-list/repo-webhooks-list'
+import { SignInView } from '@subjects/views/signin'
+import { SignUpView } from '@subjects/views/signup'
 import { SpaceSettingsMembers } from '@subjects/views/space-settings-members/space-settings-members'
 import { useTranslationsStore } from '@utils/viewUtils'
 
@@ -41,6 +45,18 @@ import RootViewWrapper from './root-view-wrapper'
 import ViewSettings from './view-settings'
 
 export const viewPreviews: Record<string, ReactNode> = {
+  signin: <SignInView />,
+  signup: <SignUpView />,
+  'repo-create': (
+    <RootViewWrapper>
+      <CreateRepoView />
+    </RootViewWrapper>
+  ),
+  'repo-import': (
+    <RootViewWrapper>
+      <ImportRepoView />
+    </RootViewWrapper>
+  ),
   'repo-summary': (
     <RepoViewWrapper>
       <RepoSummaryViewWrapper />

--- a/apps/design-system/src/subjects/views/repo-create/index.tsx
+++ b/apps/design-system/src/subjects/views/repo-create/index.tsx
@@ -1,0 +1,20 @@
+import { noop } from '@utils/viewUtils'
+
+import { RepoCreatePage } from '@harnessio/ui/views'
+
+import { useRepoCreateStore } from './repo-create-store'
+
+export const CreateRepoView = () => {
+  const { gitIgnoreOptions, licenseOptions } = useRepoCreateStore()
+
+  return (
+    <RepoCreatePage
+      onFormSubmit={noop}
+      onFormCancel={noop}
+      isLoading={false}
+      isSuccess={false}
+      gitIgnoreOptions={gitIgnoreOptions}
+      licenseOptions={licenseOptions}
+    />
+  )
+}

--- a/apps/design-system/src/subjects/views/repo-create/repo-create-store.tsx
+++ b/apps/design-system/src/subjects/views/repo-create/repo-create-store.tsx
@@ -1,0 +1,261 @@
+export const useRepoCreateStore = () => {
+  const gitIgnoreOptions = [
+    'AL',
+    'Actionscript',
+    'Ada',
+    'Agda',
+    'Android',
+    'AppEngine',
+    'AppceleratorTitanium',
+    'ArchLinuxPackages',
+    'Autotools',
+    'C++',
+    'C',
+    'CFWheels',
+    'CMake',
+    'CONTRIBUTING.md',
+    'CUDA',
+    'CakePHP',
+    'ChefCookbook',
+    'Clojure',
+    'CodeIgniter',
+    'CommonLisp',
+    'Composer',
+    'Concrete5',
+    'Coq',
+    'CraftCMS',
+    'D',
+    'DM',
+    'Dart',
+    'Delphi',
+    'Drupal',
+    'EPiServer',
+    'Eagle',
+    'Elisp',
+    'Elixir',
+    'Elm',
+    'Erlang',
+    'ExpressionEngine',
+    'ExtJs',
+    'Fancy',
+    'Finale',
+    'FlaxEngine',
+    'ForceDotCom',
+    'Fortran',
+    'FuelPHP',
+    'GWT',
+    'Gcov',
+    'GitBook',
+    'Go',
+    'Godot',
+    'Gradle',
+    'Grails',
+    'Haskell',
+    'IGORPro',
+    'Idris',
+    'JBoss',
+    'JENKINS_HOME',
+    'Java',
+    'Jekyll',
+    'Joomla',
+    'Julia',
+    'KiCad',
+    'Kohana',
+    'Kotlin',
+    'LICENSE',
+    'LabVIEW',
+    'Laravel',
+    'Leiningen',
+    'LemonStand',
+    'Lilypond',
+    'Lithium',
+    'Lua',
+    'Magento',
+    'Maven',
+    'Mercury',
+    'MetaProgrammingSystem',
+    'Nanoc',
+    'Nim',
+    'Node',
+    'OCaml',
+    'Objective-C',
+    'Opa',
+    'OpenCart',
+    'OracleForms',
+    'Packer',
+    'Perl',
+    'Phalcon',
+    'PlayFramework',
+    'Plone',
+    'Prestashop',
+    'Processing',
+    'PureScript',
+    'Python',
+    'Qooxdoo',
+    'Qt',
+    'R',
+    'README.md',
+    'ROS',
+    'Racket',
+    'Rails',
+    'Raku',
+    'RhodesRhomobile',
+    'Ruby',
+    'Rust',
+    'SCons',
+    'Sass',
+    'Scala',
+    'Scheme',
+    'Scrivener',
+    'Sdcc',
+    'SeamGen',
+    'SketchUp',
+    'Smalltalk',
+    'Stella',
+    'SugarCRM',
+    'Swift',
+    'Symfony',
+    'SymphonyCMS',
+    'TeX',
+    'Terraform',
+    'Textpattern',
+    'TurboGears2',
+    'TwinCAT3',
+    'Typo3',
+    'Unity',
+    'UnrealEngine',
+    'VVVV',
+    'VisualStudio',
+    'Waf',
+    'WordPress',
+    'Xojo',
+    'Yeoman',
+    'Yii',
+    'ZendFramework',
+    'Zephir'
+  ]
+
+  const licenseOptions = [
+    {
+      label: 'None',
+      value: 'none'
+    },
+    {
+      label: 'Academic Free License v3.0',
+      value: 'afl-3.0'
+    },
+    {
+      label: 'Apache license 2.0',
+      value: 'apache-2.0'
+    },
+    {
+      label: 'Artistic license 2.0',
+      value: 'artistic-2.0'
+    },
+    {
+      label: 'Boost Software License 1.0',
+      value: 'bsl-1.0'
+    },
+    {
+      label: 'BSD 2-clause "Simplified" license',
+      value: 'bsd-2-clause'
+    },
+    {
+      label: 'BSD 3-clause "New" or "Revised" license',
+      value: 'bsd-3-clause'
+    },
+    {
+      label: 'BSD 3-clause Clear license',
+      value: 'bsd-3-clause-clear'
+    },
+    {
+      label: 'Creative Commons license family',
+      value: 'cc'
+    },
+    {
+      label: 'Creative Commons Zero v1.0 Universal',
+      value: 'cc0-1.0'
+    },
+    {
+      label: 'Creative Commons Attribution 4.0',
+      value: 'cc-by-4.0'
+    },
+    {
+      label: 'Creative Commons Attribution Share Alike 4.0',
+      value: 'cc-by-sa-4.0'
+    },
+    {
+      label: 'Educational Community License v2.0',
+      value: 'ecl-2.0'
+    },
+    {
+      label: 'Eclipse Public License 1.0',
+      value: 'epl-1.0'
+    },
+    {
+      label: 'Eclipse Public License 2.0',
+      value: 'epl-2.0'
+    },
+    {
+      label: 'European Union Public License 1.1',
+      value: 'eupl-1.1'
+    },
+    {
+      label: 'GNU Affero General Public License v3.0',
+      value: 'agpl-3.0'
+    },
+    {
+      label: 'GNU General Public License family',
+      value: 'gpl'
+    },
+    {
+      label: 'GNU General Public License v2.0',
+      value: 'gpl-2.0'
+    },
+    {
+      label: 'GNU General Public License v3.0',
+      value: 'gpl-3.0'
+    },
+    {
+      label: 'GNU Lesser General Public License family',
+      value: 'lgpl'
+    },
+    {
+      label: 'GNU Lesser General Public License v2.1',
+      value: 'lgpl-2.1'
+    },
+    {
+      label: 'GNU Lesser General Public License v3.0',
+      value: 'lgpl-3.0'
+    },
+    {
+      label: 'ISC',
+      value: 'isc'
+    },
+    {
+      label: 'MIT',
+      value: 'mit'
+    },
+    {
+      label: 'Mozilla Public License 2.0',
+      value: 'mpl-2.0'
+    },
+    {
+      label: 'Open Software License 3.0',
+      value: 'osl-3.0'
+    },
+    {
+      label: 'The Unlicense',
+      value: 'unlicense'
+    },
+    {
+      label: 'zLib License',
+      value: 'zlib'
+    }
+  ]
+
+  return {
+    gitIgnoreOptions,
+    licenseOptions
+  }
+}

--- a/apps/design-system/src/subjects/views/repo-import/index.tsx
+++ b/apps/design-system/src/subjects/views/repo-import/index.tsx
@@ -1,0 +1,11 @@
+import { noop } from '@utils/viewUtils'
+
+import { RepoImportPage } from '@harnessio/ui/views'
+
+export const ImportRepoView = () => {
+  return (
+    <>
+      <RepoImportPage onFormSubmit={noop} onFormCancel={noop} isLoading={false} apiErrorsValue={undefined} />
+    </>
+  )
+}

--- a/apps/design-system/src/subjects/views/signin/index.tsx
+++ b/apps/design-system/src/subjects/views/signin/index.tsx
@@ -1,0 +1,7 @@
+import { noop } from '@utils/viewUtils'
+
+import { SignInPage } from '@harnessio/ui/views'
+
+export const SignInView = () => {
+  return <SignInPage isLoading={false} handleSignIn={noop} error={''} />
+}

--- a/apps/design-system/src/subjects/views/signup/index.tsx
+++ b/apps/design-system/src/subjects/views/signup/index.tsx
@@ -1,0 +1,7 @@
+import { noop } from '@utils/viewUtils'
+
+import { SignUpPage } from '@harnessio/ui/views'
+
+export const SignUpView = () => {
+  return <SignUpPage isLoading={false} handleSignUp={noop} error={''} />
+}

--- a/apps/gitness/src/components-v2/app-shell.tsx
+++ b/apps/gitness/src/components-v2/app-shell.tsx
@@ -215,7 +215,7 @@ export const AppShellMFE = () => {
 function BreadcrumbsAndOutlet() {
   return (
     <div className="flex flex-col">
-      <div className="layer-high sticky top-0 bg-background-1">
+      <div className="layer-high bg-background-1 sticky top-0">
         <Breadcrumbs />
       </div>
       <Outlet />


### PR DESCRIPTION
This pull-request brings previews for:

- signin page - https://deploy-preview-812--harness-xd-review.netlify.app/view-preview/signin
- signup page - https://deploy-preview-812--harness-xd-review.netlify.app/view-preview/signup
- create repo page - https://deploy-preview-812--harness-xd-review.netlify.app/view-preview/repo-create
- import repo page - https://deploy-preview-812--harness-xd-review.netlify.app/view-preview/repo-import

And also brings menu items for sidebar navigation

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/13ff7d67-7e13-44f8-8c2b-63e04bd1a3b5" />
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/f96f15f5-fa3b-42ed-96da-53cf263a8d2e" />
