### PR TITLE
Fixes across pages

### DIFF
--- a/packages/ui/src/components/navbar-skeleton/item.tsx
+++ b/packages/ui/src/components/navbar-skeleton/item.tsx
@@ -19,7 +19,7 @@ export function Item({ icon, text, description, active, submenuItem, className }
       <div
         className={cn(
           'group relative grid cursor-pointer select-none grid-cols-[auto_1fr] items-center gap-3 pb-[0.6875rem] pt-[0.5625rem] py-2 px-3 rounded-md',
-          { 'bg-background-4': active },
+          // { 'bg-background-4': active },
           { 'gap-0': !icon },
           className
         )}

--- a/packages/ui/src/components/navbar-skeleton/item.tsx
+++ b/packages/ui/src/components/navbar-skeleton/item.tsx
@@ -68,7 +68,7 @@ export function Item({ icon, text, description, active, submenuItem, className }
   return (
     <div
       className={cn(
-        'group flex cursor-pointer select-none gap-2 py-1.5 px-3 rounded-md',
+        'group flex cursor-pointer select-none gap-2 py-1.5 px-4 rounded-md',
         { 'bg-background-4': active },
         { 'gap-0': !icon },
         className

--- a/packages/ui/src/components/navbar/navbar-item/index.tsx
+++ b/packages/ui/src/components/navbar/navbar-item/index.tsx
@@ -79,7 +79,7 @@ export const NavbarItem = ({
         <DropdownMenu.Root>
           <DropdownMenu.Trigger asChild>
             <Button
-              className="absolute right-[-0.8125rem] top-0 text-icons-4 opacity-0 hover:text-icons-2 focus:opacity-100 focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+              className="absolute right-[-0.1rem] top-[2px] text-icons-4 opacity-0 hover:text-icons-2 focus:opacity-100 focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
               size="sm_icon"
               variant="custom"
             >

--- a/packages/ui/src/views/labels/labels-list-page.tsx
+++ b/packages/ui/src/views/labels/labels-list-page.tsx
@@ -70,7 +70,7 @@ export const LabelsListPage: FC<LabelsListPageProps> = ({
 
   return (
     <SandboxLayout.Main>
-      <SandboxLayout.Content className="mx-auto max-w-[812px]">
+      <SandboxLayout.Content className="px-0">
         <h1 className="text-2xl font-medium text-foreground-1">{t('views:labelData.title', 'Labels')}</h1>
         <Spacer size={6} />
         {isRepository && (

--- a/packages/ui/src/views/repo/webhooks/webhook-list/components/repo-webhook-list.tsx
+++ b/packages/ui/src/views/repo/webhooks/webhook-list/components/repo-webhook-list.tsx
@@ -136,7 +136,12 @@ export function RepoWebhookList({
           {webhooks.map(webhook => (
             <TableRow onClick={() => navigate(`${webhook.id}`)} key={webhook.id}>
               <TableCell>
-                <StackedList.Item key={webhook.id} className="max-w-full cursor-pointer !p-0 py-3 pr-1.5" isLast>
+                <StackedList.Item
+                  key={webhook.id}
+                  className="max-w-full cursor-pointer !p-0 py-3 pr-1.5"
+                  isLast
+                  disableHover
+                >
                   <StackedList.Field
                     primary
                     description={
@@ -160,7 +165,7 @@ export function RepoWebhookList({
                   />
                 </StackedList.Item>
               </TableCell>
-              <TableCell className="content-center">
+              <TableCell className="content-center cursor-pointer">
                 <Badge
                   size="md"
                   disableHover
@@ -183,7 +188,7 @@ export function RepoWebhookList({
                 </Badge>
               </TableCell>
 
-              <TableCell className="content-center text-right">
+              <TableCell className="content-center text-right cursor-pointer">
                 <MoreActionsTooltip
                   actions={[
                     {


### PR DESCRIPTION
- Fixes nav on `repo-settings` page. Fixes hover inside `webhook-list`. 

https://github.com/user-attachments/assets/f232bf1b-0c90-4263-99e2-11c267435394

- Fixes icon on navbar. 

Earlier: 
<img width="1752" alt="Screenshot 2025-02-05 at 11 08 39 AM" src="https://github.com/user-attachments/assets/1ec82e49-4467-4faa-bc59-7a36afa2a75f" />

Now: 
<img width="1752" alt="Screenshot 2025-02-05 at 12 20 00 PM" src="https://github.com/user-attachments/assets/382044d5-71df-4ebf-83d5-f7d66ccf73f9" />

- Allow `labels` page to occupy as much width as available and align to the left with `webhooks` and `settings`.
