### PR TITLE
fix: Fix typecheck introduced in PR#1511

### DIFF
--- a/apps/design-system/src/subjects/views/connectors/connectors-list.tsx
+++ b/apps/design-system/src/subjects/views/connectors/connectors-list.tsx
@@ -26,7 +26,7 @@ const ConnectorsListPageWrapper = (): JSX.Element => {
             name: connector.connector.name,
             identifier: connector.connector.identifier,
             type: connector.connector.type,
-            status: connector.status,
+            status: connector.status.status,
             lastTestedAt: connector.status.lastTestedAt,
             lastModifiedAt: connector.lastModifiedAt,
             spec: {


### PR DESCRIPTION
Fixes typecheck for error connector `status` prop introduced in https://github.com/harness/canary/pull/1511.