### PR TITLE
feat: add APIs and navigations

### DIFF
--- a/apps/design-system/src/subjects/views/repo-empty/repo-empty-view.tsx
+++ b/apps/design-system/src/subjects/views/repo-empty/repo-empty-view.tsx
@@ -1,3 +1,5 @@
+import { noop } from '@utils/viewUtils'
+
 import { RepoEmptyView } from '@harnessio/ui/views'
 
 export const RepoEmpty = () => {
@@ -7,6 +9,8 @@ export const RepoEmpty = () => {
       repoName="mock-repo"
       projName="mock-project"
       sshUrl="git@github.com:mock-repo.git"
+      gitRef=""
+      handleCreateToken={noop}
     />
   )
 }

--- a/apps/gitness/src/framework/routing/types.ts
+++ b/apps/gitness/src/framework/routing/types.ts
@@ -70,7 +70,8 @@ export enum RouteConstants {
   toGitOps = 'toGitOps',
   toCI = 'toCI',
   toCode = 'toCode',
-  toProfileKeys = 'toProfileKeys'
+  toProfileKeys = 'toProfileKeys',
+  toProfileGeneral = 'toProfileGeneral'
 }
 
 export interface RouteEntry {

--- a/apps/gitness/src/pages-v2/repo/repo-summary.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-summary.tsx
@@ -352,6 +352,7 @@ export default function RepoSummaryPage() {
         searchQuery={branchTagQuery}
         setSearchQuery={setBranchTagQuery}
         toRepoFiles={() => routes.toRepoFiles({ spaceId, repoId })}
+        toProfileKeys={() => routes.toProfileKeys()}
       />
       {createdTokenData && (
         <CloneCredentialDialog

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -846,7 +846,8 @@ export const routes: CustomRouteObject[] = [
             path: 'general',
             element: <SettingsProfileGeneralPage />,
             handle: {
-              breadcrumb: () => <Text>General</Text>
+              breadcrumb: () => <Text>General</Text>,
+              routeName: RouteConstants.toProfileGeneral
             }
           },
           {

--- a/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
@@ -21,6 +21,7 @@ interface RepoEmptyViewProps {
   sshUrl: string
   gitRef: string
   handleCreateToken: () => void
+  toProfileKeys?: () => string
 }
 
 export const RepoEmptyView: React.FC<RepoEmptyViewProps> = ({
@@ -29,7 +30,8 @@ export const RepoEmptyView: React.FC<RepoEmptyViewProps> = ({
   httpUrl,
   sshUrl,
   gitRef,
-  handleCreateToken
+  handleCreateToken,
+  toProfileKeys
 }) => {
   const getInitialCommitMarkdown = () => {
     return `
@@ -84,7 +86,7 @@ git push -u origin main
             </ButtonGroup>
             <p className="mt-2">
               You can also manage your git credential{' '}
-              <StyledLink to="/profile-settings/keys" relative="path">
+              <StyledLink to={toProfileKeys?.() ?? ''} relative="path">
                 here
               </StyledLink>
             </p>
@@ -102,7 +104,7 @@ git push -u origin main
             <MarkdownViewer source={getExistingRepoMarkdown()} />
             <p>
               You might need to{' '}
-              <StyledLink to="/profile-settings/keys" relative="path">
+              <StyledLink to={toProfileKeys?.() ?? ''} relative="path">
                 create an API token
               </StyledLink>{' '}
               In order to pull from or push into this repository.

--- a/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
@@ -1,5 +1,3 @@
-// import { useNavigate } from 'react-router-dom'
-
 import {
   Button,
   ButtonGroup,
@@ -33,8 +31,6 @@ export const RepoEmptyView: React.FC<RepoEmptyViewProps> = ({
   gitRef,
   handleCreateToken
 }) => {
-  //   const navigate = useNavigate()
-
   const getInitialCommitMarkdown = () => {
     return `
 \`\`\`shell
@@ -58,10 +54,6 @@ git push -u origin main
 `
   }
 
-  //   const handleCreateNewFile = () => {
-  //     console.log('Create new file')
-  //     navigate(`${projName ? `/${projName}` : ''}/repos/${repoName}/code/new/${gitRef}/~/`)
-  //   }
   return (
     <SandboxLayout.Main>
       <SandboxLayout.Content className="mx-auto max-w-[850px]">

--- a/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
@@ -68,7 +68,10 @@ git push -u origin main
           iconName="no-repository"
           title="This repository is empty"
           description={['We recommend every repository include a', 'README, LICENSE, and .gitignore.']}
-          primaryButton={{ label: 'New file' }}
+          primaryButton={{
+            label: 'New file',
+            to: `${projName ? `/${projName}` : ''}/repos/${repoName}/code/new/${gitRef}/~/`
+          }}
           className="min-h-[40vh] py-0"
         />
         <Spacer size={6} />

--- a/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
@@ -1,3 +1,5 @@
+// import { useNavigate } from 'react-router-dom'
+
 import {
   Button,
   ButtonGroup,
@@ -19,9 +21,20 @@ interface RepoEmptyViewProps {
   projName: string
   httpUrl: string
   sshUrl: string
+  gitRef: string
+  handleCreateToken: () => void
 }
 
-export const RepoEmptyView: React.FC<RepoEmptyViewProps> = ({ repoName, projName, httpUrl, sshUrl }) => {
+export const RepoEmptyView: React.FC<RepoEmptyViewProps> = ({
+  repoName,
+  projName,
+  httpUrl,
+  sshUrl,
+  gitRef,
+  handleCreateToken
+}) => {
+  //   const navigate = useNavigate()
+
   const getInitialCommitMarkdown = () => {
     return `
 \`\`\`shell
@@ -44,6 +57,11 @@ git push -u origin main
 \`\`\`
 `
   }
+
+  //   const handleCreateNewFile = () => {
+  //     console.log('Create new file')
+  //     navigate(`${projName ? `/${projName}` : ''}/repos/${repoName}/code/new/${gitRef}/~/`)
+  //   }
   return (
     <SandboxLayout.Main>
       <SandboxLayout.Content className="mx-auto max-w-[850px]">
@@ -70,11 +88,11 @@ git push -u origin main
           <Input label="SSH" value={sshUrl} readOnly rightElement={<CopyButton name={sshUrl} />} />
           <ControlGroup>
             <ButtonGroup>
-              <Button>Generate Clone Credentials</Button>
+              <Button onClick={handleCreateToken}>Generate Clone Credentials</Button>
             </ButtonGroup>
             <p className="mt-2">
               You can also manage your git credential{' '}
-              <StyledLink to="/" relative="path">
+              <StyledLink to="/profile-settings/keys" relative="path">
                 here
               </StyledLink>
             </p>
@@ -92,7 +110,7 @@ git push -u origin main
             <MarkdownViewer source={getExistingRepoMarkdown()} />
             <p>
               You might need to{' '}
-              <StyledLink to="/" relative="path">
+              <StyledLink to="/profile-settings/keys" relative="path">
                 create an API token
               </StyledLink>{' '}
               In order to pull from or push into this repository.

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -125,6 +125,8 @@ export function RepoSummaryView({
         httpUrl={repository?.git_url ?? 'could not fetch url'}
         repoName={repoId}
         projName={spaceId}
+        gitRef={gitRef || selectedBranchTag?.name || ''}
+        handleCreateToken={handleCreateToken}
       />
     )
   }

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -33,6 +33,7 @@ import { RepoEmptyView } from './repo-empty-view'
 interface RoutingProps {
   toRepoFiles: () => string
   toCommitDetails?: ({ sha }: { sha: string }) => string
+  toProfileKeys: () => string
 }
 
 export interface RepoSummaryViewProps extends Partial<RoutingProps> {
@@ -103,7 +104,8 @@ export function RepoSummaryView({
   setSearchQuery,
   handleCreateToken,
   toRepoFiles,
-  toCommitDetails
+  toCommitDetails,
+  toProfileKeys
 }: RepoSummaryViewProps) {
   const { t } = useTranslationStore()
   const { repoId, spaceId, selectedBranchTag } = useRepoBranchesStore()
@@ -127,6 +129,7 @@ export function RepoSummaryView({
         projName={spaceId}
         gitRef={gitRef || selectedBranchTag?.name || ''}
         handleCreateToken={handleCreateToken}
+        toProfileKeys={toProfileKeys}
       />
     )
   }


### PR DESCRIPTION
- Currently the `file-create` view breaks for an empty repo. (see attached video) Lets pick this up as a seperate PR. 

cc: @shaurya-harness 


https://github.com/user-attachments/assets/c986fe2b-d9b3-452f-a652-abec0e8647c0

