### PR TITLE
feat: create a radial reusuable component

### DIFF
--- a/apps/portal/src/content/docs/components/radial-input.mdx
+++ b/apps/portal/src/content/docs/components/radial-input.mdx
@@ -1,0 +1,135 @@
+---
+title: RadialInput
+description: RadialInput component documentation
+---
+
+The `RadialInput` component provides a customizable radio group input with a stacked list layout. Each option includes a title, description, and a radio button control, making it ideal for selection interfaces where users need detailed information about each choice.
+
+import { DocsPage } from "@/components/docs-page";
+
+<DocsPage.ComponentExample
+  client:only
+  code={`<RadialInput
+    options={[
+      {
+        id: "option1",
+        title: "Option 1",
+        description: "Description for option 1",
+        value: "value1"
+      },
+      {
+        id: "option2",
+        title: "Option 2",
+        description: "Description for option 2",
+        value: "value2"
+      }
+    ]}
+    value="value1"
+    onValueChange={(value) => console.log(value)}
+  />`}
+/>
+
+## Usage
+
+```typescript jsx
+import { RadialInput } from '@harnessio/ui/views'
+
+const options = [
+  {
+    id: 'option1',
+    title: 'Option 1',
+    description: 'Description for option 1',
+    value: 'value1'
+  },
+  {
+    id: 'option2',
+    title: 'Option 2',
+    description: 'Description for option 2',
+    value: 'value2'
+  }
+]
+
+return (
+  <RadialInput
+    options={options}
+    value="value1"
+    onValueChange={value => {
+      console.log('Selected value:', value)
+    }}
+  />
+)
+```
+
+## API Reference
+
+### RadialInput
+
+The main component that renders a radio group with stacked list items.
+
+<DocsPage.PropsTable
+  props={[
+    {
+      name: "options",
+      description: "Array of options to display in the radio group",
+      required: true,
+      value: "RadialOption[]",
+    },
+    {
+      name: "value",
+      description: "Currently selected value",
+      required: true,
+      value: "string",
+    },
+    {
+      name: "onValueChange",
+      description: "Callback function called when selection changes",
+      required: true,
+      value: "(value: string) => void",
+    },
+    {
+      name: "id",
+      description: "Optional ID for the radio group",
+      required: false,
+      value: "string",
+    },
+    {
+      name: "className",
+      description: "Optional CSS class name for styling",
+      required: false,
+      value: "string",
+    },
+  ]}
+/>
+
+### RadialOption
+
+The shape of each option in the options array.
+
+<DocsPage.PropsTable
+  props={[
+    {
+      name: "id",
+      description: "Unique identifier for the option",
+      required: true,
+      value: "string",
+    },
+    {
+      name: "title",
+      description: "Title text to display for the option",
+      required: true,
+      value: "string",
+    },
+    {
+      name: "description",
+      description: "Description text to display under the title",
+      required: true,
+      value: "string",
+    },
+    {
+      name: "value",
+      description: "Value associated with this option",
+      required: true,
+      value: "string",
+    },
+  ]}
+/>

--- a/packages/ui/src/views/components/RadialInput.tsx
+++ b/packages/ui/src/views/components/RadialInput.tsx
@@ -1,0 +1,63 @@
+import { RadioButton, StackedList } from '@components/index'
+import { RadioGroup } from '@radix-ui/react-radio-group'
+import { cn } from '@utils/cn'
+
+export interface RadialOption<T extends string> {
+  id: string
+  title: string
+  description: string
+  value: T
+}
+
+interface RadialInputProps<T extends string> {
+  options: RadialOption<T>[]
+  value: T
+  onValueChange: (value: T) => void
+  id?: string
+  className?: string
+}
+
+export const RadialInput = <T extends string>({
+  options,
+  value,
+  onValueChange,
+  id,
+  className
+}: RadialInputProps<T>) => {
+  return (
+    <RadioGroup value={value} onValueChange={onValueChange as (value: string) => void} id={id} className={className}>
+      <div className="flex flex-col gap-2">
+        {options.map(option => (
+          <Option
+            key={option.id}
+            id={option.id}
+            control={
+              <StackedList.Root className="overflow-hidden" borderBackground>
+                <StackedList.Item
+                  className={cn('cursor-pointer !rounded px-5 py-3', {
+                    '!bg-background-4': value === option.value
+                  })}
+                  isHeader
+                  isLast
+                  actions={<RadioButton value={option.value} />}
+                  onClick={() => onValueChange(option.value)}
+                >
+                  <StackedList.Field title={option.title} description={option.description} />
+                </StackedList.Item>
+              </StackedList.Root>
+            }
+          />
+        ))}
+      </div>
+    </RadioGroup>
+  )
+}
+
+interface OptionProps {
+  id: string
+  control: React.ReactNode
+}
+
+const Option = ({ id, control }: OptionProps) => {
+  return <div id={id}>{control}</div>
+}

--- a/packages/ui/src/views/index.ts
+++ b/packages/ui/src/views/index.ts
@@ -54,3 +54,6 @@ export * from './execution'
 
 // secrets
 export * from './secrets'
+
+// components
+export * from './components/RadialInput'

--- a/packages/ui/src/views/secrets/secrets-header.tsx
+++ b/packages/ui/src/views/secrets/secrets-header.tsx
@@ -1,7 +1,6 @@
 import { useForm } from 'react-hook-form'
 
-import { Option, RadioButton, RadioGroup, StackedList } from '@/components'
-import { cn } from '@utils/cn'
+import { RadialInput, RadialOption } from '@/views/components/RadialInput'
 
 export enum SecretType {
   New = 'new',
@@ -19,59 +18,31 @@ export const SecretsHeader = ({
   onChange: (type: SecretType) => void
   selectedType: SecretType
 }) => {
-  const { watch, setValue } = useForm<SecretTypeForm>({
+  const { setValue } = useForm<SecretTypeForm>({
     defaultValues: {
       type: selectedTypeVal
     }
   })
-
-  const selectedType = watch('type')
 
   const handleTypeChange = (value: SecretType) => {
     setValue('type', value)
     onChange(value)
   }
 
-  return (
-    <RadioGroup value={selectedTypeVal} onValueChange={handleTypeChange} id="secret-type">
-      <div className="flex flex-col gap-2">
-        <Option
-          id="new-secret"
-          control={
-            <StackedList.Root className="overflow-hidden" borderBackground>
-              <StackedList.Item
-                className={cn('cursor-pointer !rounded px-5 py-3', {
-                  '!bg-background-4': selectedType === SecretType.New
-                })}
-                isHeader
-                isLast
-                actions={<RadioButton value={SecretType.New} />}
-                onClick={() => handleTypeChange(SecretType.New)}
-              >
-                <StackedList.Field title="New Secret" description="Create a new secret." />
-              </StackedList.Item>
-            </StackedList.Root>
-          }
-        />
-        <Option
-          id="existing-secret"
-          control={
-            <StackedList.Root className="overflow-hidden" borderBackground>
-              <StackedList.Item
-                className={cn('cursor-pointer !rounded px-5 py-3', {
-                  '!bg-background-4': selectedType === SecretType.Existing
-                })}
-                isHeader
-                isLast
-                actions={<RadioButton value={SecretType.Existing} />}
-                onClick={() => handleTypeChange(SecretType.Existing)}
-              >
-                <StackedList.Field title="Existing Secret" description="Use an existing secret." />
-              </StackedList.Item>
-            </StackedList.Root>
-          }
-        />
-      </div>
-    </RadioGroup>
-  )
+  const options: Array<RadialOption<SecretType>> = [
+    {
+      id: 'new-secret',
+      title: 'New Secret',
+      description: 'Create a new secret.',
+      value: SecretType.New
+    },
+    {
+      id: 'existing-secret',
+      title: 'Existing Secret',
+      description: 'Use an existing secret.',
+      value: SecretType.Existing
+    }
+  ]
+
+  return <RadialInput options={options} value={selectedTypeVal} onValueChange={handleTypeChange} id="secret-type" />
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c5d7899a-3abf-43db-9c99-4c63379de9f3)
basically updated the radial component in the secrets header to be reusuable
![image](https://github.com/user-attachments/assets/8712bd23-3134-4d16-9245-1563b309e89e)
