### PR TITLE
Add optional attribute for checkbox and radio instances

### DIFF
--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -134,7 +134,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     asChild
   >
     <div className="flex items-center gap-x-2.5">
-      <Checkbox optional={true} checked={checked} />
+      <Checkbox optional checked={checked} />
       <span className="text-2 text-cn-foreground-1">{children}</span>
     </div>
   </DropdownMenuPrimitive.CheckboxItem>

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -134,7 +134,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     asChild
   >
     <div className="flex items-center gap-x-2.5">
-      <Checkbox checked={checked} />
+      <Checkbox optional={true} checked={checked} />
       <span className="text-2 text-cn-foreground-1">{children}</span>
     </div>
   </DropdownMenuPrimitive.CheckboxItem>

--- a/packages/ui/src/components/filters/filters-field.tsx
+++ b/packages/ui/src/components/filters/filters-field.tsx
@@ -82,11 +82,7 @@ const renderFilterValues = <T extends string, V extends FilterValueTypes, Custom
       return (
         <Button variant="secondary" theme="default" className="cursor-pointer" asChild>
           <Label className="text-1 text-cn-foreground-1 flex items-center gap-x-3">
-            <Checkbox
-              optional={true}
-              checked={checkboxFilter.value}
-              onCheckedChange={value => onUpdateFilter(value as V)}
-            />
+            <Checkbox optional checked={checkboxFilter.value} onCheckedChange={value => onUpdateFilter(value as V)} />
             <span>{filterOption.filterFieldConfig?.label}</span>
           </Label>
         </Button>

--- a/packages/ui/src/components/filters/filters-field.tsx
+++ b/packages/ui/src/components/filters/filters-field.tsx
@@ -82,7 +82,11 @@ const renderFilterValues = <T extends string, V extends FilterValueTypes, Custom
       return (
         <Button variant="secondary" theme="default" className="cursor-pointer" asChild>
           <Label className="text-1 text-cn-foreground-1 flex items-center gap-x-3">
-            <Checkbox checked={checkboxFilter.value} onCheckedChange={value => onUpdateFilter(value as V)} />
+            <Checkbox
+              optional={true}
+              checked={checkboxFilter.value}
+              onCheckedChange={value => onUpdateFilter(value as V)}
+            />
             <span>{filterOption.filterFieldConfig?.label}</span>
           </Label>
         </Button>

--- a/packages/ui/src/components/git-commit-dialog/git-commit-dialog.tsx
+++ b/packages/ui/src/components/git-commit-dialog/git-commit-dialog.tsx
@@ -161,7 +161,7 @@ export const GitCommitDialog: FC<GitCommitDialogProps> = ({
             >
               <Radio.Item
                 id={CommitToGitRefOption.DIRECTLY}
-                optional={true}
+                optional
                 className="mt-px"
                 value={CommitToGitRefOption.DIRECTLY}
                 label={
@@ -182,7 +182,7 @@ export const GitCommitDialog: FC<GitCommitDialogProps> = ({
               />
               <Radio.Item
                 id={CommitToGitRefOption.NEW_BRANCH}
-                optional={true}
+                optional
                 className="mt-px"
                 value={CommitToGitRefOption.NEW_BRANCH}
                 label="Create a new branch for this commit and start a pull request"

--- a/packages/ui/src/components/git-commit-dialog/git-commit-dialog.tsx
+++ b/packages/ui/src/components/git-commit-dialog/git-commit-dialog.tsx
@@ -161,6 +161,7 @@ export const GitCommitDialog: FC<GitCommitDialogProps> = ({
             >
               <Radio.Item
                 id={CommitToGitRefOption.DIRECTLY}
+                optional={true}
                 className="mt-px"
                 value={CommitToGitRefOption.DIRECTLY}
                 label={
@@ -181,6 +182,7 @@ export const GitCommitDialog: FC<GitCommitDialogProps> = ({
               />
               <Radio.Item
                 id={CommitToGitRefOption.NEW_BRANCH}
+                optional={true}
                 className="mt-px"
                 value={CommitToGitRefOption.NEW_BRANCH}
                 label="Create a new branch for this commit and start a pull request"

--- a/packages/ui/src/components/radio.tsx
+++ b/packages/ui/src/components/radio.tsx
@@ -16,7 +16,7 @@ interface RadioItemProps extends ComponentPropsWithoutRef<typeof RadioGroupPrimi
  * @example
  * <Radio.Item value="option1" name="group" label="Option 1" caption="This is option 1" />
  */
-const RadioItem = forwardRef<ElementRef<typeof RadioGroupPrimitive.Item>, RadioItemProps>(
+const RadioItem = forwardRef<ElementRef<typeof RadioGroupPrimitive.Item>, Omit<RadioItemProps, 'required'>>(
   ({ className, label, caption, optional, ...props }, ref) => {
     const radioId = props.id || `radio-${Math.random().toString(36).slice(2, 11)}`
 

--- a/packages/ui/src/components/split-button.tsx
+++ b/packages/ui/src/components/split-button.tsx
@@ -98,7 +98,14 @@ export const SplitButton = <T extends string>({
                     disabled={loading}
                   >
                     <Option
-                      control={<Radio.Item className="mt-px" value={String(option.value)} id={String(option.value)} />}
+                      control={
+                        <Radio.Item
+                          className="mt-px"
+                          optional={true}
+                          value={String(option.value)}
+                          id={String(option.value)}
+                        />
+                      }
                       id={String(option.value)}
                       label={option.label}
                       ariaSelected={selectedValue === option.value}

--- a/packages/ui/src/components/split-button.tsx
+++ b/packages/ui/src/components/split-button.tsx
@@ -99,12 +99,7 @@ export const SplitButton = <T extends string>({
                   >
                     <Option
                       control={
-                        <Radio.Item
-                          className="mt-px"
-                          optional={true}
-                          value={String(option.value)}
-                          id={String(option.value)}
-                        />
+                        <Radio.Item className="mt-px" value={String(option.value)} id={String(option.value)} optional />
                       }
                       id={String(option.value)}
                       label={option.label}

--- a/packages/ui/src/views/labels/label-form-page.tsx
+++ b/packages/ui/src/views/labels/label-form-page.tsx
@@ -228,6 +228,7 @@ export const LabelFormPage: FC<LabelFormPageProps> = ({
             <div className="mt-5">
               <Checkbox
                 id="type"
+                optional={true}
                 checked={isDynamicValue}
                 onCheckedChange={handleDynamicChange}
                 label={t('views:labelData.form.allowUsersCheckboxLabel', 'Allow users to add values')}

--- a/packages/ui/src/views/labels/label-form-page.tsx
+++ b/packages/ui/src/views/labels/label-form-page.tsx
@@ -228,7 +228,7 @@ export const LabelFormPage: FC<LabelFormPageProps> = ({
             <div className="mt-5">
               <Checkbox
                 id="type"
-                optional={true}
+                optional
                 checked={isDynamicValue}
                 onCheckedChange={handleDynamicChange}
                 label={t('views:labelData.form.allowUsersCheckboxLabel', 'Allow users to add values')}

--- a/packages/ui/src/views/labels/labels-list-page.tsx
+++ b/packages/ui/src/views/labels/labels-list-page.tsx
@@ -70,6 +70,7 @@ export const LabelsListPage: FC<LabelsListPageProps> = ({
           <div className="mb-[18px]">
             <Checkbox
               id="parent-labels"
+              optional={true}
               checked={getParentScopeLabels}
               onCheckedChange={setGetParentScopeLabels}
               label={t('views:labelData.showParentLabels', 'Show labels from parent scopes')}

--- a/packages/ui/src/views/labels/labels-list-page.tsx
+++ b/packages/ui/src/views/labels/labels-list-page.tsx
@@ -70,7 +70,7 @@ export const LabelsListPage: FC<LabelsListPageProps> = ({
           <div className="mb-[18px]">
             <Checkbox
               id="parent-labels"
-              optional={true}
+              optional
               checked={getParentScopeLabels}
               onCheckedChange={setGetParentScopeLabels}
               label={t('views:labelData.showParentLabels', 'Show labels from parent scopes')}

--- a/packages/ui/src/views/project/project-import.tsx
+++ b/packages/ui/src/views/project/project-import.tsx
@@ -173,10 +173,18 @@ export function ImportProjectPage({ onFormSubmit, onFormCancel, isLoading, apiEr
           {/* authorization - pipelines */}
           <Fieldset>
             <ControlGroup className="flex flex-row gap-5">
-              <Checkbox {...register('repositories')} id="authorization" checked={true} disabled label="Repositories" />
+              <Checkbox
+                {...register('repositories')}
+                id="authorization"
+                optional={true}
+                checked={true}
+                disabled
+                label="Repositories"
+              />
               <Checkbox
                 {...register('pipelines')}
                 id="pipelines"
+                optional={true}
                 checked={watch('pipelines')}
                 onCheckedChange={(checked: boolean) => setValue('pipelines', checked)}
                 label="Import Pipelines"

--- a/packages/ui/src/views/project/project-import.tsx
+++ b/packages/ui/src/views/project/project-import.tsx
@@ -176,7 +176,7 @@ export function ImportProjectPage({ onFormSubmit, onFormCancel, isLoading, apiEr
               <Checkbox
                 {...register('repositories')}
                 id="authorization"
-                optional={true}
+                optional
                 checked={true}
                 disabled
                 label="Repositories"
@@ -184,7 +184,7 @@ export function ImportProjectPage({ onFormSubmit, onFormCancel, isLoading, apiEr
               <Checkbox
                 {...register('pipelines')}
                 id="pipelines"
-                optional={true}
+                optional
                 checked={watch('pipelines')}
                 onCheckedChange={(checked: boolean) => setValue('pipelines', checked)}
                 label="Import Pipelines"

--- a/packages/ui/src/views/repo/pull-request/components/labels/labels-filter.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/labels/labels-filter.tsx
@@ -54,10 +54,7 @@ export function LabelsFilter({
                   onChange(newValue)
                 }}
               >
-                <Checkbox
-                  optional={true}
-                  checked={value[option.id] ? value[option.id] === true || 'indeterminate' : false}
-                />
+                <Checkbox optional checked={value[option.id] ? value[option.id] === true || 'indeterminate' : false} />
                 <LabelMarker color={option.color} label={option.key} value={String(option.value_count)} />
               </DropdownMenu.SubTrigger>
               <DropdownMenu.SubContent>

--- a/packages/ui/src/views/repo/pull-request/components/labels/labels-filter.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/labels/labels-filter.tsx
@@ -54,7 +54,10 @@ export function LabelsFilter({
                   onChange(newValue)
                 }}
               >
-                <Checkbox checked={value[option.id] ? value[option.id] === true || 'indeterminate' : false} />
+                <Checkbox
+                  optional={true}
+                  checked={value[option.id] ? value[option.id] === true || 'indeterminate' : false}
+                />
                 <LabelMarker color={option.color} label={option.key} value={String(option.value_count)} />
               </DropdownMenu.SubTrigger>
               <DropdownMenu.SubContent>

--- a/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes-filter.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes-filter.tsx
@@ -186,7 +186,7 @@ export const PullRequestChangesFilter: React.FC<PullRequestChangesFilterProps> =
           onClick={(e: React.MouseEvent<HTMLDivElement>) => handleCommitCheck(e, item)}
           className="flex cursor-pointer items-center"
         >
-          <Checkbox optional={true} checked={isSelected} label={item.name} />
+          <Checkbox optional checked={isSelected} label={item.name} />
         </DropdownMenu.Item>
       )
     })

--- a/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes-filter.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes-filter.tsx
@@ -186,7 +186,7 @@ export const PullRequestChangesFilter: React.FC<PullRequestChangesFilterProps> =
           onClick={(e: React.MouseEvent<HTMLDivElement>) => handleCommitCheck(e, item)}
           className="flex cursor-pointer items-center"
         >
-          <Checkbox checked={isSelected} label={item.name} />
+          <Checkbox optional={true} checked={isSelected} label={item.name} />
         </DropdownMenu.Item>
       )
     })

--- a/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes.tsx
@@ -131,7 +131,7 @@ const LineTitle: React.FC<LineTitleProps> = ({
       <div className="inline-flex items-center gap-x-6">
         {showViewed ? (
           <Checkbox
-            optional={true}
+            optional
             checked={viewed}
             onClick={e => {
               e.stopPropagation()

--- a/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes.tsx
@@ -131,6 +131,7 @@ const LineTitle: React.FC<LineTitleProps> = ({
       <div className="inline-flex items-center gap-x-6">
         {showViewed ? (
           <Checkbox
+            optional={true}
             checked={viewed}
             onClick={e => {
               e.stopPropagation()

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-panel.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-panel.tsx
@@ -309,6 +309,7 @@ const PullRequestPanel = ({
                 {!notBypassable && isMergeable && !isDraft && prPanelData.ruleViolation && (
                   <Checkbox
                     id="checkbox-bypass"
+                    optional={true}
                     checked={!!checkboxBypass}
                     onCheckedChange={() => {
                       if (typeof checkboxBypass === 'boolean') {

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-panel.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-panel.tsx
@@ -309,7 +309,7 @@ const PullRequestPanel = ({
                 {!notBypassable && isMergeable && !isDraft && prPanelData.ruleViolation && (
                   <Checkbox
                     id="checkbox-bypass"
-                    optional={true}
+                    optional
                     checked={!!checkboxBypass}
                     onCheckedChange={() => {
                       if (typeof checkboxBypass === 'boolean') {

--- a/packages/ui/src/views/repo/repo-branch-rules/components/repo-branch-rules-fields.tsx
+++ b/packages/ui/src/views/repo/repo-branch-rules/components/repo-branch-rules-fields.tsx
@@ -170,6 +170,7 @@ export const BranchSettingsRuleTargetPatternsField: FC<FieldProps> = ({ setValue
       <ControlGroup>
         <Checkbox
           id="default-branch"
+          optional={true}
           {...register!('default')}
           checked={watch!('default')}
           onCheckedChange={() => setValue!('default', !watch!('default'))}
@@ -259,6 +260,7 @@ export const BranchSettingsRuleBypassListField: FC<
       <ControlGroup>
         <Checkbox
           {...register!('repo_owners')}
+          optional={true}
           checked={watch!('repo_owners')}
           onCheckedChange={() => setValue!('repo_owners', !watch!('repo_owners'))}
           id="edit-permissons"
@@ -304,6 +306,7 @@ export const BranchSettingsRuleListField: FC<{
             <Fieldset key={rule.id} className="gap-y-4">
               <Checkbox
                 id={rule.id}
+                optional={true}
                 checked={isChecked}
                 onCheckedChange={checked => handleCheckboxChange(rule.id, checked === true)}
                 label={rule.label}
@@ -317,6 +320,7 @@ export const BranchSettingsRuleListField: FC<{
                     <Checkbox
                       key={subOption.id}
                       id={subOption.id}
+                      optional={true}
                       checked={rules[index].submenu?.includes(subOption.id as MergeStrategy)}
                       onCheckedChange={checked => handleSubmenuChange(rule.id, subOption.id, checked === true)}
                       label={subOption.label}

--- a/packages/ui/src/views/repo/repo-branch-rules/components/repo-branch-rules-fields.tsx
+++ b/packages/ui/src/views/repo/repo-branch-rules/components/repo-branch-rules-fields.tsx
@@ -170,7 +170,7 @@ export const BranchSettingsRuleTargetPatternsField: FC<FieldProps> = ({ setValue
       <ControlGroup>
         <Checkbox
           id="default-branch"
-          optional={true}
+          optional
           {...register!('default')}
           checked={watch!('default')}
           onCheckedChange={() => setValue!('default', !watch!('default'))}
@@ -260,7 +260,7 @@ export const BranchSettingsRuleBypassListField: FC<
       <ControlGroup>
         <Checkbox
           {...register!('repo_owners')}
-          optional={true}
+          optional
           checked={watch!('repo_owners')}
           onCheckedChange={() => setValue!('repo_owners', !watch!('repo_owners'))}
           id="edit-permissons"
@@ -306,7 +306,7 @@ export const BranchSettingsRuleListField: FC<{
             <Fieldset key={rule.id} className="gap-y-4">
               <Checkbox
                 id={rule.id}
-                optional={true}
+                optional
                 checked={isChecked}
                 onCheckedChange={checked => handleCheckboxChange(rule.id, checked === true)}
                 label={rule.label}
@@ -320,7 +320,7 @@ export const BranchSettingsRuleListField: FC<{
                     <Checkbox
                       key={subOption.id}
                       id={subOption.id}
-                      optional={true}
+                      optional
                       checked={rules[index].submenu?.includes(subOption.id as MergeStrategy)}
                       onCheckedChange={checked => handleSubmenuChange(rule.id, subOption.id, checked === true)}
                       label={subOption.label}

--- a/packages/ui/src/views/repo/repo-create/index.tsx
+++ b/packages/ui/src/views/repo/repo-create/index.tsx
@@ -236,6 +236,7 @@ export function RepoCreatePage({
               <div className="mt-6">
                 <Checkbox
                   id="readme"
+                  optional={true}
                   checked={readmeValue}
                   onCheckedChange={handleReadmeChange}
                   label="Add a README file"

--- a/packages/ui/src/views/repo/repo-create/index.tsx
+++ b/packages/ui/src/views/repo/repo-create/index.tsx
@@ -238,7 +238,7 @@ export function RepoCreatePage({
               <div className="mt-6">
                 <Checkbox
                   id="readme"
-                  optional={true}
+                  optional
                   checked={readmeValue}
                   onCheckedChange={handleReadmeChange}
                   label="Add a README file"

--- a/packages/ui/src/views/repo/repo-create/index.tsx
+++ b/packages/ui/src/views/repo/repo-create/index.tsx
@@ -206,7 +206,7 @@ export function RepoCreatePage({
               <Radio.Root className="mt-6" value={accessValue} onValueChange={handleAccessChange} id="access">
                 <Radio.Item
                   id="access-public"
-                  optional={true}
+                  optional
                   className="mt-px"
                   value="1"
                   label="Public"
@@ -214,7 +214,7 @@ export function RepoCreatePage({
                 />
                 <Radio.Item
                   id="access-private"
-                  optional={true}
+                  optional
                   className="mt-px"
                   value="2"
                   label="Private"

--- a/packages/ui/src/views/repo/repo-create/index.tsx
+++ b/packages/ui/src/views/repo/repo-create/index.tsx
@@ -206,6 +206,7 @@ export function RepoCreatePage({
               <Radio.Root className="mt-6" value={accessValue} onValueChange={handleAccessChange} id="access">
                 <Radio.Item
                   id="access-public"
+                  optional={true}
                   className="mt-px"
                   value="1"
                   label="Public"
@@ -213,6 +214,7 @@ export function RepoCreatePage({
                 />
                 <Radio.Item
                   id="access-private"
+                  optional={true}
                   className="mt-px"
                   value="2"
                   label="Private"

--- a/packages/ui/src/views/repo/repo-import/repo-import-mulitple.tsx
+++ b/packages/ui/src/views/repo/repo-import/repo-import-mulitple.tsx
@@ -304,10 +304,18 @@ export function RepoImportMultiplePage({
           {/* authorization - pipelines */}
           <Fieldset>
             <ControlGroup className="flex flex-row gap-5">
-              <Checkbox {...register('repositories')} id="authorization" checked={true} disabled label="Repositories" />
+              <Checkbox
+                {...register('repositories')}
+                id="authorization"
+                optional={true}
+                checked={true}
+                disabled
+                label="Repositories"
+              />
               <Checkbox
                 {...register('pipelines')}
                 id="pipelines"
+                optional={true}
                 checked={watch('pipelines')}
                 onCheckedChange={(checked: boolean) => setValue('pipelines', checked)}
                 label="Pipelines"

--- a/packages/ui/src/views/repo/repo-import/repo-import-mulitple.tsx
+++ b/packages/ui/src/views/repo/repo-import/repo-import-mulitple.tsx
@@ -307,7 +307,7 @@ export function RepoImportMultiplePage({
               <Checkbox
                 {...register('repositories')}
                 id="authorization"
-                optional={true}
+                optional
                 checked={true}
                 disabled
                 label="Repositories"
@@ -315,7 +315,7 @@ export function RepoImportMultiplePage({
               <Checkbox
                 {...register('pipelines')}
                 id="pipelines"
-                optional={true}
+                optional
                 checked={watch('pipelines')}
                 onCheckedChange={(checked: boolean) => setValue('pipelines', checked)}
                 label="Pipelines"

--- a/packages/ui/src/views/repo/repo-import/repo-import.tsx
+++ b/packages/ui/src/views/repo/repo-import/repo-import.tsx
@@ -275,6 +275,7 @@ export function RepoImportPage({
               <Checkbox
                 {...register('authorization')}
                 id="authorization"
+                optional={true}
                 checked={watch('authorization')}
                 onCheckedChange={(checked: boolean) => setValue('authorization', checked)}
                 label="Requires Authorization"
@@ -282,6 +283,7 @@ export function RepoImportPage({
               <Checkbox
                 {...register('pipelines')}
                 id="pipelines"
+                optional={true}
                 checked={watch('pipelines')}
                 onCheckedChange={(checked: boolean) => setValue('pipelines', checked)}
                 label="Import Pipelines"

--- a/packages/ui/src/views/repo/repo-import/repo-import.tsx
+++ b/packages/ui/src/views/repo/repo-import/repo-import.tsx
@@ -275,7 +275,7 @@ export function RepoImportPage({
               <Checkbox
                 {...register('authorization')}
                 id="authorization"
-                optional={true}
+                optional
                 checked={watch('authorization')}
                 onCheckedChange={(checked: boolean) => setValue('authorization', checked)}
                 label="Requires Authorization"
@@ -283,7 +283,7 @@ export function RepoImportPage({
               <Checkbox
                 {...register('pipelines')}
                 id="pipelines"
-                optional={true}
+                optional
                 checked={watch('pipelines')}
                 onCheckedChange={(checked: boolean) => setValue('pipelines', checked)}
                 label="Import Pipelines"

--- a/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-form.tsx
+++ b/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-form.tsx
@@ -164,6 +164,7 @@ export const RepoSettingsGeneralForm: FC<{
               <Radio.Root value={accessValue} onValueChange={handleAccessChange} id="visibility">
                 <Radio.Item
                   id="access-public"
+                  optional={true}
                   value="1"
                   label={t('views:repos.public', 'Public')}
                   caption={t(
@@ -173,6 +174,7 @@ export const RepoSettingsGeneralForm: FC<{
                 />
                 <Radio.Item
                   id="access-private"
+                  optional={true}
                   value="2"
                   label={t('views:repos.private', 'Private')}
                   caption={t(

--- a/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-form.tsx
+++ b/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-form.tsx
@@ -164,7 +164,7 @@ export const RepoSettingsGeneralForm: FC<{
               <Radio.Root value={accessValue} onValueChange={handleAccessChange} id="visibility">
                 <Radio.Item
                   id="access-public"
-                  optional={true}
+                  optional
                   value="1"
                   label={t('views:repos.public', 'Public')}
                   caption={t(
@@ -174,7 +174,7 @@ export const RepoSettingsGeneralForm: FC<{
                 />
                 <Radio.Item
                   id="access-private"
-                  optional={true}
+                  optional
                   value="2"
                   label={t('views:repos.private', 'Private')}
                   caption={t(

--- a/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-security.tsx
+++ b/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-security.tsx
@@ -86,7 +86,7 @@ export const RepoSettingsSecurityForm: FC<RepoSettingsSecurityFormProps> = ({
           <Checkbox
             checked={watch('secretScanning')}
             id="secret-scanning"
-            optional={true}
+            optional
             onCheckedChange={onCheckboxChange}
             disabled={isDisabled}
             title={tooltipMessage}

--- a/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-security.tsx
+++ b/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-security.tsx
@@ -86,6 +86,7 @@ export const RepoSettingsSecurityForm: FC<RepoSettingsSecurityFormProps> = ({
           <Checkbox
             checked={watch('secretScanning')}
             id="secret-scanning"
+            optional={true}
             onCheckedChange={onCheckboxChange}
             disabled={isDisabled}
             title={tooltipMessage}

--- a/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
+++ b/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
@@ -169,7 +169,7 @@ export const WebhookEventSettingsFieldset: FC<WebhookFormFieldProps & { eventLis
       {eventList.map(event => (
         <ControlGroup key={event.id} className="min-h-8 justify-center">
           <Checkbox
-            optional={true}
+            optional
             checked={currentArray?.includes(event.id as WebhookTriggerEnum)}
             onCheckedChange={() => handleCheckboxChange(event.id as WebhookTriggerEnum)}
             id={`${event.id}`}

--- a/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
+++ b/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
@@ -161,6 +161,7 @@ export const WebhookEventSettingsFieldset: FC<WebhookFormFieldProps & { eventLis
       {eventList.map(event => (
         <ControlGroup key={event.id} className="min-h-8 justify-center">
           <Checkbox
+            optional={true}
             checked={currentArray?.includes(event.id as WebhookTriggerEnum)}
             onCheckedChange={() => handleCheckboxChange(event.id as WebhookTriggerEnum)}
             id={`${event.id}`}

--- a/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
+++ b/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
@@ -101,11 +101,13 @@ export const WebhookSSLVerificationField: FC<WebhookFormFieldProps> = ({ watch, 
       <Radio.Root value={sslVerificationValue} onValueChange={handleAccessChange} id="insecure">
         <Radio.Item
           id="enable-ssl"
+          optional={true}
           value="1"
           label={t('views:repos.sslVerificationLabel', 'Enable SSL Verification')}
         />
         <Radio.Item
           id="disable-ssl"
+          optional={true}
           value="2"
           label={t('views:repos.disableSslLabel', 'Disable SSL verification')}
           caption={t('views:repos.disableSslDescription', 'Not recommended for production use')}
@@ -130,9 +132,15 @@ export const WebhookTriggerField: FC<WebhookFormFieldProps> = ({ watch, setValue
         {t('views:repos.evenTriggerLabel', 'Which events would you like to use to trigger this webhook?')}
       </Label>
       <Radio.Root value={sslVerificationValue} onValueChange={handleTriggerChange} id="trigger">
-        <Radio.Item id="all-events" value="1" label={t('views:repos.evenTriggerAllLabel', 'Send me everything')} />
+        <Radio.Item
+          id="all-events"
+          optional={true}
+          value="1"
+          label={t('views:repos.evenTriggerAllLabel', 'Send me everything')}
+        />
         <Radio.Item
           id="select-events"
+          optional={true}
           value="2"
           label={t('views:repos.eventTriggerIndividualLabel', 'Let me select individual events')}
         />

--- a/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
+++ b/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
@@ -101,13 +101,13 @@ export const WebhookSSLVerificationField: FC<WebhookFormFieldProps> = ({ watch, 
       <Radio.Root value={sslVerificationValue} onValueChange={handleAccessChange} id="insecure">
         <Radio.Item
           id="enable-ssl"
-          optional={true}
+          optional
           value="1"
           label={t('views:repos.sslVerificationLabel', 'Enable SSL Verification')}
         />
         <Radio.Item
           id="disable-ssl"
-          optional={true}
+          optional
           value="2"
           label={t('views:repos.disableSslLabel', 'Disable SSL verification')}
           caption={t('views:repos.disableSslDescription', 'Not recommended for production use')}
@@ -134,13 +134,13 @@ export const WebhookTriggerField: FC<WebhookFormFieldProps> = ({ watch, setValue
       <Radio.Root value={sslVerificationValue} onValueChange={handleTriggerChange} id="trigger">
         <Radio.Item
           id="all-events"
-          optional={true}
+          optional
           value="1"
           label={t('views:repos.evenTriggerAllLabel', 'Send me everything')}
         />
         <Radio.Item
           id="select-events"
-          optional={true}
+          optional
           value="2"
           label={t('views:repos.eventTriggerIndividualLabel', 'Let me select individual events')}
         />


### PR DESCRIPTION
Added optional attribute for checkbox and radio instances so that they are not required. We missed adding it while migrating to the new design system.

<img width="643" alt="Screenshot 2025-05-06 at 5 07 29 PM" src="https://github.com/user-attachments/assets/2912d52e-c1c2-4adc-86d4-252fbce235da" />
