### PR TITLE
Update Repo and commit page to full width

### DIFF
--- a/packages/ui/src/views/repo/repo-commits/repo-commits-view.tsx
+++ b/packages/ui/src/views/repo/repo-commits/repo-commits-view.tsx
@@ -61,7 +61,7 @@ export const RepoCommitsView: FC<RepoCommitsViewProps> = ({
   }
 
   return (
-    <SandboxLayout.Main>
+    <SandboxLayout.Main fullWidth>
       <SandboxLayout.Content>
         <Text size={5} weight={'medium'}>
           Commits

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -137,9 +137,9 @@ export function RepoSummaryView({
   }
 
   return (
-    <SandboxLayout.Main>
+    <SandboxLayout.Main fullWidth>
       <SandboxLayout.Columns columnWidths="1fr 256px">
-        <SandboxLayout.Column className="max-w-[1000px]">
+        <SandboxLayout.Column className="w-full">
           <SandboxLayout.Content className="pl-6">
             {/*
               TODO: Implement proper recent push detection logic:


### PR DESCRIPTION
Making the below pages full width:

1. Repo Overview
2. Repo Files
3. Repo Files > File View
4. Repo Files > File Edit
5. Repo Files > Blame
6. Repo Commits

![image](https://github.com/user-attachments/assets/e1ffd886-9375-4c78-adcc-c84c7eb69df5)
![image](https://github.com/user-attachments/assets/7f2cfa7c-cb7e-416c-a005-ff4f8632cc61)
![image](https://github.com/user-attachments/assets/398723e9-8231-4f52-9e78-c19d1eb770b5)
![image](https://github.com/user-attachments/assets/1d52045e-7b63-4379-999a-f67d05c1f8c7)
![image](https://github.com/user-attachments/assets/c07a89f6-798c-4767-956b-57ac5959c98c)
![image](https://github.com/user-attachments/assets/03194d1d-3718-4b45-8fce-42118851001b)
