### PR TITLE
split docker images for mfe and standalone builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 # build all the packages and apps except portal and design-system
 RUN pnpm --filter \!portal --filter \!design-system run build
 
-FROM node:20-slim AS final
+FROM alpine:3.21 AS final
 COPY --from=build /canary/apps/gitness/dist /canary-dist
 WORKDIR /canary-dist
 

--- a/Dockerfile.mfe
+++ b/Dockerfile.mfe
@@ -19,7 +19,7 @@ WORKDIR /canary/apps/gitness
 RUN rm -rf dist
 RUN pnpm run build:webpack
 
-FROM node:20-slim AS final
+FROM alpine:3.21 AS final
 COPY --from=build /canary/apps/gitness/dist /canary-dist
 WORKDIR /canary-dist
 

--- a/Dockerfile.mfe
+++ b/Dockerfile.mfe
@@ -12,8 +12,12 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-l
 FROM base AS build
 # install deps
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
-# build all the packages and apps except portal and design-system
-RUN pnpm --filter \!portal --filter \!design-system run build
+# build all the packages and apps except gitness
+RUN pnpm --filter \!gitness run build
+# build the microfrontend
+WORKDIR /canary/apps/gitness
+RUN rm -rf dist
+RUN pnpm run build:webpack
 
 FROM node:20-slim AS final
 COPY --from=build /canary/apps/gitness/dist /canary-dist


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a69a1b1f-eaf2-4aaf-b57e-df3f4c4977c9)

Update:
Using `alpine` as a base image instead of Nodejs dropped it from ~300mb to ~75mb!
![image](https://github.com/user-attachments/assets/9a424994-22fb-4a01-8e49-83df8af01eff)
