### PR TITLE
fix: getDefaultValuesFromFormDefinition if inputs are not readily available

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/forms",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Harness Forms Library",
   "scripts": {
     "playground": "vite dev --config vite.config.playground.ts",

--- a/packages/forms/src/core/utils/utils.ts
+++ b/packages/forms/src/core/utils/utils.ts
@@ -6,7 +6,7 @@ export const getDefaultValuesFromFormDefinition = (inputs: IFormDefinition): Any
   const defaultValues: AnyFormikValue = {}
 
   // TODO: this implementation is wrong
-  inputs.inputs.forEach(input => {
+  inputs?.inputs?.forEach(input => {
     // add default for nested (group),
     if (input.inputType === 'group') {
       input?.inputs?.forEach(input => {


### PR DESCRIPTION
fixes getDefaultValuesFromFormDefinition if inputs are not readily available