### PR TITLE
chore: Remove dependency on 'react-router-dom' from 'packages/ui'

### DIFF
--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -1,10 +1,11 @@
 import { I18nextProvider } from 'react-i18next'
-import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import { createBrowserRouter, Link, Outlet, RouterProvider } from 'react-router-dom'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 
 import { CodeServiceAPIClient } from '@harnessio/code-service-client'
 import { ToastProvider, TooltipProvider } from '@harnessio/ui/components'
+import { RouterProvider as RouterProviderV1 } from '@harnessio/ui/context'
 
 import { ExitConfirmProvider } from './framework/context/ExitConfirmContext'
 import { NavigationProvider } from './framework/context/NavigationContext'
@@ -39,7 +40,9 @@ export default function AppV1() {
             <TooltipProvider>
               <ExitConfirmProvider>
                 <NavigationProvider routes={routes}>
-                  <RouterProvider router={router} />
+                  <RouterProviderV1 OutletComponent={Outlet} LinkComponent={Link}>
+                    <RouterProvider router={router} />
+                  </RouterProviderV1>
                 </NavigationProvider>
               </ExitConfirmProvider>
             </TooltipProvider>

--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -1,5 +1,5 @@
 import { I18nextProvider } from 'react-i18next'
-import { createBrowserRouter, Link, Outlet, RouterProvider } from 'react-router-dom'
+import { createBrowserRouter, Link, NavLink, Outlet, RouterProvider } from 'react-router-dom'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 
@@ -40,7 +40,7 @@ export default function AppV1() {
             <TooltipProvider>
               <ExitConfirmProvider>
                 <NavigationProvider routes={routes}>
-                  <RouterProviderV1 OutletComponent={Outlet} LinkComponent={Link}>
+                  <RouterProviderV1 Link={Link} NavLink={NavLink} Outlet={Outlet} navigate={router.navigate}>
                     <RouterProvider router={router} />
                   </RouterProviderV1>
                 </NavigationProvider>

--- a/packages/ui/src/components/commit-copy-actions.tsx
+++ b/packages/ui/src/components/commit-copy-actions.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 
 import { Icon, ShaBadge } from '@/components'
+import { useRouterContext } from '@/context'
 import copy from 'clipboard-copy'
 
 export const CommitCopyActions = ({
@@ -12,7 +12,7 @@ export const CommitCopyActions = ({
   toCommitDetails?: ({ sha }: { sha: string }) => string
 }) => {
   const [copied, setCopied] = useState(false)
-  const navigate = useNavigate()
+  const { navigate } = useRouterContext()
 
   useEffect(() => {
     let timeoutId: number

--- a/packages/ui/src/components/file-additions-trigger.tsx
+++ b/packages/ui/src/components/file-additions-trigger.tsx
@@ -1,7 +1,7 @@
 import { FC, useRef } from 'react'
-import { Link } from 'react-router-dom'
 
 import { Button, DropdownMenu, Icon } from '@/components'
+import { useRouterContext } from '@/context'
 import { TranslationStore } from '@/views'
 
 export interface FileAdditionsTriggerProps {
@@ -15,6 +15,7 @@ export const FileAdditionsTrigger: FC<FileAdditionsTriggerProps> = ({
   pathNewFile,
   pathUploadFiles
 }) => {
+  const { Link } = useRouterContext()
   const triggerRef = useRef<HTMLButtonElement>(null)
   const { t } = useTranslationStore()
 

--- a/packages/ui/src/components/file-explorer.tsx
+++ b/packages/ui/src/components/file-explorer.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
-import { Link } from 'react-router-dom'
 
 import { Accordion, Icon, Text } from '@/components'
+import { useRouterContext } from '@/context'
 import { cn } from '@utils/cn'
 
 interface FolderItemProps {
@@ -14,6 +14,7 @@ interface FolderItemProps {
 }
 
 function FolderItem({ children, value = '', isActive, content, chevronClassName, link }: FolderItemProps) {
+  const { Link } = useRouterContext()
   return (
     <Accordion.Item value={value} className="border-none">
       <Accordion.Trigger
@@ -71,6 +72,7 @@ interface FileItemProps {
 }
 
 function FileItem({ children, isActive, link }: FileItemProps) {
+  const { Link } = useRouterContext()
   const comp = (
     <div
       className={cn(

--- a/packages/ui/src/components/markdown-viewer/index.tsx
+++ b/packages/ui/src/components/markdown-viewer/index.tsx
@@ -1,5 +1,4 @@
 import { CSSProperties, FC, Fragment, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 
 import { CopyButton, ImageCarousel } from '@/components'
 import MarkdownPreview from '@uiw/react-markdown-preview'
@@ -10,6 +9,7 @@ import rehypeVideo from 'rehype-video'
 
 import './style.css'
 
+import { useRouterContext } from '@/context'
 import { cn } from '@utils/cn'
 
 import { CodeSuggestionBlock, SuggestionBlock } from './CodeSuggestionBlock'
@@ -50,7 +50,7 @@ export function MarkdownViewer({
   isSuggestion,
   markdownClassName
 }: MarkdownViewerProps) {
-  const navigate = useNavigate()
+  const { navigate } = useRouterContext()
   const [isOpen, setIsOpen] = useState(false)
   const [imgEvent, setImageEvent] = useState<string[]>([])
   const refRootHref = useMemo(() => document.getElementById('repository-ref-root')?.getAttribute('href'), [])

--- a/packages/ui/src/components/more-actions-tooltip.tsx
+++ b/packages/ui/src/components/more-actions-tooltip.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
-import { Link } from 'react-router-dom'
 
+import { useRouterContext } from '@/context'
 import { Button } from '@components/button'
 import { DropdownMenu } from '@components/dropdown-menu'
 import { Icon, IconProps } from '@components/icon'
@@ -33,6 +33,7 @@ export const MoreActionsTooltip: FC<MoreActionsTooltipProps> = ({
   alignOffset = 10,
   className
 }) => {
+  const { Link } = useRouterContext()
   if (!actions.length) return <></>
 
   return (

--- a/packages/ui/src/components/more-submenu.tsx
+++ b/packages/ui/src/components/more-submenu.tsx
@@ -1,6 +1,5 @@
-import { NavLink } from 'react-router-dom'
-
 import { Icon, NavbarSkeleton, ScrollArea, Sheet, Spacer } from '@/components'
+import { useRouterContext } from '@/context'
 import { MenuGroupType } from '@components/navbar/types'
 
 interface MoreSubmenuProps {
@@ -10,6 +9,7 @@ interface MoreSubmenuProps {
 }
 
 export function MoreSubmenu({ showMoreMenu, handleMoreMenu, items }: MoreSubmenuProps) {
+  const { NavLink } = useRouterContext()
   return (
     <Sheet.Root modal={false} open={showMoreMenu}>
       <Sheet.Content

--- a/packages/ui/src/components/navbar/navbar-item/index.tsx
+++ b/packages/ui/src/components/navbar/navbar-item/index.tsx
@@ -1,6 +1,5 @@
-import { NavLink } from 'react-router-dom'
-
 import { Button, DropdownMenu, Icon, IconProps, Text } from '@/components'
+import { useRouterContext } from '@/context'
 import { NavbarSkeleton } from '@components/navbar-skeleton'
 import { TFunction } from 'i18next'
 
@@ -23,6 +22,7 @@ export const NavbarItem = ({
   handleCustomNav,
   t
 }: NavbarItemProps) => {
+  const { NavLink } = useRouterContext()
   const iconName = item.iconName && (item.iconName.replace('-gradient', '') as IconProps['name'])
 
   const handlePin = () => {

--- a/packages/ui/src/components/navbar/navbar-user/index.tsx
+++ b/packages/ui/src/components/navbar/navbar-user/index.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react'
-import { Link } from 'react-router-dom'
 
 import {
   Avatar,
@@ -13,6 +12,7 @@ import {
   ModeType,
   Text
 } from '@/components'
+import { useRouterContext } from '@/context'
 import { TypesUser } from '@/types'
 import { cn } from '@utils/cn'
 import { getInitials } from '@utils/stringUtils'
@@ -68,6 +68,7 @@ export const NavbarUser = ({
   useThemeStore,
   useTranslationStore
 }: NavbarUserProps) => {
+  const { Link } = useRouterContext()
   const username = currentUser?.display_name || currentUser?.uid || ''
   const { theme, setTheme } = useThemeStore()
   const { t, i18n, changeLanguage } = useTranslationStore()

--- a/packages/ui/src/components/navbar/navbar.tsx
+++ b/packages/ui/src/components/navbar/navbar.tsx
@@ -47,7 +47,7 @@ export const Navbar = ({
 }: NavbarProps) => {
   const { Link } = useRouterContext()
   const location = useLocation()
-  const navigate = useNavigate()
+  const { navigate } = useRouterContext()
   const { t } = useTranslationStore()
   const adminMenuItem = getAdminMenuItem(t)
 

--- a/packages/ui/src/components/navbar/navbar.tsx
+++ b/packages/ui/src/components/navbar/navbar.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from 'react'
-import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { Button, Icon, IThemeStore, NavbarProjectChooser, NavbarSkeleton, ScrollArea, Spacer } from '@/components'
+import { useRouterContext } from '@/context'
 import { TypesUser } from '@/types'
 import { TranslationStore } from '@/views'
 import { isEmpty } from 'lodash-es'
@@ -44,6 +45,7 @@ export const Navbar = ({
   useThemeStore,
   useTranslationStore
 }: NavbarProps) => {
+  const { Link } = useRouterContext()
   const location = useLocation()
   const navigate = useNavigate()
   const { t } = useTranslationStore()

--- a/packages/ui/src/components/navbar/navbar.tsx
+++ b/packages/ui/src/components/navbar/navbar.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 
 import { Button, Icon, IThemeStore, NavbarProjectChooser, NavbarSkeleton, ScrollArea, Spacer } from '@/components'
 import { useRouterContext } from '@/context'

--- a/packages/ui/src/components/no-data.tsx
+++ b/packages/ui/src/components/no-data.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, FC, SetStateAction } from 'react'
-import { NavLink } from 'react-router-dom'
 
+import { useRouterContext } from '@/context'
 import { cn } from '@utils/cn'
 
 import { Button } from './button'
@@ -53,6 +53,7 @@ export const NoData: FC<NoDataProps> = ({
   textWrapperClassName,
   className
 }) => {
+  const { NavLink } = useRouterContext()
   return (
     <div
       className={cn(

--- a/packages/ui/src/components/path-breadcrumbs.tsx
+++ b/packages/ui/src/components/path-breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react'
-import { Link } from 'react-router-dom'
 
 import { Breadcrumb, Icon, Input } from '@/components'
+import { useRouterContext } from '@/context'
 import { useDebounceSearch } from '@/hooks'
 
 interface InputPathBreadcrumbItemProps {
@@ -65,6 +65,7 @@ export interface PathBreadcrumbsInputProps {
 export type PathBreadcrumbsProps = PathBreadcrumbsBaseProps & Partial<PathBreadcrumbsInputProps>
 
 export const PathBreadcrumbs = ({ items, isEdit, isNew, ...props }: PathBreadcrumbsProps) => {
+  const { Link } = useRouterContext()
   const length = items.length
 
   const renderInput = () => {

--- a/packages/ui/src/components/settings-menu.tsx
+++ b/packages/ui/src/components/settings-menu.tsx
@@ -1,6 +1,5 @@
-import { NavLink } from 'react-router-dom'
-
 import { Icon, NavbarSkeleton, ScrollArea, Sheet, Spacer } from '@/components'
+import { useRouterContext } from '@/context'
 import { MenuGroupType } from '@components/navbar/types'
 
 interface SystemAdminMenuProps {
@@ -10,6 +9,7 @@ interface SystemAdminMenuProps {
 }
 
 export const SettingsMenu = ({ showSettingMenu, handleSettingsMenu, items }: SystemAdminMenuProps) => {
+  const { NavLink } = useRouterContext()
   return (
     <Sheet.Root modal={false} open={showSettingMenu}>
       <Sheet.Content

--- a/packages/ui/src/components/styled-link.tsx
+++ b/packages/ui/src/components/styled-link.tsx
@@ -1,10 +1,12 @@
-import { Link, type LinkProps } from 'react-router-dom'
+import type { LinkProps } from 'react-router-dom'
 
+import { useRouterContext } from '@/context'
 import { cn } from '@utils/cn'
 
 type StyledLinkProps = LinkProps & React.RefAttributes<HTMLAnchorElement>
 
 export function StyledLink({ className, ...props }: StyledLinkProps) {
+  const { Link } = useRouterContext()
   return (
     <Link
       className={cn(

--- a/packages/ui/src/components/tabnav.tsx
+++ b/packages/ui/src/components/tabnav.tsx
@@ -1,6 +1,7 @@
 import { FC, PropsWithChildren } from 'react'
-import { NavLink, NavLinkProps } from 'react-router-dom'
+import type { NavLinkProps } from 'react-router-dom'
 
+import { useRouterContext } from '@/context'
 import { cn } from '@utils/cn'
 
 const TabNavRoot: FC<PropsWithChildren<unknown>> = ({ children }) => {
@@ -15,6 +16,7 @@ const commonClasses =
   'flex h-full items-center text-center cursor-pointer border-solid border-b-2 border-b-transparent px-0 font-normal text-foreground-2 duration-150 ease-in-out hover:text-foreground-1'
 
 const TabNavItem: FC<NavLinkProps> = ({ children, ...props }) => {
+  const { NavLink } = useRouterContext()
   return (
     <NavLink
       role="tab"

--- a/packages/ui/src/context/RouterContext.tsx
+++ b/packages/ui/src/context/RouterContext.tsx
@@ -26,9 +26,7 @@ const NavLinkDefault = ({ to, children, className, style, ...props }: NavLinkPro
   const isActive = new URL(href, window.location.origin).pathname === window.location.pathname
 
   const finalClassName =
-    typeof className === 'function'
-      ? className({ isActive, isPending: false, isTransitioning: false })
-      : cn(className, isActive ? 'font-bold text-blue-600' : 'text-blue-500')
+    typeof className === 'function' ? className({ isActive, isPending: false, isTransitioning: false }) : cn(className)
 
   const finalStyle = typeof style === 'function' ? style({ isActive, isPending: false, isTransitioning: false }) : style
 

--- a/packages/ui/src/context/RouterContext.tsx
+++ b/packages/ui/src/context/RouterContext.tsx
@@ -6,7 +6,6 @@ interface RouterContextType {
   Link: ComponentType<LinkProps>
   NavLink: ComponentType<NavLinkProps>
   Outlet: ComponentType | null
-  Switch: ComponentType | null
   navigate: (to: string, options?: { replace?: boolean }) => void
 }
 
@@ -47,13 +46,10 @@ const NavLinkDefault = ({ to, children, className, style, ...props }: NavLinkPro
 
 const OutletDefault = ({ children }: { children?: ReactNode }) => <>{children}</>
 
-const SwitchDefault = ({ children }: { children?: ReactNode }) => <>{children}</>
-
 const RouterContext = createContext<RouterContextType>({
   Link: LinkDefault,
   NavLink: NavLinkDefault,
   Outlet: OutletDefault,
-  Switch: SwitchDefault,
   navigate: to => {
     window.location.href = to
   }
@@ -66,12 +62,11 @@ export const RouterProvider = ({
   Link = LinkDefault,
   NavLink = NavLinkDefault,
   Outlet = OutletDefault,
-  Switch = SwitchDefault,
   navigate = to => {
     window.location.href = to
   }
 }: {
   children: ReactNode
 } & Partial<RouterContextType>) => {
-  return <RouterContext.Provider value={{ Link, NavLink, Outlet, Switch, navigate }}>{children}</RouterContext.Provider>
+  return <RouterContext.Provider value={{ Link, NavLink, Outlet, navigate }}>{children}</RouterContext.Provider>
 }

--- a/packages/ui/src/context/RouterContext.tsx
+++ b/packages/ui/src/context/RouterContext.tsx
@@ -1,0 +1,42 @@
+import { Component, ComponentType, createContext, ReactNode, useContext } from 'react'
+import type { LinkProps as RouterLinkProps } from 'react-router-dom'
+
+// verify if final bundle doesn't have reference to react-router-dom
+
+const DefaultOutlet = () => null
+
+export type LinkProps = RouterLinkProps
+export type OutletComponentType = ComponentType | null
+
+interface RouterContextType {
+  Link: ComponentType<LinkProps>
+  Outlet: OutletComponentType
+}
+
+const RouterContext = createContext<RouterContextType>({
+  Link: Component,
+  Outlet: DefaultOutlet // Use a placeholder in v5
+})
+
+export const useRouterContext = () => useContext(RouterContext)
+
+const LinkDefault = ({ to, children, ...props }: LinkProps) => {
+  return (
+    <a href={to.toString()} {...props}>
+      {children}
+    </a>
+  )
+}
+
+// Context provider
+export const RouterProvider = ({
+  children,
+  Link = LinkDefault,
+  Outlet = DefaultOutlet // Default to null for React Router v5
+}: {
+  children: ReactNode
+  Link?: ComponentType<LinkProps>
+  Outlet?: OutletComponentType
+}) => {
+  return <RouterContext.Provider value={{ Link, Outlet }}>{children}</RouterContext.Provider>
+}

--- a/packages/ui/src/context/RouterContext.tsx
+++ b/packages/ui/src/context/RouterContext.tsx
@@ -1,7 +1,5 @@
 import { Component, ComponentType, createContext, ReactNode, useContext } from 'react'
-import type { LinkProps, NavLinkProps } from 'react-router-dom'
-
-// verify if final bundle doesn't have reference to react-router-dom
+import type { LinkProps, NavLinkProps } from 'react-router-dom' // verify if final bundle doesn't have reference to react-router-dom
 
 const DefaultOutlet = () => null
 
@@ -11,12 +9,14 @@ interface RouterContextType {
   Link: ComponentType<LinkProps>
   NavLink: ComponentType<NavLinkProps>
   Outlet: OutletComponentType
+  navigate: (to: string, options?: { replace?: boolean }) => void
 }
 
 const RouterContext = createContext<RouterContextType>({
   Link: Component,
   NavLink: Component,
-  Outlet: DefaultOutlet // Use a placeholder in v5
+  Outlet: DefaultOutlet, // Remove usages of Outlet from the package
+  navigate: () => {}
 })
 
 export const useRouterContext = () => useContext(RouterContext)
@@ -61,5 +61,18 @@ export const RouterProvider = ({
   NavLink?: ComponentType<NavLinkProps>
   Outlet?: OutletComponentType
 }) => {
-  return <RouterContext.Provider value={{ Link, NavLink, Outlet }}>{children}</RouterContext.Provider>
+  return (
+    <RouterContext.Provider
+      value={{
+        Link,
+        NavLink,
+        Outlet,
+        navigate: to => {
+          window.location.href = to
+        }
+      }}
+    >
+      {children}
+    </RouterContext.Provider>
+  )
 }

--- a/packages/ui/src/context/RouterContext.tsx
+++ b/packages/ui/src/context/RouterContext.tsx
@@ -1,20 +1,21 @@
 import { Component, ComponentType, createContext, ReactNode, useContext } from 'react'
-import type { LinkProps as RouterLinkProps } from 'react-router-dom'
+import type { LinkProps, NavLinkProps } from 'react-router-dom'
 
 // verify if final bundle doesn't have reference to react-router-dom
 
 const DefaultOutlet = () => null
 
-export type LinkProps = RouterLinkProps
-export type OutletComponentType = ComponentType | null
+type OutletComponentType = ComponentType | null
 
 interface RouterContextType {
   Link: ComponentType<LinkProps>
+  NavLink: ComponentType<NavLinkProps>
   Outlet: OutletComponentType
 }
 
 const RouterContext = createContext<RouterContextType>({
   Link: Component,
+  NavLink: Component,
   Outlet: DefaultOutlet // Use a placeholder in v5
 })
 
@@ -28,15 +29,37 @@ const LinkDefault = ({ to, children, ...props }: LinkProps) => {
   )
 }
 
+const NavLinkDefault = ({ to, children, className, style, ...props }: NavLinkProps) => {
+  // Determine active state based on window location
+  const isActive = window.location.pathname === to.toString()
+
+  const finalClassName =
+    typeof className === 'function'
+      ? className({ isActive, isPending: false, isTransitioning: false }) // Mimic React Router v6 behavior
+      : isActive
+        ? `${className || ''} active`.trim()
+        : className
+
+  const finalStyle = typeof style === 'function' ? style({ isActive, isPending: false, isTransitioning: false }) : style
+
+  return (
+    <a href={to.toString()} className={finalClassName} style={finalStyle} {...props}>
+      {children}
+    </a>
+  )
+}
+
 // Context provider
 export const RouterProvider = ({
   children,
   Link = LinkDefault,
+  NavLink = NavLinkDefault,
   Outlet = DefaultOutlet // Default to null for React Router v5
 }: {
   children: ReactNode
   Link?: ComponentType<LinkProps>
+  NavLink?: ComponentType<NavLinkProps>
   Outlet?: OutletComponentType
 }) => {
-  return <RouterContext.Provider value={{ Link, Outlet }}>{children}</RouterContext.Provider>
+  return <RouterContext.Provider value={{ Link, NavLink, Outlet }}>{children}</RouterContext.Provider>
 }

--- a/packages/ui/src/context/RouterContext.tsx
+++ b/packages/ui/src/context/RouterContext.tsx
@@ -54,22 +54,20 @@ export const RouterProvider = ({
   children,
   Link = LinkDefault,
   NavLink = NavLinkDefault,
-  Outlet = DefaultOutlet // Default to null for React Router v5
+  Outlet = DefaultOutlet, // Default to null for React Router v5,
+  navigate = to => {
+    window.location.href = to
+  }
 }: {
   children: ReactNode
-  Link?: ComponentType<LinkProps>
-  NavLink?: ComponentType<NavLinkProps>
-  Outlet?: OutletComponentType
-}) => {
+} & RouterContextType) => {
   return (
     <RouterContext.Provider
       value={{
         Link,
         NavLink,
         Outlet,
-        navigate: to => {
-          window.location.href = to
-        }
+        navigate
       }}
     >
       {children}

--- a/packages/ui/src/context/RouterContext.tsx
+++ b/packages/ui/src/context/RouterContext.tsx
@@ -1,12 +1,12 @@
-import { ComponentType, createContext, CSSProperties, ReactNode, useContext } from 'react'
-import type { LinkProps, NavLinkProps } from 'react-router-dom'
+import { ComponentType, createContext, ReactNode, useContext } from 'react'
+import type { LinkProps, NavLinkProps, OutletProps } from 'react-router-dom'
 
 import { cn } from '@utils/cn'
 
 interface RouterContextType {
   Link: ComponentType<LinkProps>
   NavLink: ComponentType<NavLinkProps>
-  Outlet: ComponentType | null
+  Outlet: ComponentType<OutletProps>
   navigate: (to: string, options?: { replace?: boolean }) => void
 }
 
@@ -39,7 +39,7 @@ const NavLinkDefault = ({ to, children, className, style, ...props }: NavLinkPro
   )
 }
 
-const OutletDefault: ComponentType<{ children?: ReactNode }> = ({ children }) => <>{children}</>
+const OutletDefault: ComponentType<OutletProps> = ({ children }) => <>{children}</>
 
 const RouterContext = createContext<RouterContextType>({
   Link: LinkDefault,

--- a/packages/ui/src/context/index.ts
+++ b/packages/ui/src/context/index.ts
@@ -1,1 +1,2 @@
 export * from './PortalContext'
+export * from './RouterContext'


### PR DESCRIPTION
**Migration - Part 1**

Removes references of `react-router-dom` from `packages/ui/src/components`.

Usage with `react-router-dom` `v6`

```
 <RouterProvider>
    <Routes>
      <Route path="/" element={<Home />} />
      <Route path="/about" element={<About />} />
    </Routes>
</RouterProvider>
```

Usage with `react-router-dom` `v5` : Uses `Switch`

```
<RouterProvider>
  <Navigation />
  <Switch>
    <Route path="/" exact component={Home} />
    <Route path="/about" exact component={About} />
  </Switch>
</RouterProvider>
```