### PR TITLE
fix: use pnpm 9 for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # install pnpm
-RUN npm install -g pnpm@latest-10
+RUN npm install -g pnpm@latest-9
 COPY . /canary
 WORKDIR /canary
 

--- a/Dockerfile.mfe
+++ b/Dockerfile.mfe
@@ -2,7 +2,7 @@ FROM node:20-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # install pnpm
-RUN npm install -g pnpm@latest-10
+RUN npm install -g pnpm@latest-9
 COPY . /canary
 WORKDIR /canary
 


### PR DESCRIPTION
we were using pnpm-10 for docker, which started failing with a frozen lockfile error.
but it works locally with pnpm-9, so i've pushed that change.