### PR TITLE
fix: Wrap code blocks with dark and dark-std-std classes

### DIFF
--- a/apps/portal/astro.config.ts
+++ b/apps/portal/astro.config.ts
@@ -2,6 +2,7 @@ import starlight from "@astrojs/starlight";
 import tailwind from "@astrojs/tailwind";
 import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
+import { wrapCodeBlocks } from "./src/wrap-code-blocks.ts";
 
 // if static building, mock `document` to prevent a bug triggered by a 3rd party dependency
 if (!("document" in globalThis)) {
@@ -65,6 +66,9 @@ export default defineConfig({
     tailwind({ applyBaseStyles: false }),
     react(),
   ],
+  markdown: {
+    rehypePlugins: [wrapCodeBlocks],
+  },
   redirects: {
     "/": "/components/accordion",
   },

--- a/apps/portal/src/wrap-code-blocks.ts
+++ b/apps/portal/src/wrap-code-blocks.ts
@@ -1,0 +1,50 @@
+interface Node {
+  type: string;
+  children?: Node[];
+  position?: unknown;
+}
+
+interface Element extends Node {
+  type: "element";
+  tagName: string;
+  properties?: {
+    className?: string | string[];
+    [key: string]: unknown;
+  };
+  children: Node[];
+}
+
+export function wrapCodeBlocks() {
+  return (tree: Node) => {
+    processNodes(tree);
+  };
+}
+
+function processNodes(node: Node): void {
+  if (!node || !Array.isArray(node.children)) return;
+
+  node.children = node.children.map((child: Node) => {
+    if (isCodeBlock(child)) {
+      return {
+        type: "element",
+        tagName: "div",
+        properties: { className: ["dark", "dark-std-std"] },
+        children: [child],
+      };
+    }
+
+    processNodes(child);
+
+    return child;
+  });
+}
+function isElement(node: Node): node is Element {
+  return node.type === "element" && "tagName" in node;
+}
+
+function isCodeBlock(node: Node): boolean {
+  if (!isElement(node) || node.tagName !== "pre") return false;
+
+  const firstChild = node.children?.[0];
+  return isElement(firstChild) && firstChild.tagName === "code";
+}


### PR DESCRIPTION
This PR adds a small rehype plugin to wrap all code blocks in an extra div which adds the `dark` and `dark-std-std` classes temporarily until the whole page can be modified to apply these classes without breaking the experience.

|Before|After|
|------|------|
|![Before](https://github.com/user-attachments/assets/b7bb2215-b4a4-415d-acf8-247786525b5f)|![After](https://github.com/user-attachments/assets/826bd83e-fb0e-4a35-a569-c79cb542153a)|

Fixes #1425 