### PR TITLE
Button typography changes

### DIFF
--- a/packages/ui/tailwind-utils-config/components/button.ts
+++ b/packages/ui/tailwind-utils-config/components/button.ts
@@ -85,7 +85,7 @@ export default {
     height: 'var(--cn-btn-size-default)',
     gap: 'var(--cn-btn-gap-default)',
     border: 'var(--cn-btn-border) solid var(--cn-set-gray-surface-border)',
-    '@apply font-body-single-line-strong select-none overflow-hidden inline-flex items-center justify-center whitespace-nowrap':
+    '@apply font-comp-button-default select-none overflow-hidden inline-flex items-center justify-center whitespace-nowrap':
       '',
 
     '&:where(.cn-button-split-dropdown)': {
@@ -108,7 +108,7 @@ export default {
       height: 'var(--cn-btn-size-sm)',
       padding: 'var(--cn-btn-py-sm) var(--cn-btn-px-sm)',
       gap: 'var(--cn-btn-gap-sm)',
-      '@apply font-caption-single-line-normal': ''
+      '@apply font-comp-button-sm': ''
     },
     '&:where(.cn-button-lg)': {
       height: 'var(--cn-btn-size-lg)',

--- a/packages/ui/tailwind-utils-config/utilities/typography.ts
+++ b/packages/ui/tailwind-utils-config/utilities/typography.ts
@@ -56,6 +56,12 @@ export default {
     },
     '&-family-default': {
       font: 'var(--cn-font-family-default)'
+    },
+    '&-comp-button-default': {
+      font: 'var(--cn-comp-button-default)'
+    },
+    '&-comp-button-sm': {
+      font: 'var(--cn-comp-button-sm)'
     }
   }
 }


### PR DESCRIPTION
This PR updates the button typography to follow `Title Casing`, even when a `sentence case` is passed to the button.

Slack discussion thread: https://harness.slack.com/archives/C08LGTBLU1K/p1748370876930049
