### PR TITLE
chore: Add view-preview, portal and gitness build and dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,13 @@
     "publish:all": "pnpm publish -r --access public",
     "preinstall": "npx only-allow pnpm",
     "pre-commit": "pnpm run -r --workspace-concurrency=1 pre-commit",
-    "test": "pnpm -r test"
+    "test": "pnpm -r test",
+    "gitness:build": "pnpm -r -F './packages/*' build:ci && pnpm -r -F ./apps/gitness build",
+    "gitness:dev": "pnpm -r -F './packages/*' build && pnpm -r -F ./apps/gitness dev",
+    "portal:build": "pnpm -r -F './packages/*' build:ci && pnpm -r -F ./apps/portal build",
+    "portal:dev": "pnpm -r -F './packages/*' build && pnpm -r -F ./apps/portal dev",
+    "view-preview:build": "pnpm -r -F './packages/*' build:ci && pnpm -r -F ./apps/design-system build",
+    "view-preview:dev": "pnpm -r -F './packages/*' build && pnpm -r -F ./apps/design-system dev"
   },
   "engines": {
     "node": ">=18.17.1"

--- a/packages/filters/package.json
+++ b/packages/filters/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "run-p build:watch",
     "build": "vite build",
+    "build:ci": "vite build",
     "build:watch": "vite build --watch",
     "prepublishOnly": "pnpm build",
     "pretty": "prettier --check ./src",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "run-p build:watch",
     "build": "vite build",
+    "build:ci": "vite build",
     "build:watch": "vite build --watch",
     "prepublishOnly": "pnpm build",
     "pretty": "prettier --check ./src",

--- a/packages/pipeline-graph/package.json
+++ b/packages/pipeline-graph/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "playground": "vite dev --config vite.config.playground.ts",
     "dev": "vite build --watch",
-    "build": "vite build"
+    "build": "vite build",
+    "build:ci": "vite build"
   },
   "peerDependencies": {
     "@types/react": "^17.0.3",


### PR DESCRIPTION
This PR adds the following root-level npm scripts to help build the 3 apps with their dependencies.

- `gitness:build` - build for production with all dependency packages
- `gitness:dev` - build all dependency packages and start gitness dev mode
- `portal:build` - build for production with all dependency packages
- `portal:dev` - build all dependency packages and start portal dev mode
- `view-preview:build` - build for production with all dependency packages
- `view-preview:dev` - build all dependency packages and start design-system dev mode