### PR TITLE
Nav spacings

### DIFF
--- a/packages/canary/src/components/navbar.tsx
+++ b/packages/canary/src/components/navbar.tsx
@@ -139,9 +139,7 @@ function Item({ icon, text, description, active, submenuItem, className }: ItemP
     )
 
   return (
-    <div
-      className={cn('group flex cursor-pointer select-none items-center gap-2 py-1', { 'gap-0': !icon }, className)}
-    >
+    <div className={cn('group flex cursor-pointer select-none items-center gap-2 py-1', { 'gap-0': !icon }, className)}>
       {icon && (
         <div
           className={cn(

--- a/packages/canary/src/components/navbar.tsx
+++ b/packages/canary/src/components/navbar.tsx
@@ -140,7 +140,7 @@ function Item({ icon, text, description, active, submenuItem, className }: ItemP
 
   return (
     <div
-      className={cn('group flex cursor-pointer select-none items-center gap-2.5 py-1', { 'gap-0': !icon }, className)}
+      className={cn('group flex cursor-pointer select-none items-center gap-2 py-1', { 'gap-0': !icon }, className)}
     >
       {icon && (
         <div

--- a/packages/ui/src/components/navbar-project-chooser.tsx
+++ b/packages/ui/src/components/navbar-project-chooser.tsx
@@ -23,7 +23,7 @@ function Root({ logo }: ProjectProps) {
   }
 
   return (
-    <div className="flex w-full flex-col place-items-start px-3 pb-4">
+    <div className="flex w-full flex-col place-items-start px-3 pb-3">
       <div className="flex h-[58px] px-1 items-center">{logo}</div>
       <SearchBox
         width="full"

--- a/packages/ui/src/components/navbar-skeleton/group.tsx
+++ b/packages/ui/src/components/navbar-skeleton/group.tsx
@@ -21,7 +21,7 @@ export function Group({ children, title, topBorder, isSubMenu = false, titleClas
       )}
     >
       {title && (
-        <div className={cn('text-foreground-7 mt-1.5', isSubMenu ? 'mb-3' : 'mb-2.5', titleClassName)}>
+        <div className={cn('text-foreground-7 mt-1.5', isSubMenu ? 'mb-3' : 'mb-1.5', titleClassName)}>
           <p className="text-xs font-normal px-2.5">{title}</p>
         </div>
       )}

--- a/packages/ui/src/components/navbar-skeleton/item.tsx
+++ b/packages/ui/src/components/navbar-skeleton/item.tsx
@@ -26,7 +26,7 @@ export function Item({ icon, text, description, active, submenuItem, className }
       >
         <div
           className={cn(
-            'group-hover:bg-background-4 absolute -inset-x-3 z-0 h-full w-auto rounded-[10px] bg-transparent transition-colors',
+            'group-hover:bg-background-4 absolute z-0 h-full w-full rounded-[10px] bg-transparent transition-colors',
             { 'bg-background-4': active }
           )}
         />

--- a/packages/ui/src/components/navbar-skeleton/item.tsx
+++ b/packages/ui/src/components/navbar-skeleton/item.tsx
@@ -68,7 +68,7 @@ export function Item({ icon, text, description, active, submenuItem, className }
   return (
     <div
       className={cn(
-        'group flex cursor-pointer select-none gap-2.5 py-2 px-3 rounded-md',
+        'group flex cursor-pointer select-none gap-2 py-1.5 px-3 rounded-md',
         { 'bg-background-4': active },
         { 'gap-0': !icon },
         className


### PR DESCRIPTION
Updated spacing values ​​to visually match Figma design + fixed hover in nav, because previously it looked like this:
![image](https://github.com/user-attachments/assets/4eee0aa9-8b82-458b-aa22-ce8a54d50dde)

I fixed that, and now it's shows correctly:
![Screen Shot 2025-02-04 at 11 50 59 PM](https://github.com/user-attachments/assets/2c1a18cd-a741-4e84-9cde-a582ea1891ea)

