### PR TITLE
Fix pure transparent token studio script build

### DIFF
--- a/packages/core-design-system/scripts/sd-file-generators.js
+++ b/packages/core-design-system/scripts/sd-file-generators.js
@@ -18,7 +18,7 @@ export const generateCoreFiles = ({ destination, type, format }) => [
     format,
     filter: lchColorsFilter,
     options: {
-      outputReferences: true,
+      outputReferences: false,
       selector: `:root, :host`
     }
   },


### PR DESCRIPTION
It will build the pure transparent color like:

```css
--cn-pure-transparent: lch(from var(--cn-pure-black) l c h / 0);
```
