### PR TITLE
feat: [pipe-24076]: fix issue with future time

### DIFF
--- a/apps/gitness/src/pages/pipeline-edit/utils/time-utils.ts
+++ b/apps/gitness/src/pages/pipeline-edit/utils/time-utils.ts
@@ -9,10 +9,12 @@ export const timeAgoFromISOTime = (timestamp: string, maxDiff: number = 2): stri
   const now = new Date()
 
   const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000)
-  const diffInDays = diffInSeconds / (3600 * 24)
+  // Always treat time differences as past events
+  const absDiffInSeconds = Math.abs(diffInSeconds)
+  const diffInDays = absDiffInSeconds / (3600 * 24)
 
   if (diffInDays <= maxDiff) {
-    return formatRelativeTime(diffInSeconds)
+    return formatRelativeTime(absDiffInSeconds)
   } else {
     return date.toLocaleDateString('en', { dateStyle: 'medium' })
   }


### PR DESCRIPTION
Used Math.abs() on time difference to ensure time are always shown as "X ago"
![image](https://github.com/user-attachments/assets/1027357a-1364-4aab-89c2-98a0839b1378)
