### PR TITLE
Removed host from shared styles

### DIFF
--- a/apps/gitness/src/pages-v2/pull-request/hooks/usePRCommonInteractions.ts
+++ b/apps/gitness/src/pages-v2/pull-request/hooks/usePRCommonInteractions.ts
@@ -12,7 +12,7 @@ import { generateAlphaNumericHash } from '@harnessio/ui/utils'
 import { CommitSuggestion } from '@harnessio/ui/views'
 
 import { useAPIPath } from '../../../hooks/useAPIPath'
-import { generateAlphaNumericHash, getErrorMessage } from '../pull-request-utils'
+import { getErrorMessage } from '../pull-request-utils'
 
 interface usePRCommonInteractionsProps {
   repoRef: string

--- a/packages/ui/src/shared-style-variables.css
+++ b/packages/ui/src/shared-style-variables.css
@@ -1,5 +1,4 @@
-:root,
-:host {
+:root {
   /* PP Figma shades */
   --canary-black: 240 13% 3%;
   --canary-grey-6: 240 6% 6%;
@@ -43,8 +42,7 @@
   /*--vscode-scrollbarSlider-activeBackground: #0000ff;*/
 }
 
-:root,
-:host {
+:root {
   /* value */
   /* color */
   --canary-pure-white: 0 0% 100%;
@@ -191,8 +189,7 @@
 
 @layer themes {
   /* TODO: replace hsl with variables for theming */
-  :root,
-  :host {
+  :root {
     --canary-background: 0 0% 100%;
     --canary-foreground: 240 10% 3.9%;
     --canary-card: 0 0% 100%;


### PR DESCRIPTION
:host was added to make styles work for Canary components in NGUI without having to import shared styles in index.scss

But, adding :host breaks styles inside a PortalContainer (Dialogs, Drawers, etc.) in MFE. Hence, removed it for now.