### PR TITLE
Added Import Page button to the Create Project page

### DIFF
--- a/apps/design-system/src/subjects/views/project-create/project-create-view.tsx
+++ b/apps/design-system/src/subjects/views/project-create/project-create-view.tsx
@@ -11,8 +11,15 @@ export const CreateProjectView = ({ isAdditional = false }: { isAdditional?: boo
   }
 
   if (isAdditional) {
-    return <CreateProjectPage {...commonProps} isAdditional={isAdditional} backLinkProps={{ to: '/' }} />
+    return (
+      <CreateProjectPage
+        {...commonProps}
+        isAdditional={isAdditional}
+        backLinkProps={{ to: '/' }}
+        importProjectLinkProps={{ to: '/' }}
+      />
+    )
   }
 
-  return <CreateProjectPage {...commonProps} logoutLinkProps={{ to: '/' }} />
+  return <CreateProjectPage {...commonProps} logoutLinkProps={{ to: '/' }} importProjectLinkProps={{ to: '/' }} />
 }

--- a/apps/gitness/src/framework/routing/types.ts
+++ b/apps/gitness/src/framework/routing/types.ts
@@ -78,7 +78,8 @@ export enum RouteConstants {
   toRepoWebhookDetails = 'toRepoWebhookDetails',
   toRepoWebhookExecutions = 'toRepoWebhookExecutions',
   toRepoWebhookExecutionDetails = 'toRepoWebhookExecutionDetails',
-  toRepoWebhookCreate = 'toRepoWebhookCreate'
+  toRepoWebhookCreate = 'toRepoWebhookCreate',
+  toImportProject = 'toImportProject'
 }
 
 export interface RouteEntry {

--- a/apps/gitness/src/pages-v2/create-project.tsx
+++ b/apps/gitness/src/pages-v2/create-project.tsx
@@ -36,8 +36,21 @@ export const CreateProject = () => {
   const commonProps = { isLoading, error: error?.message, onFormSubmit: handleFormSubmit, useTranslationStore }
 
   if (isAdditional) {
-    return <CreateProjectPage {...commonProps} isAdditional backLinkProps={{ to: routes.toHome() }} />
+    return (
+      <CreateProjectPage
+        {...commonProps}
+        isAdditional
+        backLinkProps={{ to: routes.toHome() }}
+        importProjectLinkProps={{ to: routes.toImportProject() }}
+      />
+    )
   }
 
-  return <CreateProjectPage {...commonProps} logoutLinkProps={{ to: routes.toLogout() }} />
+  return (
+    <CreateProjectPage
+      {...commonProps}
+      logoutLinkProps={{ to: routes.toLogout() }}
+      importProjectLinkProps={{ to: routes.toImportProject() }}
+    />
+  )
 }

--- a/apps/gitness/src/routes.tsx
+++ b/apps/gitness/src/routes.tsx
@@ -682,7 +682,8 @@ export const routes: CustomRouteObject[] = [
         path: 'import',
         element: <ImportProjectContainer />,
         handle: {
-          breadcrumb: () => <span>Import project</span>
+          breadcrumb: () => <span>Import project</span>,
+          routeName: RouteConstants.toImportProject
         }
       },
       {

--- a/packages/ui/locales/en/views.json
+++ b/packages/ui/locales/en/views.json
@@ -555,6 +555,8 @@
       "projectCreation": "Creating project...",
       "createProject": "Create project"
     },
+    "or": "or",
+    "importProject": "Import project",
     "logout": {
       "question": "Want to use a different account?",
       "link": "Log out"

--- a/packages/ui/locales/fr/views.json
+++ b/packages/ui/locales/fr/views.json
@@ -533,6 +533,8 @@
       "projectCreation": "Création du projet...",
       "createProject": "Créer le projet"
     },
+    "or": "ou",
+    "importProject": "Importer un projet",
     "logout": {
       "question": "Voulez-vous utiliser un autre compte ?",
       "link": "Se déconnecter"

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -63,24 +63,24 @@ const buttonVariants = cva('button', {
     {
       variant: 'secondary',
       theme: 'default',
-      class: 'button-soft button-muted'
+      class: 'button-muted button-soft'
     },
 
     // Outline
     {
       variant: 'outline',
       theme: 'default',
-      class: 'button-surface button-muted'
+      class: 'button-muted button-surface'
     },
     {
       variant: 'outline',
       theme: 'success',
-      class: 'button-surface button-success'
+      class: 'button-success button-surface'
     },
     {
       variant: 'outline',
       theme: 'danger',
-      class: 'button-surface button-danger'
+      class: 'button-danger button-surface'
     },
 
     // Ghost

--- a/packages/ui/src/views/project/create-project-page.tsx
+++ b/packages/ui/src/views/project/create-project-page.tsx
@@ -184,7 +184,7 @@ export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
             </div>
 
             {/* TODO: Update the variant of this button to outline once the component supports this style. */}
-            <Button asChild className="mt-3 w-full" rounded variant="surface" size="lg">
+            <Button asChild className="mt-3 w-full" rounded variant="outline" size="lg">
               <Link to={importProjectLinkProps.to}>{t('views:createProject.importProject', 'Import project')}</Link>
             </Button>
           </ControlGroup>

--- a/packages/ui/src/views/project/create-project-page.tsx
+++ b/packages/ui/src/views/project/create-project-page.tsx
@@ -1,8 +1,18 @@
 import { FC, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 
-import { Button, Card, Fieldset, FormWrapper, Icon, Input, StyledLink, StyledLinkProps } from '@/components'
-import { useTheme } from '@/context'
+import {
+  Button,
+  Card,
+  ControlGroup,
+  Fieldset,
+  FormWrapper,
+  Icon,
+  Input,
+  StyledLink,
+  StyledLinkProps
+} from '@/components'
+import { useRouterContext, useTheme } from '@/context'
 import { Floating1ColumnLayout, TranslationStore } from '@/views'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { cn } from '@utils/cn'
@@ -61,6 +71,7 @@ export type CreateProjectFields = z.infer<ReturnType<typeof createProjectSchema>
 export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
   const { error, isLoading, backLinkProps, onFormSubmit, useTranslationStore } = props
   const { isLightTheme } = useTheme()
+  const { Link } = useRouterContext()
 
   const isAdditional = getIsAdditionalProjectPage(props)
   const isFirst = getIsFirstProjectPage(props)
@@ -104,7 +115,7 @@ export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
 
   return (
     <Floating1ColumnLayout
-      className="flex-col justify-start bg-cn-background-1 pt-20 sm:pt-[8.75rem]"
+      className="bg-cn-background-1 flex-col justify-start pt-20 sm:pt-[8.75rem]"
       highlightTheme={hasError ? 'error' : 'green'}
       verticalCenter
     >
@@ -118,7 +129,7 @@ export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
         </StyledLink>
       )}
 
-      <div className="relative z-10 w-80 max-w-full">
+      <ControlGroup className="relative z-10 w-80 max-w-full">
         <div className="mb-10 grid justify-items-center">
           {isLightTheme ? (
             <Icon size={112} name="create-workspace-light" />
@@ -126,11 +137,11 @@ export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
             <CreateProjectAnimatedLogo hasError={hasError} />
           )}
 
-          <Card.Title className="mt-3 text-center text-cn-foreground-1" as="h1">
+          <Card.Title className="text-cn-foreground-1 mt-3 text-center" as="h1">
             {t('views:createProject.title', 'Create your new project')}
           </Card.Title>
 
-          <p className="mt-0.5 text-center text-sm leading-snug text-cn-foreground-2">
+          <p className="text-cn-foreground-2 mt-0.5 text-center text-sm leading-snug">
             {t('views:createProject.description', 'Organize your repositories, pipelines and more.')}
           </p>
         </div>
@@ -157,15 +168,27 @@ export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
             />
           </Fieldset>
 
-          <Button className="mt-3 w-full" rounded type="submit" loading={isLoading} disabled={hasError}>
-            {isLoading
-              ? t('views:createProject.create.projectCreation', 'Creating project...')
-              : t('views:createProject.create.createProject', 'Create project')}
-          </Button>
+            <ControlGroup type="button">
+              <Button className="mt-3 w-full" rounded type="submit" loading={isLoading} disabled={hasError}>
+                {isLoading
+                  ? t('views:createProject.create.projectCreation', 'Creating project...')
+                  : t('views:createProject.create.createProject', 'Create project')}
+              </Button>
+
+                <div className="mt-3 flex items-center justify-center gap-2">
+                    <div className="border-cn-borders-3 w-[145px] shrink border-t" />
+                    <span className="text-cn-foreground-3 text-sm">{t('views:createProject.or', 'or')}</span>
+                    <div className="border-cn-borders-3 w-[145px] shrink border-t" />
+                </div>
+
+                <Button asChild className="mt-3 w-full" borderRadius="full" type="button" variant="outline" size="md">
+                    <Link to="/import">{t('views:createProject.importProject', 'Import project')}</Link>
+                </Button>
+          </ControlGroup>
         </FormWrapper>
 
         {isFirst && (
-          <p className="foreground-5 mt-4 text-center text-sm text-cn-foreground-3">
+          <p className="foreground-5 text-cn-foreground-3 mt-4 text-center text-sm">
             {t('views:createProject.logout.question', 'Want to use a different account?')}{' '}
             <StyledLink {...props.logoutLinkProps} variant="accent">
               {t('views:createProject.logout.link', 'Log out')}

--- a/packages/ui/src/views/project/create-project-page.tsx
+++ b/packages/ui/src/views/project/create-project-page.tsx
@@ -1,5 +1,6 @@
 import { FC, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
+import type { LinkProps } from 'react-router-dom'
 
 import {
   Button,
@@ -25,6 +26,7 @@ export interface CreateProjectPageCommonProps {
   isLoading?: boolean
   onFormSubmit: (data: CreateProjectFields) => void
   useTranslationStore: () => TranslationStore
+  importProjectLinkProps: LinkProps
 }
 
 interface CreateFirstProjectPageProps extends CreateProjectPageCommonProps {
@@ -69,7 +71,7 @@ const createProjectSchema = (t: TranslationStore['t']) =>
 export type CreateProjectFields = z.infer<ReturnType<typeof createProjectSchema>>
 
 export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
-  const { error, isLoading, backLinkProps, onFormSubmit, useTranslationStore } = props
+  const { error, isLoading, backLinkProps, importProjectLinkProps, onFormSubmit, useTranslationStore } = props
   const { isLightTheme } = useTheme()
   const { Link } = useRouterContext()
 
@@ -115,7 +117,7 @@ export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
 
   return (
     <Floating1ColumnLayout
-      className="bg-cn-background-1 flex-col justify-start pt-20 sm:pt-[8.75rem]"
+      className="flex-col justify-start bg-cn-background-1 pt-20 sm:pt-[8.75rem]"
       highlightTheme={hasError ? 'error' : 'green'}
       verticalCenter
     >
@@ -129,7 +131,7 @@ export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
         </StyledLink>
       )}
 
-      <ControlGroup className="relative z-10 w-80 max-w-full">
+      <div className="relative z-10 w-80 max-w-full">
         <div className="mb-10 grid justify-items-center">
           {isLightTheme ? (
             <Icon size={112} name="create-workspace-light" />
@@ -137,11 +139,11 @@ export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
             <CreateProjectAnimatedLogo hasError={hasError} />
           )}
 
-          <Card.Title className="text-cn-foreground-1 mt-3 text-center" as="h1">
+          <Card.Title className="mt-3 text-center text-cn-foreground-1" as="h1">
             {t('views:createProject.title', 'Create your new project')}
           </Card.Title>
 
-          <p className="text-cn-foreground-2 mt-0.5 text-center text-sm leading-snug">
+          <p className="mt-0.5 text-center text-sm leading-snug text-cn-foreground-2">
             {t('views:createProject.description', 'Organize your repositories, pipelines and more.')}
           </p>
         </div>
@@ -168,27 +170,28 @@ export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
             />
           </Fieldset>
 
-            <ControlGroup type="button">
-              <Button className="mt-3 w-full" rounded type="submit" loading={isLoading} disabled={hasError}>
-                {isLoading
-                  ? t('views:createProject.create.projectCreation', 'Creating project...')
-                  : t('views:createProject.create.createProject', 'Create project')}
-              </Button>
+          <ControlGroup type="button">
+            <Button className="mt-3 w-full" rounded type="submit" loading={isLoading} disabled={hasError} size="lg">
+              {isLoading
+                ? t('views:createProject.create.projectCreation', 'Creating project...')
+                : t('views:createProject.create.createProject', 'Create project')}
+            </Button>
 
-                <div className="mt-3 flex items-center justify-center gap-2">
-                    <div className="border-cn-borders-3 w-[145px] shrink border-t" />
-                    <span className="text-cn-foreground-3 text-sm">{t('views:createProject.or', 'or')}</span>
-                    <div className="border-cn-borders-3 w-[145px] shrink border-t" />
-                </div>
+            <div className="mt-3 flex items-center justify-center gap-2">
+              <div className="w-[145px] shrink border-t border-cn-borders-3" />
+              <span className="text-sm text-cn-foreground-3">{t('views:createProject.or', 'or')}</span>
+              <div className="w-[145px] shrink border-t border-cn-borders-3" />
+            </div>
 
-                <Button asChild className="mt-3 w-full" borderRadius="full" type="button" variant="outline" size="md">
-                    <Link to="/import">{t('views:createProject.importProject', 'Import project')}</Link>
-                </Button>
+            {/* TODO: Update the variant of this button to outline once the component supports this style. */}
+            <Button asChild className="mt-3 w-full" rounded type="button" variant="surface" size="lg">
+              <Link to={importProjectLinkProps.to}>{t('views:createProject.importProject', 'Import project')}</Link>
+            </Button>
           </ControlGroup>
         </FormWrapper>
 
         {isFirst && (
-          <p className="foreground-5 text-cn-foreground-3 mt-4 text-center text-sm">
+          <p className="foreground-5 mt-4 text-center text-sm text-cn-foreground-3">
             {t('views:createProject.logout.question', 'Want to use a different account?')}{' '}
             <StyledLink {...props.logoutLinkProps} variant="accent">
               {t('views:createProject.logout.link', 'Log out')}

--- a/packages/ui/src/views/project/create-project-page.tsx
+++ b/packages/ui/src/views/project/create-project-page.tsx
@@ -184,7 +184,7 @@ export const CreateProjectPage: FC<CreateProjectPageProps> = props => {
             </div>
 
             {/* TODO: Update the variant of this button to outline once the component supports this style. */}
-            <Button asChild className="mt-3 w-full" rounded type="button" variant="surface" size="lg">
+            <Button asChild className="mt-3 w-full" rounded variant="surface" size="lg">
               <Link to={importProjectLinkProps.to}>{t('views:createProject.importProject', 'Import project')}</Link>
             </Button>
           </ControlGroup>


### PR DESCRIPTION
# Create Project Page Enhancement PR

## Overview
This PR enhances the Create Project page by adding an "Import project" option alongside the existing "Create project" functionality. This improvement provides users with a clear path to either create a new project from scratch or import an existing one.

## Features Added
- Added a visual separator with "or" text between the primary actions
- Implemented a new "Import project" button that routes users to the `/import` path
- Enhanced the layout to accommodate both options in a visually balanced way

## Internationalization
- Added new translation strings for both English and French:
  - `views:createProject.or`: "or" / "ou"
  - `views:createProject.importProject`: "Import project" / "Importer un projet"

This enhancement improves user experience by providing clear pathways for both creating new projects and importing existing ones directly from the project creation screen.

![image](https://github.com/user-attachments/assets/7c1bbdda-a97d-481a-8fe7-1ed79337bd94)

