### PR TITLE
lineClamp prop to Text component and update default align

### DIFF
--- a/apps/portal/src/content/docs/components/text.mdx
+++ b/apps/portal/src/content/docs/components/text.mdx
@@ -214,6 +214,10 @@ The `Text` component supports various color options to enhance visibility and co
   client:only
   code={`<div className="grid gap-4">
     <div>
+        <Text variant="heading-base" color="foreground-1" className="underline mb-1">default:</Text>
+        <Text>dummyText</Text>
+    </div>
+    <div>
         <Text variant="heading-base" color="foreground-1" className="underline mb-1">left:</Text>
         <Text align="left">dummyText</Text>
     </div>
@@ -258,6 +262,34 @@ The `Text` component supports various color options to enhance visibility and co
   )}
 />
 
+## `Truncate`
+
+The `truncate` prop allows you to truncate text with an ellipsis if it overflows its container. This is particularly useful for single-line text that should not wrap.
+
+<DocsPage.ComponentExample
+  client:only
+  code={`<div className="max-w-[400px]">
+    <Text variant="body-normal" truncate>
+        Consistency in typography helps users navigate content with ease. Always use hierarchy to guide attention and improve readability.
+    </Text>
+</div>`}
+/>
+
+## `Line Clamp`
+
+The `lineClamp` prop controls how many lines of text are shown before truncating. It can be set to a specific number or to 'default' for the component's default behavior.
+
+> Note: The `lineClamp` prop takes precedence over the `truncate` prop when both are used, as it provides more specific control over text clamping.
+
+<DocsPage.ComponentExample
+  client:only
+  code={`<div className="max-w-[400px]">
+    <Text variant="body-normal" lineClamp="2">
+        Consistency in typography helps users navigate content with ease. Always use hierarchy to guide attention and improve readability.
+    </Text>
+</div>`}
+/>
+
 ## API Reference
 
 <DocsPage.PropsTable
@@ -281,7 +313,7 @@ The `Text` component supports various color options to enhance visibility and co
     {
       name: "align",
       description: "The text alignment",
-      defaultValue: "initial",
+      defaultValue: undefined,
       required: false,
       value: "'left' | 'center' | 'right'",
     },
@@ -313,9 +345,9 @@ The `Text` component supports various color options to enhance visibility and co
       name: "lineClamp",
       description:
         "Controls how many lines of text are shown before truncating",
-      defaultValue: "none",
+      defaultValue: undefined,
       required: false,
-      value: "'1' | '2' | '3' | '4' | '5' | '6' | 'none'",
+      value: "'1' | '2' | '3' | '4' | '5' | '6' | 'default'",
     },
     {
       name: "wrap",

--- a/packages/ui/src/components/text.tsx
+++ b/packages/ui/src/components/text.tsx
@@ -72,13 +72,13 @@ const textVariants = cva('', {
       danger: 'text-cn-foreground-danger'
     },
     lineClamp: {
+      default: '',
       1: 'line-clamp-1',
       2: 'line-clamp-2',
       3: 'line-clamp-3',
       4: 'line-clamp-4',
       5: 'line-clamp-5',
-      6: 'line-clamp-6',
-      none: 'line-clamp-none'
+      6: 'line-clamp-6'
     },
     wrap: {
       wrap: 'text-wrap',
@@ -167,16 +167,16 @@ const TextWithRef = forwardRef<HTMLElement, TextProps>(
 
     const getTitleFromRef = useCallback(
       (element: HTMLElement | null) => {
-        if (element && truncate) {
+        if (element && (truncate || lineClamp)) {
           setTitleText(element.innerText || '')
         }
       },
-      [truncate]
+      [truncate, lineClamp]
     )
 
     const compRef = useMergeRefs<HTMLElement>([getTitleFromRef, ref])
 
-    const isTruncated = lineClamp && lineClamp !== 'none' ? false : truncate
+    const isTruncated = lineClamp ? false : truncate
 
     return (
       <Comp
@@ -184,7 +184,7 @@ const TextWithRef = forwardRef<HTMLElement, TextProps>(
         className={cn(textVariants({ variant, align, color, truncate: isTruncated, lineClamp, wrap }), className)}
         {...props}
         {...wrapConditionalObjectElement({ role: 'heading' }, isHeading)}
-        {...wrapConditionalObjectElement({ title: titleText }, !!isTruncated)}
+        {...wrapConditionalObjectElement({ title: titleText }, !!isTruncated || !!lineClamp)}
       >
         {children}
       </Comp>


### PR DESCRIPTION
 - Added lineClamp prop with possible values: '1' | '2' | '3' | '4' | '5' | '6' | 'default'
 - lineClamp now takes precedence over truncate
 - Removed the default value for align; it's now 'initial' instead of 'left'