### PR TITLE
Add avatar support to `RepoCommitsView`

### DIFF
--- a/packages/ui/src/components/alert/AlertContainer.tsx
+++ b/packages/ui/src/components/alert/AlertContainer.tsx
@@ -48,7 +48,7 @@ export const AlertContainer = forwardRef<HTMLDivElement, AlertContainerProps>(
         {closable && (
           <button
             type="button"
-            className="absolute top-2 right-2 text-gray-400 hover:text-gray-500"
+            className="absolute right-2 top-2 text-gray-400 hover:text-gray-500"
             onClick={() => setIsVisible(false)}
           >
             <Icon name="close" size={16} />

--- a/packages/ui/src/views/execution/console-logs.tsx
+++ b/packages/ui/src/views/execution/console-logs.tsx
@@ -63,14 +63,14 @@ const ConsoleLogs: FC<ConsoleLogsProps> = ({ logs, query }) => {
           <div className="mb-2 flex items-baseline justify-between leading-[21px]" key={index}>
             <div className="flex items-baseline gap-2">
               {pos !== undefined && !isNaN(pos) && pos >= 0 && (
-                <Text className="flex min-w-5 justify-end text-log">{pos}</Text>
+                <Text className="text-log flex min-w-5 justify-end">{pos}</Text>
               )}
               {time ? (
-                <Text className="flex text-sm font-normal text-log">[{formatTimestamp(time * 1_000)}]</Text>
+                <Text className="text-log flex text-sm font-normal">[{formatTimestamp(time * 1_000)}]</Text>
               ) : null}
               {out ? logText(out) : null}
             </div>
-            <Text className="mr-2 text-sm font-normal text-log">
+            <Text className="text-log mr-2 text-sm font-normal">
               {formatDuration(duration && duration > 0 ? duration * 1_000 : 0)}
             </Text>
           </div>

--- a/packages/ui/src/views/execution/execution-header.tsx
+++ b/packages/ui/src/views/execution/execution-header.tsx
@@ -46,7 +46,7 @@ export const ExecutionHeader: React.FC<ExecutionHeaderProps> = ({
           <span className="text-primary">{title.title}</span>
         </Text>
       </div>
-      <div className="flex items-end gap-12 h-full">
+      <div className="flex h-full items-end gap-12">
         <div className="flex flex-col">
           <span className="text-foreground-5">Storage</span>
           <span className="text-primary">{storage}</span>

--- a/packages/ui/src/views/execution/execution-status.tsx
+++ b/packages/ui/src/views/execution/execution-status.tsx
@@ -26,7 +26,7 @@ const Badge: React.FC<ExecutionStatusProps & BadgeProps> = props => {
     case ExecutionState.RUNNING:
       return minimal ? (
         <div className="flex items-center gap-1">
-          <div className="size-2 rounded-full bg-studio-3" />
+          <div className="bg-studio-3 size-2 rounded-full" />
           <span className="text-studio-3">Running</span>
         </div>
       ) : (

--- a/packages/ui/src/views/execution/key-value-table.tsx
+++ b/packages/ui/src/views/execution/key-value-table.tsx
@@ -20,12 +20,12 @@ export const KeyValueTable: React.FC<KeyValueTableProps> = ({
       if (typeof item.value === 'string') {
         return (
           <ul className="flex flex-row border-b align-middle" key={index}>
-            <li className="w-1/2 py-2.5 pr-2.5 text-studio-7" style={{ paddingLeft: `${level + 1}rem` }}>
+            <li className="text-studio-7 w-1/2 py-2.5 pr-2.5" style={{ paddingLeft: `${level + 1}rem` }}>
               <Text size={2} weight="normal">
                 {item.name}
               </Text>
             </li>
-            <li className="w-1/2 py-2.5 pl-1.5 pr-2.5 text-studio-7">
+            <li className="text-studio-7 w-1/2 py-2.5 pl-1.5 pr-2.5">
               <Text size={2} weight="normal">
                 {item.value}
               </Text>

--- a/packages/ui/src/views/execution/pipeline-status.tsx
+++ b/packages/ui/src/views/execution/pipeline-status.tsx
@@ -14,7 +14,7 @@ export const PipelineStatus = ({
   createdTime: string
 }) => {
   return (
-    <div className="flex justify-between pl-6 pr-6 pt-3 pb-4 border-b">
+    <div className="flex justify-between border-b px-6 pb-4 pt-3">
       <div className="flex flex-col">
         <span className="text-foreground-5">Status</span>
         <ExecutionStatus.Badge status={status} />

--- a/packages/ui/src/views/execution/step-execution.tsx
+++ b/packages/ui/src/views/execution/step-execution.tsx
@@ -69,7 +69,7 @@ export const StepExecution: React.FC<StepExecutionProps> = ({ step, logs, onEdit
           />
         </Layout.Horizontal>
         <TabsContent value={StepExecutionTab.LOG}>
-          <ScrollArea className="h-[calc(100vh-23rem)] border-t pt-4 px-2">
+          <ScrollArea className="h-[calc(100vh-23rem)] border-t px-2 pt-4">
             <ConsoleLogs logs={logs} query={query} />
           </ScrollArea>
         </TabsContent>

--- a/packages/ui/src/views/repo/components/commits-list.tsx
+++ b/packages/ui/src/views/repo/components/commits-list.tsx
@@ -1,7 +1,16 @@
 import { FC, useMemo } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
-import { Avatar, AvatarFallback, Button, CommitCopyActions, Icon, NodeGroup, StackedList } from '@/components'
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+  Button,
+  CommitCopyActions,
+  Icon,
+  NodeGroup,
+  StackedList
+} from '@/components'
 import { formatDate, getInitials } from '@/utils/utils'
 import { TypesCommit } from '@/views'
 
@@ -43,6 +52,7 @@ export const CommitsList: FC<CommitProps> = ({ data, toCommitDetails, toCode, cl
               <StackedList.Root>
                 {commitData.map((commit, repo_idx) => {
                   const authorName = commit.author?.identity?.name
+                  const avatarUrl = commit.author?.identity?.avatarUrl
 
                   return (
                     <StackedList.Item
@@ -76,6 +86,7 @@ export const CommitsList: FC<CommitProps> = ({ data, toCommitDetails, toCode, cl
                               <div className="flex items-center gap-x-1.5">
                                 {authorName && (
                                   <Avatar className="size-[18px]">
+                                    {avatarUrl && <AvatarImage src={avatarUrl} alt={`${authorName} avatar`} />}
                                     <AvatarFallback className="text-10">{getInitials(authorName)}</AvatarFallback>
                                   </Avatar>
                                 )}

--- a/packages/ui/src/views/repo/repo.types.ts
+++ b/packages/ui/src/views/repo/repo.types.ts
@@ -152,6 +152,7 @@ export interface TypesSignature {
 export interface TypesIdentity {
   email?: string
   name?: string
+  avatarUrl?: string
 }
 
 export interface TypesCommit {

--- a/packages/ui/src/views/repo/webhooks/webhook-executions/repo-webhook-executions-page.tsx
+++ b/packages/ui/src/views/repo/webhooks/webhook-executions/repo-webhook-executions-page.tsx
@@ -42,14 +42,14 @@ const RepoWebhookExecutionsPage: FC<RepoWebhookExecutionsPageProps> = ({
 
   return (
     <SandboxLayout.Main className="mx-0">
-      <SandboxLayout.Content className="pl-0 max-w-[812px]">
-        <h1 className="text-2xl font-medium text-foreground-1 mb-4">Order Status Update Webhook</h1>
+      <SandboxLayout.Content className="max-w-[812px] pl-0">
+        <h1 className="mb-4 text-2xl font-medium text-foreground-1">Order Status Update Webhook</h1>
         <Text>
           This webhook triggers every time an order status is updated, sending data to the specified endpoint for
           real-time tracking.
         </Text>
         <FormSeparator className="my-6" />
-        <h1 className="text-xl font-medium text-foreground-1 mb-4">Executions</h1>
+        <h1 className="mb-4 text-xl font-medium text-foreground-1">Executions</h1>
         {isLoading ? (
           <SkeletonList />
         ) : executions && executions.length > 0 ? (


### PR DESCRIPTION
This PR adds `avatarUrl` support to the `RepoCommitsView`. This PR also adds lint fixes that were left behind by another PR.

Fixes #951 