### PR TITLE
Change in the Optional prop behavior for Radio, Switch and Checkbox

### DIFF
--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -15,7 +15,7 @@ interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxPrimitiv
  * Built on top of Radix UI Checkbox primitive with additional styling.
  */
 const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Omit<CheckboxProps, 'required'>>(
-  ({ className, label, caption, showOptionalLabel: optional, ...props }, ref) => {
+  ({ className, label, caption, showOptionalLabel, ...props }, ref) => {
     const checkboxId = props.id || `checkbox-${Math.random().toString(36).slice(2, 11)}`
 
     return (
@@ -34,7 +34,7 @@ const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Omit<Chec
           <div className="cn-checkbox-label-wrapper">
             <Label
               htmlFor={checkboxId}
-              optional={optional}
+              optional={showOptionalLabel}
               className={`cn-checkbox-label ${props.disabled ? 'disabled' : ''}`}
             >
               {label}

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -14,7 +14,7 @@ interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxPrimitiv
  * Checkbox component that provides a customizable, accessible checkbox input.
  * Built on top of Radix UI Checkbox primitive with additional styling.
  */
-const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, CheckboxProps>(
+const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Omit<CheckboxProps, 'required'>>(
   ({ className, label, caption, optional, ...props }, ref) => {
     const checkboxId = props.id || `checkbox-${Math.random().toString(36).slice(2, 11)}`
 

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -7,7 +7,7 @@ import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
 interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> {
   label?: string
   caption?: string
-  optional?: boolean
+  showOptionalLabel?: boolean
 }
 
 /**
@@ -15,7 +15,7 @@ interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxPrimitiv
  * Built on top of Radix UI Checkbox primitive with additional styling.
  */
 const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Omit<CheckboxProps, 'required'>>(
-  ({ className, label, caption, optional, ...props }, ref) => {
+  ({ className, label, caption, showOptionalLabel: optional, ...props }, ref) => {
     const checkboxId = props.id || `checkbox-${Math.random().toString(36).slice(2, 11)}`
 
     return (

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -20,13 +20,7 @@ const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Omit<Chec
 
     return (
       <div className={cn('cn-checkbox-wrapper', className)}>
-        <CheckboxPrimitive.Root
-          id={checkboxId}
-          ref={ref}
-          className={cn('cn-checkbox-root')}
-          required={!optional}
-          {...props}
-        >
+        <CheckboxPrimitive.Root id={checkboxId} ref={ref} className={cn('cn-checkbox-root')} {...props}>
           <CheckboxPrimitive.Indicator className="cn-checkbox-indicator">
             {props.checked === 'indeterminate' ? (
               <Icon name="minus" className="cn-checkbox-icon" skipSize />

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -14,7 +14,7 @@ interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxPrimitiv
  * Checkbox component that provides a customizable, accessible checkbox input.
  * Built on top of Radix UI Checkbox primitive with additional styling.
  */
-const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Omit<CheckboxProps, 'required'>>(
+const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, CheckboxProps>(
   ({ className, label, caption, optional, ...props }, ref) => {
     const checkboxId = props.id || `checkbox-${Math.random().toString(36).slice(2, 11)}`
 

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -134,7 +134,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     asChild
   >
     <div className="flex items-center gap-x-2.5">
-      <Checkbox optional checked={checked} />
+      <Checkbox checked={checked} />
       <span className="text-2 text-cn-foreground-1">{children}</span>
     </div>
   </DropdownMenuPrimitive.CheckboxItem>

--- a/packages/ui/src/components/filters/filters-field.tsx
+++ b/packages/ui/src/components/filters/filters-field.tsx
@@ -84,7 +84,6 @@ const renderFilterValues = <T extends string, V extends FilterValueTypes, Custom
           <Label className="gap-x-3">
             <Checkbox
               className="pb-1"
-              optional
               checked={checkboxFilter.value}
               onCheckedChange={value => onUpdateFilter(value as V)}
             />

--- a/packages/ui/src/components/git-commit-dialog/git-commit-dialog.tsx
+++ b/packages/ui/src/components/git-commit-dialog/git-commit-dialog.tsx
@@ -169,7 +169,6 @@ export const GitCommitDialog: FC<GitCommitDialogProps> = ({
             >
               <Radio.Item
                 id={CommitToGitRefOption.DIRECTLY}
-                optional
                 className="mt-px"
                 value={CommitToGitRefOption.DIRECTLY}
                 label={
@@ -190,7 +189,6 @@ export const GitCommitDialog: FC<GitCommitDialogProps> = ({
               />
               <Radio.Item
                 id={CommitToGitRefOption.NEW_BRANCH}
-                optional
                 className="mt-px"
                 value={CommitToGitRefOption.NEW_BRANCH}
                 label="Create a new branch for this commit and start a pull request"

--- a/packages/ui/src/components/radio.tsx
+++ b/packages/ui/src/components/radio.tsx
@@ -16,7 +16,7 @@ interface RadioItemProps extends ComponentPropsWithoutRef<typeof RadioGroupPrimi
  * @example
  * <Radio.Item value="option1" name="group" label="Option 1" caption="This is option 1" />
  */
-const RadioItem = forwardRef<ElementRef<typeof RadioGroupPrimitive.Item>, RadioItemProps>(
+const RadioItem = forwardRef<ElementRef<typeof RadioGroupPrimitive.Item>, Omit<RadioItemProps, 'required'>>(
   ({ className, label, caption, optional, ...props }, ref) => {
     const radioId = props.id || `radio-${Math.random().toString(36).slice(2, 11)}`
 

--- a/packages/ui/src/components/radio.tsx
+++ b/packages/ui/src/components/radio.tsx
@@ -16,7 +16,7 @@ interface RadioItemProps extends ComponentPropsWithoutRef<typeof RadioGroupPrimi
  * @example
  * <Radio.Item value="option1" name="group" label="Option 1" caption="This is option 1" />
  */
-const RadioItem = forwardRef<ElementRef<typeof RadioGroupPrimitive.Item>, Omit<RadioItemProps, 'required'>>(
+const RadioItem = forwardRef<ElementRef<typeof RadioGroupPrimitive.Item>, RadioItemProps>(
   ({ className, label, caption, optional, ...props }, ref) => {
     const radioId = props.id || `radio-${Math.random().toString(36).slice(2, 11)}`
 

--- a/packages/ui/src/components/radio.tsx
+++ b/packages/ui/src/components/radio.tsx
@@ -7,7 +7,7 @@ import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 interface RadioItemProps extends ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item> {
   label?: string | ReactElement
   caption?: string | ReactElement
-  optional?: boolean
+  showOptionalLabel?: boolean
 }
 
 /**
@@ -17,7 +17,7 @@ interface RadioItemProps extends ComponentPropsWithoutRef<typeof RadioGroupPrimi
  * <Radio.Item value="option1" name="group" label="Option 1" caption="This is option 1" />
  */
 const RadioItem = forwardRef<ElementRef<typeof RadioGroupPrimitive.Item>, Omit<RadioItemProps, 'required'>>(
-  ({ className, label, caption, optional, ...props }, ref) => {
+  ({ className, label, caption, showOptionalLabel: optional, ...props }, ref) => {
     const radioId = props.id || `radio-${Math.random().toString(36).slice(2, 11)}`
 
     return (

--- a/packages/ui/src/components/radio.tsx
+++ b/packages/ui/src/components/radio.tsx
@@ -17,7 +17,7 @@ interface RadioItemProps extends ComponentPropsWithoutRef<typeof RadioGroupPrimi
  * <Radio.Item value="option1" name="group" label="Option 1" caption="This is option 1" />
  */
 const RadioItem = forwardRef<ElementRef<typeof RadioGroupPrimitive.Item>, Omit<RadioItemProps, 'required'>>(
-  ({ className, label, caption, showOptionalLabel: optional, ...props }, ref) => {
+  ({ className, label, caption, showOptionalLabel, ...props }, ref) => {
     const radioId = props.id || `radio-${Math.random().toString(36).slice(2, 11)}`
 
     return (
@@ -30,7 +30,7 @@ const RadioItem = forwardRef<ElementRef<typeof RadioGroupPrimitive.Item>, Omit<R
           <div className="cn-radio-label-wrapper">
             <Label
               htmlFor={radioId}
-              optional={optional}
+              optional={showOptionalLabel}
               className={`cn-radio-label ${props.disabled ? 'disabled' : ''}`}
             >
               {label}

--- a/packages/ui/src/components/split-button.tsx
+++ b/packages/ui/src/components/split-button.tsx
@@ -100,7 +100,12 @@ export const SplitButton = <T extends string>({
                   >
                     <Option
                       control={
-                        <Radio.Item className="mt-px" value={String(option.value)} id={String(option.value)} optional />
+                        <Radio.Item
+                          className="mt-px"
+                          value={String(option.value)}
+                          id={String(option.value)}
+                          showOptionalLabel
+                        />
                       }
                       id={String(option.value)}
                       label={option.label}

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -9,7 +9,7 @@ interface SwitchProps extends ComponentPropsWithoutRef<typeof SwitchPrimitives.R
 
 const Switch = forwardRef<
   ElementRef<typeof SwitchPrimitives.Root>,
-  SwitchProps & {
+  Omit<SwitchProps, 'required'> & {
     label?: string
     caption?: string
     optional?: boolean

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -12,9 +12,9 @@ const Switch = forwardRef<
   Omit<SwitchProps, 'required'> & {
     label?: string
     caption?: string
-    optional?: boolean
+    showOptionalLabel?: boolean
   }
->(({ className, label, caption, optional, ...props }, ref) => {
+>(({ className, label, caption, showOptionalLabel: optional, ...props }, ref) => {
   const switchId = `switch-${Math.random().toString(36).slice(2, 11)}`
   return (
     <div className="cn-switch-wrapper">

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -9,7 +9,7 @@ interface SwitchProps extends ComponentPropsWithoutRef<typeof SwitchPrimitives.R
 
 const Switch = forwardRef<
   ElementRef<typeof SwitchPrimitives.Root>,
-  Omit<SwitchProps, 'required'> & {
+  SwitchProps & {
     label?: string
     caption?: string
     optional?: boolean

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -14,7 +14,7 @@ const Switch = forwardRef<
     caption?: string
     showOptionalLabel?: boolean
   }
->(({ className, label, caption, showOptionalLabel: optional, ...props }, ref) => {
+>(({ className, label, caption, showOptionalLabel, ...props }, ref) => {
   const switchId = `switch-${Math.random().toString(36).slice(2, 11)}`
   return (
     <div className="cn-switch-wrapper">
@@ -23,7 +23,7 @@ const Switch = forwardRef<
       </SwitchPrimitives.Root>
       {(label || caption) && (
         <div className="cn-switch-label-wrapper">
-          <Label htmlFor={props.id || switchId} optional={optional} className="cn-switch-label">
+          <Label htmlFor={props.id || switchId} optional={showOptionalLabel} className="cn-switch-label">
             {label}
           </Label>
           {/* TODO: Design system: update to Text component once available */}

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -18,13 +18,7 @@ const Switch = forwardRef<
   const switchId = `switch-${Math.random().toString(36).slice(2, 11)}`
   return (
     <div className="cn-switch-wrapper">
-      <SwitchPrimitives.Root
-        id={props.id || switchId}
-        className={cn('cn-switch-root', className)}
-        required={!optional}
-        {...props}
-        ref={ref}
-      >
+      <SwitchPrimitives.Root id={props.id || switchId} className={cn('cn-switch-root', className)} {...props} ref={ref}>
         <SwitchPrimitives.Thumb className="cn-switch-thumb" />
       </SwitchPrimitives.Root>
       {(label || caption) && (

--- a/packages/ui/src/views/labels/label-form-page.tsx
+++ b/packages/ui/src/views/labels/label-form-page.tsx
@@ -228,7 +228,6 @@ export const LabelFormPage: FC<LabelFormPageProps> = ({
             <div className="mt-5">
               <Checkbox
                 id="type"
-                optional
                 checked={isDynamicValue}
                 onCheckedChange={handleDynamicChange}
                 label={t('views:labelData.form.allowUsersCheckboxLabel', 'Allow users to add values')}

--- a/packages/ui/src/views/labels/labels-list-page.tsx
+++ b/packages/ui/src/views/labels/labels-list-page.tsx
@@ -70,7 +70,6 @@ export const LabelsListPage: FC<LabelsListPageProps> = ({
           <div className="mb-[18px]">
             <Checkbox
               id="parent-labels"
-              optional
               checked={getParentScopeLabels}
               onCheckedChange={setGetParentScopeLabels}
               label={t('views:labelData.showParentLabels', 'Show labels from parent scopes')}

--- a/packages/ui/src/views/project/project-import.tsx
+++ b/packages/ui/src/views/project/project-import.tsx
@@ -173,18 +173,10 @@ export function ImportProjectPage({ onFormSubmit, onFormCancel, isLoading, apiEr
           {/* authorization - pipelines */}
           <Fieldset>
             <ControlGroup className="flex flex-row gap-5">
-              <Checkbox
-                {...register('repositories')}
-                id="authorization"
-                optional
-                checked={true}
-                disabled
-                label="Repositories"
-              />
+              <Checkbox {...register('repositories')} id="authorization" checked={true} disabled label="Repositories" />
               <Checkbox
                 {...register('pipelines')}
                 id="pipelines"
-                optional
                 checked={watch('pipelines')}
                 onCheckedChange={(checked: boolean) => setValue('pipelines', checked)}
                 label="Import Pipelines"

--- a/packages/ui/src/views/repo/pull-request/components/labels/labels-filter.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/labels/labels-filter.tsx
@@ -54,7 +54,7 @@ export function LabelsFilter({
                   onChange(newValue)
                 }}
               >
-                <Checkbox optional checked={value[option.id] ? value[option.id] === true || 'indeterminate' : false} />
+                <Checkbox checked={value[option.id] ? value[option.id] === true || 'indeterminate' : false} />
                 <LabelMarker color={option.color} label={option.key} value={String(option.value_count)} />
               </DropdownMenu.SubTrigger>
               <DropdownMenu.SubContent>

--- a/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes-filter.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes-filter.tsx
@@ -186,7 +186,7 @@ export const PullRequestChangesFilter: React.FC<PullRequestChangesFilterProps> =
           onClick={(e: React.MouseEvent<HTMLDivElement>) => handleCommitCheck(e, item)}
           className="flex cursor-pointer items-center"
         >
-          <Checkbox optional checked={isSelected} label={item.name} />
+          <Checkbox checked={isSelected} label={item.name} />
         </DropdownMenu.Item>
       )
     })

--- a/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/changes/pull-request-changes.tsx
@@ -131,7 +131,6 @@ const LineTitle: React.FC<LineTitleProps> = ({
       <div className="inline-flex items-center gap-x-6">
         {showViewed ? (
           <Checkbox
-            optional
             checked={viewed}
             onClick={e => {
               e.stopPropagation()

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-panel.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-panel.tsx
@@ -321,7 +321,7 @@ const PullRequestPanel = ({
                   {!notBypassable && isMergeable && !isDraft && prPanelData.ruleViolation && (
                     <Checkbox
                       id="checkbox-bypass"
-                      optional
+                      showOptionalLabel
                       checked={!!checkboxBypass}
                       onCheckedChange={() => {
                         if (typeof checkboxBypass === 'boolean') {

--- a/packages/ui/src/views/repo/repo-branch-rules/components/repo-branch-rules-fields.tsx
+++ b/packages/ui/src/views/repo/repo-branch-rules/components/repo-branch-rules-fields.tsx
@@ -170,7 +170,6 @@ export const BranchSettingsRuleTargetPatternsField: FC<FieldProps> = ({ setValue
       <ControlGroup>
         <Checkbox
           id="default-branch"
-          optional
           {...register!('default')}
           checked={watch!('default')}
           onCheckedChange={() => setValue!('default', !watch!('default'))}
@@ -260,7 +259,6 @@ export const BranchSettingsRuleBypassListField: FC<
       <ControlGroup>
         <Checkbox
           {...register!('repo_owners')}
-          optional
           checked={watch!('repo_owners')}
           onCheckedChange={() => setValue!('repo_owners', !watch!('repo_owners'))}
           id="edit-permissons"
@@ -306,7 +304,6 @@ export const BranchSettingsRuleListField: FC<{
             <Fieldset key={rule.id} className="gap-y-4">
               <Checkbox
                 id={rule.id}
-                optional
                 checked={isChecked}
                 onCheckedChange={checked => handleCheckboxChange(rule.id, checked === true)}
                 label={rule.label}
@@ -320,7 +317,6 @@ export const BranchSettingsRuleListField: FC<{
                     <Checkbox
                       key={subOption.id}
                       id={subOption.id}
-                      optional
                       checked={rules[index].submenu?.includes(subOption.id as MergeStrategy)}
                       onCheckedChange={checked => handleSubmenuChange(rule.id, subOption.id, checked === true)}
                       label={subOption.label}

--- a/packages/ui/src/views/repo/repo-create/index.tsx
+++ b/packages/ui/src/views/repo/repo-create/index.tsx
@@ -206,7 +206,6 @@ export function RepoCreatePage({
               <Radio.Root className="mt-6" value={accessValue} onValueChange={handleAccessChange} id="access">
                 <Radio.Item
                   id="access-public"
-                  optional
                   className="mt-px"
                   value="1"
                   label="Public"
@@ -214,7 +213,6 @@ export function RepoCreatePage({
                 />
                 <Radio.Item
                   id="access-private"
-                  optional
                   className="mt-px"
                   value="2"
                   label="Private"

--- a/packages/ui/src/views/repo/repo-create/index.tsx
+++ b/packages/ui/src/views/repo/repo-create/index.tsx
@@ -236,7 +236,6 @@ export function RepoCreatePage({
               <div className="mt-6">
                 <Checkbox
                   id="readme"
-                  optional
                   checked={readmeValue}
                   onCheckedChange={handleReadmeChange}
                   label="Add a README file"

--- a/packages/ui/src/views/repo/repo-import/repo-import-mulitple.tsx
+++ b/packages/ui/src/views/repo/repo-import/repo-import-mulitple.tsx
@@ -304,18 +304,10 @@ export function RepoImportMultiplePage({
           {/* authorization - pipelines */}
           <Fieldset>
             <ControlGroup className="flex flex-row gap-5">
-              <Checkbox
-                {...register('repositories')}
-                id="authorization"
-                optional
-                checked={true}
-                disabled
-                label="Repositories"
-              />
+              <Checkbox {...register('repositories')} id="authorization" checked={true} disabled label="Repositories" />
               <Checkbox
                 {...register('pipelines')}
                 id="pipelines"
-                optional
                 checked={watch('pipelines')}
                 onCheckedChange={(checked: boolean) => setValue('pipelines', checked)}
                 label="Pipelines"

--- a/packages/ui/src/views/repo/repo-import/repo-import.tsx
+++ b/packages/ui/src/views/repo/repo-import/repo-import.tsx
@@ -275,7 +275,6 @@ export function RepoImportPage({
               <Checkbox
                 {...register('authorization')}
                 id="authorization"
-                optional
                 checked={watch('authorization')}
                 onCheckedChange={(checked: boolean) => setValue('authorization', checked)}
                 label="Requires Authorization"
@@ -283,7 +282,6 @@ export function RepoImportPage({
               <Checkbox
                 {...register('pipelines')}
                 id="pipelines"
-                optional
                 checked={watch('pipelines')}
                 onCheckedChange={(checked: boolean) => setValue('pipelines', checked)}
                 label="Import Pipelines"

--- a/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-form.tsx
+++ b/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-form.tsx
@@ -164,7 +164,6 @@ export const RepoSettingsGeneralForm: FC<{
               <Radio.Root value={accessValue} onValueChange={handleAccessChange} id="visibility">
                 <Radio.Item
                   id="access-public"
-                  optional
                   value="1"
                   label={t('views:repos.public', 'Public')}
                   caption={t(
@@ -174,7 +173,6 @@ export const RepoSettingsGeneralForm: FC<{
                 />
                 <Radio.Item
                   id="access-private"
-                  optional
                   value="2"
                   label={t('views:repos.private', 'Private')}
                   caption={t(

--- a/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-security.tsx
+++ b/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-security.tsx
@@ -86,7 +86,6 @@ export const RepoSettingsSecurityForm: FC<RepoSettingsSecurityFormProps> = ({
           <Checkbox
             checked={watch('secretScanning')}
             id="secret-scanning"
-            optional
             onCheckedChange={onCheckboxChange}
             disabled={isDisabled}
             title={tooltipMessage}

--- a/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
+++ b/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
@@ -101,13 +101,11 @@ export const WebhookSSLVerificationField: FC<WebhookFormFieldProps> = ({ watch, 
       <Radio.Root value={sslVerificationValue} onValueChange={handleAccessChange} id="insecure">
         <Radio.Item
           id="enable-ssl"
-          optional
           value="1"
           label={t('views:repos.sslVerificationLabel', 'Enable SSL Verification')}
         />
         <Radio.Item
           id="disable-ssl"
-          optional
           value="2"
           label={t('views:repos.disableSslLabel', 'Disable SSL verification')}
           caption={t('views:repos.disableSslDescription', 'Not recommended for production use')}
@@ -132,15 +130,9 @@ export const WebhookTriggerField: FC<WebhookFormFieldProps> = ({ watch, setValue
         {t('views:repos.evenTriggerLabel', 'Which events would you like to use to trigger this webhook?')}
       </Label>
       <Radio.Root value={sslVerificationValue} onValueChange={handleTriggerChange} id="trigger">
-        <Radio.Item
-          id="all-events"
-          optional
-          value="1"
-          label={t('views:repos.evenTriggerAllLabel', 'Send me everything')}
-        />
+        <Radio.Item id="all-events" value="1" label={t('views:repos.evenTriggerAllLabel', 'Send me everything')} />
         <Radio.Item
           id="select-events"
-          optional
           value="2"
           label={t('views:repos.eventTriggerIndividualLabel', 'Let me select individual events')}
         />

--- a/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
+++ b/packages/ui/src/views/repo/webhooks/webhook-create/components/create-webhooks-form-fields.tsx
@@ -161,7 +161,6 @@ export const WebhookEventSettingsFieldset: FC<WebhookFormFieldProps & { eventLis
       {eventList.map(event => (
         <ControlGroup key={event.id} className="min-h-8 justify-center">
           <Checkbox
-            optional
             checked={currentArray?.includes(event.id as WebhookTriggerEnum)}
             onCheckedChange={() => handleCheckboxChange(event.id as WebhookTriggerEnum)}
             id={`${event.id}`}

--- a/packages/ui/src/views/unified-pipeline-studio/components/form-inputs/BooleanInput.tsx
+++ b/packages/ui/src/views/unified-pipeline-studio/components/form-inputs/BooleanInput.tsx
@@ -36,7 +36,7 @@ function BooleanInputInternal(props: BooleanInputInternalProps): JSX.Element {
           }}
           label={label}
           caption={description}
-          optional={!required}
+          showOptionalLabel={!required}
         />
         <InputError path={path} />
         {inputConfig?.tooltip && <InputTooltip tooltip={inputConfig.tooltip} />}

--- a/packages/ui/src/views/unified-pipeline-studio/components/form-inputs/BooleanInput.tsx
+++ b/packages/ui/src/views/unified-pipeline-studio/components/form-inputs/BooleanInput.tsx
@@ -36,7 +36,7 @@ function BooleanInputInternal(props: BooleanInputInternalProps): JSX.Element {
           }}
           label={label}
           caption={description}
-          optional={!required}
+          required={required}
         />
         <InputError path={path} />
         {inputConfig?.tooltip && <InputTooltip tooltip={inputConfig.tooltip} />}

--- a/packages/ui/src/views/unified-pipeline-studio/components/form-inputs/BooleanInput.tsx
+++ b/packages/ui/src/views/unified-pipeline-studio/components/form-inputs/BooleanInput.tsx
@@ -36,7 +36,7 @@ function BooleanInputInternal(props: BooleanInputInternalProps): JSX.Element {
           }}
           label={label}
           caption={description}
-          required={required}
+          optional={!required}
         />
         <InputError path={path} />
         {inputConfig?.tooltip && <InputTooltip tooltip={inputConfig.tooltip} />}


### PR DESCRIPTION
The `optional` prop will now apply only to the label and not to the element.

The `optional` prop is now renamed to `showOptionalLabel`.

Validation can be taken care of by validation libraries, so we are no longer taking into account the optional attribute for setting the required attribute of the elements.