### PR TITLE
Fix canary components styling inside a Shadow Root

### DIFF
--- a/apps/gitness/src/AppMFE.tsx
+++ b/apps/gitness/src/AppMFE.tsx
@@ -147,12 +147,12 @@ export default function AppMFE({
   }, [theme])
 
   const shadowRef = useRef<HTMLDivElement>(null)
-  const shadowRootElement = shadowRef.current?.shadowRoot as ShadowRoot | undefined
+  const shadowRoot = shadowRef.current?.shadowRoot as ShadowRoot | undefined
 
   const portalRef = useRef<HTMLDivElement>(null)
   const portalContainer = portalRef.current as Element | undefined
 
-  const isStylesLoaded = useLoadMFEStyles(shadowRootElement)
+  const isStylesLoaded = useLoadMFEStyles(shadowRoot)
 
   // Router Configuration
   const basename = `/ng${renderUrl}`

--- a/apps/gitness/src/AppMFE.tsx
+++ b/apps/gitness/src/AppMFE.tsx
@@ -146,11 +146,13 @@ export default function AppMFE({
     }
   }, [theme])
 
+  // Styles will be loaded inside shadowRoot
   const shadowRef = useRef<HTMLDivElement>(null)
   const shadowRoot = shadowRef.current?.shadowRoot as ShadowRoot | undefined
 
-  const portalRef = useRef<HTMLDivElement>(null)
-  const portalContainer = portalRef.current as Element | undefined
+  // Radix UI elements will be rendered inside radixContainer
+  const radixRef = useRef<HTMLDivElement>(null)
+  const radixContainer = radixRef.current as Element | undefined
 
   const isStylesLoaded = useLoadMFEStyles(shadowRoot)
 
@@ -167,12 +169,12 @@ export default function AppMFE({
   return (
     <div ref={shadowRef}>
       <ShadowRootWrapper>
-        <div className={theme.toLowerCase()} ref={portalRef}>
+        <div className={theme.toLowerCase()} ref={radixRef}>
           {!isStylesLoaded ? (
             // Replace it with spinner once it is available
             <ShadowRootLoader theme={theme} />
           ) : (
-            <PortalProvider portalContainer={portalContainer}>
+            <PortalProvider portalContainer={radixContainer}>
               <MFEContext.Provider
                 value={{
                   scope,

--- a/apps/gitness/src/AppMFE.tsx
+++ b/apps/gitness/src/AppMFE.tsx
@@ -150,9 +150,9 @@ export default function AppMFE({
   const shadowRef = useRef<HTMLDivElement>(null)
   const shadowRoot = shadowRef.current?.shadowRoot as ShadowRoot | undefined
 
-  // Radix UI elements will be rendered inside radixContainer
-  const radixRef = useRef<HTMLDivElement>(null)
-  const radixContainer = radixRef.current as Element | undefined
+  // Radix UI elements will be rendered inside portalContainer
+  const portalRef = useRef<HTMLDivElement>(null)
+  const portalContainer = portalRef.current as Element | undefined
 
   const isStylesLoaded = useLoadMFEStyles(shadowRoot)
 
@@ -169,12 +169,13 @@ export default function AppMFE({
   return (
     <div ref={shadowRef}>
       <ShadowRootWrapper>
-        <div className={theme.toLowerCase()} ref={radixRef}>
+        {/* Radix UI elements need to be rendered inside the following div with the theme class */}
+        <div className={theme.toLowerCase()} ref={portalRef}>
           {!isStylesLoaded ? (
             // Replace it with spinner once it is available
             <ShadowRootLoader theme={theme} />
           ) : (
-            <PortalProvider portalContainer={radixContainer}>
+            <PortalProvider portalContainer={portalContainer}>
               <MFEContext.Provider
                 value={{
                   scope,

--- a/apps/gitness/src/AppMFE.tsx
+++ b/apps/gitness/src/AppMFE.tsx
@@ -148,11 +148,11 @@ export default function AppMFE({
 
   // Styles will be loaded inside shadowRoot
   const shadowRef = useRef<HTMLDivElement>(null)
-  const shadowRoot = shadowRef.current?.shadowRoot as ShadowRoot | undefined
+  const shadowRoot = shadowRef.current?.shadowRoot
 
   // Radix UI elements will be rendered inside portalContainer
   const portalRef = useRef<HTMLDivElement>(null)
-  const portalContainer = portalRef.current as Element | undefined
+  const portalContainer = portalRef.current
 
   const isStylesLoaded = useLoadMFEStyles(shadowRoot)
 

--- a/apps/gitness/src/AppMFE.tsx
+++ b/apps/gitness/src/AppMFE.tsx
@@ -1,5 +1,3 @@
-import './styles/AppMFE.css'
-
 import { useEffect, useMemo, useRef } from 'react'
 import { I18nextProvider } from 'react-i18next'
 import {
@@ -148,10 +146,13 @@ export default function AppMFE({
     }
   }, [theme])
 
-  const portalRef = useRef<HTMLDivElement>(null)
-  const portalContainer = portalRef.current?.shadowRoot as Element | undefined
+  const shadowRef = useRef<HTMLDivElement>(null)
+  const shadowRootElement = shadowRef.current?.shadowRoot as ShadowRoot | undefined
 
-  const isStylesLoaded = useLoadMFEStyles(portalContainer)
+  const portalRef = useRef<HTMLDivElement>(null)
+  const portalContainer = portalRef.current as Element | undefined
+
+  const isStylesLoaded = useLoadMFEStyles(shadowRootElement)
 
   // Router Configuration
   const basename = `/ng${renderUrl}`
@@ -164,9 +165,9 @@ export default function AppMFE({
   const router = createBrowserRouter(routesToRender, { basename })
 
   return (
-    <div ref={portalRef}>
+    <div ref={shadowRef}>
       <ShadowRootWrapper>
-        <div className={theme.toLowerCase()}>
+        <div className={theme.toLowerCase()} ref={portalRef}>
           {!isStylesLoaded ? (
             // Replace it with spinner once it is available
             <ShadowRootLoader theme={theme} />

--- a/apps/gitness/src/hooks/useLoadMFEStyles.ts
+++ b/apps/gitness/src/hooks/useLoadMFEStyles.ts
@@ -19,21 +19,21 @@ const fetchMarkdownPreviewStyles = async () => {
   return markdownPreviewStyles.default
 }
 
-export function useLoadMFEStyles(portalContainer?: ShadowRoot) {
+export function useLoadMFEStyles(shadowRoot?: ShadowRoot) {
   const [isStylesLoaded, setIsStylesLoaded] = useState(false)
 
   useEffect(() => {
-    if (portalContainer) {
+    if (shadowRoot) {
       Promise.all([fetchUIStyles(), fetchMonacoStyles(), fetchMarkdownPreviewStyles()]).then(
         ([uiStyles, monacoStyles, markdownPreviewStyles]) => {
           const styleElement = document.createElement('style')
           styleElement.innerHTML = `${uiStyles}\n${monacoStyles}\n${markdownPreviewStyles}`
-          portalContainer?.appendChild(styleElement)
+          shadowRoot?.appendChild(styleElement)
           setIsStylesLoaded(true)
         }
       )
     }
-  }, [portalContainer])
+  }, [shadowRoot])
 
   return isStylesLoaded
 }

--- a/apps/gitness/src/hooks/useLoadMFEStyles.ts
+++ b/apps/gitness/src/hooks/useLoadMFEStyles.ts
@@ -19,7 +19,7 @@ const fetchMarkdownPreviewStyles = async () => {
   return markdownPreviewStyles.default
 }
 
-export function useLoadMFEStyles(portalContainer: Element | undefined) {
+export function useLoadMFEStyles(portalContainer?: ShadowRoot) {
   const [isStylesLoaded, setIsStylesLoaded] = useState(false)
 
   useEffect(() => {

--- a/apps/gitness/src/hooks/useLoadMFEStyles.ts
+++ b/apps/gitness/src/hooks/useLoadMFEStyles.ts
@@ -19,7 +19,7 @@ const fetchMarkdownPreviewStyles = async () => {
   return markdownPreviewStyles.default
 }
 
-export function useLoadMFEStyles(shadowRoot?: ShadowRoot) {
+export function useLoadMFEStyles(shadowRoot?: ShadowRoot | null) {
   const [isStylesLoaded, setIsStylesLoaded] = useState(false)
 
   useEffect(() => {

--- a/apps/gitness/src/styles/AppMFE.css
+++ b/apps/gitness/src/styles/AppMFE.css
@@ -1,1 +1,0 @@
-@import '@harnessio/ui/shared-style-variables.css';

--- a/packages/ui/src/context/portal-context.tsx
+++ b/packages/ui/src/context/portal-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, ReactNode, useContext } from 'react'
 
 interface PortalContextProps {
-  portalContainer?: HTMLDivElement | null
+  portalContainer?: Element | null
 }
 
 const PortalContext = createContext<PortalContextProps>({})

--- a/packages/ui/src/context/portal-context.tsx
+++ b/packages/ui/src/context/portal-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, ReactNode, useContext } from 'react'
 
 interface PortalContextProps {
-  portalContainer?: Element
+  portalContainer?: HTMLDivElement | null
 }
 
 const PortalContext = createContext<PortalContextProps>({})

--- a/packages/ui/src/shared-style-variables.css
+++ b/packages/ui/src/shared-style-variables.css
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
   /* PP Figma shades */
   --canary-black: 240 13% 3%;
   --canary-grey-6: 240 6% 6%;
@@ -42,7 +43,8 @@
   /*--vscode-scrollbarSlider-activeBackground: #0000ff;*/
 }
 
-:root {
+:root,
+:host {
   /* value */
   /* color */
   --canary-pure-white: 0 0% 100%;
@@ -189,7 +191,8 @@
 
 @layer themes {
   /* TODO: replace hsl with variables for theming */
-  :root {
+  :root,
+  :host {
     --canary-background: 0 0% 100%;
     --canary-foreground: 240 10% 3.9%;
     --canary-card: 0 0% 100%;


### PR DESCRIPTION
This PR aims to fix the styling for Canary Components rendered in NGUI without having to import the Shared Styles separately in NGUI index.scss

Adding :host selector for CSS variables fixed this issue previously, but was breaking the styling for Radix UI elements rendered inside a container. That issue is also taken care of in this PR.

Before Change:
https://github.com/user-attachments/assets/85e82f41-3baf-4559-9b64-e71e62ae924e

After Change:
https://github.com/user-attachments/assets/57f7c580-775a-4300-b588-8d617ab16899

Standalone Test:
https://github.com/user-attachments/assets/b45f8142-72c5-4da9-a78c-0af778748c6c
