### PR TITLE
Fix card select gradient issue

### DIFF
--- a/packages/ui/tailwind-utils-config/components/card-select.ts
+++ b/packages/ui/tailwind-utils-config/components/card-select.ts
@@ -41,7 +41,7 @@ export default {
 
     '&:where([data-state="checked"])': {
       borderColor: 'var(--cn-border-accent)',
-      backgroundColor: 'var(--cn-comp-card-gradient)'
+      backgroundImage: 'var(--cn-comp-card-gradient)'
     },
 
     '.cn-card-select-content': {


### PR DESCRIPTION
Gradient was not getting applied correctly to the selected card in the Card Select component. This PR fixes that issue.