### PR TITLE
fix: added router issue for both mfe and design-system

### DIFF
--- a/apps/design-system/src/App.tsx
+++ b/apps/design-system/src/App.tsx
@@ -1,26 +1,24 @@
 import { FC, useEffect, useState } from 'react'
-import {
-  createBrowserRouter,
-  Link,
-  Navigate,
-  NavLink,
-  Outlet,
-  RouterProvider,
-  useMatches,
-  useSearchParams
-} from 'react-router-dom'
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 
 import ComponentPage from '@/pages/component-page'
 import ViewPreview from '@/pages/view-preview/view-preview'
 import DocsLayout from '@components/docs-layout/docs-layout'
 import { useThemeStore } from '@utils/theme-utils'
 
-import { RouterContextProvider, ThemeProvider } from '@harnessio/ui/context'
+import { ThemeProvider } from '@harnessio/ui/context'
+
+import AppRouterProvider from './AppRouterProvider'
 
 const router = createBrowserRouter([
-  { path: '/view-preview/*', element: <ViewPreview /> },
-  { path: '/docs/*', element: <DocsLayout />, children: [{ path: 'components/*', element: <ComponentPage /> }] },
-  { path: '/*', element: <Navigate to="/docs" /> }
+  {
+    element: <AppRouterProvider />,
+    children: [
+      { path: '/view-preview/*', element: <ViewPreview /> },
+      { path: '/docs/*', element: <DocsLayout />, children: [{ path: 'components/*', element: <ComponentPage /> }] },
+      { path: '/*', element: <Navigate to="/docs" /> }
+    ]
+  }
 ])
 
 const App: FC = () => {
@@ -44,17 +42,7 @@ const App: FC = () => {
 
   return (
     <ThemeProvider {...{ ...themeStore, isInset }}>
-      <RouterContextProvider
-        Link={Link}
-        NavLink={NavLink}
-        Outlet={Outlet}
-        navigate={router.navigate}
-        location={{ ...window.location, state: {}, key: '' }}
-        useSearchParams={useSearchParams}
-        useMatches={useMatches}
-      >
-        <RouterProvider router={router} />
-      </RouterContextProvider>
+      <RouterProvider router={router} />
     </ThemeProvider>
   )
 }

--- a/apps/design-system/src/AppRouterProvider.tsx
+++ b/apps/design-system/src/AppRouterProvider.tsx
@@ -1,13 +1,9 @@
-import { FC, ReactNode } from 'react'
+import { FC } from 'react'
 import { Link, NavLink, Outlet, useLocation, useMatches, useNavigate, useSearchParams } from 'react-router-dom'
 
 import { RouterContextProvider } from '@harnessio/ui/context'
 
-interface AppRouterProviderProps {
-  children: ReactNode
-}
-
-const AppRouterProvider: FC<AppRouterProviderProps> = ({ children }) => {
+const AppRouterProvider: FC = () => {
   const navigate = useNavigate()
   const location = useLocation()
 
@@ -21,9 +17,9 @@ const AppRouterProvider: FC<AppRouterProviderProps> = ({ children }) => {
       useSearchParams={useSearchParams}
       useMatches={useMatches}
     >
-      {children}
+      <Outlet />
     </RouterContextProvider>
   )
 }
 
-export { AppRouterProvider }
+export default AppRouterProvider

--- a/apps/gitness/src/AppMFE.tsx
+++ b/apps/gitness/src/AppMFE.tsx
@@ -1,23 +1,12 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { I18nextProvider } from 'react-i18next'
-import {
-  createBrowserRouter,
-  Link,
-  matchPath,
-  NavLink,
-  Outlet,
-  RouterProvider,
-  useLocation,
-  useMatches,
-  useNavigate,
-  useSearchParams
-} from 'react-router-dom'
+import { createBrowserRouter, matchPath, RouterProvider, useLocation, useNavigate } from 'react-router-dom'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 
 import { CodeServiceAPIClient } from '@harnessio/code-service-client'
 import { Toast, Tooltip } from '@harnessio/ui/components'
-import { PortalProvider, RouterContextProvider } from '@harnessio/ui/context'
+import { PortalProvider } from '@harnessio/ui/context'
 
 import ShadowRootWrapper from './components-v2/shadow-root-wrapper'
 import { ExitConfirmProvider } from './framework/context/ExitConfirmContext'
@@ -191,17 +180,7 @@ export default function AppMFE({
                         <Tooltip.Provider>
                           <ExitConfirmProvider>
                             <NavigationProvider routes={routesToRender}>
-                              <RouterContextProvider
-                                Link={Link}
-                                NavLink={NavLink}
-                                Outlet={Outlet}
-                                location={{ ...window.location, state: {}, key: '' }}
-                                navigate={router.navigate}
-                                useSearchParams={useSearchParams}
-                                useMatches={useMatches}
-                              >
-                                <RouterProvider router={router} />
-                              </RouterContextProvider>
+                              <RouterProvider router={router} />
                             </NavigationProvider>
                           </ExitConfirmProvider>
                         </Tooltip.Provider>

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -1133,10 +1133,12 @@ export const mfeRoutes = (mfeProjectId = '', mfeRouteRenderer: JSX.Element | nul
   {
     path: '/',
     element: (
-      <AppProvider>
-        {mfeRouteRenderer}
-        <AppShellMFE />
-      </AppProvider>
+      <AppRouterProvider>
+        <AppProvider>
+          {mfeRouteRenderer}
+          <AppShellMFE />
+        </AppProvider>
+      </AppRouterProvider>
     ),
     handle: { routeName: RouteConstants.toHome },
     children: [


### PR DESCRIPTION
Fixed the same issue mentioned here #1413 for mfe and design-system
Updated `window.location` to `useLocation`, 
since mfe would break if window.location is used, as it will contain path for both parent app and child mfe

https://github.com/user-attachments/assets/85c78e20-bda7-406b-b46f-b66348fc6b44

https://github.com/user-attachments/assets/e767f97d-0d77-4163-b80a-acda6891eb3c

