### PR TITLE
fix: Add App Router Provider to avoid re-routing issue

### DIFF
--- a/apps/gitness/src/App.tsx
+++ b/apps/gitness/src/App.tsx
@@ -1,19 +1,10 @@
 import { I18nextProvider } from 'react-i18next'
-import {
-  createBrowserRouter,
-  Link,
-  NavLink,
-  Outlet,
-  RouterProvider,
-  useMatches,
-  useSearchParams
-} from 'react-router-dom'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 
 import { CodeServiceAPIClient } from '@harnessio/code-service-client'
 import { Toast, Tooltip } from '@harnessio/ui/components'
-import { RouterContextProvider } from '@harnessio/ui/context'
 
 import { ExitConfirmProvider } from './framework/context/ExitConfirmContext'
 import { NavigationProvider } from './framework/context/NavigationContext'
@@ -48,17 +39,7 @@ export default function App() {
             <Tooltip.Provider>
               <ExitConfirmProvider>
                 <NavigationProvider routes={routes}>
-                  <RouterContextProvider
-                    Link={Link}
-                    NavLink={NavLink}
-                    Outlet={Outlet}
-                    location={{ ...window.location, state: {}, key: '' }}
-                    navigate={router.navigate}
-                    useSearchParams={useSearchParams}
-                    useMatches={useMatches}
-                  >
-                    <RouterProvider router={router} />
-                  </RouterContextProvider>
+                  <RouterProvider router={router} />
                 </NavigationProvider>
               </ExitConfirmProvider>
             </Tooltip.Provider>

--- a/apps/gitness/src/framework/context/AppRouterProvider.tsx
+++ b/apps/gitness/src/framework/context/AppRouterProvider.tsx
@@ -24,4 +24,4 @@ const AppRouterProvider: React.FC<AppRouterProviderProps> = ({ children }) => {
   )
 }
 
-export { AppRouterProvider }
+export default AppRouterProvider

--- a/apps/gitness/src/framework/context/AppRouterProvider.tsx
+++ b/apps/gitness/src/framework/context/AppRouterProvider.tsx
@@ -7,7 +7,7 @@ interface AppRouterProviderProps {
   children: ReactNode
 }
 
-const AppRouterProvider: React.FC<AppRouterProviderProps> = ({ children }) => {
+const AppRouterProvider: FC<AppRouterProviderProps> = ({ children }) => {
   const navigate = useNavigate()
   return (
     <RouterContextProvider

--- a/apps/gitness/src/framework/context/AppRouterProvider.tsx
+++ b/apps/gitness/src/framework/context/AppRouterProvider.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { FC, ReactNode } from 'react'
 import { Link, NavLink, Outlet, useMatches, useNavigate, useSearchParams } from 'react-router-dom'
 
 import { RouterContextProvider } from '@harnessio/ui/context'
@@ -24,4 +24,4 @@ const AppRouterProvider: React.FC<AppRouterProviderProps> = ({ children }) => {
   )
 }
 
-export default AppRouterProvider
+export { AppRouterProvider }

--- a/apps/gitness/src/framework/context/AppRouterProvider.tsx
+++ b/apps/gitness/src/framework/context/AppRouterProvider.tsx
@@ -1,0 +1,27 @@
+import React, { ReactNode } from 'react'
+import { Link, NavLink, Outlet, useMatches, useNavigate, useSearchParams } from 'react-router-dom'
+
+import { RouterContextProvider } from '@harnessio/ui/context'
+
+interface AppRouterProviderProps {
+  children: ReactNode
+}
+
+const AppRouterProvider: React.FC<AppRouterProviderProps> = ({ children }) => {
+  const navigate = useNavigate()
+  return (
+    <RouterContextProvider
+      Link={Link}
+      NavLink={NavLink}
+      Outlet={Outlet}
+      location={{ ...window.location, state: {}, key: '' }}
+      navigate={navigate}
+      useSearchParams={useSearchParams}
+      useMatches={useMatches}
+    >
+      {children}
+    </RouterContextProvider>
+  )
+}
+
+export { AppRouterProvider }

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -12,6 +12,7 @@ import {
 import { AppShell, AppShellMFE } from './components-v2/app-shell'
 import { ProjectDropdown } from './components-v2/breadcrumbs/project-dropdown'
 import { AppProvider } from './framework/context/AppContext'
+import { AppRouterProvider } from './framework/context/AppRouterProvider'
 import { ExplorerPathsProvider } from './framework/context/ExplorerPathsContext'
 import { CustomRouteObject, RouteConstants } from './framework/routing/types'
 import { useTranslationStore } from './i18n/stores/i18n-store'
@@ -659,9 +660,11 @@ export const routes: CustomRouteObject[] = [
   {
     path: '/',
     element: (
-      <AppProvider>
-        <AppShell />
-      </AppProvider>
+      <AppRouterProvider>
+        <AppProvider>
+          <AppShell />
+        </AppProvider>
+      </AppRouterProvider>
     ),
     handle: { routeName: 'toHome' },
     children: [

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -12,7 +12,7 @@ import {
 import { AppShell, AppShellMFE } from './components-v2/app-shell'
 import { ProjectDropdown } from './components-v2/breadcrumbs/project-dropdown'
 import { AppProvider } from './framework/context/AppContext'
-import AppRouterProvider from './framework/context/AppRouterProvider'
+import { AppRouterProvider } from './framework/context/AppRouterProvider'
 import { ExplorerPathsProvider } from './framework/context/ExplorerPathsContext'
 import { CustomRouteObject, RouteConstants } from './framework/routing/types'
 import { useTranslationStore } from './i18n/stores/i18n-store'

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -12,7 +12,7 @@ import {
 import { AppShell, AppShellMFE } from './components-v2/app-shell'
 import { ProjectDropdown } from './components-v2/breadcrumbs/project-dropdown'
 import { AppProvider } from './framework/context/AppContext'
-import { AppRouterProvider } from './framework/context/AppRouterProvider'
+import AppRouterProvider from './framework/context/AppRouterProvider'
 import { ExplorerPathsProvider } from './framework/context/ExplorerPathsContext'
 import { CustomRouteObject, RouteConstants } from './framework/routing/types'
 import { useTranslationStore } from './i18n/stores/i18n-store'


### PR DESCRIPTION
- Moves `RouterContextProvider` inside `RouterProvider` to allow calling `useNavigate` hooks and pass down the correct implementation of `navigate` function to be used via `useRouterContext`.
- This fixes the unexpected re-routing issue seen while visiting Pull Requests list page.

**Without fix:**

https://github.com/user-attachments/assets/74d1266a-37dc-4af3-99eb-740b651a0129

**With fix:**

https://github.com/user-attachments/assets/b959600e-814f-4305-849a-463eaf1765f4