### PR TITLE
Checkbox hover fix for error state

### DIFF
--- a/packages/ui/tailwind-utils-config/components/checkbox.ts
+++ b/packages/ui/tailwind-utils-config/components/checkbox.ts
@@ -38,7 +38,9 @@ export default {
     '&:where(.cn-checkbox-error:where(:not([data-state=checked])))': {
       borderColor: 'var(--cn-border-danger)',
       boxShadow: `var(--cn-ring-danger)`,
-      '&:where(:hover)': {
+      '&:hover': {
+        backgroundColor: 'var(--cn-comp-selection-unselected-bg)',
+        borderColor: 'var(--cn-border-danger)',
         boxShadow: `var(--cn-ring-danger-hover)`
       }
     },
@@ -52,7 +54,6 @@ export default {
     '&:where([data-state=checked])': {
       backgroundColor: 'var(--cn-comp-selection-selected-bg)',
       borderColor: 'var(--cn-comp-selection-selected-border)',
-
       '&:hover': {
         backgroundColor: 'var(--cn-comp-selection-selected-bg-hover)',
         borderColor: 'var(--cn-comp-selection-selected-border-hover)'
@@ -67,7 +68,6 @@ export default {
     '&:where([data-state=indeterminate])': {
       backgroundColor: 'var(--cn-comp-selection-selected-bg)',
       borderColor: 'var(--cn-comp-selection-selected-border)',
-
       '&:hover': {
         backgroundColor: 'var(--cn-comp-selection-selected-bg-hover)',
         borderColor: 'var(--cn-comp-selection-selected-border-hover)'
@@ -77,7 +77,9 @@ export default {
         backgroundColor: 'var(--cn-set-red-solid-bg)',
         borderColor: 'var(--cn-border-danger)',
         boxShadow: `var(--cn-ring-danger)`,
-        '&:where(:hover)': {
+        '&:hover': {
+          backgroundColor: 'var(--cn-set-red-solid-bg)',
+          borderColor: 'var(--cn-border-danger)',
           boxShadow: `var(--cn-ring-danger-hover)`
         }
       }


### PR DESCRIPTION
The checkbox hover for error state is working incorrectly after a merge conflict. This PR fixes the issue.


https://github.com/user-attachments/assets/7881d6ac-f21c-4770-811b-e69322b4c390

