### PR TITLE
fix: fix sheet component when modal false

### DIFF
--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -85,31 +85,40 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Con
     ref
   ) => {
     const { portalContainer } = usePortal()
+
+    const content = (
+      <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+        {children}
+        {!hideCloseButton && (
+          <SheetPrimitive.Close
+            className="absolute right-[0.1875rem] top-2 flex items-center justify-center transition-colors disabled:pointer-events-none"
+            asChild
+          >
+            <Button
+              className={cn('text-icons-4 hover:text-icons-2 focus:ring-0 focus-visible:outline-none', closeClassName)}
+              variant="custom"
+              size="icon"
+            >
+              <Icon name="close" size={16} />
+              <span className="sr-only">Close</span>
+            </Button>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    )
+
     return (
       <SheetPortal container={portalContainer}>
-        <SheetOverlay modal={modal} className={overlayClassName} handleClose={handleClose || props.onClick}>
-          <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
-            {children}
-            {!hideCloseButton && (
-              <SheetPrimitive.Close
-                className="absolute right-[0.1875rem] top-2 flex items-center justify-center transition-colors disabled:pointer-events-none"
-                asChild
-              >
-                <Button
-                  className={cn(
-                    'text-icons-4 hover:text-icons-2 focus:ring-0 focus-visible:outline-none',
-                    closeClassName
-                  )}
-                  variant="custom"
-                  size="icon"
-                >
-                  <Icon name="close" size={16} />
-                  <span className="sr-only">Close</span>
-                </Button>
-              </SheetPrimitive.Close>
-            )}
-          </SheetPrimitive.Content>
-        </SheetOverlay>
+        {modal ? (
+          <SheetOverlay modal={modal} className={overlayClassName} handleClose={handleClose || props.onClick}>
+            {content}
+          </SheetOverlay>
+        ) : (
+          <>
+            <SheetOverlay modal={modal} className={overlayClassName} handleClose={handleClose || props.onClick} />
+            {content}
+          </>
+        )}
       </SheetPortal>
     )
   }


### PR DESCRIPTION
In this [PR](https://github.com/harness/canary/pull/1292), the display of the "Settings" and "More" submenus in the sidebar was broken.
The issue occurred when `modal=false`.