### PR TITLE
Added useAPIPath hook to check for mfe condition

### DIFF
--- a/apps/gitness/src/components-v2/file-content-viewer.tsx
+++ b/apps/gitness/src/components-v2/file-content-viewer.tsx
@@ -18,8 +18,8 @@ import { useRoutes } from '../framework/context/NavigationContext'
 import { useThemeStore } from '../framework/context/ThemeContext'
 import { useDownloadRawFile } from '../framework/hooks/useDownloadRawFile'
 import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
-import { useIsMFE } from '../framework/hooks/useIsMFE'
 import { parseAsInteger, useQueryState } from '../framework/hooks/useQueryState'
+import { useAPIPath } from '../hooks/useAPIPath'
 import useCodePathDetails from '../hooks/useCodePathDetails'
 import { useTranslationStore } from '../i18n/stores/i18n-store'
 import { themes } from '../pages-v2/pipeline/pipeline-edit/theme/monaco-theme'
@@ -52,7 +52,6 @@ interface FileContentViewerProps {
 export default function FileContentViewer({ repoContent }: FileContentViewerProps) {
   const routes = useRoutes()
   const { spaceId, repoId } = useParams<PathParams>()
-  const isMFE = useIsMFE()
   const fileName = repoContent?.name || ''
   const language = filenameToLanguage(fileName) || ''
   const fileContent = decodeGitContent(repoContent?.content?.data)
@@ -61,7 +60,7 @@ export default function FileContentViewer({ repoContent }: FileContentViewerProp
   const parentPath = fullResourcePath?.split(FILE_SEPERATOR).slice(0, -1).join(FILE_SEPERATOR)
   const downloadFile = useDownloadRawFile()
   const navigate = useNavigate()
-  const rawURL = `${isMFE ? '/code' : ''}/api/v1/repos/${repoRef}/raw/${fullResourcePath}?git_ref=${fullGitRef}`
+  const rawURL = useAPIPath(`/api/v1/repos/${repoRef}/raw/${fullResourcePath}?git_ref=${fullGitRef}`)
   const [view, setView] = useState<ViewTypeValue>(getDefaultView(language))
   const [isDeleteFileDialogOpen, setIsDeleteFileDialogOpen] = useState(false)
   const { selectedBranchTag, selectedRefType } = useRepoBranchesStore()

--- a/apps/gitness/src/framework/hooks/useDownloadRawFile.ts
+++ b/apps/gitness/src/framework/hooks/useDownloadRawFile.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { useMutation } from '@tanstack/react-query'
 
-import { useIsMFE } from './useIsMFE'
+import { useAPIPath } from '../../hooks/useAPIPath'
 
 interface UseDownloadRawFileParams {
   repoRef: string
@@ -12,9 +12,8 @@ interface UseDownloadRawFileParams {
 }
 
 export function useDownloadRawFile() {
-  const isMFE = useIsMFE()
   const mutation = useMutation(async ({ repoRef, resourcePath, gitRef }: UseDownloadRawFileParams) => {
-    const url = `${isMFE ? '/code' : ''}/api/v1/repos/${repoRef}/raw/${resourcePath}?git_ref=${gitRef ?? ''}`
+    const url = useAPIPath(`/api/v1/repos/${repoRef}/raw/${resourcePath}?git_ref=${gitRef ?? ''}`)
 
     const response = await fetch(url)
     if (!response.ok) {

--- a/apps/gitness/src/framework/hooks/useDownloadRawFile.ts
+++ b/apps/gitness/src/framework/hooks/useDownloadRawFile.ts
@@ -12,8 +12,9 @@ interface UseDownloadRawFileParams {
 }
 
 export function useDownloadRawFile() {
+  const baseAPIURL = useAPIPath('/api/v1/repos')
   const mutation = useMutation(async ({ repoRef, resourcePath, gitRef }: UseDownloadRawFileParams) => {
-    const url = useAPIPath(`/api/v1/repos/${repoRef}/raw/${resourcePath}?git_ref=${gitRef ?? ''}`)
+    const url = `${baseAPIURL}/${repoRef}/raw/${resourcePath}?git_ref=${gitRef ?? ''}`
 
     const response = await fetch(url)
     if (!response.ok) {

--- a/apps/gitness/src/hooks/useAPIPath.ts
+++ b/apps/gitness/src/hooks/useAPIPath.ts
@@ -1,9 +1,10 @@
-import { useIsMFE } from '../framework/hooks/useIsMFE'
+import { useMFEContext } from '../framework/hooks/useMFEContext'
 
 export function useAPIPath(path: string) {
-  const isMFE = useIsMFE()
+  const mfeContext = useMFEContext()
+  const isMFE = mfeContext.renderUrl !== ''
   if (isMFE) {
-    return `/code${path}`
+    return `${window.apiUrl || ''}/code${path}${path.includes('?') ? '&' : '?'}routingId=${mfeContext.scope.accountId}`
   }
   return path
 }

--- a/apps/gitness/src/hooks/useAPIPath.ts
+++ b/apps/gitness/src/hooks/useAPIPath.ts
@@ -1,0 +1,9 @@
+import { useIsMFE } from '../framework/hooks/useIsMFE'
+
+export function useAPIPath(path: string) {
+  const isMFE = useIsMFE()
+  if (isMFE) {
+    return `/code${path}`
+  }
+  return path
+}


### PR DESCRIPTION
This hook adds required prefix to the API Path for MFE including window.apiURL along with /code and also adds routingId as a query param.

Before:
const rawURL = `${isMFE ? '/code' : ''}/api/v1/repos/${repoRef}/raw/${fullResourcePath}?git_ref=${fullGitRef}`

After:
const rawURL = useAPIPath(`/api/v1/repos/${repoRef}/raw/${fullResourcePath}?git_ref=${fullGitRef}`)