### PR TITLE
feat: [pipe-24076]: PR changes page diffs optimizations - scrollbar flickering and in view diffInstance cleanup

### DIFF
--- a/apps/design-system/src/subjects/views/pull-request-compare/pull-request-compare.tsx
+++ b/apps/design-system/src/subjects/views/pull-request-compare/pull-request-compare.tsx
@@ -69,7 +69,7 @@ const PullRequestCompareWrapper: FC<Partial<PullRequestComparePageProps>> = prop
       setSearchTargetQuery={noop}
       searchReviewersQuery=""
       setSearchReviewersQuery={noop}
-      jumpToDiff=''
+      jumpToDiff=""
       setJumpToDiff={noop}
       {...props}
     />

--- a/apps/design-system/src/subjects/views/pull-request-compare/pull-request-compare.tsx
+++ b/apps/design-system/src/subjects/views/pull-request-compare/pull-request-compare.tsx
@@ -69,6 +69,8 @@ const PullRequestCompareWrapper: FC<Partial<PullRequestComparePageProps>> = prop
       setSearchTargetQuery={noop}
       searchReviewersQuery=""
       setSearchReviewersQuery={noop}
+      jumpToDiff=''
+      setJumpToDiff={noop}
       {...props}
     />
   )

--- a/apps/design-system/src/subjects/views/pull-request-conversation/pull-request-changes.tsx
+++ b/apps/design-system/src/subjects/views/pull-request-conversation/pull-request-changes.tsx
@@ -100,7 +100,7 @@ const PullRequestChanges: FC<PullRequestChangesProps> = ({ state }) => {
         onGetFullDiff={() => Promise.resolve()}
         scrolledToComment={undefined}
         setScrolledToComment={noop}
-        jumpToDiff=''
+        jumpToDiff=""
         setJumpToDiff={noop}
       />
     </>

--- a/apps/design-system/src/subjects/views/pull-request-conversation/pull-request-changes.tsx
+++ b/apps/design-system/src/subjects/views/pull-request-conversation/pull-request-changes.tsx
@@ -100,6 +100,8 @@ const PullRequestChanges: FC<PullRequestChangesProps> = ({ state }) => {
         onGetFullDiff={() => Promise.resolve()}
         scrolledToComment={undefined}
         setScrolledToComment={noop}
+        jumpToDiff=''
+        setJumpToDiff={noop}
       />
     </>
   )

--- a/apps/gitness/src/pages-v2/pull-request/pull-request-changes.tsx
+++ b/apps/gitness/src/pages-v2/pull-request/pull-request-changes.tsx
@@ -82,6 +82,7 @@ export default function PullRequestChanges() {
   const prId = (pullRequestId && Number(pullRequestId)) || -1
   const [commentId] = useQueryState('commentId')
   const [scrolledToComment, setScrolledToComment] = useState(false)
+  const [jumpToDiff, setJumpToDiff] = useState('')
 
   const {
     data: { body: reviewers } = {},
@@ -459,6 +460,8 @@ export default function PullRequestChanges() {
         onGetFullDiff={onGetFullDiff}
         scrolledToComment={scrolledToComment}
         setScrolledToComment={setScrolledToComment}
+        jumpToDiff={jumpToDiff}
+        setJumpToDiff={setJumpToDiff}
       />
     </>
   )

--- a/apps/gitness/src/pages-v2/pull-request/pull-request-compare.tsx
+++ b/apps/gitness/src/pages-v2/pull-request/pull-request-compare.tsx
@@ -84,6 +84,7 @@ export const CreatePullRequest = () => {
   const sourceRef = useMemo(() => selectedSourceBranch.name, [selectedSourceBranch])
   const [cachedDiff, setCachedDiff] = useAtom(changesInfoAtom)
   const [mergeability, setMergeabilty] = useState<boolean>()
+  const [jumpToDiff, setJumpToDiff] = useState('')
   const diffApiPath = useMemo(
     () =>
       // show range of commits and user selected subrange
@@ -548,6 +549,8 @@ export const CreatePullRequest = () => {
         handleAddReviewer={handleAddReviewer}
         handleDeleteReviewer={handleDeleteReviewer}
         isFetchingCommits={isFetchingCommits}
+        jumpToDiff={jumpToDiff}
+        setJumpToDiff={setJumpToDiff}
       />
     )
   }

--- a/packages/ui/src/hooks/use-memory-cleanup.ts
+++ b/packages/ui/src/hooks/use-memory-cleanup.ts
@@ -53,7 +53,7 @@ const getMemoryUsage = (): number | null => {
  * @param threshold Memory threshold in MB
  * @param interval Check interval in ms
  */
-export const useMemoryCleanup = (cleanupFn: () => void, threshold = 800, interval = 30000) => {
+export const useMemoryCleanup = (cleanupFn: () => void, threshold = 1200, interval = 30000) => {
   useEffect(() => {
     if (!hasMemoryAPI()) {
       console.debug('Memory API not available - memory cleanup disabled')

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1168,3 +1168,20 @@ mark {
 .monaco-diff-editor.side-by-side .editor.modified {
   @apply !border-borders-1 !border-l !border-solid !shadow-none;
 }
+
+/* In View Diff Renderer */
+.diffViewBlock {
+  @apply visible box-border flex h-auto min-h-[48px] flex-col;
+}
+
+/* .hidden extension */
+.diffViewBlock.hiddenDiff {
+  @apply invisible h-[var(--block-height)] [contain-intrinsic-size:auto_var(--block-height)] [content-visibility:auto];
+}
+
+.diffViewBlock.hiddenDiff > * {
+  visibility: hidden !important;
+}
+.diffViewBlock.hiddenDiff > * > * {
+  display: none !important;
+}

--- a/packages/ui/src/views/repo/pull-request/compare/components/pull-request-compare-diff-list.tsx
+++ b/packages/ui/src/views/repo/pull-request/compare/components/pull-request-compare-diff-list.tsx
@@ -69,7 +69,6 @@ const PullRequestAccordion: FC<PullRequestAccordionProps> = ({
   const { t: _ts } = useTranslationStore()
   const { highlight, wrap, fontsize } = useDiffConfig()
   const [showHiddenDiff, setShowHiddenDiff] = useState(false)
-  const [isDiffReady, setIsDiffReady] = useState(false)
   const startingLine = useMemo(
     () => (parseStartingLineIfOne(header?.data ?? '') !== null ? parseStartingLineIfOne(header?.data ?? '') : null),
     [header?.data]
@@ -86,13 +85,6 @@ const PullRequestAccordion: FC<PullRequestAccordionProps> = ({
     () => header?.unchangedPercentage === 100 || (header?.addedLines === 0 && header?.removedLines === 0),
     [header?.addedLines, header?.removedLines, header?.unchangedPercentage]
   )
-
-  const shouldShowDiff = !fileDeleted && !isDiffTooLarge && !fileUnchanged && !header?.isBinary
-  const isContentReady = isDiffReady || !shouldShowDiff
-
-  if (!isContentReady) {
-    return null
-  }
 
   return (
     <StackedList.Root>
@@ -148,7 +140,6 @@ const PullRequestAccordion: FC<PullRequestAccordionProps> = ({
                       deleted={header?.deleted}
                       unchangedPercentage={header?.unchangedPercentage}
                       useTranslationStore={useTranslationStore}
-                      onReady={() => setIsDiffReady(true)}
                     />
                   </>
                 )}

--- a/packages/ui/src/views/repo/pull-request/compare/components/pull-request-compare-diff-list.tsx
+++ b/packages/ui/src/views/repo/pull-request/compare/components/pull-request-compare-diff-list.tsx
@@ -68,9 +68,12 @@ const PullRequestAccordion: FC<PullRequestAccordionProps> = ({
 }) => {
   const { t: _ts } = useTranslationStore()
   const { highlight, wrap, fontsize } = useDiffConfig()
-  const startingLine =
-    parseStartingLineIfOne(header?.data ?? '') !== null ? parseStartingLineIfOne(header?.data ?? '') : null
   const [showHiddenDiff, setShowHiddenDiff] = useState(false)
+  const [isDiffReady, setIsDiffReady] = useState(false)
+  const startingLine = useMemo(
+    () => (parseStartingLineIfOne(header?.data ?? '') !== null ? parseStartingLineIfOne(header?.data ?? '') : null),
+    [header?.data]
+  )
 
   const fileDeleted = useMemo(() => header?.deleted, [header?.deleted])
   const isDiffTooLarge = useMemo(() => {
@@ -83,6 +86,13 @@ const PullRequestAccordion: FC<PullRequestAccordionProps> = ({
     () => header?.unchangedPercentage === 100 || (header?.addedLines === 0 && header?.removedLines === 0),
     [header?.addedLines, header?.removedLines, header?.unchangedPercentage]
   )
+
+  const shouldShowDiff = !fileDeleted && !isDiffTooLarge && !fileUnchanged && !header?.isBinary
+  const isContentReady = isDiffReady || !shouldShowDiff
+
+  if (!isContentReady) {
+    return null
+  }
 
   return (
     <StackedList.Root>
@@ -117,11 +127,11 @@ const PullRequestAccordion: FC<PullRequestAccordionProps> = ({
                   </Layout.Vertical>
                 ) : (
                   <>
-                    {startingLine ? (
+                    {startingLine && (
                       <div className="bg-[--diff-hunk-lineNumber--]">
                         <div className="ml-16 w-full px-2 py-1">{startingLine}</div>
                       </div>
-                    ) : null}
+                    )}
                     <PullRequestDiffViewer
                       currentUser={currentUser}
                       data={header?.data}
@@ -138,6 +148,7 @@ const PullRequestAccordion: FC<PullRequestAccordionProps> = ({
                       deleted={header?.deleted}
                       unchangedPercentage={header?.unchangedPercentage}
                       useTranslationStore={useTranslationStore}
+                      onReady={() => setIsDiffReady(true)}
                     />
                   </>
                 )}

--- a/packages/ui/src/views/repo/pull-request/compare/components/pull-request-compare-diff-list.tsx
+++ b/packages/ui/src/views/repo/pull-request/compare/components/pull-request-compare-diff-list.tsx
@@ -12,7 +12,7 @@ import {
   StackedList,
   Text
 } from '@/components'
-import { DiffModeOptions, InViewDiffRenderer, TranslationStore, TypesDiffStats } from '@/views'
+import { DiffModeOptions, InViewDiffRenderer, jumpToFile, TranslationStore, TypesDiffStats } from '@/views'
 import { DiffModeEnum } from '@git-diff-view/react'
 import { chunk } from 'lodash-es'
 
@@ -56,6 +56,7 @@ interface PullRequestAccordionProps {
   useTranslationStore: () => TranslationStore
   openItems: string[]
   onToggle: () => void
+  setCollapsed: (val: boolean) => void
 }
 
 const PullRequestAccordion: FC<PullRequestAccordionProps> = ({
@@ -64,7 +65,8 @@ const PullRequestAccordion: FC<PullRequestAccordionProps> = ({
   currentUser,
   useTranslationStore,
   openItems,
-  onToggle
+  onToggle,
+  setCollapsed
 }) => {
   const { t: _ts } = useTranslationStore()
   const { highlight, wrap, fontsize } = useDiffConfig()
@@ -74,7 +76,7 @@ const PullRequestAccordion: FC<PullRequestAccordionProps> = ({
     [header?.data]
   )
 
-  const fileDeleted = useMemo(() => header?.deleted, [header?.deleted])
+  const fileDeleted = useMemo(() => header?.isDeleted, [header?.isDeleted])
   const isDiffTooLarge = useMemo(() => {
     if (header?.addedLines && header?.removedLines) {
       return header?.addedLines + header?.removedLines > PULL_REQUEST_LARGE_DIFF_CHANGES_LIMIT
@@ -137,9 +139,10 @@ const PullRequestAccordion: FC<PullRequestAccordionProps> = ({
                       isBinary={header?.isBinary}
                       addedLines={header?.addedLines}
                       removedLines={header?.removedLines}
-                      deleted={header?.deleted}
+                      deleted={header?.isDeleted}
                       unchangedPercentage={header?.unchangedPercentage}
                       useTranslationStore={useTranslationStore}
+                      collapseDiff={() => setCollapsed(true)}
                     />
                   </>
                 )}
@@ -157,13 +160,17 @@ interface PullRequestCompareDiffListProps {
   diffData: HeaderProps[]
   currentUser?: string
   useTranslationStore: () => TranslationStore
+  jumpToDiff?: string
+  setJumpToDiff: (fileName: string) => void
 }
 
 const PullRequestCompareDiffList: FC<PullRequestCompareDiffListProps> = ({
   diffStats,
   diffData,
   currentUser,
-  useTranslationStore
+  useTranslationStore,
+  jumpToDiff,
+  setJumpToDiff
 }) => {
   const [diffMode, setDiffMode] = useState<DiffModeEnum>(DiffModeEnum.Split)
   const handleDiffModeChange = (value: string) => {
@@ -171,7 +178,6 @@ const PullRequestCompareDiffList: FC<PullRequestCompareDiffListProps> = ({
   }
   const [openItems, setOpenItems] = useState<string[]>([])
   const diffBlocks = useMemo(() => chunk(diffData, PULL_REQUEST_DIFF_RENDERING_BLOCK_SIZE), [diffData])
-  const rootref = useRef<HTMLDivElement>(null)
   const diffsContainerRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
@@ -187,6 +193,23 @@ const PullRequestCompareDiffList: FC<PullRequestCompareDiffListProps> = ({
   const toggleOpen = useCallback(
     (fileText: string) => {
       setOpenItems(curr => (curr.includes(fileText) ? curr.filter(t => t !== fileText) : [...curr, fileText]))
+    },
+    [setOpenItems]
+  )
+  useEffect(() => {
+    if (!jumpToDiff) return
+    jumpToFile(jumpToDiff, diffBlocks, setJumpToDiff)
+  }, [jumpToDiff, diffBlocks])
+
+  const setCollapsed = useCallback(
+    (fileText: string, val: boolean) => {
+      setOpenItems(items => {
+        if (val) {
+          return items.filter(item => item !== fileText)
+        } else {
+          return items.includes(fileText) ? items : [...items, fileText]
+        }
+      })
     },
     [setOpenItems]
   )
@@ -210,7 +233,11 @@ const PullRequestCompareDiffList: FC<PullRequestCompareDiffListProps> = ({
                 {diffData?.map(diff => (
                   <DropdownMenu.Item
                     key={diff.filePath}
-                    onClick={() => {}}
+                    onClick={() => {
+                      if (diff.filePath) {
+                        setJumpToDiff(diff.filePath)
+                      }
+                    }}
                     className="flex w-80 cursor-pointer items-center justify-between px-3 py-2"
                   >
                     <Text size={1} className="flex-1 overflow-hidden truncate text-primary">
@@ -244,13 +271,13 @@ const PullRequestCompareDiffList: FC<PullRequestCompareDiffListProps> = ({
         </ListActions.Right>
       </ListActions.Root>
       <Spacer size={3} />
-      <div className="flex flex-col gap-4" ref={rootref}>
+      <div className="flex flex-col" ref={diffsContainerRef}>
         {diffBlocks?.map((diffsBlock, blockIndex) => {
           return (
             <InViewDiffRenderer
               key={blockIndex}
               blockName={outterBlockName(blockIndex)}
-              root={rootref as RefObject<Element>}
+              root={document as unknown as RefObject<Element>}
               shouldRetainChildren={shouldRetainDiffChildren}
               detectionMargin={calculateDetectionMargin(diffData?.length)}
             >
@@ -272,6 +299,7 @@ const PullRequestCompareDiffList: FC<PullRequestCompareDiffListProps> = ({
                       useTranslationStore={useTranslationStore}
                       openItems={openItems}
                       onToggle={() => toggleOpen(item.text)}
+                      setCollapsed={val => setCollapsed(item.text, val)}
                     />
                   </InViewDiffRenderer>
                 </div>

--- a/packages/ui/src/views/repo/pull-request/compare/pull-request-compare-page.tsx
+++ b/packages/ui/src/views/repo/pull-request/compare/pull-request-compare-page.tsx
@@ -96,6 +96,8 @@ export interface PullRequestComparePageProps extends Partial<RoutingProps> {
   desc?: string
   setDesc: (desc: string) => void
   isFetchingCommits?: boolean
+  jumpToDiff: string
+  setJumpToDiff: (fileName: string) => void
 }
 
 export const PullRequestComparePage: FC<PullRequestComparePageProps> = ({
@@ -132,7 +134,9 @@ export const PullRequestComparePage: FC<PullRequestComparePageProps> = ({
   handleUpload,
   desc,
   setDesc,
-  isFetchingCommits
+  isFetchingCommits,
+  jumpToDiff,
+  setJumpToDiff
 }) => {
   const { commits: commitData } = useRepoCommitsStore()
   const formRef = useRef<HTMLFormElement>(null) // Create a ref for the form
@@ -434,6 +438,8 @@ export const PullRequestComparePage: FC<PullRequestComparePageProps> = ({
                     currentUser={currentUser}
                     diffStats={diffStats}
                     useTranslationStore={useTranslationStore}
+                    jumpToDiff={jumpToDiff}
+                    setJumpToDiff={setJumpToDiff}
                   />
                 ) : (
                   <NoData

--- a/packages/ui/src/views/repo/pull-request/compare/pull-request-compare.types.ts
+++ b/packages/ui/src/views/repo/pull-request/compare/pull-request-compare.types.ts
@@ -6,7 +6,7 @@ export interface HeaderProps {
   addedLines?: number
   removedLines?: number
   isBinary?: boolean
-  deleted?: boolean
+  isDeleted?: boolean
   unchangedPercentage?: number
   filePath?: string
 }

--- a/packages/ui/src/views/repo/pull-request/components/in-view-diff-renderer.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/in-view-diff-renderer.tsx
@@ -3,7 +3,11 @@ import { useInView } from 'react-intersection-observer'
 
 import { useIsMounted } from '@hooks/use-is-mounted'
 import { useResizeObserver } from '@hooks/use-resize-observer'
+import { cn } from '@utils/cn'
 
+const BLOCK_HEIGHT = '--block-height'
+const AUTO = 'auto'
+const RESET_MIN_HEIGHT_TIMEOUT = 2000
 interface InViewDiffRendererProps {
   root: RefObject<Element>
   blockName: string
@@ -85,14 +89,15 @@ const InViewDiffRendererInternal: FC<InViewDiffRendererProps> = ({
   )
 
   return (
-    <div data-block={blockName} data-rendered={showChildren} ref={setContainerRef}>
+    <div
+      data-block={blockName}
+      data-rendered={showChildren}
+      ref={setContainerRef}
+      className={cn('diffViewBlock', { hiddenDiff: !inView })}
+    >
       {showChildren ? children : null}
     </div>
   )
 }
-
-const BLOCK_HEIGHT = '--block-height'
-const AUTO = 'auto'
-const RESET_MIN_HEIGHT_TIMEOUT = 2000
 
 export const InViewDiffRenderer = memo(InViewDiffRendererInternal)

--- a/packages/ui/src/views/repo/pull-request/components/pull-request-diff-viewer.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/pull-request-diff-viewer.tsx
@@ -59,7 +59,6 @@ interface PullRequestDiffviewerProps {
   handleUpload?: (blob: File, setMarkdownContent: (data: string) => void) => void
   scrolledToComment?: boolean
   setScrolledToComment?: (val: boolean) => void
-  onReady?: () => void
 }
 
 const PullRequestDiffViewer = ({
@@ -88,8 +87,7 @@ const PullRequestDiffViewer = ({
   toggleConversationStatus,
   handleUpload,
   scrolledToComment,
-  setScrolledToComment,
-  onReady
+  setScrolledToComment
 }: PullRequestDiffviewerProps) => {
   const { t } = useTranslationStore()
   const ref = useRef<{ getDiffFileInstance: () => DiffFile }>(null)
@@ -101,7 +99,7 @@ const PullRequestDiffViewer = ({
   highlightRef.current = highlight
   const [diffFileInstance, setDiffFileInstance] = useState<DiffFile>()
   const overlayScrollbarsInstances = useRef<OverlayScrollbars[]>([])
-  const diffInstanceRef = useRef<HTMLElement | null>(null)
+  const diffInstanceRef = useRef<HTMLDivElement | null>(null)
   const [isInView, setIsInView] = useState(false)
 
   useEffect(() => {
@@ -128,13 +126,9 @@ const PullRequestDiffViewer = ({
     }
   }, [])
 
-  const isDiffInstanceInView = () => {
-    return isInView
-  }
-
   const cleanup = useCallback(() => {
-    // Only clean up diff instance if it is not in view
-    if (!isDiffInstanceInView() && diffFileInstance) {
+    // clean up diff instance if it is not in view
+    if (!isInView && diffFileInstance) {
       diffFileInstance._destroy?.()
       setDiffFileInstance(undefined)
     }
@@ -321,12 +315,6 @@ const PullRequestDiffViewer = ({
       setDiffInstanceCb(fileName, lang, data, fullContent)
     }
   }, [data, fileName, lang, fullContent, setDiffInstanceCb])
-
-  useEffect(() => {
-    if (diffFileInstance && onReady) {
-      onReady()
-    }
-  }, [diffFileInstance, onReady])
 
   const [editModes, setEditModes] = useState<{ [key: string]: boolean }>({})
   const [editComments, setEditComments] = useState<{ [key: string]: string }>({})

--- a/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes-filter.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes-filter.tsx
@@ -52,6 +52,7 @@ export interface PullRequestChangesFilterProps {
     deletedLines: number
   }[]
   pullReqStats?: TypesPullReqStats
+  setJumpToDiff: (fileName: string) => void
 }
 
 export const PullRequestChangesFilter: React.FC<PullRequestChangesFilterProps> = ({
@@ -71,7 +72,8 @@ export const PullRequestChangesFilter: React.FC<PullRequestChangesFilterProps> =
   commitSuggestionsBatchCount,
   onCommitSuggestionsBatch,
   diffData,
-  pullReqStats
+  pullReqStats,
+  setJumpToDiff
 }) => {
   const { t } = useTranslationStore()
   const [commitFilterOptions, setCommitFilterOptions] = useState([defaultCommitFilter])
@@ -240,7 +242,7 @@ export const PullRequestChangesFilter: React.FC<PullRequestChangesFilterProps> =
             <Icon name="chevron-fill-down" size={6} className="chevron-down text-icons-7" />
           </DropdownMenu.Trigger>
           <DropdownMenu.Content className="w-96" align="start">
-            <DropdownMenu.Group>{commitDropdownItems}</DropdownMenu.Group>
+            <div className="max-h-[360px] overflow-y-auto px-1">{commitDropdownItems}</div>
           </DropdownMenu.Content>
         </DropdownMenu.Root>
 
@@ -283,7 +285,9 @@ export const PullRequestChangesFilter: React.FC<PullRequestChangesFilterProps> =
               {diffData?.map(diff => (
                 <DropdownMenu.Item
                   key={diff.filePath}
-                  onClick={() => {}}
+                  onClick={() => {
+                    setJumpToDiff(diff.filePath)
+                  }}
                   className="flex w-80 cursor-pointer items-center justify-between px-3 py-2"
                 >
                   <span className="flex-1 overflow-hidden truncate text-12 text-primary">{diff.filePath}</span>

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-comment-box.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-comment-box.tsx
@@ -154,7 +154,7 @@ const PullRequestCommentBox = ({
   }
 
   return (
-    <div className="flex items-start gap-x-3 font-sans">
+    <div className="flex items-start gap-x-3 font-sans" data-comment-editor-shown="true">
       {!inReplyMode && !isEditMode && avatar}
 
       <div

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-overview.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-overview.tsx
@@ -48,7 +48,7 @@ interface PullRequestOverviewProps extends RoutingProps {
   dateOrderSort: { label: string; value: string } // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   commentStatusPullReq: any
   repoId: string
-  diffData?: { text: string; numAdditions?: number; numDeletions?: number; data?: string; title: string; lang: string }
+  diffData?: { text: string; addedLines?: number; deletedLines?: number; data?: string; title: string; lang: string }
   onCopyClick: (commentId?: number) => void
   suggestionsBatch: CommitSuggestion[]
   onCommitSuggestion: (suggestion: CommitSuggestion) => void

--- a/packages/ui/src/views/repo/pull-request/details/pull-request-changes-page.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/pull-request-changes-page.tsx
@@ -55,6 +55,8 @@ interface RepoPullRequestChangesPageProps {
   onGetFullDiff: (path?: string) => Promise<string | void>
   scrolledToComment?: boolean
   setScrolledToComment?: (val: boolean) => void
+  jumpToDiff?: string
+  setJumpToDiff: (fileName: string) => void
 }
 const PullRequestChangesPage: FC<RepoPullRequestChangesPageProps> = ({
   useTranslationStore,
@@ -92,7 +94,9 @@ const PullRequestChangesPage: FC<RepoPullRequestChangesPageProps> = ({
   handleUpload,
   onGetFullDiff,
   scrolledToComment,
-  setScrolledToComment
+  setScrolledToComment,
+  jumpToDiff,
+  setJumpToDiff
 }) => {
   const { diffs, pullReqStats } = usePullRequestProviderStore()
 
@@ -124,8 +128,8 @@ const PullRequestChangesPage: FC<RepoPullRequestChangesPageProps> = ({
         data={
           diffs?.map(item => ({
             text: item.filePath,
-            numAdditions: item.addedLines,
-            numDeletions: item.deletedLines,
+            addedLines: item.addedLines,
+            deletedLines: item.deletedLines,
             data: item.raw,
             title: item.filePath,
             lang: item.filePath.split('.')[1],
@@ -161,6 +165,8 @@ const PullRequestChangesPage: FC<RepoPullRequestChangesPageProps> = ({
         onGetFullDiff={onGetFullDiff}
         scrolledToComment={scrolledToComment}
         setScrolledToComment={setScrolledToComment}
+        jumpToDiff={jumpToDiff}
+        setJumpToDiff={setJumpToDiff}
       />
     )
   }
@@ -191,6 +197,7 @@ const PullRequestChangesPage: FC<RepoPullRequestChangesPageProps> = ({
           addedLines: diff.addedLines,
           deletedLines: diff.deletedLines
         }))}
+        setJumpToDiff={setJumpToDiff}
       />
       <Spacer aria-setsize={5} />
 

--- a/packages/ui/src/views/repo/pull-request/details/pull-request-details-types.ts
+++ b/packages/ui/src/views/repo/pull-request/details/pull-request-details-types.ts
@@ -589,3 +589,19 @@ export enum MergeStrategy {
   SQUASH = 'squash',
   REBASE = 'rebase'
 }
+
+export interface DiffHeaderProps {
+  text: string
+  data?: string
+  title: string
+  lang: string
+  addedLines?: number
+  deletedLines?: number
+  isBinary?: boolean
+  isDeleted?: boolean
+  unchangedPercentage?: number
+  filePath?: string
+  fileViews?: Map<string, string>
+  checksumAfter?: string
+  diffData?: DiffFileEntry
+}

--- a/packages/ui/src/views/repo/pull-request/utils.ts
+++ b/packages/ui/src/views/repo/pull-request/utils.ts
@@ -72,7 +72,7 @@ export function quoteTransform(raw: string): string {
     .join(CRLF)
 }
 
-// If a diff container has a Markdown Editor active, retain it event it's off-screen to make
+// If a diff container has a Markdown Editor active, retain it even if it's off-screen to make
 // sure editor content is not cleared out during off-screen optimization
 export const shouldRetainDiffChildren = (dom: HTMLElement | null) =>
   !!dom?.querySelector('[data-comment-editor-shown="true"]')


### PR DESCRIPTION
PR changes page diffs optimizations :
1. scrollbar flicker on viewing diffs out of viewport
2. diff memory cleanup by toggling diff below viewport
3. jump to diff file on clicking filename in "x files changed" dropdown