### PR TITLE
fix: Repo Files sort, PR comments, reviewers labels and branch search

### DIFF
--- a/apps/design-system/src/subjects/views/pull-request-compare/pull-request-compare.tsx
+++ b/apps/design-system/src/subjects/views/pull-request-compare/pull-request-compare.tsx
@@ -61,8 +61,10 @@ const PullRequestCompareWrapper: FC<Partial<PullRequestComparePageProps>> = prop
       setSearchCommitQuery={noop}
       useTranslationStore={useTranslationsStore}
       isLoading={false}
-      searchBranchQuery=""
-      setSearchBranchQuery={noop}
+      searchSourceQuery=""
+      setSearchSourceQuery={noop}
+      searchTargetQuery=""
+      setSearchTargetQuery={noop}
       searchReviewersQuery=""
       setSearchReviewersQuery={noop}
       {...props}

--- a/apps/gitness/src/pages-v2/pull-request/pull-request-compare.tsx
+++ b/apps/gitness/src/pages-v2/pull-request/pull-request-compare.tsx
@@ -93,8 +93,9 @@ export const CreatePullRequest = () => {
   )
   const path = useMemo(() => `/api/v1/repos/${repoRef}/+/${diffApiPath}`, [repoRef, diffApiPath])
 
-  const [branchTagQuery, setBranchTagQuery] = useQueryState('branch', { defaultValue: '' })
-  const [searchReviewers, setSearchReviewers] = useQueryState('reviewer', { defaultValue: '' })
+  const [sourceQuery, setSourceQuery] = useState('')
+  const [targetQuery, setTargetQuery] = useState('')
+  const [searchReviewers, setSearchReviewers] = useState('')
 
   const { data: { body: rawDiff } = {}, isFetching: loadingRawDiff } = useRawDiffQuery(
     {
@@ -236,7 +237,7 @@ export const CreatePullRequest = () => {
   }
   const { data: { body: branches } = {} } = useListBranchesQuery({
     repo_ref: repoRef,
-    queryParams: { page: 0, limit: 10, query: branchTagQuery, include_pullreqs: true }
+    queryParams: { page: 0, limit: 10, query: sourceQuery || targetQuery || '', include_pullreqs: true }
   })
 
   useEffect(() => {
@@ -329,7 +330,7 @@ export const CreatePullRequest = () => {
       order: 'asc',
       limit: 20,
       page: 1,
-      query: branchTagQuery
+      query: sourceQuery || targetQuery || ''
     }
   })
 
@@ -374,7 +375,11 @@ export const CreatePullRequest = () => {
           }
         }
       }
-      setBranchTagQuery('')
+      if (sourceBranch) {
+        setSourceQuery('')
+      } else {
+        setTargetQuery('')
+      }
     },
     [branchList, tagsList, setSelectedSourceBranch, setSelectedTargetBranch]
   )
@@ -470,8 +475,10 @@ export const CreatePullRequest = () => {
               }
             : {}
         }
-        searchBranchQuery={branchTagQuery}
-        setSearchBranchQuery={setBranchTagQuery}
+        searchSourceQuery={sourceQuery}
+        setSearchSourceQuery={setSourceQuery}
+        searchTargetQuery={targetQuery}
+        setSearchTargetQuery={setTargetQuery}
         usersList={reviewUsers}
         searchReviewersQuery={searchReviewers}
         setSearchReviewersQuery={setSearchReviewers}

--- a/apps/gitness/src/pages-v2/pull-request/pull-request-conversation.tsx
+++ b/apps/gitness/src/pages-v2/pull-request/pull-request-conversation.tsx
@@ -86,10 +86,19 @@ export default function PullRequestConversationPage() {
   }))
   const { currentUser: currentUserData } = useAppContext()
   const [checkboxBypass, setCheckboxBypass] = useState(false)
+  const [searchReviewers, setSearchReviewers] = useState('')
+  const [addReviewerError, setAddReviewerError] = useState('')
+  const [removeReviewerError, setRemoveReviewerError] = useState('')
+  const [searchLabel, setSearchLabel] = useState('')
+  const [changesLoading, setChangesLoading] = useState(true)
+  const [showDeleteBranchButton, setShowDeleteBranchButton] = useState(false)
+  const [showRestoreBranchButton, setShowRestoreBranchButton] = useState(false)
+  const [errorMsg, setErrorMsg] = useState('')
   const { spaceId, repoId } = useParams<PathParams>()
+
   const { data: { body: principals } = {} } = useListPrincipalsQuery({
     // @ts-expect-error : BE issue - not implemnted
-    queryParams: { page: 1, limit: 100, type: 'user' }
+    queryParams: { page: 1, limit: 100, type: 'user', query: searchReviewers }
   })
   const [comment, setComment] = useState<string>('')
   const [commentId] = useQueryState('commentId', { defaultValue: '' })
@@ -116,15 +125,6 @@ export default function PullRequestConversationPage() {
     pullreq_number: prId,
     queryParams: {}
   })
-
-  const [searchReviewers, setSearchReviewers] = useQueryState('reviewer', { defaultValue: '' })
-  const [addReviewerError, setAddReviewerError] = useState('')
-  const [removeReviewerError, setRemoveReviewerError] = useState('')
-  const [searchLabel, setSearchLabel] = useQueryState('label', { defaultValue: '' })
-  const [changesLoading, setChangesLoading] = useState(true)
-  const [showDeleteBranchButton, setShowDeleteBranchButton] = useState(false)
-  const [showRestoreBranchButton, setShowRestoreBranchButton] = useState(false)
-  const [errorMsg, setErrorMsg] = useState('')
 
   const { data: { body: labelsList } = {} } = useListRepoLabelsQuery({
     repo_ref: repoRef,
@@ -337,19 +337,19 @@ export default function PullRequestConversationPage() {
     }
   }
   useEffect(() => {
-    if (!commentId || isScrolledToComment) return
+    if (!commentId || isScrolledToComment || prPanelData.PRStateLoading || activityData?.length === 0) return
     // Slight timeout so the UI has time to expand/hydrate
     const timeoutId = setTimeout(() => {
       const elem = document.getElementById(`comment-${commentId}`)
       if (!elem) return
       elem.scrollIntoView({ behavior: 'smooth', block: 'center' })
       setIsScrolledToComment(true)
-    }, 2500)
+    }, 500)
 
     return () => {
       clearTimeout(timeoutId)
     }
-  }, [commentId])
+  }, [commentId, isScrolledToComment, prPanelData.PRStateLoading, activityData])
 
   const changesInfo = extractInfoForCodeOwnerContent({
     approvedEvaluations,

--- a/apps/gitness/src/pages-v2/repo/repo-code.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-code.tsx
@@ -116,23 +116,18 @@ export const RepoCode = () => {
           if (response?.details && response.details.length > 0) {
             setFiles(
               sortFilesByType(
-                response.details.map(
-                  (item: GitPathDetails) =>
-                    ({
-                      id: item?.path || '',
-                      type: item?.path
-                        ? getSummaryItemType(repoEntryPathToFileTypeMap.get(item.path))
-                        : SummaryItemType.File,
-                      name: getLastPathSegment(item?.path || ''),
-                      lastCommitMessage: item?.last_commit?.message || '',
-                      timestamp: item?.last_commit?.author?.when
-                        ? timeAgoFromISOTime(item.last_commit.author.when)
-                        : '',
-                      user: { name: item?.last_commit?.author?.identity?.name },
-                      sha: item?.last_commit?.sha && getTrimmedSha(item.last_commit.sha),
-                      path: `${fullGitRef || selectedBranch}/~/${item?.path}`
-                    }) as RepoFile
-                )
+                response.details.map((item: GitPathDetails) => ({
+                  id: item?.path || '',
+                  type: item?.path
+                    ? getSummaryItemType(repoEntryPathToFileTypeMap.get(item.path))
+                    : SummaryItemType.File,
+                  name: getLastPathSegment(item?.path || '') || '',
+                  lastCommitMessage: item?.last_commit?.message || '',
+                  timestamp: item?.last_commit?.author?.when ? timeAgoFromISOTime(item.last_commit.author.when) : '',
+                  user: { name: item?.last_commit?.author?.identity?.name || '' },
+                  sha: item?.last_commit?.sha && getTrimmedSha(item.last_commit.sha),
+                  path: `${fullGitRef || selectedBranch}/~/${item?.path}`
+                }))
               )
             )
           }

--- a/apps/gitness/src/pages-v2/repo/repo-code.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-code.tsx
@@ -22,6 +22,17 @@ import { FILE_SEPERATOR, getTrimmedSha, normalizeGitRef } from '../../utils/git-
 import { splitPathWithParents } from '../../utils/path-utils'
 import { useRepoBranchesStore } from './stores/repo-branches-store'
 
+const sortFilesByType = (entries: RepoFile[]): RepoFile[] => {
+  return entries.sort((a, b) => {
+    if (a.type === SummaryItemType.Folder && b.type === SummaryItemType.File) {
+      return -1
+    } else if (a.type === SummaryItemType.File && b.type === SummaryItemType.Folder) {
+      return 1
+    }
+    return 0
+  })
+}
+
 /**
  * TODO: This code was migrated from V2 and needs to be refactored.
  */
@@ -104,20 +115,24 @@ export const RepoCode = () => {
         .then(({ body: response }) => {
           if (response?.details && response.details.length > 0) {
             setFiles(
-              response.details.map(
-                (item: GitPathDetails) =>
-                  ({
-                    id: item?.path || '',
-                    type: item?.path
-                      ? getSummaryItemType(repoEntryPathToFileTypeMap.get(item.path))
-                      : SummaryItemType.File,
-                    name: getLastPathSegment(item?.path || ''),
-                    lastCommitMessage: item?.last_commit?.message || '',
-                    timestamp: item?.last_commit?.author?.when ? timeAgoFromISOTime(item.last_commit.author.when) : '',
-                    user: { name: item?.last_commit?.author?.identity?.name },
-                    sha: item?.last_commit?.sha && getTrimmedSha(item.last_commit.sha),
-                    path: `${fullGitRef || selectedBranch}/~/${item?.path}`
-                  }) as RepoFile
+              sortFilesByType(
+                response.details.map(
+                  (item: GitPathDetails) =>
+                    ({
+                      id: item?.path || '',
+                      type: item?.path
+                        ? getSummaryItemType(repoEntryPathToFileTypeMap.get(item.path))
+                        : SummaryItemType.File,
+                      name: getLastPathSegment(item?.path || ''),
+                      lastCommitMessage: item?.last_commit?.message || '',
+                      timestamp: item?.last_commit?.author?.when
+                        ? timeAgoFromISOTime(item.last_commit.author.when)
+                        : '',
+                      user: { name: item?.last_commit?.author?.identity?.name },
+                      sha: item?.last_commit?.sha && getTrimmedSha(item.last_commit.sha),
+                      path: `${fullGitRef || selectedBranch}/~/${item?.path}`
+                    }) as RepoFile
+                )
               )
             )
           }

--- a/packages/ui/src/views/repo/pull-request/compare/pull-request-compare-page.tsx
+++ b/packages/ui/src/views/repo/pull-request/compare/pull-request-compare-page.tsx
@@ -81,8 +81,10 @@ export interface PullRequestComparePageProps extends Partial<RoutingProps> {
   searchCommitQuery: string | null
   setSearchCommitQuery: (query: string | null) => void
   currentUser?: string
-  searchBranchQuery: string
-  setSearchBranchQuery: (query: string) => void
+  searchSourceQuery?: string
+  setSearchSourceQuery: (query: string) => void
+  searchTargetQuery?: string
+  setSearchTargetQuery: (query: string) => void
   searchReviewersQuery: string
   setSearchReviewersQuery: (query: string) => void
   usersList?: { display_name?: string; id?: number; uid?: string }[]
@@ -110,8 +112,10 @@ export const PullRequestComparePage: FC<PullRequestComparePageProps> = ({
   useRepoBranchesStore,
   useRepoCommitsStore,
   currentUser,
-  searchBranchQuery,
-  setSearchBranchQuery,
+  searchSourceQuery,
+  setSearchSourceQuery,
+  searchTargetQuery,
+  setSearchTargetQuery,
   searchReviewersQuery,
   setSearchReviewersQuery,
   usersList,
@@ -201,8 +205,8 @@ export const PullRequestComparePage: FC<PullRequestComparePageProps> = ({
                 selectBranch(branchTag, type, false)
                 handleBranchSelection()
               }}
-              searchQuery={searchBranchQuery}
-              setSearchQuery={setSearchBranchQuery}
+              searchQuery={searchTargetQuery}
+              setSearchQuery={setSearchTargetQuery}
             />
 
             <Icon name="arrow-long" size={12} className="rotate-180 text-icons-1" />
@@ -215,8 +219,8 @@ export const PullRequestComparePage: FC<PullRequestComparePageProps> = ({
                 selectBranch(branchTag, type, true)
                 handleBranchSelection()
               }}
-              searchQuery={searchBranchQuery}
-              setSearchQuery={setSearchBranchQuery}
+              searchQuery={searchSourceQuery}
+              setSearchQuery={setSearchSourceQuery}
             />
 
             {isBranchSelected &&

--- a/packages/ui/src/views/repo/pull-request/components/pull-request-side-bar.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/pull-request-side-bar.tsx
@@ -79,24 +79,22 @@ const PullRequestSideBar = (props: PullRequestSideBarProps) => {
           removeReviewerError={removeReviewerError}
         />
       </div>
-      {labelsList && labelsList.length > 0 && (
-        <div className="flex flex-col gap-3 pt-5">
-          <LabelsHeader
-            labelsList={labelsList}
-            selectedLabels={PRLabels}
-            addLabel={addLabel}
-            searchQuery={searchLabelQuery}
-            setSearchQuery={setSearchLabelQuery}
-            useTranslationStore={useTranslationStore}
-          />
-          <LabelsList
-            labels={PRLabels}
-            handleDelete={removeLabel}
-            addLabelError={addLabelError}
-            removeLabelError={removeLabelError}
-          />
-        </div>
-      )}
+      <div className="flex flex-col gap-3 pt-5">
+        <LabelsHeader
+          labelsList={labelsList}
+          selectedLabels={PRLabels}
+          addLabel={addLabel}
+          searchQuery={searchLabelQuery}
+          setSearchQuery={setSearchLabelQuery}
+          useTranslationStore={useTranslationStore}
+        />
+        <LabelsList
+          labels={PRLabels}
+          handleDelete={removeLabel}
+          addLabelError={addLabelError}
+          removeLabelError={removeLabelError}
+        />
+      </div>
     </div>
   )
 }

--- a/packages/ui/src/views/repo/repo-branch/components/create-branch-dialog.tsx
+++ b/packages/ui/src/views/repo/repo-branch/components/create-branch-dialog.tsx
@@ -84,7 +84,7 @@ export function CreateBranchDialog({
 
   return (
     <Dialog.Root open={open} onOpenChange={handleClose}>
-      <Dialog.Content className="border-border bg-background-1 max-w-xl" aria-describedby={undefined}>
+      <Dialog.Content className="max-w-xl border-border bg-background-1" aria-describedby={undefined}>
         <Dialog.Header>
           <Dialog.Title>{t('views:repos.createBranch', 'Create Branch')}</Dialog.Title>
         </Dialog.Header>

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -131,7 +131,7 @@ export function RepoSummaryView({
   return (
     <SandboxLayout.Main>
       <SandboxLayout.Columns columnWidths="1fr 256px">
-        <SandboxLayout.Column>
+        <SandboxLayout.Column className="max-w-[1000px]">
           <SandboxLayout.Content className="pl-6">
             {/*
               TODO: Implement proper recent push detection logic:
@@ -231,7 +231,7 @@ export function RepoSummaryView({
               hideHeader
             />
             <Spacer size={5} />
-            <StackedList.Root>
+            <StackedList.Root onlyTopRounded borderBackground>
               <StackedList.Item className="py-2" isHeader disableHover>
                 <StackedList.Field
                   title={<Text color="tertiaryBackground">{t('views:repos.readme', 'README.md')}</Text>}
@@ -253,10 +253,8 @@ export function RepoSummaryView({
                   }
                 />
               </StackedList.Item>
-              <StackedList.Item className="px-16 py-6" disableHover>
-                <MarkdownViewer source={decodedReadmeContent || ''} />
-              </StackedList.Item>
             </StackedList.Root>
+            <MarkdownViewer source={decodedReadmeContent || ''} withBorderWrapper />
           </SandboxLayout.Content>
         </SandboxLayout.Column>
         <SandboxLayout.Column>


### PR DESCRIPTION
PR includes fixes for the following bugs : 

1. Repo Summary - huge line in readme was adding horizontal scroll 
<img width="1728" alt="Screenshot 2025-01-23 at 11 14 35 PM" src="https://github.com/user-attachments/assets/0ff50407-594a-41ba-893d-77f2acae9a53" />

2. PR conversation and changes page - scroll comment into view if commentId copied and link shared

3. Repo Files - files and folders sorting
<img width="1728" alt="Screenshot 2025-01-23 at 11 15 11 PM" src="https://github.com/user-attachments/assets/2896a9bd-5e27-4a08-8253-44f66f5f2376" />

4. PR compare/conversation - Search in reviewers doesnt work
5. PR conversation - searching for labels collapses it and shuts it off. Eventually it vanishes
6. PR compare/conversation - same query param is used to filter source and target branch