### PR TITLE
feat: Collapse example code by default

### DIFF
--- a/apps/portal/astro.config.ts
+++ b/apps/portal/astro.config.ts
@@ -64,6 +64,9 @@ export default defineConfig({
         PageTitle: "./src/components/layout/PageTitle.astro",
         ThemeSelect: "./src/components/layout/ThemeSelect.astro",
       },
+      expressiveCode: {
+        themes: ["github-light", "github-dark"],
+      },
     }),
     tailwind({ applyBaseStyles: false }),
     react(),

--- a/apps/portal/src/components/CompactIconGrid.astro
+++ b/apps/portal/src/components/CompactIconGrid.astro
@@ -1,5 +1,5 @@
 ---
-import { Card, CopyButton, Icon, IconNameMap } from "@harnessio/ui/components";
+import { Icon, IconNameMap } from "@harnessio/ui/components";
 ---
 
 <div

--- a/apps/portal/src/components/docs-page/component-example.tsx
+++ b/apps/portal/src/components/docs-page/component-example.tsx
@@ -5,20 +5,15 @@ import Example, { type ExampleProps } from "./example";
 
 export type ComponentExampleProps = Omit<ExampleProps, "scope"> & {
   scope?: ExampleProps["scope"];
-  padding?: boolean;
 };
 
-const ComponentExample: FC<ComponentExampleProps> = ({
-  code,
-  scope,
-  padding = true,
-}) => {
+const ComponentExample: FC<ComponentExampleProps> = ({ code, scope }) => {
   const combinedScope = useMemo<ExampleProps["scope"]>(
     () => ({ ...components, ...scope }),
     [scope],
   );
 
-  return <Example code={code} scope={combinedScope} padding={padding} />;
+  return <Example code={code} scope={combinedScope} />;
 };
 
 export default ComponentExample;

--- a/apps/portal/src/components/docs-page/example.tsx
+++ b/apps/portal/src/components/docs-page/example.tsx
@@ -1,42 +1,88 @@
-import { type ComponentProps, type FC, useMemo } from "react";
+import {
+  type ComponentProps,
+  type FC,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { LiveEditor, LivePreview, LiveProvider } from "react-live";
-
+import { Icon } from "@harnessio/ui/components";
+import { RouterContextProvider } from "@harnessio/ui/context";
 import ExampleLayout from "./example-layout";
 import { themes } from "prism-react-renderer";
-import { createMemoryRouter, RouterProvider } from "react-router-dom";
-import { cn } from "@/lib/utils.ts";
+import {
+  createMemoryRouter,
+  Link,
+  NavLink,
+  Outlet,
+  RouterProvider,
+} from "react-router-dom";
 
 type LiveProviderProps = ComponentProps<typeof LiveProvider>;
 
-export type ExampleProps = Pick<LiveProviderProps, "code" | "scope"> & {
-  padding?: boolean;
-};
+export type ExampleProps = Pick<LiveProviderProps, "code" | "scope">;
 
-const Example: FC<ExampleProps> = ({ code, scope, padding = true }) => {
+const Example: FC<ExampleProps> = ({ code, scope }) => {
+  const [isLightTheme, setIsLightTheme] = useState(
+    () => document.querySelector("html")?.dataset.theme === "light",
+  );
   const scopeWithLayout = useMemo<ExampleProps["scope"]>(
     () => ({ ...scope, ExampleLayout }),
     [scope],
   );
+
+  useEffect(() => {
+    const element = document.querySelector("html");
+    if (!element) return;
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (
+          mutation.type === "attributes" &&
+          mutation.attributeName?.startsWith("data-")
+        ) {
+          setIsLightTheme(
+            document.querySelector("html")?.dataset.theme === "light",
+          );
+        }
+      });
+    });
+
+    observer.observe(element, {
+      attributes: true,
+      attributeFilter: Object.keys(element.dataset).map((key) => `data-${key}`),
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
   const router = createMemoryRouter([
     {
       path: "*",
       element: (
-        <LivePreview
-          className={cn(
-            "not-content border-cn-borders-3 bg-cn-background-hover mb-0 rounded-lg border shadow-md",
-            { "p-6": padding },
-          )}
-        />
+        <RouterContextProvider Link={Link} NavLink={NavLink} Outlet={Outlet}>
+          <LivePreview />
+        </RouterContextProvider>
       ),
     },
   ]);
+
   return (
-    <div className="my-12 flex flex-col justify-start gap-0 pb-3">
-      <LiveProvider code={code} scope={scopeWithLayout}>
-        <h2>Preview</h2>
-        <RouterProvider router={router} />
-        <h3>Live editor</h3>
-        <LiveEditor theme={themes["vsDark"]} />
+    <div className="bg-cn-background-1 not-content my-12 overflow-hidden rounded-md border">
+      <LiveProvider code={code} scope={scopeWithLayout} enableTypeScript>
+        <div className="grid place-items-center p-12">
+          <RouterProvider router={router} />
+        </div>
+        <details className="example-expand bg-cn-background-2 border-t p-3">
+          <summary className="flex cursor-pointer select-none items-center gap-1 text-sm">
+            <Icon name="chevron-right" size={12} className="disclosure-icon" />
+            Show code
+          </summary>
+          <LiveEditor
+            theme={isLightTheme ? themes.vsLight : themes.vsDark}
+            className="p-1 text-sm"
+          />
+        </details>
       </LiveProvider>
     </div>
   );

--- a/apps/portal/src/components/layout/PageFrame.astro
+++ b/apps/portal/src/components/layout/PageFrame.astro
@@ -1,5 +1,4 @@
 ---
-import type { StarlightRouteData } from "@astrojs/starlight/route-data";
 import DocTemplate from "./DocTemplate.astro";
 import SplashTemplate from "./SplashTemplate.astro";
 

--- a/apps/portal/src/content/docs/components/accordion.mdx
+++ b/apps/portal/src/content/docs/components/accordion.mdx
@@ -9,58 +9,69 @@ import { DocsPage } from "@/components/docs-page";
 
 <DocsPage.ComponentExample
   client:only
-  code={`<>
-<h5>Single non-collapsible</h5>
-<Accordion.Root type="single" defaultValue="item1">
-  <Accordion.Item value="item1">
-    <Accordion.Trigger className="text-cn-foreground-2">Item 1</Accordion.Trigger>
-    <Accordion.Content>
-      <p>This is the content of item 1</p>
-    </Accordion.Content>
-  </Accordion.Item>
+  code={`<div className="min-w-[400px] flex flex-col gap-8">
+    <div>
+        <h5>Single non-collapsible</h5>
+        <Accordion.Root type="single" defaultValue="item1">
+            <Accordion.Item value="item1">
+                <Accordion.Trigger className="text-cn-foreground-2">Item 1</Accordion.Trigger>
+                <Accordion.Content>
+                    <p>This is the content of item 1</p>
+                </Accordion.Content>
+            </Accordion.Item>
 
-  <Accordion.Item value="item2" isLast>
-    <Accordion.Trigger className="text-cn-foreground-2">Item 2</Accordion.Trigger>
-    <Accordion.Content>
-      <p>This is the content of item 2</p>
-    </Accordion.Content>
-  </Accordion.Item>
-</Accordion.Root>
+            <Accordion.Item value="item2" isLast>
+                <Accordion.Trigger className="text-cn-foreground-2">Item 2</Accordion.Trigger>
+                <Accordion.Content>
+                    <p>This is the content of item 2</p>
+                </Accordion.Content>
+            </Accordion.Item>
+        </Accordion.Root>
+    </div>
 
-<h5>Single collapsible</h5>
-<Accordion.Root type="single" collapsible>
-  <Accordion.Item value="item1">
-    <Accordion.Trigger className="text-cn-foreground-2">Item 1</Accordion.Trigger>
-    <Accordion.Content>
-      <p>This is the content of item 1</p>
-    </Accordion.Content>
-  </Accordion.Item>
+    <hr />
 
-  <Accordion.Item value="item2" isLast>
-    <Accordion.Trigger className="text-cn-foreground-2">Item 2</Accordion.Trigger>
-    <Accordion.Content>
-      <p>This is the content of item 2</p>
-    </Accordion.Content>
-  </Accordion.Item>
-</Accordion.Root>
+    <div>
+        <h5>Single collapsible</h5>
+        <Accordion.Root type="single" collapsible>
+            <Accordion.Item value="item1">
+                <Accordion.Trigger className="text-cn-foreground-2">Item 1</Accordion.Trigger>
+                <Accordion.Content>
+                    <p>This is the content of item 1</p>
+                </Accordion.Content>
+            </Accordion.Item>
 
-<h5>Multiple</h5>
-<Accordion.Root type="multiple">
-  <Accordion.Item value="item1">
-    <Accordion.Trigger className="text-cn-foreground-2">Item 1</Accordion.Trigger>
-    <Accordion.Content>
-      <p>This is the content of item 1</p>
-    </Accordion.Content>
-  </Accordion.Item>
+            <Accordion.Item value="item2" isLast>
+                <Accordion.Trigger className="text-cn-foreground-2">Item 2</Accordion.Trigger>
+                <Accordion.Content>
+                   <p>This is the content of item 2</p>
+                </Accordion.Content>
+            </Accordion.Item>
+        </Accordion.Root>
+    </div>
 
-  <Accordion.Item value="item2" isLast>
-    <Accordion.Trigger className="text-cn-foreground-2">Item 2</Accordion.Trigger>
-    <Accordion.Content>
-      <p>This is the content of item 2</p>
-    </Accordion.Content>
-  </Accordion.Item>
-</Accordion.Root>
-</>`}
+    <hr />
+
+    <div>
+        <h5>Multiple</h5>
+        <Accordion.Root type="multiple">
+            <Accordion.Item value="item1">
+                <Accordion.Trigger className="text-cn-foreground-2">Item 1</Accordion.Trigger>
+                <Accordion.Content>
+                   <p>This is the content of item 1</p>
+                </Accordion.Content>
+            </Accordion.Item>
+
+            <Accordion.Item value="item2" isLast>
+                <Accordion.Trigger className="text-cn-foreground-2">Item 2</Accordion.Trigger>
+                <Accordion.Content>
+                    <p>This is the content of item 2</p>
+                </Accordion.Content>
+            </Accordion.Item>
+        </Accordion.Root>
+    </div>
+
+</div>`}
 />
 
 ## Usage

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -110,8 +110,12 @@ ul.top-level summary svg {
   @apply rounded-md overflow-hidden border border-cn-borders-3 bg-cn-background-3 !important;
 }
 
+.expressive-code .frame {
+  box-shadow: none !important;
+}
+
 pre.prism-code {
-  @apply rounded-md overflow-hidden border border-cn-borders-3 bg-cn-background-2 !important;
+  @apply overflow-hidden bg-cn-background-2 !important;
 }
 
 /* Pagination overrides */
@@ -127,5 +131,27 @@ pre.prism-code {
 @media (prefers-reduced-motion: no-preference) {
   @view-transition {
     navigation: auto;
+  }
+}
+
+.example-expand {
+  .disclosure-icon {
+    display: none;
+  }
+
+  &[open] .disclosure-icon {
+    transform: rotate(90deg);
+  }
+
+  @supports selector(summary::marker) {
+    summary::-webkit-details-marker,
+    summary::marker {
+      content: "";
+      display: none;
+    }
+
+    .disclosure-icon {
+      display: block;
+    }
   }
 }


### PR DESCRIPTION
This PR alters the code example component to render with the example code collapsed by default.

|Before|After|
|------|------|
|![Before](https://github.com/user-attachments/assets/51b0acd8-bd41-4948-9331-06b555c7ef52)|![After](https://github.com/user-attachments/assets/d1ed7650-1c96-45c2-bdbf-9f0680229c56)|
||![After](https://github.com/user-attachments/assets/b20f544e-6a0f-451f-b938-b544d555c6d3)|
|![Before](https://github.com/user-attachments/assets/45e7b752-5eeb-4a26-afd5-55d4e3ea8380)|![After](https://github.com/user-attachments/assets/9d92504c-556d-4cf2-902b-d11b8aa1c11c)|
||![After](https://github.com/user-attachments/assets/f9241f0f-505c-4994-a94a-4728614536d7)|

fixes #1464 