### PR TITLE
Update CounterBadge to have success and danger themes

### DIFF
--- a/apps/portal/src/content/docs/components/counter-badge.mdx
+++ b/apps/portal/src/content/docs/components/counter-badge.mdx
@@ -12,8 +12,8 @@ import { DocsPage } from "../../../components/docs-page";
   code={`<div className="flex gap-5">
         <CounterBadge>1</CounterBadge>
         <CounterBadge theme="info">42</CounterBadge>
-        <CounterBadge>10</CounterBadge>
-        <CounterBadge theme="info">99+</CounterBadge>
+        <CounterBadge theme="success">+2345</CounterBadge>
+        <CounterBadge theme="danger">-123</CounterBadge>
     </div>
 `}
 />
@@ -30,18 +30,44 @@ import { CounterBadge } from '@harnessio/ui/components'
 
 // Info theme counter badge
 <CounterBadge theme="info">42</CounterBadge>
+
+// Success theme counter badge
+<CounterBadge theme="success">10</CounterBadge>
+
+// Danger theme counter badge
+<CounterBadge theme="danger">99+</CounterBadge>
 ```
 
 ## Themes
 
-The `CounterBadge` component supports two color themes: `default` and `info`.
+The `CounterBadge` component supports four color themes that can be categorized into different groups based on their semantic meaning.
+
+### Theme Categories
+
+#### Neutral Indicators
+
+Neutral indicators are used for displaying general counts or values that don't carry specific positive or negative connotations.
 
 <DocsPage.ComponentExample
   client:only
   code={`
     <div className="flex gap-2">
-        <CounterBadge>1</CounterBadge>
-        <CounterBadge theme="info">1024</CounterBadge>
+        <CounterBadge>0</CounterBadge>
+        <CounterBadge theme="info">42</CounterBadge>
+    </div>
+`}
+/>
+
+#### Status Indicators
+
+Status indicators communicate the nature of the change or value - whether it represents an improvement (success) or a concern (danger).
+
+<DocsPage.ComponentExample
+  client:only
+  code={`
+    <div className="flex gap-2">
+        <CounterBadge theme="success">+2345</CounterBadge>
+        <CounterBadge theme="danger">-123</CounterBadge>
     </div>
 `}
 />
@@ -56,7 +82,7 @@ The `CounterBadge` component has the following props to control its appearance:
       name: "theme",
       description: "Color theme of the badge",
       required: false,
-      value: "'default' | 'info'",
+      value: "'default' | 'info' | 'success' | 'danger'",
       defaultValue: "'default'",
     },
     {

--- a/packages/ui/src/components/counter-badge.tsx
+++ b/packages/ui/src/components/counter-badge.tsx
@@ -1,11 +1,13 @@
 import { cn } from '@utils/cn'
 import { cva, type VariantProps } from 'class-variance-authority'
 
-const counterBadgeVariants = cva('cn-badge cn-badge-counter inline-flex w-fit items-center', {
+const counterBadgeVariants = cva('cn-badge cn-badge-surface cn-badge-counter inline-flex w-fit items-center', {
   variants: {
     theme: {
       default: 'cn-badge-muted',
-      info: 'cn-badge-info'
+      info: 'cn-badge-info',
+      success: 'cn-badge-success',
+      danger: 'cn-badge-danger'
     }
   },
   defaultVariants: {

--- a/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes.tsx
@@ -1,6 +1,6 @@
 import { memo, RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { Accordion, Button, Checkbox, CopyButton, Icon, Layout, StackedList, StatusBadge, Text } from '@/components'
+import { Accordion, Button, Checkbox, CopyButton, CounterBadge, Icon, Layout, StackedList } from '@/components'
 import {
   CommentItem,
   CommitFilterItemProps,
@@ -124,16 +124,8 @@ const LineTitle: React.FC<LineTitleProps> = ({
         </div>
 
         <div className="flex items-center gap-x-1">
-          {addedLines != null && addedLines > 0 && (
-            <StatusBadge variant="outline" size="sm" theme="success">
-              +{addedLines}
-            </StatusBadge>
-          )}
-          {deletedLines != null && deletedLines > 0 && (
-            <StatusBadge variant="outline" size="sm" theme="danger">
-              -{deletedLines}
-            </StatusBadge>
-          )}
+          {addedLines != null && addedLines > 0 && <CounterBadge theme="success">+{addedLines}</CounterBadge>}
+          {deletedLines != null && deletedLines > 0 && <CounterBadge theme="danger">-{deletedLines}</CounterBadge>}
         </div>
       </div>
       <div className="inline-flex items-center gap-x-6">
@@ -153,7 +145,6 @@ const LineTitle: React.FC<LineTitleProps> = ({
               }
             }}
             label={t('views:pullRequests.markViewed')}
-            className="size-4"
           />
         ) : null}
 

--- a/packages/ui/tailwind-utils-config/components/badge.ts
+++ b/packages/ui/tailwind-utils-config/components/badge.ts
@@ -85,13 +85,7 @@ export default {
       backgroundColor: 'var(--cn-set-gray-surface-bg)',
       height: 'var(--cn-badge-counter-size-default)',
       padding: 'var(--cn-badge-counter-py) var(--cn-badge-counter-px)',
-      '@apply font-caption-tight-normal': '',
-
-      '&.cn-badge-info': {
-        backgroundColor: 'var(--cn-set-blue-surface-bg)',
-        color: 'var(--cn-set-blue-surface-text)',
-        borderColor: 'var(--cn-set-blue-surface-border)'
-      }
+      '@apply font-caption-tight-normal': ''
     },
 
     '&:where(.cn-badge-status)': {


### PR DESCRIPTION
### New variants for CounterBadge

<img width="765" alt="image" src="https://github.com/user-attachments/assets/677b216b-8a7e-400b-b61b-34344eb2d923" />

---

### CounterBadge in PR changes screen

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/6e029be1-fe72-464b-bca7-bdd3116c3ff7" />
