### PR TITLE
fix: fix summary line

### DIFF
--- a/packages/ui/src/components/tabnav.tsx
+++ b/packages/ui/src/components/tabnav.tsx
@@ -8,7 +8,10 @@ const TabNavRoot: FC<PropsWithChildren<HTMLAttributes<HTMLElement>>> = ({ classN
   return (
     <nav
       {...props}
-      className={cn('flex h-11 w-full items-center gap-6 border-b border-borders-5 px-6 text-foreground-4', className)}
+      className={cn(
+        'flex h-11 w-full items-center gap-6 border-b-2 border-borders-5 px-6 text-foreground-4',
+        className
+      )}
     />
   )
 }
@@ -24,7 +27,7 @@ const TabNavItem: FC<NavLinkProps> = ({ className, ...props }) => {
           'block relative place-content-center whitespace-nowrap m-0 my-1 h-9 px-0 text-14 font-normal leading-none text-foreground-2 focus-visible:duration-0 duration-150 ease-in-out hover:text-foreground-1 disabled:pointer-events-none disabled:opacity-50 ',
           // bottom border of active tab
           'after:pointer-events-none after:absolute after:inset-[-0.25rem_0] after:block after:border-b after:border-solid after:border-b-transparent',
-          { 'text-foreground-1 after:border-borders-9': isActive },
+          { 'text-foreground-1 after:border-borders-7': isActive },
           /*
            * TODO: Active tab Radial background is hidden until it's adjusted to the light theme
            */


### PR DESCRIPTION
fix summary line
-Can we make the line under "Summary" to be 2px instead of 1px and use a dark black color?
<img width="166" alt="image" src="https://github.com/user-attachments/assets/59c6bc46-244e-4d60-ba28-1d904622f664" />
