### PR TITLE
fix: auto-open sort dropdown on selecting a sort option

### DIFF
--- a/packages/ui/src/components/sorts/sort-select.tsx
+++ b/packages/ui/src/components/sorts/sort-select.tsx
@@ -10,8 +10,14 @@ interface SortTriggerProps {
 }
 
 const SortSelect = ({ displayLabel, buttonLabel }: SortTriggerProps) => {
-  const { sortOptions, sortSelections, updateSortSelections } = useSort()
+  const { sortOptions, sortSelections, updateSortSelections, setSortOpen } = useSort()
   const filteredSortOptions = sortOptions.filter(option => !sortSelections.some(sort => sort.type === option.value))
+
+  const onSelectChange = (option: SortOption) => {
+    updateSortSelections([...sortSelections, { type: option.value, direction: Direction.ASC }])
+    setSortOpen(true)
+  }
+
   return (
     <SearchableDropdown<SortOption>
       displayLabel={
@@ -24,7 +30,7 @@ const SortSelect = ({ displayLabel, buttonLabel }: SortTriggerProps) => {
       }
       inputPlaceholder="Select..."
       options={filteredSortOptions}
-      onChange={option => updateSortSelections([...sortSelections, { type: option.value, direction: Direction.ASC }])}
+      onChange={onSelectChange}
       customFooter={
         <button className="w-full font-medium" onClick={() => updateSortSelections([])}>
           {buttonLabel}


### PR DESCRIPTION
On selecting a sort from sort-select does not open the sort dropdown to further configure the order of the sort