### PR TITLE
changes in branch selector

### DIFF
--- a/apps/design-system/src/subjects/views/repo-branches/index.tsx
+++ b/apps/design-system/src/subjects/views/repo-branches/index.tsx
@@ -14,7 +14,7 @@ export function RepoBranchesView() {
     <RepoBranchListView
       isLoading={false}
       isCreatingBranch={false}
-      onSubmit={noop}
+      onSubmit={async () => {}}
       useRepoBranchesStore={useRepoBranchesStore}
       useTranslationStore={useTranslationStore}
       isCreateBranchDialogOpen={isCreateBranchDialogOpen}

--- a/apps/gitness/src/components-v2/branch-selector-container.tsx
+++ b/apps/gitness/src/components-v2/branch-selector-container.tsx
@@ -15,12 +15,14 @@ interface BranchSelectorContainerProps {
   onSelectBranchorTag: (branchTag: BranchSelectorListItem, type: BranchSelectorTab) => void
   isBranchOnly?: boolean
   dynamicWidth?: boolean
+  preSelectedTab?: BranchSelectorTab
 }
 export const BranchSelectorContainer: React.FC<BranchSelectorContainerProps> = ({
   selectedBranch,
   onSelectBranchorTag,
   isBranchOnly = false,
-  dynamicWidth = false
+  dynamicWidth = false,
+  preSelectedTab
 }) => {
   const repoRef = useGetRepoRef()
   const { spaceId, repoId } = useParams<PathParams>()
@@ -95,6 +97,7 @@ export const BranchSelectorContainer: React.FC<BranchSelectorContainerProps> = (
       onSelectBranch={onSelectBranchorTag}
       isBranchOnly={isBranchOnly}
       dynamicWidth={dynamicWidth}
+      preSelectedTab={preSelectedTab}
     />
   )
 }

--- a/apps/gitness/src/components-v2/create-branch-dialog.tsx
+++ b/apps/gitness/src/components-v2/create-branch-dialog.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { useCreateBranchMutation } from '@harnessio/code-service-client'
+import {
+  BranchSelectorListItem,
+  BranchSelectorTab,
+  CreateBranchDialog as CreateBranchDialogComp,
+  CreateBranchFormFields
+} from '@harnessio/ui/views'
+
+import { useGetRepoRef } from '../framework/hooks/useGetRepoPath'
+import { useTranslationStore } from '../i18n/stores/i18n-store'
+import { BranchSelectorContainer } from './branch-selector-container'
+
+interface CreateBranchDialogProps {
+  open: boolean
+  onClose: () => void
+  onSuccess?: () => void
+  preselectedBranchOrTag?: BranchSelectorListItem | null
+  preselectedTab?: BranchSelectorTab
+}
+
+export const CreateBranchDialog = ({
+  open,
+  onClose,
+  onSuccess,
+  preselectedBranchOrTag,
+  preselectedTab
+}: CreateBranchDialogProps) => {
+  const repo_ref = useGetRepoRef()
+
+  const [selectedBranchOrTag, setSelectedBranchOrTag] = useState<BranchSelectorListItem | null>(null)
+
+  const selectBranchOrTag = useCallback((branchTagName: BranchSelectorListItem) => {
+    setSelectedBranchOrTag(branchTagName)
+  }, [])
+
+  const {
+    mutateAsync: createBranch,
+    error: createBranchError,
+    isLoading: isCreatingBranch,
+    reset: resetBranchMutation
+  } = useCreateBranchMutation(
+    {},
+    {
+      onSuccess: () => {
+        onClose()
+        onSuccess?.()
+      }
+    }
+  )
+
+  const handleCreateBranch = async (data: CreateBranchFormFields) => {
+    await createBranch({
+      repo_ref,
+      body: {
+        ...data
+      }
+    })
+  }
+
+  useEffect(() => {
+    if (!open) {
+      resetBranchMutation()
+    }
+  }, [open, resetBranchMutation])
+
+  useEffect(() => {
+    if (preselectedBranchOrTag) {
+      setSelectedBranchOrTag(preselectedBranchOrTag)
+    }
+  }, [open, preselectedBranchOrTag])
+
+  return (
+    <CreateBranchDialogComp
+      useTranslationStore={useTranslationStore}
+      open={open}
+      onClose={onClose}
+      selectedBranchOrTag={selectedBranchOrTag}
+      onSubmit={handleCreateBranch}
+      isCreatingBranch={isCreatingBranch}
+      error={createBranchError?.message}
+      renderProp={() => (
+        <BranchSelectorContainer
+          onSelectBranchorTag={selectBranchOrTag}
+          selectedBranch={selectedBranchOrTag}
+          preSelectedTab={preselectedTab}
+        />
+      )}
+    />
+  )
+}

--- a/apps/gitness/src/pages-v2/repo/repo-branch-list.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-branch-list.tsx
@@ -13,6 +13,7 @@ import {
 import { DeleteAlertDialog } from '@harnessio/ui/components'
 import { CreateBranchFormFields, RepoBranchListView } from '@harnessio/ui/views'
 
+import { CreateBranchDialog } from '../../components-v2/create-branch-dialog'
 import { useRoutes } from '../../framework/context/NavigationContext'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
 import { useQueryState } from '../../framework/hooks/useQueryState'
@@ -189,6 +190,12 @@ export function RepoBranchesListPage() {
         onDeleteBranch={handleSetDeleteBranch}
         searchBranches={searchBranches || []}
         setCreateBranchSearchQuery={setCreateBranchSearchQuery}
+      />
+
+      <CreateBranchDialog
+        open={isCreateBranchDialogOpen}
+        onClose={() => setCreateBranchDialogOpen(false)}
+        onSuccess={handleInvalidateBranchList}
       />
 
       <DeleteAlertDialog

--- a/apps/gitness/src/pages-v2/repo/repo-sidebar.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-sidebar.tsx
@@ -20,7 +20,7 @@ import { useTranslationStore } from '../../i18n/stores/i18n-store'
 import { PathParams } from '../../RouteDefinitions'
 import { orderSortDate } from '../../types'
 import { FILE_SEPERATOR, normalizeGitRef, REFS_TAGS_PREFIX } from '../../utils/git-utils'
-import { useRepoBranchesStore } from '././stores/repo-branches-store'
+import { useRepoBranchesStore } from './stores/repo-branches-store'
 import { transformBranchList } from './transform-utils/branch-transform'
 
 /**

--- a/apps/gitness/src/pages-v2/repo/repo-tags-list-container.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-tags-list-container.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import {
-  useCreateBranchMutation,
   useCreateTagMutation,
   useDeleteTagMutation,
   useFindRepositoryQuery,
@@ -10,15 +9,9 @@ import {
   useListTagsQuery
 } from '@harnessio/code-service-client'
 import { DeleteAlertDialog } from '@harnessio/ui/components'
-import {
-  CommitTagType,
-  CreateBranchDialog,
-  CreateBranchFormFields,
-  CreateTagDialog,
-  CreateTagFromFields,
-  RepoTagsListView
-} from '@harnessio/ui/views'
+import { CommitTagType, CreateTagDialog, CreateTagFromFields, RepoTagsListView } from '@harnessio/ui/views'
 
+import { CreateBranchDialog } from '../../components-v2/create-branch-dialog'
 import { useRoutes } from '../../framework/context/NavigationContext'
 import { useGetRepoRef } from '../../framework/hooks/useGetRepoPath'
 import { useQueryState } from '../../framework/hooks/useQueryState'
@@ -86,15 +79,6 @@ export const RepoTagsListContainer = () => {
     }
   )
 
-  const { mutate: createBranch, error: createBranchError } = useCreateBranchMutation(
-    {},
-    {
-      onSuccess: () => {
-        setOpenCreateBranchDialog(false)
-      }
-    }
-  )
-
   useEffect(() => {
     if (tagsList) {
       setTags(tagsList as CommitTagType[])
@@ -139,15 +123,6 @@ export const RepoTagsListContainer = () => {
     })
   }
 
-  const handleCreateBranch = (data: CreateBranchFormFields) => {
-    createBranch({
-      repo_ref,
-      body: {
-        ...data
-      }
-    })
-  }
-
   return (
     <>
       <RepoTagsListView
@@ -174,15 +149,7 @@ export const RepoTagsListContainer = () => {
         useRepoBranchesStore={useRepoBranchesStore}
         isLoading={isCreatingTag}
       />
-      <CreateBranchDialog
-        open={openCreateBranchDialog}
-        onClose={() => setOpenCreateBranchDialog(false)}
-        useRepoBranchesStore={useRepoBranchesStore}
-        onSubmit={handleCreateBranch}
-        useTranslationStore={useTranslationStore}
-        handleChangeSearchValue={setBranchQuery}
-        error={createBranchError?.message}
-      />
+      <CreateBranchDialog open={openCreateBranchDialog} onClose={() => setOpenCreateBranchDialog(false)} />
       <DeleteAlertDialog
         open={deleteTagDialog}
         onClose={() => setDeleteTagDialog(false)}

--- a/packages/ui/locales/en/views.json
+++ b/packages/ui/locales/en/views.json
@@ -110,6 +110,13 @@
     "viewRules": "View Rules",
     "browse": "Browse",
     "deleteBranch": "Delete Branch",
+    "createBranchDialog": {
+      "validation": {
+        "name": "Branch name is required",
+        "noSpaces": "Name cannot contain spaces",
+        "target": "Base branch is required"
+      }
+    },
     "createBranchTitle": "Create a branch",
     "createBranchButton": "Create branch",
     "newBranch": "New branch",
@@ -189,14 +196,6 @@
     "status": "Status",
     "tagger": "Tagger",
     "creationDate": "Creation date",
-    "createBranchDialog": {
-      "validation": {
-        "name": "Branch name is required",
-        "nameRegex": "Name must contain only letters, numbers, and the characters: - _ .",
-        "noSpaces": "Name cannot contain spaces",
-        "target": "Base branch is required"
-      }
-    },
     "createTagDialog": {
       "validation": {
         "name": "Tag name is required",
@@ -210,6 +209,8 @@
       "target": "Target",
       "message": "Message"
     },
+    "branchCreated": "Branch created",
+    "branchCreatedDescription": "Branch {{name}} created successfully",
     "renameBranch": "Rename Branch",
     "add": "Add",
     "users": "Users",
@@ -547,10 +548,10 @@
     "selectMember": "Select member",
     "selectRole": "Select role",
     "enterBranchName": "Enter branch name",
-    "createBranchError": "Branch name is required",
-    "enterTagName": "Enter a tag name here",
-    "tagName": "Name",
     "basedOn": "Based on",
+    "enterTagName": "Enter a tag name here",
+    "createBranchError": "Branch name is required",
+    "tagName": "Name",
     "select": "Select",
     "baseBranch": "Base branch",
     "selectBranchError": "Base branch is required",

--- a/packages/ui/locales/fr/views.json
+++ b/packages/ui/locales/fr/views.json
@@ -110,6 +110,13 @@
     "viewRules": "Voir les règles",
     "browse": "Browse",
     "deleteBranch": "Delete Branch",
+    "createBranchDialog": {
+      "validation": {
+        "name": "Le nom de la branche est requis",
+        "noSpaces": "Le nom ne peut pas contenir d'espaces",
+        "target": "La branche de base est requise"
+      }
+    },
     "createBranchTitle": "Créer une branche",
     "createBranchButton": "Créer une branche",
     "newBranch": "Nouvelle branche",
@@ -184,6 +191,8 @@
     "creatingWebhook": "Creating webhook...",
     "updateWebhook": "Update webhook",
     "createWebhook": "Create webhook",
+    "branchCreated": "Branche créée",
+    "branchCreatedDescription": "La branche {{name}} a été créée avec succès",
     "status": "Statut",
     "tagger": "Tagger",
     "renameBranch": "Renommer la branche",
@@ -515,12 +524,13 @@
     "selectMember": "",
     "selectRole": "",
     "enterBranchName": "Entrez le nom de la branche",
+    "basedOn": "Basé sur",
+    "enterTagName": "Entrez le nom de l'étiquette",
     "createBranchError": "Le nom de la branche est requis",
-    "enterTagName": "Enter tag name",
     "select": "Sélectionner",
     "baseBranch": "Branche de base",
     "selectBranchError": "La branche de base est requise",
-    "baseTag": "Based on",
+    "baseTag": "Basé sur",
     "selectMemberError": "",
     "selectRoleError": ""
   },

--- a/packages/ui/src/components/toast/use-toast.ts
+++ b/packages/ui/src/components/toast/use-toast.ts
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useCallback, useEffect, useState } from 'react'
 
 import type { ToastActionElement, ToastProps } from './toast'
 
@@ -150,3 +150,37 @@ function useToast() {
 }
 
 export { useToast, toast }
+
+interface UseToastNotificationProps {
+  title: string
+  description: string
+  duration?: number
+  action?: ToastActionElement
+}
+
+export function useToastNotification({ title, description, duration, action }: UseToastNotificationProps) {
+  const { toast } = useToast()
+
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    if (show) {
+      toast({
+        title,
+        description,
+        duration,
+        action
+      })
+
+      setShow(false)
+    }
+  }, [title, description, toast, show, duration, action])
+
+  const showToast = useCallback(() => {
+    setShow(true)
+  }, [setShow])
+
+  return {
+    showToast
+  }
+}

--- a/packages/ui/src/views/repo/components/branch-selector-v2/branch-selector-dropdown.tsx
+++ b/packages/ui/src/views/repo/components/branch-selector-v2/branch-selector-dropdown.tsx
@@ -17,10 +17,11 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
   isBranchOnly = false,
   searchQuery,
   setSearchQuery,
-  dynamicWidth = false
+  dynamicWidth = false,
+  preSelectedTab = BranchSelectorTab.BRANCHES
 }) => {
   const { Link } = useRouterContext()
-  const [activeTab, setActiveTab] = useState<BranchSelectorTab>(BranchSelectorTab.BRANCHES)
+  const [activeTab, setActiveTab] = useState<BranchSelectorTab>(preSelectedTab)
   const { t } = useTranslationStore()
   const BRANCH_SELECTOR_LABELS = getBranchSelectorLabels(t)
 
@@ -110,7 +111,7 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
       <div className="mt-1">
         {filteredItems.length === 0 && (
           <div className="px-5 py-4 text-center">
-            <span className="text-2 leading-tight text-cn-foreground-2">
+            <span className="text-14 text-cn-foreground-2 leading-tight">
               {t('views:noData.noResults', 'No search results')}
             </span>
           </div>
@@ -136,7 +137,7 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
                 key={item.name}
               >
                 <div className="flex w-full min-w-0 items-center gap-x-2">
-                  {isSelected && <Icon name="tick" size={12} className="min-w-[12px] text-cn-foreground-1" />}
+                  {isSelected && <Icon name="tick" size={12} className="text-cn-foreground-1 min-w-[12px]" />}
                   <span
                     className={cn('text-cn-foreground-2 truncate', {
                       'text-cn-foreground-1': isSelected
@@ -158,8 +159,8 @@ export const BranchSelectorDropdown: FC<BranchSelectorDropdownProps> = ({
 
         <DropdownMenu.Item className="p-0" asChild>
           <Link to={viewAllUrl}>
-            <div className="w-full border-t border-cn-borders-2 px-3 py-2">
-              <span className="text-2 font-medium leading-none transition-colors duration-200 hover:text-cn-foreground-1">
+            <div className="border-cn-borders-2 w-full border-t px-3 py-2">
+              <span className="text-14 hover:text-cn-foreground-1 font-medium leading-none transition-colors duration-200">
                 {t('views:repos.viewAll', `View all ${activeTab}`, {
                   type:
                     activeTab === BranchSelectorTab.BRANCHES

--- a/packages/ui/src/views/repo/components/branch-selector-v2/branch-selector.tsx
+++ b/packages/ui/src/views/repo/components/branch-selector-v2/branch-selector.tsx
@@ -20,6 +20,7 @@ interface BranchSelectorProps {
   searchQuery?: string
   setSearchQuery: (query: string) => void
   dynamicWidth?: boolean
+  preSelectedTab?: BranchSelectorTab
 }
 export const BranchSelectorV2: FC<BranchSelectorProps> = ({
   repoId,
@@ -35,7 +36,8 @@ export const BranchSelectorV2: FC<BranchSelectorProps> = ({
   isBranchOnly = false,
   searchQuery = '',
   setSearchQuery,
-  dynamicWidth = false
+  dynamicWidth = false,
+  preSelectedTab
 }) => {
   const isTag = selectedBranchorTag
     ? tagList?.some(tag => tag.name === selectedBranchorTag.name && tag.sha === selectedBranchorTag.sha)
@@ -45,19 +47,19 @@ export const BranchSelectorV2: FC<BranchSelectorProps> = ({
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
         <Button
-          className="flex items-center gap-1.5 overflow-hidden bg-cn-background-2 px-3 data-[state=open]:border-cn-borders-9"
+          className="data-[state=open]:border-cn-borders-9 bg-cn-background-2 flex items-center gap-1.5 overflow-hidden px-3"
           variant="outline"
           size={buttonSize}
         >
           {!branchPrefix && (
-            <Icon className="shrink-0 fill-transparent text-icons-9" name={isTag ? 'tag' : 'branch'} size={14} />
+            <Icon className="text-icons-9 shrink-0 fill-transparent" name={isTag ? 'tag' : 'branch'} size={14} />
           )}
-          <span className="w-full truncate text-left text-cn-foreground-1">
+          <span className="text-cn-foreground-1 w-full truncate text-left">
             {branchPrefix
               ? `${branchPrefix}: ${selectedBranch?.name || selectedBranchorTag.name}`
               : selectedBranch?.name || selectedBranchorTag.name}
           </span>
-          <Icon name="chevron-down" className="chevron-down shrink-0 text-icons-2" size={12} />
+          <Icon name="chevron-down" className="chevron-down text-icons-2 shrink-0" size={12} />
         </Button>
       </DropdownMenu.Trigger>
       <BranchSelectorDropdown
@@ -72,6 +74,7 @@ export const BranchSelectorV2: FC<BranchSelectorProps> = ({
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}
         dynamicWidth={dynamicWidth}
+        preSelectedTab={preSelectedTab}
       />
     </DropdownMenu.Root>
   )

--- a/packages/ui/src/views/repo/components/branch-selector/branch-selector.tsx
+++ b/packages/ui/src/views/repo/components/branch-selector/branch-selector.tsx
@@ -41,15 +41,15 @@ export const BranchSelector: FC<BranchSelectorProps> = ({
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
         <Button
-          className="flex items-center gap-1.5 overflow-hidden bg-cn-background-2 pl-3 pr-2 data-[state=open]:border-cn-borders-9"
+          className="data-[state=open]:border-cn-borders-9 bg-cn-background-2 flex items-center gap-1.5 overflow-hidden pl-3 pr-2"
           variant="outline"
           size={buttonSize}
         >
           {!branchPrefix && (
-            <Icon className="shrink-0 fill-transparent text-icons-9" name={isTag ? 'tag' : 'branch'} size={14} />
+            <Icon className="text-icons-9 shrink-0 fill-transparent" name={isTag ? 'tag' : 'branch'} size={14} />
           )}
 
-          <span className="w-full truncate text-left text-cn-foreground-1">
+          <span className="text-cn-foreground-1 w-full truncate text-left">
             {branchPrefix ? `${branchPrefix}: ${branchName}` : branchName}
           </span>
 

--- a/packages/ui/src/views/repo/components/branch-selector/types.ts
+++ b/packages/ui/src/views/repo/components/branch-selector/types.ts
@@ -30,6 +30,7 @@ export interface BranchSelectorDropdownProps {
   searchQuery: string
   setSearchQuery: (query: string) => void
   dynamicWidth?: boolean
+  preSelectedTab?: BranchSelectorTab
 }
 
 export interface BranchSelectorProps extends BranchSelectorDropdownProps {

--- a/packages/ui/src/views/repo/repo-branch/repo-branch-list-view.tsx
+++ b/packages/ui/src/views/repo/repo-branch/repo-branch-list-view.tsx
@@ -3,24 +3,19 @@ import { FC, useMemo } from 'react'
 import { Button, ListActions, Pagination, SearchBox, Spacer } from '@/components'
 import { SandboxLayout } from '@/views'
 import { useDebounceSearch } from '@hooks/use-debounce-search'
+import { cn } from '@utils/cn'
 
 import { BranchesList } from './components/branch-list'
-import { CreateBranchDialog } from './components/create-branch-dialog'
 import { RepoBranchListViewProps } from './types'
 
 export const RepoBranchListView: FC<RepoBranchListViewProps> = ({
   isLoading,
   useRepoBranchesStore,
   useTranslationStore,
-  isCreateBranchDialogOpen,
   setCreateBranchDialogOpen,
-  onSubmit,
-  createBranchError,
-  isCreatingBranch,
   searchQuery,
   setSearchQuery,
   onDeleteBranch,
-  setCreateBranchSearchQuery,
   ...routingProps
 }) => {
   const { t } = useTranslationStore()
@@ -42,11 +37,12 @@ export const RepoBranchListView: FC<RepoBranchListViewProps> = ({
 
   return (
     <SandboxLayout.Main>
-      <SandboxLayout.Content>
+      <SandboxLayout.Content className={cn({ 'h-full': !isLoading && !branchList.length && !searchQuery })}>
+        <Spacer size={2} />
         {(isLoading || !!branchList.length || isDirtyList) && (
           <>
-            <h1 className="text-cn-foreground-1 mb-6 text-2xl font-medium">{t('views:repos.branches', 'Branches')}</h1>
-
+            <span className="text-24 text-cn-foreground-1 font-medium">{t('views:repos.branches', 'Branches')}</span>
+            <Spacer size={6} />
             <ListActions.Root>
               <ListActions.Left>
                 <SearchBox.Root
@@ -87,19 +83,6 @@ export const RepoBranchListView: FC<RepoBranchListViewProps> = ({
           <Pagination nextPage={xNextPage} previousPage={xPrevPage} currentPage={page} goToPage={setPage} t={t} />
         )}
       </SandboxLayout.Content>
-      <CreateBranchDialog
-        open={isCreateBranchDialogOpen}
-        onClose={() => {
-          setCreateBranchDialogOpen(false)
-        }}
-        useRepoBranchesStore={useRepoBranchesStore}
-        onSubmit={onSubmit}
-        isCreatingBranch={isCreatingBranch}
-        useTranslationStore={useTranslationStore}
-        error={createBranchError}
-        defaultBranch={defaultBranch}
-        handleChangeSearchValue={setCreateBranchSearchQuery}
-      />
     </SandboxLayout.Main>
   )
 }

--- a/packages/ui/src/views/repo/repo-branch/types.ts
+++ b/packages/ui/src/views/repo/repo-branch/types.ts
@@ -1,13 +1,13 @@
-import { Dispatch, SetStateAction } from 'react'
+import { Dispatch, ReactNode, SetStateAction } from 'react'
 
 import { TranslationStore } from '@/views'
 import { z } from 'zod'
 
 import { PullRequestType } from '../pull-request/pull-request.types'
-import { IBranchSelectorStore } from '../repo.types'
+import { BranchSelectorListItem, IBranchSelectorStore } from '../repo.types'
 import { createBranchFormSchema } from './components/create-branch-dialog'
 
-export type CreateBranchFormFields = z.infer<typeof createBranchFormSchema>
+export type CreateBranchFormFields = z.infer<ReturnType<typeof createBranchFormSchema>>
 export interface BranchProps {
   id: number
   name: string
@@ -60,7 +60,7 @@ export interface RepoBranchListViewProps extends Partial<RoutingProps> {
   useTranslationStore: () => TranslationStore
   isCreateBranchDialogOpen: boolean
   setCreateBranchDialogOpen: (isOpen: boolean) => void
-  onSubmit: (formValues: CreateBranchFormFields) => void
+  onSubmit: (formValues: CreateBranchFormFields) => Promise<void>
   isCreatingBranch: boolean
   createBranchError?: string
   searchQuery: string | null
@@ -77,11 +77,10 @@ interface Branch {
 export interface CreateBranchDialogProps {
   open: boolean
   onClose: () => void
-  onSubmit: (formValues: CreateBranchFormFields) => void
+  onSubmit: (formValues: CreateBranchFormFields) => Promise<void>
   error?: string
   isCreatingBranch?: boolean
   useTranslationStore: () => TranslationStore
-  defaultBranch?: string
-  handleChangeSearchValue: Dispatch<SetStateAction<string>>
-  useRepoBranchesStore: () => IBranchSelectorStore
+  selectedBranchOrTag: BranchSelectorListItem | null
+  renderProp: () => ReactNode
 }


### PR DESCRIPTION
# Branch Creation Encapsulation PR

This PR introduces a new component that encapsulates all data-fetching logic for the CreateBranchDialog UI component, following the common approach described in the [wiki](https://github.com/harness/canary/wiki/State-Management-Patterns) 

Key changes include:

1. Added a new reusable `CreateBranchDialog` component in `apps/gitness/src/components-v2/create-branch-dialog.tsx` that provides a consistent interface for branch creation throughout the application.

2. Improved the branch selector component by adding a `preSelectedTab` prop that allows pre-selecting either branches or tags tab when opening the selector. We need it to preselect Tag tab, when user selects Create Branch menu from a specific tag on Tags page

3. Integrated the toast notification system for branch creation with a new `useToastNotification` hook in `packages/ui/src/components/toast/use-toast.ts` to provide consistent success messages.

4. Refactored the branch creation flow in multiple places to use the new centralized dialog component, reducing code duplication.

5. Added and improved translations for branch-related operations in both English and French locales.

6. Updated the UI styling to maintain consistency with the application's design system.