### PR TITLE
Fixed success icon color

### DIFF
--- a/packages/ui/src/components/treeview.tsx
+++ b/packages/ui/src/components/treeview.tsx
@@ -19,7 +19,7 @@ const getStatusIcon = (status: ExecutionState): React.ReactElement => {
     case ExecutionState.RUNNING:
       return <CanaryIcon size={16} name="running" className="animate-spin text-warning" />
     case ExecutionState.SUCCESS:
-      return <CanaryIcon name="success" size={16} />
+      return <CanaryIcon name="success" size={16} className="text-foreground-success" />
     case ExecutionState.FAILURE:
       return <CanaryIcon name="fail" size={16} />
     case ExecutionState.WAITING_ON_DEPENDENCIES:

--- a/packages/ui/src/views/execution/execution-status.tsx
+++ b/packages/ui/src/views/execution/execution-status.tsx
@@ -59,15 +59,15 @@ const Badge: React.FC<ExecutionStatusProps & BadgeProps> = props => {
       return minimal ? (
         <div className="flex items-center gap-1">
           <div className="size-2 rounded-full bg-success" />
-          <span className="text-success">Success</span>
+          <span className="text-foreground-success">Success</span>
         </div>
       ) : (
         <div className="flex items-center gap-1 rounded-md">
-          <div className="flex items-center gap-0.5">
-            <CanaryIcon size={12} name="success" className="text-foreground-success" />
-            <span className="text-success">Success</span>
+          <div className="flex items-center gap-0.5 text-foreground-success">
+            <CanaryIcon size={12} name="success" />
+            <span>Success</span>
           </div>
-          {duration && <span className="text-success">{duration}</span>}
+          {duration && <span className="text-foreground-success">{duration}</span>}
         </div>
       )
     case ExecutionState.SKIPPED:

--- a/packages/ui/src/views/execution/execution-status.tsx
+++ b/packages/ui/src/views/execution/execution-status.tsx
@@ -64,7 +64,7 @@ const Badge: React.FC<ExecutionStatusProps & BadgeProps> = props => {
       ) : (
         <div className="flex items-center gap-1 rounded-md">
           <div className="flex items-center gap-0.5">
-            <CanaryIcon size={12} name="success" />
+            <CanaryIcon size={12} name="success" className="text-foreground-success" />
             <span className="text-success">Success</span>
           </div>
           {duration && <span className="text-success">{duration}</span>}
@@ -87,7 +87,7 @@ const Icon: React.FC<ExecutionStatusProps> = props => {
     case ExecutionState.ERROR:
       return <CanaryIcon size={16} name="fail" />
     case ExecutionState.SUCCESS:
-      return <CanaryIcon size={16} name="success" />
+      return <CanaryIcon size={16} name="success" className="text-foreground-success" />
     case ExecutionState.RUNNING:
       return <CanaryIcon size={20} name="running" className="animate-spin text-warning" />
     case ExecutionState.SKIPPED:

--- a/packages/ui/src/views/pipelines/components/execution-status-badge.tsx
+++ b/packages/ui/src/views/pipelines/components/execution-status-badge.tsx
@@ -65,15 +65,15 @@ export const ExecutionStatusBadge: React.FC<IExecutionStatusBadgeProps> = props 
       return minimal ? (
         <div className="flex items-center gap-1">
           <div className="size-2 rounded-full bg-success" />
-          <span className="text-success">Success</span>
+          <span className="text-foreground-success">Success</span>
         </div>
       ) : (
         <div className="flex items-center gap-1 rounded-md border border-solid border-success bg-success/[0.1] px-1 py-0.5">
-          <div className="flex items-center gap-0.5">
-            <CanaryIcon size={12} name="success" className="text-foreground-success" />
-            <span className="text-success">Success</span>
+          <div className="flex items-center gap-0.5 text-foreground-success">
+            <CanaryIcon size={12} name="success" />
+            <span>Success</span>
           </div>
-          {duration && <span className="text-success">{duration}</span>}
+          {duration && <span className="text-foreground-success">{duration}</span>}
         </div>
       )
     case PipelineExecutionStatus.SKIPPED:

--- a/packages/ui/src/views/pipelines/components/execution-status-badge.tsx
+++ b/packages/ui/src/views/pipelines/components/execution-status-badge.tsx
@@ -70,7 +70,7 @@ export const ExecutionStatusBadge: React.FC<IExecutionStatusBadgeProps> = props 
       ) : (
         <div className="flex items-center gap-1 rounded-md border border-solid border-success bg-success/[0.1] px-1 py-0.5">
           <div className="flex items-center gap-0.5">
-            <CanaryIcon size={12} name="success" />
+            <CanaryIcon size={12} name="success" className="text-foreground-success" />
             <span className="text-success">Success</span>
           </div>
           {duration && <span className="text-success">{duration}</span>}

--- a/packages/ui/src/views/pipelines/components/execution-status-icon.tsx
+++ b/packages/ui/src/views/pipelines/components/execution-status-icon.tsx
@@ -17,7 +17,7 @@ export const ExecutionStatusIcon: React.FC<IExecutionStatusIconProps> = props =>
     case PipelineExecutionStatus.ERROR:
       return <CanaryIcon size={16} name="fail" />
     case PipelineExecutionStatus.SUCCESS:
-      return <CanaryIcon size={16} name="success" />
+      return <CanaryIcon size={16} name="success" className="text-foreground-success" />
     case PipelineExecutionStatus.RUNNING:
       return <CanaryIcon size={20} name="running" className="animate-spin text-warning" />
     case PipelineExecutionStatus.SKIPPED:


### PR DESCRIPTION
Before fix:
<img width="1422" alt="successicon-before-fix" src="https://github.com/user-attachments/assets/f9314764-6aa1-4e20-941f-ddb00ce4452d" />


After fix:
<img width="1387" alt="success-icon-after-fix" src="https://github.com/user-attachments/assets/40cda4ae-722f-49ec-8d03-0ca497967aad" />

