### PR TITLE
PS - Multiple improvements

### DIFF
--- a/packages/pipeline-graph/examples/src/main.tsx
+++ b/packages/pipeline-graph/examples/src/main.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import ReactDOM from 'react-dom/client'
+import { render } from 'react-dom'
 
 import Examples from './examples'
 
-const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
-root.render(
+render(
   <React.StrictMode>
     <Examples />
-  </React.StrictMode>
+  </React.StrictMode>,
+  document.getElementById('root')
 )

--- a/packages/pipeline-graph/src/components/canvas/canvas.css
+++ b/packages/pipeline-graph/src/components/canvas/canvas.css
@@ -5,6 +5,10 @@
   height: 100%;
 }
 
+.PipelineGraph-Canvas.PipelineGraph-CanvasMove {
+  cursor: move;
+}
+
 .PipelineGraph-Canvas > div {
   transform: translate(var(--x), var(--y)) scale(var(--scale));
   transform-origin: top left;

--- a/packages/pipeline-graph/src/components/canvas/canvas.tsx
+++ b/packages/pipeline-graph/src/components/canvas/canvas.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
 import { useCanvasContext } from '../../context/canvas-provider'
 import { calculateTransform, MousePoint } from './canvas-utils'
@@ -9,6 +9,8 @@ export function Canvas({ children }: React.PropsWithChildren<React.HTMLAttribute
   const { setCanvasTransform, canvasTransformRef, config } = useCanvasContext()
 
   const mainRef = useRef<HTMLDivElement | null>(null)
+
+  const [isMove, setIsMove] = useState(false)
 
   // handle zoom-to-pinch (wheel)
   useEffect(() => {
@@ -107,12 +109,14 @@ export function Canvas({ children }: React.PropsWithChildren<React.HTMLAttribute
     setCanvasTransform(newTransform)
     canvasTransformRef.current = newTransform
     latestPointRef.current = event
+    if (!isMove) setIsMove(true)
   }
 
   const mouseUpHandler = (event: MouseEvent) => {
     mainRef.current?.removeEventListener('mousemove', mouseMoveHandler)
     document.removeEventListener('mouseup', mouseUpHandler)
     latestPointRef.current = null
+    setIsMove(false)
   }
 
   const mouseDownHandler = (event: MouseEvent | any) => {
@@ -133,7 +137,11 @@ export function Canvas({ children }: React.PropsWithChildren<React.HTMLAttribute
   }, [mainRef])
 
   return (
-    <div ref={mainRef} className="PipelineGraph-Canvas" onMouseDown={mouseDownHandler}>
+    <div
+      ref={mainRef}
+      className={`PipelineGraph-Canvas ${isMove ? 'PipelineGraph-CanvasMove' : ''}`}
+      onMouseDown={mouseDownHandler}
+    >
       {children}
     </div>
   )

--- a/packages/ui/src/views/pipeline-edit/components/pipeline-studio-internal.tsx
+++ b/packages/ui/src/views/pipeline-edit/components/pipeline-studio-internal.tsx
@@ -1,16 +1,17 @@
 import { ContentNodeFactory, YamlRevision } from '../pipeline-studio'
 import { PipelineStudioGraphView } from './pipeline-studio-graph-view'
-import { PipelineStudioYamlView } from './pipeline-studio-yaml-view'
+import { PipelineStudioYamlView, PipelineStudioYamlViewProps } from './pipeline-studio-yaml-view'
 
 export interface PipelineStudioInternalProps {
   view: 'yaml' | 'graph'
   contentNodeFactory: ContentNodeFactory
   yamlRevision: YamlRevision
   onYamlRevisionChange: (YamlRevision: YamlRevision) => void
+  yamlEditorConfig?: PipelineStudioYamlViewProps['yamlEditorConfig']
 }
 
 export default function PipelineStudioInternal(props: PipelineStudioInternalProps) {
-  const { view, yamlRevision, onYamlRevisionChange, contentNodeFactory } = props
+  const { view, yamlRevision, onYamlRevisionChange, contentNodeFactory, yamlEditorConfig } = props
 
   return view === 'graph' ? (
     <PipelineStudioGraphView
@@ -19,6 +20,10 @@ export default function PipelineStudioInternal(props: PipelineStudioInternalProp
       onYamlRevisionChange={onYamlRevisionChange}
     />
   ) : (
-    <PipelineStudioYamlView yamlRevision={yamlRevision} onYamlRevisionChange={onYamlRevisionChange} />
+    <PipelineStudioYamlView
+      yamlRevision={yamlRevision}
+      onYamlRevisionChange={onYamlRevisionChange}
+      yamlEditorConfig={yamlEditorConfig}
+    />
   )
 }

--- a/packages/ui/src/views/pipeline-edit/components/pipeline-studio-yaml-view.tsx
+++ b/packages/ui/src/views/pipeline-edit/components/pipeline-studio-yaml-view.tsx
@@ -19,10 +19,14 @@ MonacoGlobals.set({
 export interface PipelineStudioYamlViewProps {
   yamlRevision: YamlRevision
   onYamlRevisionChange: (YamlRevision: YamlRevision) => void
+  yamlEditorConfig?: {
+    folding?: boolean
+    minimap?: boolean
+  }
 }
 
 const PipelineStudioYamlView = (props: PipelineStudioYamlViewProps): JSX.Element => {
-  const { yamlRevision, onYamlRevisionChange } = props
+  const { yamlRevision, onYamlRevisionChange, yamlEditorConfig = {} } = props
 
   const [reRenderYamlEditor, setRerenderYamlEditor] = useState(0)
   const forceRerender = () => {
@@ -125,6 +129,7 @@ const PipelineStudioYamlView = (props: PipelineStudioYamlViewProps): JSX.Element
           schemaConfig={schemaConfig}
           // inlineActions={inlineActions} // TODO
           // selection={selection} // TODO
+          {...yamlEditorConfig}
         />
       </div>
     )

--- a/packages/ui/src/views/pipeline-edit/pipeline-edit.tsx
+++ b/packages/ui/src/views/pipeline-edit/pipeline-edit.tsx
@@ -11,7 +11,7 @@ import { CommonNodeDataType } from './components/graph-implementation/types/comm
 import { ContentNodeType } from './components/graph-implementation/types/content-node-type'
 import { YamlEntityType } from './components/graph-implementation/types/yaml-entity-type'
 import { PipelineStudioNodeContextMenu } from './components/pipeline-studio-node-context-menu'
-import { ContentNodeFactory, PipelineStudio, YamlRevision } from './pipeline-studio'
+import { ContentNodeFactory, PipelineStudio, PipelineStudioProps, YamlRevision } from './pipeline-studio'
 
 export interface PipelineEditProps {
   /* pipeline view */
@@ -29,6 +29,7 @@ export interface PipelineEditProps {
   onEditIntention: (nodeData: CommonNodeDataType) => undefined
   onDeleteIntention: (nodeData: CommonNodeDataType) => undefined
   onRevealInYaml: (_path: string | undefined) => undefined
+  yamlEditorConfig?: PipelineStudioProps['yamlEditorConfig']
 }
 
 export const PipelineEdit = (props: PipelineEditProps): JSX.Element => {
@@ -40,7 +41,8 @@ export const PipelineEdit = (props: PipelineEditProps): JSX.Element => {
     onDeleteIntention,
     onEditIntention,
     onSelectIntention,
-    onRevealInYaml
+    onRevealInYaml,
+    yamlEditorConfig
   } = props
 
   const contentNodeFactory = new ContentNodeFactory()
@@ -94,6 +96,7 @@ export const PipelineEdit = (props: PipelineEditProps): JSX.Element => {
         view={view}
         yamlRevision={yamlRevision}
         onYamlRevisionChange={onYamlRevisionChange}
+        yamlEditorConfig={yamlEditorConfig}
       />
       <PipelineStudioNodeContextMenu />
     </PipelineStudioNodeContextProvider>

--- a/packages/ui/src/views/pipeline-edit/pipeline-studio.tsx
+++ b/packages/ui/src/views/pipeline-edit/pipeline-studio.tsx
@@ -1,7 +1,7 @@
 import { NodeContent } from '@harnessio/pipeline-graph'
 
 import { ContentNodeType } from './components/graph-implementation/types/content-node-type'
-import PipelineStudioInternal from './components/pipeline-studio-internal'
+import PipelineStudioInternal, { PipelineStudioInternalProps } from './components/pipeline-studio-internal'
 
 export class ContentNodeFactory {
   private entityBank: Map<ContentNodeType, any>
@@ -33,6 +33,7 @@ export interface PipelineStudioProps {
   contentNodeFactory: ContentNodeFactory
   yamlRevision: YamlRevision
   onYamlRevisionChange: (YamlRevision: YamlRevision) => void
+  yamlEditorConfig?: PipelineStudioInternalProps['yamlEditorConfig']
 }
 
 const PipelineStudio = (props: PipelineStudioProps): JSX.Element => {

--- a/packages/yaml-editor-playground/src/index.tsx
+++ b/packages/yaml-editor-playground/src/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import ReactDOM from 'react-dom/client'
+import { render } from 'react-dom'
 
 import App from './App'
 
-const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
-root.render(
+render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
+  document.getElementById('root')
 )


### PR DESCRIPTION
- react downgrade 18>17 fixes
- show move cursor while move canvas - pipeline-graph
- expose yamlEditorConfig (folding and minimap props of monaco editor) - yaml-editor
- fix "left line flickering"  - workaround - yaml-editor