### PR TITLE
Make checkbox optional by default if the prop is not passed

### DIFF
--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -17,6 +17,7 @@ interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxPrimitiv
 const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Omit<CheckboxProps, 'required'>>(
   ({ className, label, caption, optional, ...props }, ref) => {
     const checkboxId = props.id || `checkbox-${Math.random().toString(36).slice(2, 11)}`
+    const isOptional = optional === undefined ? true : optional
 
     return (
       <div className={cn('cn-checkbox-wrapper', className)}>
@@ -24,7 +25,7 @@ const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Omit<Chec
           id={checkboxId}
           ref={ref}
           className={cn('cn-checkbox-root')}
-          required={!optional}
+          required={!isOptional}
           {...props}
         >
           <CheckboxPrimitive.Indicator className="cn-checkbox-indicator">
@@ -40,7 +41,7 @@ const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Omit<Chec
           <div className="cn-checkbox-label-wrapper">
             <Label
               htmlFor={checkboxId}
-              optional={optional}
+              optional={isOptional}
               className={`cn-checkbox-label ${props.disabled ? 'disabled' : ''}`}
             >
               {label}


### PR DESCRIPTION
Changed the API to make the checkbox optional by default when the prop is not passed.

Previously, it made it required when the optional prop was not passed. This made it confusing since the API was in-consistent compared to the default html checkbox API where we need to set it `required` for making the checkbox required, or else it is optional by default.

As per the current API, we are not allowing the `required` prop, instead the user needs to use the `optional` prop.

This also fixes all the checkboxes where it made it required by default since the optional prop was not passed.