### PR TITLE
fix: repo summary empty state and generateToken from NGUI MFE

### DIFF
--- a/apps/gitness/src/AppMFE.tsx
+++ b/apps/gitness/src/AppMFE.tsx
@@ -83,6 +83,9 @@ interface AppMFEProps {
   customHooks: Partial<{
     useGenerateToken: Unknown
   }>
+  customUtils: Partial<{
+    navigateToUserProfile: Unknown
+  }>
 }
 
 function decode<T = unknown>(arg: string): T {
@@ -96,7 +99,8 @@ export default function AppMFE({
   useMFEThemeContext,
   parentLocationPath,
   onRouteChange,
-  customHooks
+  customHooks,
+  customUtils
 }: AppMFEProps) {
   new CodeServiceAPIClient({
     urlInterceptor: (url: string) =>
@@ -153,7 +157,14 @@ export default function AppMFE({
             <ShadowRootLoader theme={theme} />
           ) : (
             <PortalProvider portalContainer={portalContainer}>
-              <MFEContext.Provider value={{ scope, renderUrl, customHooks }}>
+              <MFEContext.Provider
+                value={{
+                  scope,
+                  renderUrl,
+                  customHooks,
+                  customUtils
+                }}
+              >
                 <I18nextProvider i18n={i18n}>
                   <ThemeProvider defaultTheme={theme === 'Light' ? 'light-std-std' : 'dark-std-std'}>
                     <QueryClientProvider client={queryClient}>

--- a/apps/gitness/src/AppMFE.tsx
+++ b/apps/gitness/src/AppMFE.tsx
@@ -12,7 +12,7 @@ import { PortalProvider } from '@harnessio/ui/context'
 
 import ShadowRootWrapper from './components-v2/shadow-root-wrapper'
 import { ExitConfirmProvider } from './framework/context/ExitConfirmContext'
-import { MFEContext } from './framework/context/MFEContext'
+import { MFEContext, Unknown } from './framework/context/MFEContext'
 import { NavigationProvider } from './framework/context/NavigationContext'
 import { ThemeProvider, useThemeStore } from './framework/context/ThemeContext'
 import { queryClient } from './framework/queryClient'
@@ -80,6 +80,9 @@ interface AppMFEProps {
   useMFEThemeContext: () => { theme: string }
   parentLocationPath: string
   onRouteChange: (updatedLocationPathname: string) => void
+  customHooks: Partial<{
+    useGenerateToken: Unknown
+  }>
 }
 
 function decode<T = unknown>(arg: string): T {
@@ -92,7 +95,8 @@ export default function AppMFE({
   on401,
   useMFEThemeContext,
   parentLocationPath,
-  onRouteChange
+  onRouteChange,
+  customHooks
 }: AppMFEProps) {
   new CodeServiceAPIClient({
     urlInterceptor: (url: string) =>
@@ -149,7 +153,7 @@ export default function AppMFE({
             <ShadowRootLoader theme={theme} />
           ) : (
             <PortalProvider portalContainer={portalContainer}>
-              <MFEContext.Provider value={{ scope, renderUrl }}>
+              <MFEContext.Provider value={{ scope, renderUrl, customHooks }}>
                 <I18nextProvider i18n={i18n}>
                   <ThemeProvider defaultTheme={theme === 'Light' ? 'light-std-std' : 'dark-std-std'}>
                     <QueryClientProvider client={queryClient}>

--- a/apps/gitness/src/framework/context/MFEContext.tsx
+++ b/apps/gitness/src/framework/context/MFEContext.tsx
@@ -6,14 +6,20 @@ interface Scope {
   projectIdentifier?: string
 }
 
+export type Unknown = any
+
 interface IMFEContext {
   /**
    * Scope will be later referred from "Scope" from @harness/microfrontends
    *  */
   scope: Scope
   renderUrl: string
+  customHooks: Partial<{
+    useGenerateToken: Unknown
+  }>
 }
 export const MFEContext = createContext<IMFEContext>({
   scope: {},
-  renderUrl: ''
+  renderUrl: '',
+  customHooks: {}
 })

--- a/apps/gitness/src/framework/context/MFEContext.tsx
+++ b/apps/gitness/src/framework/context/MFEContext.tsx
@@ -17,9 +17,13 @@ interface IMFEContext {
   customHooks: Partial<{
     useGenerateToken: Unknown
   }>
+  customUtils: Partial<{
+    navigateToUserProfile: Unknown
+  }>
 }
 export const MFEContext = createContext<IMFEContext>({
   scope: {},
   renderUrl: '',
-  customHooks: {}
+  customHooks: {},
+  customUtils: {}
 })

--- a/apps/gitness/src/pages-v2/repo/repo-summary.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-summary.tsx
@@ -68,7 +68,7 @@ export default function RepoSummaryPage() {
 
   const { currentUser } = useAppContext()
   const isMFE = useIsMFE()
-  const { customHooks } = useMFEContext()
+  const { customHooks, customUtils } = useMFEContext()
 
   const { data: { body: repository } = {}, refetch: refetchRepo } = useFindRepositoryQuery({ repo_ref: repoRef })
 
@@ -385,14 +385,14 @@ export default function RepoSummaryPage() {
         searchQuery={branchTagQuery}
         setSearchQuery={setBranchTagQuery}
         toRepoFiles={() => routes.toRepoFiles({ spaceId, repoId })}
-        toProfileKeys={() => routes.toProfileKeys()}
+        navigateToProfileKeys={() => (isMFE ? customUtils.navigateToUserProfile() : navigate(routes.toProfileKeys()))}
         isRepoEmpty={repository?.is_empty}
       />
       {showTokenDialog && createdTokenData && (
         <CloneCredentialDialog
           open={successTokenDialog}
           onClose={() => setSuccessTokenDialog(false)}
-          toManageToken={() => routes.toProfileKeys({ spaceId, repoId })}
+          navigateToManageToken={() => (isMFE ? customUtils.navigateToUserProfile() : navigate(routes.toProfileKeys()))}
           tokenData={createdTokenData}
           useTranslationStore={useTranslationStore}
         />

--- a/apps/gitness/src/pages-v2/repo/repo-summary.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-summary.tsx
@@ -31,6 +31,8 @@ import { SummaryItemType } from '@harnessio/views'
 
 import { useRoutes } from '../../framework/context/NavigationContext'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
+import { useIsMFE } from '../../framework/hooks/useIsMFE'
+import { useMFEContext } from '../../framework/hooks/useMFEContext'
 import { useTranslationStore } from '../../i18n/stores/i18n-store'
 import { generateAlphaNumericHash } from '../../pages-v2/pull-request/pull-request-utils'
 import { timeAgoFromISOTime } from '../../pages/pipeline-edit/utils/time-utils'
@@ -40,6 +42,7 @@ import { sortFilesByType } from '../../utils/common-utils'
 import { decodeGitContent, getTrimmedSha, normalizeGitRef, REFS_TAGS_PREFIX } from '../../utils/git-utils'
 import { useRepoBranchesStore } from '././stores/repo-branches-store'
 import { transformBranchList } from './transform-utils/branch-transform'
+import { useAppContext } from '../../framework/context/AppContext'
 
 export default function RepoSummaryPage() {
   const routes = useRoutes()
@@ -62,6 +65,10 @@ export default function RepoSummaryPage() {
     setSelectedBranchTag,
     setSelectedRefType
   } = useRepoBranchesStore()
+
+  const { currentUser } = useAppContext()
+  const isMFE = useIsMFE()
+  const { customHooks } = useMFEContext()
 
   const { data: { body: repository } = {}, refetch: refetchRepo } = useFindRepositoryQuery({ repo_ref: repoRef })
 
@@ -122,6 +129,9 @@ export default function RepoSummaryPage() {
     setUpdateError('')
   }, [isEditDialogOpen])
 
+  const [MFETokenFlag, setMFETokenFlag] = useState(false)
+  const [showTokenDialog, setShowTokenDialog] = useState(false)
+  const MFEtokenData = isMFE ? customHooks.useGenerateToken(generateAlphaNumericHash(5), currentUser?.uid, MFETokenFlag) : null
   const [createdTokenData, setCreatedTokenData] = useState<(TokenFormType & { token: string }) | null>(null)
   const [successTokenDialog, setSuccessTokenDialog] = useState(false)
 
@@ -218,17 +228,36 @@ export default function RepoSummaryPage() {
         }
 
         setCreatedTokenData(tokenData)
+        setShowTokenDialog(true)
         setSuccessTokenDialog(true)
       }
     }
   )
 
   const handleCreateToken = () => {
-    const body = {
-      identifier: `code_token_${generateAlphaNumericHash(5)}`
+    if (isMFE) {
+      setMFETokenFlag(true)
+    } else {
+      const body = {
+        identifier: `code_token_${generateAlphaNumericHash(5)}`
+      }
+      createToken({ body })
     }
-    createToken({ body })
   }
+  useEffect(() => {
+    if (MFEtokenData) {
+      const tokenDataNew = {
+        identifier: MFEtokenData.token?.identifier ?? 'Unknown',
+        lifetime: MFEtokenData.token?.expires_at
+          ? new Date(MFEtokenData.token.expires_at).toLocaleDateString()
+          : 'No Expiration',
+        token: MFEtokenData.data ?? 'Token not available'
+      }
+      setCreatedTokenData(tokenDataNew)
+      setShowTokenDialog(true)
+      setSuccessTokenDialog(true)
+    }
+  }, [MFEtokenData])
 
   const repoEntryPathToFileTypeMap: Map<string, OpenapiGetContentOutput['type']> = useMemo(() => {
     const entries = repoDetails?.content?.entries
@@ -249,11 +278,10 @@ export default function RepoSummaryPage() {
   }
 
   useEffect(() => {
-    setLoading(true)
-
     if (!repoEntryPathToFileTypeMap.size) {
       return
     }
+    setLoading(true)
 
     pathDetails({
       queryParams: { git_ref: normalizeGitRef(gitRef || selectedBranchTag?.name) },
@@ -327,7 +355,7 @@ export default function RepoSummaryPage() {
     [default_branch_commit_count, branch_count, tag_count, pull_req_summary]
   )
 
-  const isLoading = (loading || isLoadingRepoDetails) && !repository?.is_empty
+  const isLoading = loading || isLoadingRepoDetails
 
   return (
     <>
@@ -356,8 +384,9 @@ export default function RepoSummaryPage() {
         setSearchQuery={setBranchTagQuery}
         toRepoFiles={() => routes.toRepoFiles({ spaceId, repoId })}
         toProfileKeys={() => routes.toProfileKeys()}
+        isRepoEmpty={repository?.is_empty}
       />
-      {createdTokenData && (
+      {showTokenDialog && createdTokenData && (
         <CloneCredentialDialog
           open={successTokenDialog}
           onClose={() => setSuccessTokenDialog(false)}

--- a/apps/gitness/src/pages-v2/repo/repo-summary.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-summary.tsx
@@ -29,6 +29,7 @@ import {
 } from '@harnessio/ui/views'
 import { SummaryItemType } from '@harnessio/views'
 
+import { useAppContext } from '../../framework/context/AppContext'
 import { useRoutes } from '../../framework/context/NavigationContext'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
 import { useIsMFE } from '../../framework/hooks/useIsMFE'
@@ -42,7 +43,6 @@ import { sortFilesByType } from '../../utils/common-utils'
 import { decodeGitContent, getTrimmedSha, normalizeGitRef, REFS_TAGS_PREFIX } from '../../utils/git-utils'
 import { useRepoBranchesStore } from '././stores/repo-branches-store'
 import { transformBranchList } from './transform-utils/branch-transform'
-import { useAppContext } from '../../framework/context/AppContext'
 
 export default function RepoSummaryPage() {
   const routes = useRoutes()
@@ -131,7 +131,9 @@ export default function RepoSummaryPage() {
 
   const [MFETokenFlag, setMFETokenFlag] = useState(false)
   const [showTokenDialog, setShowTokenDialog] = useState(false)
-  const MFEtokenData = isMFE ? customHooks.useGenerateToken(generateAlphaNumericHash(5), currentUser?.uid, MFETokenFlag) : null
+  const MFEtokenData = isMFE
+    ? customHooks.useGenerateToken(generateAlphaNumericHash(5), currentUser?.uid, MFETokenFlag)
+    : null
   const [createdTokenData, setCreatedTokenData] = useState<(TokenFormType & { token: string }) | null>(null)
   const [successTokenDialog, setSuccessTokenDialog] = useState(false)
 

--- a/packages/ui/src/views/repo/components/token-dialog/clone-credential-dialog.tsx
+++ b/packages/ui/src/views/repo/components/token-dialog/clone-credential-dialog.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react'
 import { useForm } from 'react-hook-form'
-import { Link } from 'react-router-dom'
 
 import { Button, ButtonGroup, CopyButton, Dialog, Input } from '@/components'
 import { TranslationStore } from '@/views'

--- a/packages/ui/src/views/repo/components/token-dialog/clone-credential-dialog.tsx
+++ b/packages/ui/src/views/repo/components/token-dialog/clone-credential-dialog.tsx
@@ -8,7 +8,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 
 interface RoutingProps {
-  toManageToken?: () => string
+  navigateToManageToken?: () => void
 }
 interface CloneCredentialDialogProps extends Partial<RoutingProps> {
   open: boolean
@@ -31,7 +31,7 @@ export type TCloneCredentialsDialog = z.infer<typeof formSchema>
 export const CloneCredentialDialog: FC<CloneCredentialDialogProps> = ({
   open,
   onClose,
-  toManageToken,
+  navigateToManageToken,
   tokenData,
   useTranslationStore
 }) => {
@@ -89,8 +89,8 @@ export const CloneCredentialDialog: FC<CloneCredentialDialogProps> = ({
               <Button variant="outline" onClick={onClose}>
                 Close
               </Button>
-              <Button type="button">
-                <Link to={`${toManageToken?.()}`}>{t('views:repos.manageAPIToken')}</Link>
+              <Button type="button" onClick={() => navigateToManageToken?.()}>
+                {t('views:repos.manageAPIToken')}
               </Button>
             </>
           </ButtonGroup>

--- a/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
@@ -9,7 +9,6 @@ import {
   MarkdownViewer,
   NoData,
   Spacer,
-  StyledLink,
   Text
 } from '@/components'
 import { SandboxLayout } from '@/views'
@@ -90,8 +89,16 @@ git push -u origin main
             <p className="mt-2">
               You can also manage your git credential{' '}
               <span
+                role="button"
+                tabIndex={0}
                 className="text-foreground-accent hover:decoration-foreground-accent underline decoration-transparent underline-offset-4 transition-colors duration-200"
                 onClick={() => navigateToProfileKeys?.()}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    e.stopPropagation()
+                  }
+                }}
               >
                 here
               </span>
@@ -111,8 +118,16 @@ git push -u origin main
             <p>
               You might need to{' '}
               <span
+                role="button"
+                tabIndex={0}
                 className="text-foreground-accent hover:decoration-foreground-accent underline decoration-transparent underline-offset-4 transition-colors duration-200"
                 onClick={() => navigateToProfileKeys?.()}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    e.stopPropagation()
+                  }
+                }}
               >
                 create an API token
               </span>

--- a/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
@@ -21,7 +21,7 @@ interface RepoEmptyViewProps {
   sshUrl: string
   gitRef: string
   handleCreateToken: () => void
-  toProfileKeys?: () => string
+  navigateToProfileKeys?: () => void
 }
 
 export const RepoEmptyView: React.FC<RepoEmptyViewProps> = ({
@@ -31,7 +31,7 @@ export const RepoEmptyView: React.FC<RepoEmptyViewProps> = ({
   sshUrl,
   gitRef,
   handleCreateToken,
-  toProfileKeys
+  navigateToProfileKeys
 }) => {
   const getInitialCommitMarkdown = () => {
     return `
@@ -89,9 +89,12 @@ git push -u origin main
             </ButtonGroup>
             <p className="mt-2">
               You can also manage your git credential{' '}
-              <StyledLink to={toProfileKeys?.() ?? ''} relative="path">
+              <span
+                className="text-foreground-accent hover:decoration-foreground-accent underline decoration-transparent underline-offset-4 transition-colors duration-200"
+                onClick={() => navigateToProfileKeys?.()}
+              >
                 here
-              </StyledLink>
+              </span>
             </p>
           </ControlGroup>
 
@@ -107,9 +110,12 @@ git push -u origin main
             <MarkdownViewer source={getExistingRepoMarkdown()} />
             <p>
               You might need to{' '}
-              <StyledLink to={toProfileKeys?.() ?? ''} relative="path">
+              <span
+                className="text-foreground-accent hover:decoration-foreground-accent underline decoration-transparent underline-offset-4 transition-colors duration-200"
+                onClick={() => navigateToProfileKeys?.()}
+              >
                 create an API token
-              </StyledLink>{' '}
+              </span>
               In order to pull from or push into this repository.
             </p>
           </ControlGroup>

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -32,7 +32,7 @@ import { RepoEmptyView } from './repo-empty-view'
 interface RoutingProps {
   toRepoFiles: () => string
   toCommitDetails?: ({ sha }: { sha: string }) => string
-  toProfileKeys: () => string
+  navigateToProfileKeys: () => void
 }
 
 export interface RepoSummaryViewProps extends Partial<RoutingProps> {
@@ -107,7 +107,7 @@ export function RepoSummaryView({
   handleCreateToken,
   toRepoFiles,
   toCommitDetails,
-  toProfileKeys,
+  navigateToProfileKeys,
   renderSidebarComponent,
   isRepoEmpty
 }: RepoSummaryViewProps) {
@@ -133,7 +133,7 @@ export function RepoSummaryView({
         projName={spaceId}
         gitRef={gitRef || selectedBranchTag?.name || ''}
         handleCreateToken={handleCreateToken}
-        toProfileKeys={toProfileKeys}
+        navigateToProfileKeys={navigateToProfileKeys}
       />
     )
   }

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -80,6 +80,7 @@ export interface RepoSummaryViewProps extends Partial<RoutingProps> {
   searchQuery: string
   setSearchQuery: (query: string) => void
   renderSidebarComponent?: React.ReactNode
+  isRepoEmpty?: boolean
 }
 
 export function RepoSummaryView({
@@ -107,7 +108,8 @@ export function RepoSummaryView({
   toRepoFiles,
   toCommitDetails,
   toProfileKeys,
-  renderSidebarComponent
+  renderSidebarComponent,
+  isRepoEmpty
 }: RepoSummaryViewProps) {
   const { t } = useTranslationStore()
   const { repoId, spaceId, selectedBranchTag } = useRepoBranchesStore()
@@ -122,7 +124,7 @@ export function RepoSummaryView({
     )
   }
 
-  if (!repoEntryPathToFileTypeMap.size) {
+  if (isRepoEmpty) {
     return (
       <RepoEmptyView
         sshUrl={repository?.git_ssh_url ?? 'could not fetch url'}


### PR DESCRIPTION
fixes:
empty repo page based on is_empty from repoMetadata
profile keys route is different for NGUI - passed navigate hook as part of customUtil
clone credential token generation api is different for NGUI, goes through gateway and is passed as a hook from NGUI - added the customHook to be used in case of MFE