### PR TITLE
fix: remove variants from Label and add empty render

### DIFF
--- a/apps/portal/src/content/docs/components/label.mdx
+++ b/apps/portal/src/content/docs/components/label.mdx
@@ -4,7 +4,7 @@ description: Label component
 beta: true
 ---
 
-The `Label` component is a customizable label for form elements. It supports various styling options through colors and includes an optional indicator.
+The `Label` component is a customizable label for form elements. It includes an optional required indicator and follows consistent styling across the design system.
 
 import { DocsPage } from "../../../components/docs-page";
 
@@ -25,14 +25,6 @@ import { DocsPage } from "../../../components/docs-page";
           <h5>With optional indicator</h5>
           <Label htmlFor="email" optional>Email</Label>
           <input id="email" type="email" />
-      </div>
-
-      <hr />
-
-      <div className="flex flex-col gap-4">
-          <h5>Primary variant</h5>
-          <Label variant="primary" htmlFor="password">Password</Label>
-          <input id="password" type="password" />
       </div>
 
       <hr />
@@ -78,13 +70,6 @@ The `Label` component provides a styled label for form elements with customizabl
 
 <DocsPage.PropsTable
   props={[
-    {
-      name: "variant",
-      description: "The color variant of the label",
-      defaultValue: "default",
-      required: false,
-      value: "'default' | 'primary'",
-    },
     {
       name: "htmlFor",
       description: "The id of the form control this label is associated with",

--- a/packages/ui/src/components/form-primitives/label.tsx
+++ b/packages/ui/src/components/form-primitives/label.tsx
@@ -4,34 +4,22 @@ import { Informer, InformerProps } from '@/components'
 import { NonEmptyReactNode } from '@/types'
 import * as LabelPrimitive from '@radix-ui/react-label'
 import { cn } from '@utils/cn'
-import { cva, type VariantProps } from 'class-variance-authority'
 
-const labelVariants = cva('cn-label', {
-  variants: {
-    variant: {
-      default: 'cn-label-default',
-      primary: 'cn-label-primary'
-    }
-  },
-  defaultVariants: {
-    variant: 'default'
-  }
-})
-
-export type LabelProps = Omit<ComponentPropsWithoutRef<typeof LabelPrimitive.Root>, 'color'> &
-  VariantProps<typeof labelVariants> & {
-    disabled?: boolean
-    optional?: boolean
-    informerProps?: InformerProps
-    informerContent?: NonEmptyReactNode
-  }
+export type LabelProps = Omit<ComponentPropsWithoutRef<typeof LabelPrimitive.Root>, 'color'> & {
+  disabled?: boolean
+  optional?: boolean
+  informerProps?: InformerProps
+  informerContent?: NonEmptyReactNode
+}
 
 const Label = forwardRef<ElementRef<typeof LabelPrimitive.Root>, LabelProps>(
-  ({ className, children, variant = 'default', optional, disabled, informerContent, informerProps, ...props }, ref) => {
+  ({ className, children, optional, disabled, informerContent, informerProps, ...props }, ref) => {
+    if (!children) return null
+
     const LabelComponent = ({ className }: { className?: string }) => (
       <LabelPrimitive.Root
         ref={ref}
-        className={cn(labelVariants({ variant }), { 'cn-label-disabled': disabled }, className)}
+        className={cn('cn-label', { 'cn-label-disabled': disabled }, className)}
         {...props}
       >
         <span className="cn-label-text">{children}</span>

--- a/packages/ui/src/components/option.tsx
+++ b/packages/ui/src/components/option.tsx
@@ -34,7 +34,7 @@ export const Option: FC<OptionProps> = ({ control, id, label, description, ariaS
     >
       <div className="mt-0.5">{control}</div>
       <div className="flex flex-col gap-0">
-        <Label htmlFor={id} className="mb-1 cursor-pointer pl-2.5" variant="primary">
+        <Label htmlFor={id} className="mb-1 cursor-pointer pl-2.5">
           {label}
         </Label>
         {description && (

--- a/packages/ui/tailwind-utils-config/components/label.ts
+++ b/packages/ui/tailwind-utils-config/components/label.ts
@@ -5,21 +5,10 @@ export default {
     gridTemplateColumns: 'auto auto',
     justifyContent: 'start',
     gap: 'var(--cn-spacing-half)',
+    color: 'var(--cn-text-1)',
 
-    '&:where(.cn-label-default)': {
-      color: 'var(--cn-text-2)',
-
-      '+ .cn-label-informer': {
-        color: 'var(--cn-text-2)'
-      }
-    },
-
-    '&:where(.cn-label-primary)': {
-      color: 'var(--cn-text-1)',
-
-      '+ .cn-label-informer': {
-        color: 'var(--cn-text-1)'
-      }
+    '&-informer': {
+      color: 'var(--cn-text-1)'
     },
 
     '&:where(.cn-label-disabled), &:where(.cn-label-disabled) > .cn-label-optional': {


### PR DESCRIPTION
- Remove `variants` from Label (use a single default style)
- Return `null` from Label if no `children` are passed