### PR TITLE
Minor table fixes

### DIFF
--- a/apps/portal/src/content/docs/components/advanced-table.mdx
+++ b/apps/portal/src/content/docs/components/advanced-table.mdx
@@ -1,10 +1,10 @@
 ---
-title: Advanced Table
-description: Advanced data table component with sorting, selection, and expansion capabilities
+title: Data Table
+description: Data table component with sorting, selection, and expansion capabilities
 beta: true
 ---
 
-The `Advanced Table` component provides a powerful way to display and interact with tabular data, featuring row selection, expansion, sorting, and custom cell rendering. Built on TanStack Table, it offers a comprehensive solution for complex data display needs.
+The `Data Table` component provides a powerful way to display and interact with tabular data, featuring row selection, expansion, sorting, and custom cell rendering. Built on TanStack Table, it offers a comprehensive solution for complex data display needs.
 
 import { DocsPage } from "@/components/docs-page";
 import { Aside } from "@astrojs/starlight/components";

--- a/apps/portal/src/content/docs/components/table-v2.mdx
+++ b/apps/portal/src/content/docs/components/table-v2.mdx
@@ -326,6 +326,7 @@ import { Aside } from "@astrojs/starlight/components";
           <TableV2.Cell>CI/CD platform built on Docker</TableV2.Cell>
           <TableV2.Cell>★ 312</TableV2.Cell>
         </TableV2.Row>
+        
       </TableV2.Body>
     </TableV2.Root>
   </div>

--- a/packages/ui/src/components/table-v2.tsx
+++ b/packages/ui/src/components/table-v2.tsx
@@ -78,6 +78,9 @@ const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(({ className, se
   if (props.to || props.linkProps) {
     rowChildren = Children.map(rowChildren, child => {
       if (isValidElement(child)) {
+        if (child.props.to || child.props.linkProps) {
+          return child
+        }
         return cloneElement(child, {
           to: props.to,
           linkProps: props.linkProps
@@ -88,12 +91,7 @@ const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(({ className, se
   }
 
   return (
-    <tr
-      ref={ref}
-      className={cn('cn-table-v2-row', props.to || props.linkProps ? 'row-link-no-underline' : '', className)}
-      data-checked={selected ? 'true' : undefined}
-      {...props}
-    >
+    <tr ref={ref} className={cn('cn-table-v2-row', className)} data-checked={selected ? 'true' : undefined} {...props}>
       {rowChildren}
     </tr>
   )
@@ -171,7 +169,12 @@ const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
     if (shouldRenderLink) {
       return (
         <td ref={ref} className={cn('cn-table-v2-cell !p-0', className)} {...props}>
-          <Link to={to || ''} className={cn('cn-table-v2-cell-link', linkProps?.className)} {...(linkProps || {})}>
+          <Link
+            to={to || ''}
+            variant="secondary"
+            className={cn('cn-table-v2-cell-link', linkProps?.className)}
+            {...(linkProps || {})}
+          >
             {children}
           </Link>
         </td>

--- a/packages/ui/tailwind-utils-config/components/table-v2.ts
+++ b/packages/ui/tailwind-utils-config/components/table-v2.ts
@@ -117,23 +117,9 @@ export default {
 
     // Cell link
     '&-cell-link': {
-      '@apply block w-full h-full flex items-center': '',
+      '@apply block w-full h-full flex items-center no-underline inset-0 text-cn-foreground-2': '',
       paddingLeft: 'var(--cn-table-cell-px)',
       paddingRight: 'var(--cn-table-cell-px)'
-    },
-
-    // Variant-specific cell link padding
-    '&:where(.cn-table-v2-default) .cn-table-v2-cell-link': {
-      paddingTop: 'var(--cn-table-cell-py-default)',
-      paddingBottom: 'var(--cn-table-cell-py-default)'
-    },
-    '&:where(.cn-table-v2-relaxed) .cn-table-v2-cell-link': {
-      paddingTop: 'var(--cn-table-cell-py-relaxed)',
-      paddingBottom: 'var(--cn-table-cell-py-relaxed)'
-    },
-    '&:where(.cn-table-v2-compact) .cn-table-v2-cell-link': {
-      paddingTop: 'var(--cn-table-cell-py-compact)',
-      paddingBottom: 'var(--cn-table-cell-py-compact)'
     },
 
     // Caption


### PR DESCRIPTION
- Fixes link-cell / linked-row styles and behavior. 
- Renames `advanced-table` to `data-table`