### PR TITLE
Remove react-router-dom dependencies from sidebar

### DIFF
--- a/packages/ui/src/components/navbar-new/app-sidebar.tsx
+++ b/packages/ui/src/components/navbar-new/app-sidebar.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
 
-import { IThemeStore } from '@/context'
+import { IThemeStore, useRouterContext } from '@/context'
 import { TypesUser } from '@/types'
 import { TranslationStore } from '@/views'
 import { Icon } from '@components/icon'
@@ -50,7 +49,7 @@ export const AppSidebar = ({
 }: SidebarProps) => {
   const { t, i18n, changeLanguage } = useTranslationStore()
   const { theme, setTheme } = useThemeStore()
-  const navigate = useNavigate()
+  const { Link, navigate } = useRouterContext()
 
   const [openThemeDialog, setOpenThemeDialog] = useState(false)
   const [openLanguageDialog, setOpenLanguageDialog] = useState(false)

--- a/packages/ui/src/components/navbar-new/sidebar-item.tsx
+++ b/packages/ui/src/components/navbar-new/sidebar-item.tsx
@@ -1,5 +1,4 @@
-import { NavLink } from 'react-router-dom'
-
+import { useRouterContext } from '@/context'
 import { DropdownMenu } from '@components/dropdown-menu'
 import { Icon, IconProps } from '@components/icon'
 import { Sidebar } from '@components/sidebar/sidebar'
@@ -34,6 +33,8 @@ export const SidebarItem = ({
   t
 }: //   t,
 NavbarItemProps) => {
+  const { NavLink } = useRouterContext()
+
   const iconName = item.iconName && (item.iconName.replace('-gradient', '') as IconProps['name'])
 
   const handlePin = () => {

--- a/packages/ui/src/components/navbar-new/sidebar-user.tsx
+++ b/packages/ui/src/components/navbar-new/sidebar-user.tsx
@@ -1,5 +1,4 @@
-import { Link } from 'react-router-dom'
-
+import { useRouterContext } from '@/context'
 import { TypesUser } from '@/types'
 import { Avatar } from '@components/avatar'
 import { DropdownMenu } from '@components/dropdown-menu'
@@ -17,6 +16,8 @@ interface UserProps {
 }
 
 export function User({ user, openThemeDialog, openLanguageDialog, handleLogOut, t }: UserProps) {
+  const { Link } = useRouterContext()
+
   const userName = user?.display_name || user?.uid || ''
   return (
     <Sidebar.Menu>


### PR DESCRIPTION
Used the new `useRouterContext()` utility for importing React Router Dom elements instead of using the package itself.