### PR TITLE
Yaml Editor fixes

### DIFF
--- a/packages/yaml-editor-playground/src/examples/data-flow/YamlEditorWrapper.tsx
+++ b/packages/yaml-editor-playground/src/examples/data-flow/YamlEditorWrapper.tsx
@@ -77,15 +77,6 @@ export const YamlEditorWrapper: React.FC<React.PropsWithChildren<React.HTMLAttri
             onAnimateEnd={() => {
               console.log('animation ended')
             }}
-            options={{
-              minimap: {
-                enabled: false
-              },
-              overviewRulerBorder: false,
-              overviewRulerLanes: 0,
-              scrollBeyondLastLine: false,
-              renderLineHighlight: 'none'
-            }}
           />
         )}
       </div>

--- a/packages/yaml-editor/src/components/BlameEditor.tsx
+++ b/packages/yaml-editor/src/components/BlameEditor.tsx
@@ -38,6 +38,7 @@ export interface BlameEditorProps {
   blameData: BlameItem[]
   showSeparators?: boolean
   height?: EditorProps['height']
+  options?: monaco.editor.IStandaloneEditorConstructionOptions
 }
 
 export function BlameEditor({
@@ -48,7 +49,8 @@ export function BlameEditor({
   blameData,
   showSeparators = true,
   theme: themeFromProps,
-  height = '75vh'
+  height = '75vh',
+  options
 }: BlameEditorProps): JSX.Element {
   const blameDataRef = useRef(blameData)
 
@@ -208,6 +210,14 @@ export function BlameEditor({
     height:100% !important;
    }`
 
+  const mergedOptions = useMemo(
+    () => ({
+      ...defaultOptions,
+      ...options
+    }),
+    [options]
+  )
+
   return (
     <>
       <style
@@ -220,7 +230,7 @@ export function BlameEditor({
         height={height}
         language={language}
         theme={theme}
-        options={defaultOptions}
+        options={mergedOptions}
         onMount={handleEditorDidMount}
       />
     </>

--- a/packages/yaml-editor/src/components/CodeEditor.tsx
+++ b/packages/yaml-editor/src/components/CodeEditor.tsx
@@ -24,9 +24,7 @@ export interface CodeEditorProps<_> {
   language: string
   themeConfig?: { rootElementSelector?: string; defaultTheme?: string; themes?: ThemeDefinition[] }
   theme?: string
-  options?: {
-    readOnly?: boolean
-  }
+  options?: monaco.editor.IStandaloneEditorConstructionOptions
   height?: EditorProps['height']
 }
 

--- a/packages/yaml-editor/src/components/DiffEditor.tsx
+++ b/packages/yaml-editor/src/components/DiffEditor.tsx
@@ -16,7 +16,6 @@ export interface CodeRevision {
 
 const defaultOptions: monaco.editor.IStandaloneDiffEditorConstructionOptions = {
   ...MonacoCommonDefaultOptions,
-  minimap: { enabled: false },
   codeLens: false,
   smartSelect: {
     selectLeadingAndTrailingWhitespace: true
@@ -31,9 +30,7 @@ export interface DiffEditorProps<_> {
   language: string
   themeConfig?: { rootElementSelector?: string; defaultTheme?: string; themes?: ThemeDefinition[] }
   theme?: string
-  options?: {
-    readOnly?: boolean
-  }
+  options?: monaco.editor.IStandaloneEditorConstructionOptions
   height?: EditorProps['height']
 }
 

--- a/packages/yaml-editor/src/components/YamlEditor.tsx
+++ b/packages/yaml-editor/src/components/YamlEditor.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Editor, { loader, Monaco, useMonaco } from '@monaco-editor/react'
 import * as monaco from 'monaco-editor'
 
+import { MonacoCommonDefaultOptions } from '../constants/monaco-common-default-options'
 import { useCodeLenses } from '../hooks/useCodeLens'
 import { useDecoration } from '../hooks/useDecoration'
 import { useProblems } from '../hooks/useProblems'
@@ -22,10 +23,7 @@ export interface YamlRevision {
 }
 
 const options: monaco.editor.IStandaloneEditorConstructionOptions = {
-  selectOnLineNumbers: true,
-  minimap: {
-    enabled: true
-  },
+  ...MonacoCommonDefaultOptions,
   folding: true
 }
 
@@ -42,8 +40,6 @@ export interface YamlEditorProps<T> {
     className: string
     revealInCenter?: boolean
   }
-  minimap?: boolean
-  folding?: boolean
   animateOnUpdate?: boolean
   onAnimateEnd?: () => void
 }
@@ -58,8 +54,6 @@ export const YamlEditor = function YamlEditor<T>(props: YamlEditorProps<T>): JSX
     selection,
     theme: themeFromProps,
     options: userOptions,
-    minimap = false,
-    folding = true,
     animateOnUpdate = false,
     onAnimateEnd
   } = props
@@ -167,11 +161,9 @@ export const YamlEditor = function YamlEditor<T>(props: YamlEditorProps<T>): JSX
   const mergedOptions = useMemo(
     () => ({
       ...options,
-      folding,
-      minimap: { ...options.minimap, enabled: minimap },
       ...userOptions
     }),
-    [folding, minimap, userOptions]
+    [userOptions]
   )
 
   return (

--- a/packages/yaml-editor/src/constants/monaco-common-default-options.ts
+++ b/packages/yaml-editor/src/constants/monaco-common-default-options.ts
@@ -8,7 +8,7 @@ export const MonacoCommonDefaultOptions: monaco.editor.IStandaloneDiffEditorCons
     bottom: 16
   },
   minimap: { enabled: false },
-  fontSize: 14,
+  fontSize: 13,
   fontFamily: '"JetBrains Mono", "monospace"',
   lineHeight: 20,
   scrollbar: {
@@ -16,5 +16,8 @@ export const MonacoCommonDefaultOptions: monaco.editor.IStandaloneDiffEditorCons
     horizontalScrollbarSize: 14,
     verticalSliderSize: 6,
     horizontalSliderSize: 6
-  }
+  },
+  overviewRulerBorder: false,
+  overviewRulerLanes: 0,
+  renderLineHighlight: 'none'
 }


### PR DESCRIPTION
- use same default options for all editors
- 13px default font size
- hide unnecessary elements