### PR TITLE
chore: remove unneeded eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,23 +45,6 @@
 
     "jsx-a11y/click-events-have-key-events": "warn",
     "jsx-a11y/no-autofocus": "off",
-    "no-restricted-imports": [
-      "warn",
-      {
-        "paths": [
-          {
-            "name": "@harnessio/canary",
-            "message": " @harnessio/canary is deprecated. Import from @harnessio/ui/components instead"
-          }
-        ],
-        "patterns": [
-          {
-            "group": ["@harnessio/canary/*"],
-            "message": " @harnessio/canary is deprecated. Import from @harnessio/ui/components instead"
-          }
-        ]
-      }
-    ],
     "i18next/no-literal-string": [
       "warn",
       {


### PR DESCRIPTION
This PR removes the ESLint rule to restrict canary imports now that the canary package has been removed.