### PR TITLE
Prefixed tag classes with "cn-"

### DIFF
--- a/packages/ui/src/components/tag.tsx
+++ b/packages/ui/src/components/tag.tsx
@@ -2,34 +2,34 @@ import { Icon } from '@components/icon'
 import { cn } from '@utils/cn'
 import { cva, type VariantProps } from 'class-variance-authority'
 
-const tagVariants = cva('tag', {
+const tagVariants = cva('cn-tag', {
   variants: {
     variant: {
-      outline: 'tag-outline',
-      secondary: 'tag-secondary'
+      outline: 'cn-tag-outline',
+      secondary: 'cn-tag-secondary'
     },
     size: {
       default: '',
-      sm: 'tag-sm'
+      sm: 'cn-tag-sm'
     },
     theme: {
-      gray: 'tag-gray',
-      blue: 'tag-blue',
-      brown: 'tag-brown',
-      cyan: 'tag-cyan',
-      green: 'tag-green',
-      indigo: 'tag-indigo',
-      lime: 'tag-lime',
-      mint: 'tag-mint',
-      orange: 'tag-orange',
-      pink: 'tag-pink',
-      purple: 'tag-purple',
-      red: 'tag-red',
-      violet: 'tag-violet',
-      yellow: 'tag-yellow'
+      gray: 'cn-tag-gray',
+      blue: 'cn-tag-blue',
+      brown: 'cn-tag-brown',
+      cyan: 'cn-tag-cyan',
+      green: 'cn-tag-green',
+      indigo: 'cn-tag-indigo',
+      lime: 'cn-tag-lime',
+      mint: 'cn-tag-mint',
+      orange: 'cn-tag-orange',
+      pink: 'cn-tag-pink',
+      purple: 'cn-tag-purple',
+      red: 'cn-tag-red',
+      violet: 'cn-tag-violet',
+      yellow: 'cn-tag-yellow'
     },
     rounded: {
-      true: 'tag-rounded'
+      true: 'cn-tag-rounded'
     }
   },
   defaultVariants: {
@@ -72,13 +72,13 @@ function Tag({
 
   return (
     <div tabIndex={-1} className={cn(tagVariants({ variant, size, theme, rounded }), className)} {...props}>
-      {showIcon && <Icon skipSize name={icon || 'tag-2'} className="tag-icon" />}
+      {showIcon && <Icon skipSize name={icon || 'tag-2'} className="cn-tag-icon" />}
       <span className="truncate" title={value}>
         {value}
       </span>
       {showReset && (
         <button onClick={onReset}>
-          <Icon skipSize name="close-2" className="tag-reset-icon" />
+          <Icon skipSize name="close-2" className="cn-tag-reset-icon" />
         </button>
       )}
     </div>
@@ -89,12 +89,12 @@ function TagSplit({ variant, size, theme, rounded, icon, showIcon, showReset, va
   const sharedProps = { variant, size, theme, rounded, icon }
 
   return (
-    <div className="tag-split flex w-fit cursor-pointer items-center justify-center">
+    <div className="cn-tag-split flex w-fit cursor-pointer items-center justify-center">
       {/* LEFT TAG - should never have a Reset Icon */}
-      <Tag {...sharedProps} showIcon={showIcon} value={label} className="tag-split-left" />
+      <Tag {...sharedProps} showIcon={showIcon} value={label} className="cn-tag-split-left" />
 
       {/* RIGHT TAG - should never have a tag Icon */}
-      <Tag {...sharedProps} showReset={showReset} onReset={onReset} value={value} className="tag-split-right" />
+      <Tag {...sharedProps} showReset={showReset} onReset={onReset} value={value} className="cn-tag-split-right" />
     </div>
   )
 }

--- a/packages/ui/tailwind-utils-config/components/tag.ts
+++ b/packages/ui/tailwind-utils-config/components/tag.ts
@@ -32,41 +32,41 @@ function createTagVariantStyles(variant: 'outline' | 'secondary'): CSSRuleObject
       backgroundColor: `var(--cn-set-${theme}-${isOutline ? 'surface-bg' : 'soft-bg'})`,
       borderColor: `var(--cn-set-${theme}-${isOutline ? 'surface-border' : 'soft-bg'})`,
 
-      '&:hover:not(.tag-split *)': getHoverStyles(theme, isOutline),
-      '&:where(.tag-split-left)': {
-        '.tag-split:hover &': getHoverStyles(theme, isOutline)
+      '&:hover:not(.cn-tag-split *)': getHoverStyles(theme, isOutline),
+      '&:where(.cn-tag-split-left)': {
+        '.cn-tag-split:hover &': getHoverStyles(theme, isOutline)
       },
-      '&:where(.tag-split-right)': isOutline
+      '&:where(.cn-tag-split-right)': isOutline
         ? {
             borderColor: `var(--cn-set-${theme}-soft-bg)`,
-            '.tag-split:hover &': {
+            '.cn-tag-split:hover &': {
               borderColor: `var(--cn-set-${theme}-soft-bg-hover)`
             }
           }
         : {
             backgroundColor: `var(--cn-set-${theme}-surface-bg)`,
-            '.tag-split:hover &': {
+            '.cn-tag-split:hover &': {
               backgroundColor: `var(--cn-set-${theme}-surface-bg-hover)`
             }
           },
 
       // ICON STYLES
-      '.tag-icon': {
+      '.cn-tag-icon': {
         color: `var(--cn-set-${theme}-${isOutline ? 'surface-text' : 'soft-text'})`
       },
-      '.tag-reset-icon': {
+      '.cn-tag-reset-icon': {
         color: `var(--cn-set-${theme}-${isOutline ? 'surface-text' : 'soft-text'})`
       }
     }
 
-    styles[`&:where(.tag-${theme})`] = style
+    styles[`&:where(.cn-tag-${theme})`] = style
   })
 
   return styles
 }
 
 export default {
-  '.tag': {
+  '.cn-tag': {
     display: 'inline-flex',
     alignItems: 'center',
     padding: 'var(--cn-tag-py) var(--cn-tag-px)',
@@ -77,43 +77,43 @@ export default {
     height: `var(--cn-tag-size-default)`,
     '@apply w-fit flex items-center transition-colors cursor-pointer font-body-tight-normal': '',
 
-    '&:where(.tag-sm)': {
+    '&:where(.cn-tag-sm)': {
       height: `var(--cn-tag-size-sm)`,
       '@apply font-caption-tight-normal': ''
     },
 
-    '&:where(.tag-rounded)': {
+    '&:where(.cn-tag-rounded)': {
       borderRadius: `var(--cn-tag-radius-full)`
     },
 
-    '&:where(.tag-split-left)': {
+    '&:where(.cn-tag-split-left)': {
       borderRadius: `var(--cn-tag-split-left-radius-l) var(--cn-tag-split-left-radius-r) var(--cn-tag-split-left-radius-r) var(--cn-tag-split-left-radius-l)`,
-      '&.tag-rounded': {
+      '&.cn-tag-rounded': {
         borderRadius: `var(--cn-tag-radius-full) 0 0 var(--cn-tag-radius-full)`
       }
     },
 
-    '&:where(.tag-split-right)': {
+    '&:where(.cn-tag-split-right)': {
       borderRadius: `var(--cn-tag-split-right-radius-l) var(--cn-tag-split-right-radius-r) var(--cn-tag-split-right-radius-r) var(--cn-tag-split-right-radius-l)`,
       borderWidth: `var(--cn-tag-border) var(--cn-tag-border) var(--cn-tag-border) 0`,
-      '&.tag-rounded': {
+      '&.cn-tag-rounded': {
         borderRadius: `0 var(--cn-tag-radius-full) var(--cn-tag-radius-full) 0`
       }
     },
 
-    '&:where(.tag-outline)': {
+    '&:where(.cn-tag-outline)': {
       ...createTagVariantStyles('outline')
     },
-    '&:where(.tag-secondary)': {
+    '&:where(.cn-tag-secondary)': {
       ...createTagVariantStyles('secondary')
     },
 
     // ICON STYLES
-    '.tag-icon': {
+    '.cn-tag-icon': {
       width: `var(--cn-icon-size-default, 16px)`,
       height: `var(--cn-icon-size-default, 16px)`
     },
-    '.tag-reset-icon': {
+    '.cn-tag-reset-icon': {
       width: `var(--cn-icon-size-xs, 12px)`,
       height: `var(--cn-icon-size-xs, 12px)`
     }


### PR DESCRIPTION
The tag class was breaking the `Show Code` section in the portal app, hence we decided to prefix all the design system classes with "cn-" going forward.

This PR fixes the UI for the `Show Code` section in the portal app.