### PR TITLE
chore: add exported files to files entry

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,12 +10,17 @@
     "./views": "./dist/views.js",
     "./hooks": "./dist/hooks.js",
     "./locales": "./dist/locales.js",
-    "./tailwind.config": "./tailwind.config.js",
+    "./tailwind.config": "./dist/tailwind.config.js",
     "./styles.css": "./dist/styles.css",
     "./shared-style-variables.css": "./src/shared-style-variables.css",
     "./markdown-preview-styles.css": "./src/components/markdown-viewer/style.css",
     "./context": "./dist/context.js"
   },
+  "files": [
+    "dist/**.*",
+    "src/shared-style-variables.css",
+    "src/components/markdown-viewer/style.css"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "vite build && pnpm extract",
@@ -36,9 +41,6 @@
   },
   "types": "./dist/index.d.ts",
   "style": "./dist/styles.css",
-  "files": [
-    "dist/**.*"
-  ],
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/packages/ui/vite-base.config.ts
+++ b/packages/ui/vite-base.config.ts
@@ -26,7 +26,8 @@ export default defineConfig({
         hooks: resolve(__dirname, 'src/hooks/index.ts'),
         locales: resolve(__dirname, 'locales/index.ts'),
         index: resolve(__dirname, 'src/index.ts'),
-        context: resolve(__dirname, 'src/context/index.ts')
+        context: resolve(__dirname, 'src/context/index.ts'),
+        'tailwind.config': resolve(__dirname, 'tailwind.config.js')
       },
       formats: ['es']
     },


### PR DESCRIPTION
This PR adds files that were missing from the `files` entry in the `package.json` file and ensures the `tailwind.config` entry is processed.