### PR TITLE
feat: added support for genenric sort

### DIFF
--- a/packages/ui/locales/en/component.json
+++ b/packages/ui/locales/en/component.json
@@ -121,8 +121,8 @@
   },
   "sort": {
     "defaultLabel": "Sort",
+    "resetSort": "Reset sort",
     "inputPlaceholder": "Sort by...",
-    "buttonLabel": "Reset sort",
     "lastUpdated": "Last updated",
     "stars": "Stars",
     "forks": "Forks",

--- a/packages/ui/locales/fr/component.json
+++ b/packages/ui/locales/fr/component.json
@@ -121,8 +121,9 @@
   },
   "sort": {
     "defaultLabel": "Trier",
-    "inputPlaceholder": "Trier par...",
+    "resetSort": "Reset sort",
     "buttonLabel": "Réinitialiser le tri",
+    "inputPlaceholder": "Trier par...",
     "lastUpdated": "Dernière mise à jour",
     "stars": "Étoiles",
     "forks": "Bifurcations",

--- a/packages/ui/src/components/searchable-dropdown/searchable-dropdown.tsx
+++ b/packages/ui/src/components/searchable-dropdown/searchable-dropdown.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react'
+
+import { Button, DropdownMenu, Icon, Input } from '@/components'
+
+interface SearchableDropdownProps<T> {
+  options: T[]
+  displayLabel?: React.ReactNode | string
+  dropdownAlign?: 'start' | 'end'
+  inputPlaceholder?: string
+  onChange: (option: T) => void
+  customFooter?: React.ReactNode
+}
+
+const SearchableDropdown = <T extends { label: string; value: string }>({
+  displayLabel,
+  dropdownAlign = 'end',
+  onChange,
+  customFooter,
+  options,
+  inputPlaceholder
+}: SearchableDropdownProps<T>) => {
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const filteredBySearchOptions = options.filter(
+    option => !searchQuery || option.label.toLowerCase().includes(searchQuery.toLowerCase())
+  )
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger className="flex items-center gap-x-1.5">{displayLabel}</DropdownMenu.Trigger>
+      <DropdownMenu.Content
+        className="min-w-[224px] p-0"
+        align={dropdownAlign}
+        onCloseAutoFocus={e => e.preventDefault()}
+      >
+        <div className="border-cn-borders-4 flex items-center border-b px-3 py-2.5">
+          <Input
+            type="text"
+            placeholder={inputPlaceholder}
+            value={searchQuery}
+            variant="extended"
+            // This is stop focus shift by dropdown,
+            // It will try to focus on first dropdown menu item on keychange
+            onKeyDown={e => e.stopPropagation()}
+            onChange={e => setSearchQuery(e.target.value)}
+            rightElement={
+              <Button
+                variant="ghost"
+                iconOnly
+                onClick={() => {
+                  setSearchQuery('')
+                }}
+              >
+                <Icon className="rotate-45" name="plus" size={12} />
+              </Button>
+            }
+          />
+        </div>
+
+        <div className="p-1">
+          {filteredBySearchOptions.map(option => (
+            <DropdownMenu.Item key={option.value as string} onSelect={() => onChange(option)}>
+              {option.label}
+            </DropdownMenu.Item>
+          ))}
+
+          {filteredBySearchOptions.length === 0 && (
+            <div className="flex items-center justify-center p-4">
+              <span className="text-2 leading-none text-cn-foreground-2">No results</span>
+            </div>
+          )}
+        </div>
+
+        {customFooter && (
+          <div className="border-cn-borders-4 border-t p-1">
+            <DropdownMenu.Item asChild>{customFooter}</DropdownMenu.Item>
+          </div>
+        )}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  )
+}
+
+export default SearchableDropdown

--- a/packages/ui/src/components/sorts/index.ts
+++ b/packages/ui/src/components/sorts/index.ts
@@ -1,0 +1,12 @@
+import MultiSort from './multi-sort'
+import { Sort as SortRoot } from './sort'
+import SortSelect from './sort-select'
+
+const Sort = {
+  Root: SortRoot,
+  Select: SortSelect,
+  MultiSort: MultiSort
+}
+
+export default Sort
+export * from './type'

--- a/packages/ui/src/components/sorts/multi-sort.tsx
+++ b/packages/ui/src/components/sorts/multi-sort.tsx
@@ -1,0 +1,220 @@
+// TODO: we should rethink the approach and stop using the @dnd-kit library
+
+import { Button, DropdownMenu, Icon } from '@/components'
+import SearchableDropdown from '@components/searchable-dropdown/searchable-dropdown'
+import { closestCenter, DndContext } from '@dnd-kit/core'
+import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import useDragAndDrop from '@hooks/use-drag-and-drop'
+import { cn } from '@utils/cn'
+
+import { useSort } from './sort-context'
+import { SortDirection, SortOption, SortValue } from './type'
+
+export const getSortTriggerLabel = (sortSelections: SortValue[], sortOptions: SortOption[]) => {
+  if (sortSelections.length === 0) return { label: '', icon: 'circle-arrows-updown' as const }
+
+  if (sortSelections.length === 1) {
+    const currentSort = sortSelections[0]
+    const label = sortOptions.find(opt => opt.value === currentSort.type)?.label
+
+    return {
+      label,
+      icon: 'circle-arrow-top' as const,
+      isDescending: currentSort.direction === 'desc'
+    }
+  }
+
+  return {
+    label: `${sortSelections.length} sorts`,
+    icon: 'circle-arrows-updown' as const,
+    isDescending: false
+  }
+}
+
+interface SortableItemProps {
+  id: string
+  sort: SortValue
+  index: number
+  onUpdateSort: (index: number, sort: SortValue) => void
+  onRemoveSort: (index: number) => void
+  sortOptions: SortOption[]
+  sortDirections: SortDirection[]
+}
+
+const SortableItem = ({
+  id,
+  sort,
+  index,
+  onUpdateSort,
+  onRemoveSort,
+  sortOptions,
+  sortDirections
+}: SortableItemProps) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1
+  }
+
+  return (
+    <div className={cn('relative', isDragging && 'z-10', 'flex items-center gap-x-2')} ref={setNodeRef} style={style}>
+      <div
+        className="cursor-grab rounded p-1 hover:bg-cn-background-3 active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+      >
+        <Icon className="text-icons-1" name="grid-dots" size={12} />
+      </div>
+
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <Button variant="outline" size="sm" className="gap-x-1.5">
+            {sortOptions.find(opt => opt.value === sort.type)?.label}
+            <Icon className="chevron-down text-icons-1" name="chevron-down" size={10} />
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="start">
+          {sortOptions.map(option => (
+            <DropdownMenu.Item
+              onSelect={() => onUpdateSort?.(index, { ...sort, type: option.value })}
+              key={option.value}
+            >
+              {option.label}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <Button variant="outline" size="sm" className="gap-x-1.5">
+            {sortDirections.find(dir => dir.value === sort.direction)?.label}
+            <Icon className="chevron-down text-icons-1" name="chevron-down" size={10} />
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="start">
+          {sortDirections.map(direction => (
+            <DropdownMenu.Item
+              onSelect={() => onUpdateSort?.(index, { ...sort, direction: direction.value })}
+              key={direction.value}
+            >
+              {direction.label}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+
+      <Button variant="ghost" size="sm" iconOnly className="ml-auto" onClick={() => onRemoveSort(index)}>
+        <Icon className="rotate-45" name="plus" size={12} />
+      </Button>
+    </div>
+  )
+}
+
+export default function MultiSort() {
+  const { sortSelections, updateSortSelections, sortOptions, sortDirections, sortOpen, setSortOpen } = useSort()
+  const { handleDragEnd, getItemId } = useDragAndDrop({
+    items: sortSelections,
+    onReorder: newSorts => updateSortSelections(newSorts)
+  })
+
+  const filteredBySearchSortOptions = sortOptions.filter(
+    option => !sortSelections.some(sort => sort.type === option.value)
+  )
+
+  // Handler for resetting all sorts
+  const handleResetSorts = () => {
+    updateSortSelections([])
+    setSortOpen(false)
+  }
+
+  // Handler for adding a new sort
+  const handleSortChange = (sort: SortValue) => {
+    updateSortSelections([...sortSelections, sort])
+  }
+
+  if (sortSelections.length <= 0) {
+    return null
+  }
+
+  return (
+    <DropdownMenu.Root open={sortOpen} onOpenChange={setSortOpen}>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="secondary" className="gap-x-1.5">
+          <Icon
+            className={cn(
+              'text-icons-1',
+              getSortTriggerLabel(sortSelections, sortOptions).isDescending && 'rotate-180'
+            )}
+            name={getSortTriggerLabel(sortSelections, sortOptions).icon}
+            size={10}
+          />
+          <span className="text-cn-foreground-1">{getSortTriggerLabel(sortSelections, sortOptions).label}</span>
+          <Icon className="chevron-down text-icons-1 ml-3" name="chevron-down" size={10} />
+        </Button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Content className="min-w-[310px] px-3 py-2.5" align="start">
+        <DndContext onDragEnd={handleDragEnd} collisionDetection={closestCenter}>
+          <SortableContext
+            items={sortSelections.map((_, index) => getItemId(index))}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="flex flex-col gap-y-2.5">
+              {sortSelections.map((sort, index) => {
+                const itemOption = sortOptions.find(option => option.value === sort.type)
+                if (!itemOption) return null
+
+                return (
+                  <SortableItem
+                    key={index}
+                    id={getItemId(index)}
+                    sort={sort}
+                    index={index}
+                    onUpdateSort={(index, sort) => {
+                      const newSorts = [...sortSelections]
+                      newSorts[index] = sort
+                      updateSortSelections(newSorts)
+                    }}
+                    onRemoveSort={index => {
+                      const newSorts = sortSelections.filter((_, i) => i !== index)
+                      updateSortSelections(newSorts)
+                    }}
+                    sortOptions={[itemOption, ...filteredBySearchSortOptions]}
+                    sortDirections={sortDirections}
+                  />
+                )
+              })}
+            </div>
+          </SortableContext>
+        </DndContext>
+
+        <div className="mt-3 inline-flex flex-col gap-1">
+          {filteredBySearchSortOptions.length > 0 && (
+            <SearchableDropdown
+              options={filteredBySearchSortOptions}
+              dropdownAlign="start"
+              inputPlaceholder="Select..."
+              onChange={(sortValue: SortOption) => handleSortChange({ type: sortValue.value, direction: 'asc' })}
+              displayLabel={
+                <Button size="sm" variant="ghost" className="gap-x-1.5">
+                  <Icon name="plus" size={12} />
+                  Add sort
+                </Button>
+              }
+            />
+          )}
+          <Button size="sm" variant="ghost" className="hover:text-cn-foreground-danger" onClick={handleResetSorts}>
+            <Icon name="trash" size={12} />
+            Delete sort
+          </Button>
+        </div>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  )
+}

--- a/packages/ui/src/components/sorts/sort-context.tsx
+++ b/packages/ui/src/components/sorts/sort-context.tsx
@@ -1,0 +1,62 @@
+import { createContext, ReactNode, useContext, useState } from 'react'
+
+import { noop } from 'lodash-es'
+
+import { SortDirection, SortOption, SortValue } from './type'
+
+interface SortContextProps {
+  sortOptions: SortOption[]
+  sortDirections: SortDirection[]
+  sortSelections: SortValue[]
+  updateSortSelections: (sortSelections: SortValue[]) => void
+  sortOpen: boolean
+  setSortOpen: (sortOpen: boolean) => void
+}
+
+export const DefaultSortDirections = [
+  { label: 'Ascending', value: 'asc' as const },
+  { label: 'Descending', value: 'desc' as const }
+]
+
+const SortContext = createContext<SortContextProps>({
+  sortDirections: DefaultSortDirections,
+  sortOptions: [],
+  sortSelections: [],
+  updateSortSelections: noop,
+  sortOpen: false,
+  setSortOpen: noop
+})
+
+const SortProvider = ({
+  children,
+  sortOptions,
+  sortDirections,
+  sortSelections,
+  updateSortSelections
+}: {
+  children: ReactNode
+  sortOptions: SortOption[]
+  sortDirections?: SortDirection[]
+  sortSelections: SortValue[]
+  updateSortSelections: (sortSelections: SortValue[]) => void
+}) => {
+  const [sortOpen, setSortOpen] = useState(false)
+  return (
+    <SortContext.Provider
+      value={{
+        sortOptions,
+        sortDirections: sortDirections || DefaultSortDirections,
+        sortSelections,
+        updateSortSelections,
+        sortOpen,
+        setSortOpen
+      }}
+    >
+      {children}
+    </SortContext.Provider>
+  )
+}
+
+const useSort = () => useContext(SortContext)
+
+export { SortProvider, useSort }

--- a/packages/ui/src/components/sorts/sort-select.tsx
+++ b/packages/ui/src/components/sorts/sort-select.tsx
@@ -1,0 +1,37 @@
+import { Icon } from '@/components'
+import SearchableDropdown from '@components/searchable-dropdown/searchable-dropdown'
+
+import { useSort } from './sort-context'
+import { SortOption } from './type'
+
+interface SortTriggerProps {
+  displayLabel?: React.ReactNode | string
+  buttonLabel?: string
+}
+
+const SortSelect = ({ displayLabel, buttonLabel }: SortTriggerProps) => {
+  const { sortOptions, sortSelections, updateSortSelections } = useSort()
+  const filteredSortOptions = sortOptions.filter(option => !sortSelections.some(sort => sort.type === option.value))
+  return (
+    <SearchableDropdown<SortOption>
+      displayLabel={
+        <>
+          <span className="text-cn-foreground-2 hover:text-cn-foreground-1 flex items-center gap-x-1">
+            {displayLabel}
+          </span>
+          <Icon className="chevron-down text-icons-4" name="chevron-fill-down" size={6} />
+        </>
+      }
+      inputPlaceholder="Select..."
+      options={filteredSortOptions}
+      onChange={option => updateSortSelections([...sortSelections, { type: option.value, direction: 'asc' }])}
+      customFooter={
+        <button className="w-full font-medium" onClick={() => updateSortSelections([])}>
+          {buttonLabel}
+        </button>
+      }
+    />
+  )
+}
+
+export default SortSelect

--- a/packages/ui/src/components/sorts/sort.tsx
+++ b/packages/ui/src/components/sorts/sort.tsx
@@ -1,0 +1,31 @@
+import { ReactNode, useState } from 'react'
+
+import { SortProvider } from './sort-context'
+import { SortDirection, SortOption, SortValue } from './type'
+
+export function Sort({
+  sortOptions,
+  sortDirections,
+  onSortChange,
+  children
+}: {
+  children: ReactNode
+  sortOptions: SortOption[]
+  sortDirections: SortDirection[]
+  onSortChange?: (sortSelections: SortValue[]) => void
+}) {
+  const [sortSelections, updateSortSelections] = useState<SortValue[]>([])
+  return (
+    <SortProvider
+      sortOptions={sortOptions}
+      sortDirections={sortDirections}
+      sortSelections={sortSelections}
+      updateSortSelections={(newSortSelections: SortValue[]) => {
+        onSortChange?.(newSortSelections)
+        updateSortSelections(newSortSelections)
+      }}
+    >
+      {children}
+    </SortProvider>
+  )
+}

--- a/packages/ui/src/components/sorts/type.ts
+++ b/packages/ui/src/components/sorts/type.ts
@@ -1,0 +1,16 @@
+export interface SortOption {
+  label: string
+  value: string
+}
+
+type Direction = 'asc' | 'desc'
+
+export interface SortDirection {
+  label: string
+  value: Direction
+}
+
+export interface SortValue {
+  type: string
+  direction: Direction
+}


### PR DESCRIPTION
Added support for sort with sort selection and multi-sort
TODO - Once single-sort design is ready, create new component under Sort

```
<Sort.Root {..props}> <br>
    <Sort.Select>       // list sort to select from
    <Sort.MultiSort>. //  Add additional sorts .. Update sort order
</Sort.Root>
```

This screenshot is just an example usage of sort and pr-list-page does not contain any sort 
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/0551f9ec-d716-4e67-b9ef-edf1f76a5776" />