### PR TITLE
Delegate Selector Refactoring

### DIFF
--- a/apps/design-system/src/subjects/views/delegates/delegate-connectivity.tsx
+++ b/apps/design-system/src/subjects/views/delegates/delegate-connectivity.tsx
@@ -1,30 +1,18 @@
-import { useTranslationStore } from '@utils/viewUtils'
-import { defaultTo } from 'lodash-es'
+import { DelegateConnectivityWrapper as DelegateConnectivityWrapperComponent } from '@harnessio/ui/views'
+import { useTranslationStore } from '@utils/viewUtils.ts'
+import { useDelegateData } from '@subjects/views/delegates/hooks'
+import { isDelegateSelected } from '@subjects/views/delegates/utils.ts'
 
-import { DelegateConnectivityList, SandboxLayout } from '@harnessio/ui/views'
+const DelegateConnectivityWrapper = (): JSX.Element => {
+  const delegates = useDelegateData();
 
-import mockDelegatesList from './mock-delegates-list.json'
-import { isDelegateSelected } from './utils'
-
-const DelegateConnectivityWrapper = (): JSX.Element => (
-  <SandboxLayout.Main>
-    <SandboxLayout.Content>
-      <DelegateConnectivityList
-        delegates={mockDelegatesList.map(delegate => ({
-          groupId: delegate.groupId,
-          groupName: delegate.groupName,
-          lastHeartBeat: delegate.lastHeartBeat,
-          activelyConnected: delegate.activelyConnected,
-          groupCustomSelectors: delegate.groupCustomSelectors || [],
-          groupImplicitSelectors: [...Object.keys(defaultTo(delegate.groupImplicitSelectors, {}))]
-        }))}
-        useTranslationStore={useTranslationStore}
-        isLoading={false}
-        selectedTags={[]}
-        isDelegateSelected={isDelegateSelected}
-      />
-    </SandboxLayout.Content>
-  </SandboxLayout.Main>
-)
+  return (
+    <DelegateConnectivityWrapperComponent
+      useTranslationStore={useTranslationStore}
+      delegates={delegates}
+      isDelegateSelected={isDelegateSelected}
+    />
+  );
+};
 
 export { DelegateConnectivityWrapper }

--- a/apps/design-system/src/subjects/views/delegates/delegate-selector.tsx
+++ b/apps/design-system/src/subjects/views/delegates/delegate-selector.tsx
@@ -1,146 +1,21 @@
-import { useState } from 'react'
+import { DelegateSelector as DelegateSelectorComponent } from '@harnessio/ui/views';
 
-import { useTranslationStore } from '@utils/viewUtils'
-import { defaultTo } from 'lodash-es'
+import mockTagsList from './mock-tags-list.json';
 
-import { Drawer, FormSeparator, Icon, StyledLink } from '@harnessio/ui/components'
-import {
-  DelegateSelectionTypes,
-  DelegateSelectorForm,
-  DelegateSelectorFormFields,
-  DelegateSelectorInput
-} from '@harnessio/ui/views'
+import { getMatchedDelegatesCount, isDelegateSelected } from '@subjects/views/delegates/utils.ts'
+import { useTranslationStore } from '@utils/viewUtils.ts'
+import { useDelegateData } from '@subjects/views/delegates/hooks'
 
-import mockDelegatesList from './mock-delegates-list.json'
-import { getMatchedDelegatesCount, isDelegateSelected } from './utils'
-
-const delegatesData = mockDelegatesList.map(delegate => ({
-  groupId: delegate.groupId,
-  groupName: delegate.groupName,
-  lastHeartBeat: delegate.lastHeartBeat,
-  activelyConnected: delegate.activelyConnected,
-  groupCustomSelectors: delegate.groupCustomSelectors || [],
-  groupImplicitSelectors: [...Object.keys(defaultTo(delegate.groupImplicitSelectors, {}))]
-}))
-
-const mockTagsList = [
-  'sanity-windows',
-  'eightfivetwoold',
-  'qa-automation',
-  'sanity',
-  'self-hosted-vpc-delegate',
-  'local',
-  '_testDocker',
-  'myrunner',
-  'macos-arm64',
-  'west1-delegate-qa',
-  'linux-amd64',
-  'eightfivetwo',
-  'automation-eks-delegate'
-]
-
-const renderSelectedValue = (type: DelegateSelectionTypes | null, tags: string[]) =>
-  type === DelegateSelectionTypes.TAGS ? tags.join(', ') : type === DelegateSelectionTypes.ANY ? 'any delegate' : null
-
-/* ----------  DRAWER COMPONENT  -------------- */
-interface DrawerProps {
-  open: boolean
-  setOpen: (open: boolean) => void
-  preSelectedTags: string[]
-  onSubmit: (data: DelegateSelectorFormFields) => void
-  disableAnyDelegate?: boolean
-}
-
-const DelegateSelectorDrawer = ({ open, setOpen, preSelectedTags, onSubmit, disableAnyDelegate }: DrawerProps) => (
-  <Drawer.Root open={open} onOpenChange={setOpen} direction="right">
-    <Drawer.Content className="w-1/2">
-      <Drawer.Header>
-        <Drawer.Title className="text-cn-foreground-1 mb-2 text-xl">Delegate selector</Drawer.Title>
-        <FormSeparator className="w-full" />
-        <div className="flex">
-          Haven&apos;t installed a delegate yet?
-          <StyledLink className="flex flex-row items-center ml-1" variant="accent" to="#">
-            Install delegate <Icon name="attachment-link" className="ml-1" size={12} />
-          </StyledLink>
-        </div>
-        <Drawer.Close onClick={() => setOpen(false)} />
-      </Drawer.Header>
-
-      <DelegateSelectorForm
-        delegates={delegatesData}
-        tagsList={mockTagsList}
-        useTranslationStore={useTranslationStore}
-        isLoading={false}
-        onFormSubmit={onSubmit}
-        onBack={() => setOpen(false)}
-        isDelegateSelected={isDelegateSelected}
-        getMatchedDelegatesCount={getMatchedDelegatesCount}
-        preSelectedTags={preSelectedTags}
-        disableAnyDelegate={disableAnyDelegate}
-      />
-    </Drawer.Content>
-  </Drawer.Root>
-)
-
-/* ----------  MAIN COMPONENT  -------------------------- */
 export const DelegateSelector = () => {
-  /* ---- FIRST (ANY allowed) ---- */
-  const [openA, setOpenA] = useState(false)
-  const [typeA, setTypeA] = useState<DelegateSelectionTypes | null>(null)
-  const [tagsA, setTagsA] = useState<string[]>([])
-
-  /* ---- SECOND (ANY disabled) --- */
-  const [openB, setOpenB] = useState(false)
-  const [typeB, setTypeB] = useState<DelegateSelectionTypes | null>(null)
-  const [tagsB, setTagsB] = useState<string[]>([])
-
-  const handleSubmitA = ({ type, tags }: DelegateSelectorFormFields) => {
-    setTypeA(type === DelegateSelectionTypes.ANY ? DelegateSelectionTypes.ANY : DelegateSelectionTypes.TAGS)
-    setTagsA(type === DelegateSelectionTypes.TAGS ? tags.map(t => t.id) : [])
-    setOpenA(false)
-  }
-
-  const handleSubmitB = ({ tags }: DelegateSelectorFormFields) => {
-    setTypeB(DelegateSelectionTypes.TAGS)
-    setTagsB(tags.map(t => t.id))
-    setOpenB(false)
-  }
+  const delegatesData = useDelegateData();
 
   return (
-    <div className="p-5">
-      <DelegateSelectorInput
-        placeholder={<StyledLink to="#"> select a delegate</StyledLink>}
-        value={renderSelectedValue(typeA, tagsA)}
-        label="Delegate selector"
-        onClick={() => setOpenA(true)}
-        onEdit={() => setOpenA(true)}
-        onClear={() => setTagsA([])}
-        renderValue={tag => tag}
-        className="max-w-xs mb-8"
-      />
-
-      <DelegateSelectorDrawer open={openA} setOpen={setOpenA} preSelectedTags={tagsA} onSubmit={handleSubmitA} />
-
-      <div className="pt-10">
-        <DelegateSelectorInput
-          placeholder={<StyledLink to="#">select a delegate (any disabled)</StyledLink>}
-          value={renderSelectedValue(typeB, tagsB)}
-          label="Delegate selector"
-          onClick={() => setOpenB(true)}
-          onEdit={() => setOpenB(true)}
-          onClear={() => setTagsB([])}
-          renderValue={tag => tag}
-          className="max-w-xs mb-8"
-        />
-
-        <DelegateSelectorDrawer
-          open={openB}
-          setOpen={setOpenB}
-          preSelectedTags={tagsB}
-          onSubmit={handleSubmitB}
-          disableAnyDelegate
-        />
-      </div>
-    </div>
+    <DelegateSelectorComponent
+      delegates={delegatesData}
+      getMatchedDelegatesCount={getMatchedDelegatesCount}
+      isDelegateSelected={isDelegateSelected}
+      tagsList={mockTagsList}
+      useTranslationStore={useTranslationStore}
+    />
   )
 }

--- a/apps/design-system/src/subjects/views/delegates/hooks/index.ts
+++ b/apps/design-system/src/subjects/views/delegates/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-delegates.ts';

--- a/apps/design-system/src/subjects/views/delegates/hooks/use-delegates.ts
+++ b/apps/design-system/src/subjects/views/delegates/hooks/use-delegates.ts
@@ -1,0 +1,14 @@
+import mockDelegatesList from '@subjects/views/delegates/mock-delegates-list.json'
+import { defaultTo } from 'lodash-es'
+import { useMemo } from 'react'
+
+export const useDelegateData = () => useMemo(() =>
+  mockDelegatesList.map(delegate => ({
+    groupId: delegate.groupId,
+    groupName: delegate.groupName,
+    lastHeartBeat: delegate.lastHeartBeat,
+    activelyConnected: delegate.activelyConnected,
+    groupCustomSelectors: delegate.groupCustomSelectors || [],
+    groupImplicitSelectors: [...Object.keys(defaultTo(delegate.groupImplicitSelectors, {}))]
+  })),
+[]);

--- a/apps/design-system/src/subjects/views/delegates/mock-tags-list.json
+++ b/apps/design-system/src/subjects/views/delegates/mock-tags-list.json
@@ -1,0 +1,15 @@
+[
+  "sanity-windows",
+  "eightfivetwoold",
+  "qa-automation",
+  "sanity",
+  "self-hosted-vpc-delegate",
+  "local",
+  "_testDocker",
+  "myrunner",
+  "macos-arm64",
+  "west1-delegate-qa",
+  "linux-amd64",
+  "eightfivetwo",
+  "automation-eks-delegate"
+]

--- a/packages/ui/src/views/delegates/delegate-connectivity/delegate-connectivity-list.tsx
+++ b/packages/ui/src/views/delegates/delegate-connectivity/delegate-connectivity-list.tsx
@@ -60,7 +60,7 @@ export function DelegateConnectivityList({
               groupImplicitSelectors
             }) => {
               return (
-                <Table.Row key={groupId} className="hover:cn-background-1">
+                <Table.Row key={groupId} className="hover:bg-cn-borders-2">
                   <Table.Cell className="max-w-40 content-center truncate">
                     <div className="flex items-center gap-2.5">
                       <Title title={groupName} />

--- a/packages/ui/src/views/delegates/delegate-connectivity/delegate-connectivity-list.tsx
+++ b/packages/ui/src/views/delegates/delegate-connectivity/delegate-connectivity-list.tsx
@@ -35,15 +35,15 @@ export function DelegateConnectivityList({
 
   return (
     <Table.Root
-      className={isLoading ? '[mask-image:linear-gradient(to_bottom,black_30%,transparent_100%)]' : ''}
+      className={cn(isLoading ? '[mask-image:linear-gradient(to_bottom,black_30%,transparent_100%)]' : '', 'overflow-visible', 'pt-[0.3125rem]')}
       variant="asStackedList"
     >
       <Table.Header>
         <Table.Row>
-          <Table.Head className="w-96">Delegate</Table.Head>
+          <Table.Head className="w-60">Delegate</Table.Head>
           <Table.Head className="w-44 whitespace-nowrap">Heartbeat</Table.Head>
           <Table.Head className="w-96">Tags</Table.Head>
-          <Table.Head className="w-44">Selected</Table.Head>
+          <Table.Head className="w-44 text-center">Selected</Table.Head>
         </Table.Row>
       </Table.Header>
       {isLoading ? (
@@ -60,13 +60,13 @@ export function DelegateConnectivityList({
               groupImplicitSelectors
             }) => {
               return (
-                <Table.Row key={groupId}>
-                  <Table.Cell className="max-w-80 content-center truncate">
+                <Table.Row key={groupId} className="hover:cn-background-1">
+                  <Table.Cell className="max-w-40 content-center truncate">
                     <div className="flex items-center gap-2.5">
                       <Title title={groupName} />
                     </div>
                   </Table.Cell>
-                  <Table.Cell className="content-center">
+                  <Table.Cell className="min-w-40 content-center">
                     <div className="inline-flex items-center gap-2">
                       <Icon
                         name="dot"
@@ -77,17 +77,23 @@ export function DelegateConnectivityList({
                     </div>
                   </Table.Cell>
                   <Table.Cell className="max-w-80 content-center truncate">
-                    {groupCustomSelectors.map((selector: string) => (
-                      <Badge variant="soft" theme="merged" key={selector} className="mr-2">
-                        {selector}
-                      </Badge>
-                    ))}
+                    <div className="flex flex-wrap gap-2">
+                      {groupCustomSelectors.map((selector: string) => (
+                        <Badge variant="soft" theme="merged" key={selector}>
+                          {selector}
+                        </Badge>
+                      ))}
+                    </div>
                   </Table.Cell>
-                  <Table.Cell className="min-w-8 text-right">
-                    {isDelegateSelected(
-                      [...defaultTo(groupImplicitSelectors, []), ...defaultTo(groupCustomSelectors, [])],
-                      selectedTags || []
-                    ) && <Icon name="tick" size={12} className="text-icons-success" />}
+                  <Table.Cell className="relative min-w-6 text-right">
+                      {isDelegateSelected(
+                        [...defaultTo(groupImplicitSelectors, []), ...defaultTo(groupCustomSelectors, [])],
+                        selectedTags || []
+                      ) &&
+                        <div className="absolute inset-0 flex w-full items-center justify-center">
+                          <Icon name="tick" size={12} className="text-icons-success" />
+                        </div>
+                      }
                   </Table.Cell>
                 </Table.Row>
               )

--- a/packages/ui/src/views/delegates/delegate-connectivity/delegate-connectivity-list.tsx
+++ b/packages/ui/src/views/delegates/delegate-connectivity/delegate-connectivity-list.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react'
-
 import { Badge, Icon, NoData, SkeletonList, SkeletonTable, Table } from '@/components'
 import { cn } from '@utils/cn'
 import { timeAgo } from '@utils/utils'

--- a/packages/ui/src/views/delegates/delegate-connectivity/delegate-connectivity-wrapper.tsx
+++ b/packages/ui/src/views/delegates/delegate-connectivity/delegate-connectivity-wrapper.tsx
@@ -1,0 +1,26 @@
+import { DelegateItem, SandboxLayout, TranslationStore } from '@/views'
+import { DelegateConnectivityList } from './delegate-connectivity-list';
+
+interface DelegateConnectivityWrapperProps {
+  useTranslationStore: () => TranslationStore;
+  delegates: DelegateItem[];
+  isDelegateSelected: (selectors: string[], tags: string[]) => boolean;
+}
+
+const DelegateConnectivityWrapper = ({ delegates, useTranslationStore, isDelegateSelected }: DelegateConnectivityWrapperProps): JSX.Element => {
+  return (
+    <SandboxLayout.Main>
+      <SandboxLayout.Content>
+        <DelegateConnectivityList
+          delegates={delegates}
+          useTranslationStore={useTranslationStore}
+          isLoading={false}
+          selectedTags={[]}
+          isDelegateSelected={isDelegateSelected}
+        />
+      </SandboxLayout.Content>
+    </SandboxLayout.Main>
+  );
+}
+
+export { DelegateConnectivityWrapper }

--- a/packages/ui/src/views/delegates/delegate-connectivity/index.ts
+++ b/packages/ui/src/views/delegates/delegate-connectivity/index.ts
@@ -1,0 +1,3 @@
+export {
+  DelegateConnectivityWrapper
+} from './delegate-connectivity-wrapper';

--- a/packages/ui/src/views/delegates/delegate-selector/delegate-selector-form.tsx
+++ b/packages/ui/src/views/delegates/delegate-selector/delegate-selector-form.tsx
@@ -201,7 +201,7 @@ export const DelegateSelectorForm = (props: DelegateSelectorFormProps): JSX.Elem
           </>
         )}
 
-        <div className="bg-cn-background-2 b-0 sticky inset-x-0 bottom-0 -ml-5 w-[calc(100%+theme('spacing.10'))] border-t p-4 shadow-md">
+        <div className="bg-cn-background-2 b-0 sticky inset-x-0 bottom-0 -ml-5 mt-auto w-[calc(100%+theme('spacing.10'))] border-t p-4 shadow-md">
           <ControlGroup>
             <ButtonGroup className="flex flex-row justify-between">
               <Button type="button" variant="ghost" onClick={onBack}>

--- a/packages/ui/src/views/delegates/delegate-selector/delegate-selector-form.tsx
+++ b/packages/ui/src/views/delegates/delegate-selector/delegate-selector-form.tsx
@@ -14,13 +14,12 @@ import {
   Spacer,
   Text
 } from '@/components'
-import { SandboxLayout, TranslationStore } from '@/views'
+import { SandboxLayout, TranslationStore , DelegateItem } from '@/views'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { RadioOption, RadioSelect } from '@views/components/RadioSelect'
 import { z } from 'zod'
 
-import { DelegateConnectivityList } from '../components/delegate-connectivity-list'
-import { DelegateItem } from '../types'
+import { DelegateConnectivityList } from '../delegate-connectivity/delegate-connectivity-list'
 
 export enum DelegateSelectionTypes {
   ANY = 'any',
@@ -202,7 +201,7 @@ export const DelegateSelectorForm = (props: DelegateSelectorFormProps): JSX.Elem
           </>
         )}
 
-        <div className="absolute inset-x-0 bottom-0 bg-cn-background-2 p-4 shadow-md">
+        <div className="bg-cn-background-2 absolute inset-x-0 bottom-0 p-4 shadow-md">
           <ControlGroup>
             <ButtonGroup className="flex flex-row justify-between">
               <Button type="button" variant="ghost" onClick={onBack}>

--- a/packages/ui/src/views/delegates/delegate-selector/delegate-selector-form.tsx
+++ b/packages/ui/src/views/delegates/delegate-selector/delegate-selector-form.tsx
@@ -5,7 +5,7 @@ import {
   Alert,
   Button,
   ButtonGroup,
-  ControlGroup, Drawer,
+  ControlGroup,
   Fieldset,
   FormSeparator,
   FormWrapper,
@@ -150,7 +150,7 @@ export const DelegateSelectorForm = (props: DelegateSelectorFormProps): JSX.Elem
   )
 
   return (
-    <SandboxLayout.Content className="h-full py-0">
+    <SandboxLayout.Content className="h-[calc(100%-theme('spacing.28'))] py-0">
       <Spacer size={5} />
       <FormWrapper className="flex h-full flex-col pb-0" onSubmit={handleSubmit(onSubmit)}>
         <Fieldset className="mb-0">

--- a/packages/ui/src/views/delegates/delegate-selector/delegate-selector-form.tsx
+++ b/packages/ui/src/views/delegates/delegate-selector/delegate-selector-form.tsx
@@ -5,7 +5,7 @@ import {
   Alert,
   Button,
   ButtonGroup,
-  ControlGroup,
+  ControlGroup, Drawer,
   Fieldset,
   FormSeparator,
   FormWrapper,
@@ -150,9 +150,9 @@ export const DelegateSelectorForm = (props: DelegateSelectorFormProps): JSX.Elem
   )
 
   return (
-    <SandboxLayout.Content className="h-full px-0 pt-0">
+    <SandboxLayout.Content className="h-full py-0">
       <Spacer size={5} />
-      <FormWrapper className="flex h-full flex-col" onSubmit={handleSubmit(onSubmit)}>
+      <FormWrapper className="flex h-full flex-col pb-0" onSubmit={handleSubmit(onSubmit)}>
         <Fieldset className="mb-0">
           <RadioSelect
             id="type"
@@ -201,7 +201,7 @@ export const DelegateSelectorForm = (props: DelegateSelectorFormProps): JSX.Elem
           </>
         )}
 
-        <div className="bg-cn-background-2 absolute inset-x-0 bottom-0 p-4 shadow-md">
+        <div className="bg-cn-background-2 b-0 sticky inset-x-0 bottom-0 -ml-5 w-[calc(100%+theme('spacing.10'))] border-t p-4 shadow-md">
           <ControlGroup>
             <ButtonGroup className="flex flex-row justify-between">
               <Button type="button" variant="ghost" onClick={onBack}>
@@ -215,8 +215,6 @@ export const DelegateSelectorForm = (props: DelegateSelectorFormProps): JSX.Elem
             </ButtonGroup>
           </ControlGroup>
         </div>
-
-        <div className="pb-16"></div>
       </FormWrapper>
     </SandboxLayout.Content>
   )

--- a/packages/ui/src/views/delegates/delegate-selector/delegate-selector.tsx
+++ b/packages/ui/src/views/delegates/delegate-selector/delegate-selector.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react'
+
+import { Drawer, FormSeparator, Icon, StyledLink } from '@/components'
+
+import { DelegateItem, TranslationStore } from '@/views'
+import { DelegateSelectorForm, DelegateSelectorFormFields, DelegateSelectionTypes } from './delegate-selector-form';
+import { DelegateSelectorInput } from './delegate-selector-input';
+
+const renderSelectedValue = (type: DelegateSelectionTypes | null, tags: string[]) =>
+  type === DelegateSelectionTypes.TAGS ? tags.join(', ') : type === DelegateSelectionTypes.ANY ? 'any delegate' : null
+
+interface UseTranslationStoreProps {
+  useTranslationStore: () => TranslationStore
+}
+
+interface DelegatesSelectorProps {
+  delegates: DelegateItem[]
+  isDelegateSelected: (selectors: string[], tags: string[]) => boolean
+  getMatchedDelegatesCount: (delegates: DelegateItem[], tags: string[]) => number
+  tagsList: string[]
+}
+
+/* ----------  DRAWER COMPONENT  -------------- */
+interface DrawerProps extends UseTranslationStoreProps, DelegatesSelectorProps {
+  open: boolean
+  delegates: DelegateItem[]
+  setOpen: (open: boolean) => void
+  preSelectedTags: string[]
+  onSubmit: (data: DelegateSelectorFormFields) => void
+  disableAnyDelegate?: boolean
+  isDelegateSelected: (selectors: string[], tags: string[]) => boolean
+  getMatchedDelegatesCount: (delegates: DelegateItem[], tags: string[]) => number
+  tagsList: string[]
+}
+
+const DelegateSelectorDrawer = ({
+  open,
+  setOpen,
+  delegates,
+  tagsList,
+  preSelectedTags,
+  onSubmit,
+  disableAnyDelegate,
+  isDelegateSelected,
+  getMatchedDelegatesCount,
+  useTranslationStore
+}: DrawerProps) => (
+  <Drawer.Root open={open} onOpenChange={setOpen} direction="right">
+    <Drawer.Content className="w-1/2">
+      <Drawer.Header>
+        <Drawer.Title className="text-cn-foreground-1 mb-2 text-xl">Delegate selector</Drawer.Title>
+        <FormSeparator className="w-full" />
+        <div className="flex">
+          Haven&apos;t installed a delegate yet?
+          <StyledLink className="ml-1 flex flex-row items-center" variant="accent" to="#">
+            Install delegate <Icon name="attachment-link" className="ml-1" size={12} />
+          </StyledLink>
+        </div>
+        <Drawer.Close onClick={() => setOpen(false)} />
+      </Drawer.Header>
+
+      <DelegateSelectorForm
+        delegates={delegates}
+        tagsList={tagsList}
+        useTranslationStore={useTranslationStore}
+        isLoading={false}
+        onFormSubmit={onSubmit}
+        onBack={() => setOpen(false)}
+        isDelegateSelected={isDelegateSelected}
+        getMatchedDelegatesCount={getMatchedDelegatesCount}
+        preSelectedTags={preSelectedTags}
+        disableAnyDelegate={disableAnyDelegate}
+      />
+    </Drawer.Content>
+  </Drawer.Root>
+)
+
+interface DelegateSelectorProps extends UseTranslationStoreProps, DelegatesSelectorProps {}
+
+/* ----------  MAIN COMPONENT  -------------------------- */
+export const DelegateSelector = ({
+   delegates,
+   isDelegateSelected,
+   getMatchedDelegatesCount,
+   tagsList,
+   useTranslationStore
+}: DelegateSelectorProps) => {
+  /* ---- FIRST (ANY allowed) ---- */
+  const [openA, setOpenA] = useState(false)
+  const [typeA, setTypeA] = useState<DelegateSelectionTypes | null>(null)
+  const [tagsA, setTagsA] = useState<string[]>([])
+
+  /* ---- SECOND (ANY disabled) --- */
+  const [openB, setOpenB] = useState(false)
+  const [typeB, setTypeB] = useState<DelegateSelectionTypes | null>(null)
+  const [tagsB, setTagsB] = useState<string[]>([])
+
+  const handleSubmitA = ({ type, tags }: DelegateSelectorFormFields) => {
+    setTypeA(type === DelegateSelectionTypes.ANY ? DelegateSelectionTypes.ANY : DelegateSelectionTypes.TAGS)
+    setTagsA(type === DelegateSelectionTypes.TAGS ? tags.map(t => t.id) : [])
+    setOpenA(false)
+  }
+
+  const handleSubmitB = ({ tags }: DelegateSelectorFormFields) => {
+    setTypeB(DelegateSelectionTypes.TAGS)
+    setTagsB(tags.map(t => t.id))
+    setOpenB(false)
+  }
+
+  return (
+    <div className="p-5">
+      <DelegateSelectorInput
+        placeholder={<StyledLink to="#"> select a delegate</StyledLink>}
+        value={renderSelectedValue(typeA, tagsA)}
+        label="Delegate selector"
+        onClick={() => setOpenA(true)}
+        onEdit={() => setOpenA(true)}
+        onClear={() => setTagsA([])}
+        renderValue={tag => tag}
+        className="mb-8 max-w-xs"
+      />
+
+      <DelegateSelectorDrawer
+        open={openA}
+        setOpen={setOpenA}
+        preSelectedTags={tagsA}
+        onSubmit={handleSubmitA}
+        useTranslationStore={useTranslationStore}
+        delegates={delegates}
+        isDelegateSelected={isDelegateSelected}
+        getMatchedDelegatesCount={getMatchedDelegatesCount}
+        tagsList={tagsList}
+      />
+
+      <div className="pt-10">
+        <DelegateSelectorInput
+          placeholder={<StyledLink to="#">select a delegate (any disabled)</StyledLink>}
+          value={renderSelectedValue(typeB, tagsB)}
+          label="Delegate selector"
+          onClick={() => setOpenB(true)}
+          onEdit={() => setOpenB(true)}
+          onClear={() => setTagsB([])}
+          renderValue={tag => tag}
+          className="mb-8 max-w-xs"
+        />
+
+        <DelegateSelectorDrawer
+          open={openB}
+          setOpen={setOpenB}
+          preSelectedTags={tagsB}
+          onSubmit={handleSubmitB}
+          useTranslationStore={useTranslationStore}
+          disableAnyDelegate
+          delegates={delegates}
+          isDelegateSelected={isDelegateSelected}
+          getMatchedDelegatesCount={getMatchedDelegatesCount}
+          tagsList={tagsList}
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/views/delegates/delegate-selector/delegate-selector.tsx
+++ b/packages/ui/src/views/delegates/delegate-selector/delegate-selector.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import { Drawer, FormSeparator, Icon, StyledLink } from '@/components'
+import { Drawer, Icon, StyledLink } from '@/components'
 
 import { DelegateItem, TranslationStore } from '@/views'
 import { DelegateSelectorForm, DelegateSelectorFormFields, DelegateSelectionTypes } from './delegate-selector-form';
@@ -46,18 +46,18 @@ const DelegateSelectorDrawer = ({
   useTranslationStore
 }: DrawerProps) => (
   <Drawer.Root open={open} onOpenChange={setOpen} direction="right">
-    <Drawer.Content className="w-1/2">
-      <Drawer.Header>
-        <Drawer.Title className="text-cn-foreground-1 mb-2 text-xl">Delegate selector</Drawer.Title>
-        <FormSeparator className="w-full" />
-        <div className="flex">
-          Haven&apos;t installed a delegate yet?
-          <StyledLink className="ml-1 flex flex-row items-center" variant="accent" to="#">
-            Install delegate <Icon name="attachment-link" className="ml-1" size={12} />
-          </StyledLink>
-        </div>
+    <Drawer.Content className="w-1/2 overflow-y-auto p-0">
+      <Drawer.Header className="z-1 bg-cn-background-2 sticky top-0 -ml-5 w-[calc(100%+theme('spacing.10'))] gap-0 border-b px-5">
+        <Drawer.Title className="text-cn-foreground-1 p-5 text-xl">Delegate selector</Drawer.Title>
         <Drawer.Close onClick={() => setOpen(false)} />
       </Drawer.Header>
+
+      <div className="flex p-5 pb-0">
+        Haven&apos;t installed a delegate yet?
+        <StyledLink className="ml-1 flex flex-row items-center" variant="accent" to="#">
+          Install delegate <Icon name="attachment-link" className="ml-1" size={12} />
+        </StyledLink>
+      </div>
 
       <DelegateSelectorForm
         delegates={delegates}
@@ -110,7 +110,7 @@ export const DelegateSelector = ({
   return (
     <div className="p-5">
       <DelegateSelectorInput
-        placeholder={<StyledLink to="#"> select a delegate</StyledLink>}
+        placeholder={<StyledLink to="#">select a delegate</StyledLink>}
         value={renderSelectedValue(typeA, tagsA)}
         label="Delegate selector"
         onClick={() => setOpenA(true)}

--- a/packages/ui/src/views/delegates/delegate-selector/delegate-selector.tsx
+++ b/packages/ui/src/views/delegates/delegate-selector/delegate-selector.tsx
@@ -46,7 +46,7 @@ const DelegateSelectorDrawer = ({
   useTranslationStore
 }: DrawerProps) => (
   <Drawer.Root open={open} onOpenChange={setOpen} direction="right">
-    <Drawer.Content className="w-1/2 overflow-y-auto p-0">
+    <Drawer.Content className="w-1/2 overflow-y-auto overflow-x-hidden p-0">
       <Drawer.Header className="z-1 bg-cn-background-2 sticky top-0 -ml-5 w-[calc(100%+theme('spacing.10'))] gap-0 border-b px-5">
         <Drawer.Title className="text-cn-foreground-1 p-5 text-xl">Delegate selector</Drawer.Title>
         <Drawer.Close onClick={() => setOpen(false)} />

--- a/packages/ui/src/views/delegates/delegate-selector/index.ts
+++ b/packages/ui/src/views/delegates/delegate-selector/index.ts
@@ -1,0 +1,1 @@
+export { DelegateSelector } from './delegate-selector';

--- a/packages/ui/src/views/delegates/index.ts
+++ b/packages/ui/src/views/delegates/index.ts
@@ -1,4 +1,3 @@
 export * from './types'
-export * from './components/delegate-connectivity-list'
-export * from './delegate-selector/delegate-selector-form'
-export * from './delegate-selector/delegate-selector-input'
+export * from './delegate-selector'
+export * from './delegate-connectivity'


### PR DESCRIPTION
Task 1.
- Moved DelegateSelector and DelegateConnectivity from `apps/design-system/src/subjects/views/delegates` to `packages/ui/src/views/delegates`.
- Delegates sticky header + footer.
- Data table refactoring:
  - Make the table fit to the entire wid
  - Aligns `Selected` cell to the center.
  - Color cells row on hover.
 
<img width="1337" alt="#347 Screenshot@2025-04-28" src="https://github.com/user-attachments/assets/071f867d-d14b-4b0a-a1c6-6b93c455258a" />
<img width="1337" alt="#346 Screenshot@2025-04-28" src="https://github.com/user-attachments/assets/23d53d2b-17ad-45dd-b9b1-913b0dae144b" />

<img width="2056" alt="#344 Screenshot@2025-04-28" src="https://github.com/user-attachments/assets/7aab87d7-f4d0-4613-98c9-f5d2c47d16e2" />
<img width="2056" alt="#343 Screenshot@2025-04-28" src="https://github.com/user-attachments/assets/b7966a7d-9b6c-4910-ac3f-d3cd1ebe8384" />
