### PR TITLE
feat: add widget gradient color variables for light and dark themes

### DIFF
--- a/packages/ui/src/shared-style-variables.css
+++ b/packages/ui/src/shared-style-variables.css
@@ -945,6 +945,13 @@
     --canary-graph-gradient-executing-1: hsla(var(--canary-amber-150));
     --canary-graph-gradient-executing-2: hsla(var(--canary-amber-600));
     --canary-graph-viewport-bg: hsla(var(--canary-base-chrome-150));
+
+    --canary-widget-bg-gradient-from: var(--canary-base-chrome-100);
+    --canary-widget-bg-gradient-to: var(--canary-pure-white);
+    --canary-widget-number-gradient-from: var(--canary-base-chrome-500);
+    --canary-widget-number-gradient-to: var(--canary-base-chrome-600);
+    --canary-widget-number-bg-gradient-from: var(--canary-base-chrome-150);
+    --canary-widget-number-bg-gradient-to: var(--canary-pure-white);
   }
 
   .dark,
@@ -1407,6 +1414,13 @@
     --canary-graph-gradient-executing-2: hsla(var(--canary-base-chrome-850));
     --canary-graph-viewport-bg: hsla(var(--canary-base-chrome-850) / 0.6);
 
+    --canary-widget-number-gradient-from: var(--canary-base-chrome-150);
+    --canary-widget-number-gradient-to: var(--canary-pure-white);
+    --canary-widget-number-bg-gradient-from: var(--canary-base-chrome-800);
+    --canary-widget-number-bg-gradient-to: var(--canary-base-chrome-850);
+    --canary-widget-bg-gradient-from: var(--canary-base-chrome-850);
+    --canary-widget-bg-gradient-to: var(--canary-base-chrome-950);
+
     /* Navigation gradients */
     /* We’ve removed them until we find a better solution in the design.
     --canary-nav-gradient-1-1: var();
@@ -1660,6 +1674,13 @@
     --canary-graph-gradient-executing-2: hsla(var(--canary-base-chrome-700));
     --canary-graph-viewport-bg: hsla(var(--canary-base-chrome-700) / 0.5);
 
+    --canary-widget-number-gradient-from: var(--canary-base-chrome-150);
+    --canary-widget-number-gradient-to: var(--canary-pure-white);
+    --canary-widget-number-bg-gradient-from: var(--canary-base-chrome-800);
+    --canary-widget-number-bg-gradient-to: var(--canary-base-chrome-850);
+    --canary-widget-bg-gradient-from: var(--canary-base-chrome-850);
+    --canary-widget-bg-gradient-to: var(--canary-base-chrome-950);
+
     /* Navigation gradients */
     /* We’ve removed them until we find a better solution in the design.
     --canary-nav-gradient-1-1: var();
@@ -1909,5 +1930,12 @@
     --canary-graph-gradient-executing-1: hsla(var(--canary-amber-200));
     --canary-graph-gradient-executing-2: hsla(var(--canary-base-chrome-850));
     --canary-graph-viewport-bg: hsla(var(--canary-base-chrome-850) / 0.4);
+
+    --canary-widget-number-gradient-from: var(--canary-base-chrome-150);
+    --canary-widget-number-gradient-to: var(--canary-pure-white);
+    --canary-widget-number-bg-gradient-from: var(--canary-base-chrome-800);
+    --canary-widget-number-bg-gradient-to: var(--canary-base-chrome-850);
+    --canary-widget-bg-gradient-from: var(--canary-base-chrome-850);
+    --canary-widget-bg-gradient-to: var(--canary-base-chrome-950);
   }
 }

--- a/packages/ui/src/shared-style-variables.css
+++ b/packages/ui/src/shared-style-variables.css
@@ -1414,8 +1414,8 @@
     --canary-graph-gradient-executing-2: hsla(var(--canary-base-chrome-850));
     --canary-graph-viewport-bg: hsla(var(--canary-base-chrome-850) / 0.6);
 
-    --canary-widget-number-gradient-from: var(--canary-base-chrome-150);
-    --canary-widget-number-gradient-to: var(--canary-pure-white);
+    --canary-widget-number-gradient-from: var(--canary-grey-200) / 1;
+    --canary-widget-number-gradient-to: var(--canary-base-chrome-600) / 0;
     --canary-widget-number-bg-gradient-from: var(--canary-base-chrome-800);
     --canary-widget-number-bg-gradient-to: var(--canary-base-chrome-850);
     --canary-widget-bg-gradient-from: var(--canary-base-chrome-850);
@@ -1674,8 +1674,8 @@
     --canary-graph-gradient-executing-2: hsla(var(--canary-base-chrome-700));
     --canary-graph-viewport-bg: hsla(var(--canary-base-chrome-700) / 0.5);
 
-    --canary-widget-number-gradient-from: var(--canary-base-chrome-150);
-    --canary-widget-number-gradient-to: var(--canary-pure-white);
+    --canary-widget-number-gradient-from: var(--canary-base-chrome-100);
+    --canary-widget-number-gradient-to: var(--canary-base-chrome-500);
     --canary-widget-number-bg-gradient-from: var(--canary-base-chrome-800);
     --canary-widget-number-bg-gradient-to: var(--canary-base-chrome-850);
     --canary-widget-bg-gradient-from: var(--canary-base-chrome-850);
@@ -1931,8 +1931,8 @@
     --canary-graph-gradient-executing-2: hsla(var(--canary-base-chrome-850));
     --canary-graph-viewport-bg: hsla(var(--canary-base-chrome-850) / 0.4);
 
-    --canary-widget-number-gradient-from: var(--canary-base-chrome-150);
-    --canary-widget-number-gradient-to: var(--canary-pure-white);
+    --canary-widget-number-gradient-from: var(--canary-grey-200) / 1;
+    --canary-widget-number-gradient-to: var(--canary-base-chrome-600) / 0;
     --canary-widget-number-bg-gradient-from: var(--canary-base-chrome-800);
     --canary-widget-number-bg-gradient-to: var(--canary-base-chrome-850);
     --canary-widget-bg-gradient-from: var(--canary-base-chrome-850);

--- a/packages/ui/src/shared-style-variables.css
+++ b/packages/ui/src/shared-style-variables.css
@@ -1414,7 +1414,7 @@
     --canary-graph-gradient-executing-2: hsla(var(--canary-base-chrome-850));
     --canary-graph-viewport-bg: hsla(var(--canary-base-chrome-850) / 0.6);
 
-    --canary-widget-number-gradient-from: var(--canary-grey-200) / 1;
+    --canary-widget-number-gradient-from: var(--canary-base-chrome-200) / 1;
     --canary-widget-number-gradient-to: var(--canary-base-chrome-600) / 0;
     --canary-widget-number-bg-gradient-from: var(--canary-base-chrome-800);
     --canary-widget-number-bg-gradient-to: var(--canary-base-chrome-850);


### PR DESCRIPTION
**Description:**
This pull request makes corrections to the gradients for the widget on the `Repo Summary` page

**Dark Std Std**
<img width="309" alt="image" src="https://github.com/user-attachments/assets/baf54e03-b290-4280-8ed7-4564d190eede" />


**Light Std Std**
<img width="317" alt="image" src="https://github.com/user-attachments/assets/19140930-060d-487c-806e-15c08765669f" />

**Light Std Prot**
<img width="320" alt="image" src="https://github.com/user-attachments/assets/13fbf232-68f9-4f18-8b5b-23072124eaa2" />

