### PR TITLE
Update Button component default size and Add disabled state for SplitButton

### DIFF
--- a/apps/portal/src/content/docs/components/button.mdx
+++ b/apps/portal/src/content/docs/components/button.mdx
@@ -49,7 +49,7 @@ Primary buttons are the most prominent buttons in the interface.
 <h4>Primary Button with Sizes</h4>
 
 <div className="flex gap-3 items-end">
-  <Button variant="primary">Default</Button>
+  <Button variant="primary">Medium</Button>
   <Button variant="primary" size="sm">
     Small
   </Button>
@@ -97,7 +97,7 @@ Secondary buttons are less prominent than primary buttons.
 <h4>Secondary Button with Sizes</h4>
 
 <div className="flex gap-3 items-end">
-  <Button variant="secondary">Default</Button>
+  <Button variant="secondary">Medium</Button>
   <Button variant="secondary" size="sm">
     Small
   </Button>
@@ -153,7 +153,7 @@ Outline buttons have a transparent background with a visible border.
 <h4>Outline Button with Sizes</h4>
 
 <div className="flex gap-3 items-end">
-  <Button variant="outline">Default</Button>
+  <Button variant="outline">Medium</Button>
   <Button variant="outline" size="sm">
     Small
   </Button>
@@ -219,9 +219,12 @@ Ghost buttons are minimally styled and blend into the background when not intera
 <h4>Ghost Button with Sizes</h4>
 
 <div className="flex gap-3 items-end">
-  <Button variant="ghost">Default</Button>
+  <Button variant="ghost">Medium</Button>
   <Button variant="ghost" size="sm">
     Small
+  </Button>
+  <Button variant="ghost" size="xs">
+    Extra Small
   </Button>
 </div>
 
@@ -254,7 +257,7 @@ AI variant buttons are used specifically for AI-related actions.
 <h4>AI Button with Sizes</h4>
 
 <div className="flex gap-3 items-end">
-  <Button variant="ai">Default</Button>
+  <Button variant="ai">Medium</Button>
   <Button variant="ai" size="sm">
     Small
   </Button>
@@ -292,7 +295,7 @@ Link buttons appear as text links and don't accept theme props.
 <h4>Link Button with Sizes</h4>
 
 <div className="flex gap-3 items-end">
-  <Button variant="link">Default</Button>
+  <Button variant="link">Medium</Button>
   <Button variant="link" size="sm">
     Small
   </Button>
@@ -330,7 +333,7 @@ Transparent buttons have no background or border and don't accept theme props.
 <h4>Transparent Button with Sizes</h4>
 
 <div className="flex gap-3 items-end">
-  <Button variant="transparent">Default</Button>
+  <Button variant="transparent">Medium</Button>
   <Button variant="transparent" size="sm">
     Small
   </Button>

--- a/apps/portal/src/content/docs/components/button.mdx
+++ b/apps/portal/src/content/docs/components/button.mdx
@@ -423,7 +423,7 @@ import { Button } from '@harnessio/ui/components'
 <Button variant="transparent">Transparent Button</Button>
 
 // Button sizes
-<Button>Default Size Button</Button>
+<Button>Medium Size Button (default)</Button>
 <Button size="sm">Small Button</Button>
 <Button size="xs">Extra Small Button</Button>
 
@@ -483,8 +483,8 @@ This ensures type safety and provides proper development-time feedback on invali
       name: "size",
       description: "Size of the button.",
       required: false,
-      value: "'default' | 'sm' | 'xs'",
-      defaultValue: "'default'",
+      value: "'md' | 'sm' | 'xs'",
+      defaultValue: "'md'",
     },
     {
       name: "rounded",

--- a/apps/portal/src/content/docs/components/split-button.mdx
+++ b/apps/portal/src/content/docs/components/split-button.mdx
@@ -131,7 +131,7 @@ import { Aside } from "@astrojs/starlight/components";
   </div>
 </div>
 
-{/* Disabled State */}
+{/* Disabled States */}
 
   <div>
     <h5 className="text-lg font-semibold mb-3">Disabled State</h5>
@@ -139,7 +139,7 @@ import { Aside } from "@astrojs/starlight/components";
       <SplitButton
         id="disabled-state"
         handleButtonClick={() => {}}
-        disabled={true}
+        disabled
         options={[
           { value: 'option1', label: 'Option 1', description: 'Description for option 1' },
           { value: 'option2', label: 'Option 2', description: 'Description for option 2' },
@@ -147,6 +147,30 @@ import { Aside } from "@astrojs/starlight/components";
         handleOptionChange={() => {}}
       >
         Disabled
+      </SplitButton>
+      <SplitButton
+        id="disabled-state"
+        handleButtonClick={() => {}}
+        disableButton
+        options={[
+          { value: 'option1', label: 'Option 1', description: 'Description for option 1' },
+          { value: 'option2', label: 'Option 2', description: 'Description for option 2' },
+        ]}
+        handleOptionChange={() => {}}
+      >
+        Disabled (Button)
+      </SplitButton>
+      <SplitButton
+        id="disabled-state"
+        handleButtonClick={() => {}}
+        disableDropdown
+        options={[
+          { value: 'option1', label: 'Option 1', description: 'Description for option 1' },
+          { value: 'option2', label: 'Option 2', description: 'Description for option 2' },
+        ]}
+        handleOptionChange={() => {}}
+      >
+        Disabled (Dropdown)
       </SplitButton>
     </div>
   </div>
@@ -250,6 +274,20 @@ return (
     {
       name: "disabled",
       description: "Disables the button and dropdown.",
+      required: false,
+      value: "boolean",
+      defaultValue: "false",
+    },
+    {
+      name: "disableButton",
+      description: "Disables the button while dropdown is enabled.",
+      required: false,
+      value: "boolean",
+      defaultValue: "false",
+    },
+    {
+      name: "disableDropdown",
+      description: "Disables the dropdown while button is enabled.",
       required: false,
       value: "boolean",
       defaultValue: "false",

--- a/apps/portal/src/content/docs/components/toggle-group.mdx
+++ b/apps/portal/src/content/docs/components/toggle-group.mdx
@@ -390,8 +390,8 @@ The `Root` component serves as the main container for all toggle group elements.
       name: "size",
       description: "The size of the buttons",
       required: false,
-      value: "'default' | 'sm' | 'xs'",
-      defaultValue: "default",
+      value: "'md' | 'sm' | 'xs'",
+      defaultValue: "md",
     },
   ]}
 />

--- a/apps/portal/src/content/docs/components/toggle-group.mdx
+++ b/apps/portal/src/content/docs/components/toggle-group.mdx
@@ -180,7 +180,7 @@ The `ToggleGroup.Root` component accepts a `size` prop to control its overall di
   code={`
     <Layout.Vertical spacing="large">
       <Layout.Vertical spacing="small">
-        <Text variant="heading-subsection">Default size</Text>
+        <Text variant="heading-subsection">Medium size (md)</Text>
         <ToggleGroup.Root value="2">
           <ToggleGroup.Item value="1">Option 1</ToggleGroup.Item>
           <ToggleGroup.Item value="2">Option 2</ToggleGroup.Item>
@@ -188,7 +188,7 @@ The `ToggleGroup.Root` component accepts a `size` prop to control its overall di
         </ToggleGroup.Root>
       </Layout.Vertical>
       <Layout.Vertical spacing="small">
-        <Text variant="heading-subsection">SM size</Text>
+        <Text variant="heading-subsection">Small size (sm)</Text>
         <ToggleGroup.Root value="2" size="sm">
           <ToggleGroup.Item value="1">Option 1</ToggleGroup.Item>
           <ToggleGroup.Item value="2">Option 2</ToggleGroup.Item>
@@ -196,7 +196,7 @@ The `ToggleGroup.Root` component accepts a `size` prop to control its overall di
         </ToggleGroup.Root>
       </Layout.Vertical>
       <Layout.Vertical spacing="small">
-        <Text variant="heading-subsection">XS size</Text>
+        <Text variant="heading-subsection">Extra Small size (xs)</Text>
         <ToggleGroup.Root value="2" size="xs">
           <ToggleGroup.Item value="1">Option 1</ToggleGroup.Item>
           <ToggleGroup.Item value="2">Option 2</ToggleGroup.Item>

--- a/apps/portal/src/content/docs/components/toggle.mdx
+++ b/apps/portal/src/content/docs/components/toggle.mdx
@@ -127,8 +127,8 @@ The `Toggle` component is a button that can be toggled on and off.
       name: "size",
       description: "The size of the toggle.",
       required: false,
-      defaultValue: "default",
-      value: "'default' | 'sm' | 'xs'",
+      defaultValue: "md",
+      value: "'md' | 'sm' | 'xs'",
     },
     {
       name: "className",

--- a/apps/portal/src/content/docs/components/toggle.mdx
+++ b/apps/portal/src/content/docs/components/toggle.mdx
@@ -60,9 +60,9 @@ The `Toggle` component accepts a `size` prop to control its overall dimensions. 
   client:only
   code={`
     <ButtonLayout orientation="vertical">
-        <Toggle>default size</Toggle>
-        <Toggle size="sm">sm size</Toggle>
-        <Toggle size="xs">xs size</Toggle>
+        <Toggle>Medium</Toggle>
+        <Toggle size="sm">Small</Toggle>
+        <Toggle size="xs">Extra Small</Toggle>
     </ButtonLayout>
 `}
 />

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva('cn-button', {
       transparent: 'cn-button-transparent'
     },
     size: {
-      default: '',
+      md: '',
       xs: 'cn-button-xs',
       sm: 'cn-button-sm'
     },
@@ -77,7 +77,7 @@ const buttonVariants = cva('cn-button', {
   ],
   defaultVariants: {
     variant: 'primary',
-    size: 'default',
+    size: 'md',
     theme: 'default'
   }
 })
@@ -100,7 +100,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     {
       className,
       variant = 'primary',
-      size = 'default',
+      size = 'md',
       theme = 'default',
       rounded,
       iconOnly,
@@ -129,7 +129,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         className={cn(
           buttonVariants({
             variant: variant || 'primary',
-            size: size || 'default',
+            size: size || 'md',
             theme: theme || 'default',
             rounded,
             iconOnly,

--- a/packages/ui/src/components/split-button.tsx
+++ b/packages/ui/src/components/split-button.tsx
@@ -23,6 +23,8 @@ interface SplitButtonBaseProps<T extends string> {
   className?: string
   buttonClassName?: string
   disabled?: boolean
+  disableButton?: boolean
+  disableDropdown?: boolean
   children: ReactNode
   dropdownContentClassName?: string
 }
@@ -62,6 +64,8 @@ export const SplitButton = <T extends string>({
   theme = 'default',
   variant = 'primary',
   disabled = false,
+  disableDropdown = false,
+  disableButton = false,
   children,
   dropdownContentClassName
 }: SplitButtonProps<T>) => {
@@ -73,7 +77,7 @@ export const SplitButton = <T extends string>({
         variant={variant}
         onClick={handleButtonClick}
         type="button"
-        disabled={disabled}
+        disabled={disabled || disableButton}
         loading={loading}
       >
         {children}
@@ -81,7 +85,7 @@ export const SplitButton = <T extends string>({
       <DropdownMenu.Root>
         <DropdownMenu.Trigger
           className={cn(buttonVariants({ theme, variant }), 'cn-button-split-dropdown')}
-          disabled={disabled || loading}
+          disabled={disabled || loading || disableDropdown}
         >
           <IconV2 name="nav-arrow-down" />
         </DropdownMenu.Trigger>

--- a/packages/ui/src/components/toggle-group.tsx
+++ b/packages/ui/src/components/toggle-group.tsx
@@ -29,7 +29,7 @@ interface ToggleGroupContextValue {
 
 const ToggleGroupContext = createContext<ToggleGroupContextValue>({
   variant: 'outline-primary',
-  size: 'default',
+  size: 'md',
   selectedValues: new Map<string, boolean>()
 })
 
@@ -59,7 +59,7 @@ const ToggleGroupRoot = forwardRef<ElementRef<typeof ToggleGroupPrimitive.Root>,
     {
       children,
       variant = 'outline-primary',
-      size = 'default',
+      size = 'md',
       disabled = false,
       type = 'single',
       value,

--- a/packages/ui/src/components/toggle.tsx
+++ b/packages/ui/src/components/toggle.tsx
@@ -34,7 +34,7 @@ const Toggle = forwardRef<
     {
       className,
       variant = 'outline-primary',
-      size = 'default',
+      size = 'md',
       pressed: pressedProp = false,
       rounded,
       iconOnly,


### PR DESCRIPTION
### SplitButton different disabled states

<img width="709" alt="image" src="https://github.com/user-attachments/assets/79462bba-2a50-45cb-8225-695504348b9e" />


### Updated Button default size to "md" from "default"
<img width="664" alt="image" src="https://github.com/user-attachments/assets/6fcab726-b59d-49c4-8d7b-56aa6bd135b4" />
<img width="587" alt="image" src="https://github.com/user-attachments/assets/601082db-0ba9-4f2e-bece-8593de9fc149" />
<img width="580" alt="image" src="https://github.com/user-attachments/assets/c360cbaf-d40e-4363-8ff8-43d29161b76e" />
<img width="497" alt="image" src="https://github.com/user-attachments/assets/8373e65c-e7fa-44f0-b846-f3ea8d380854" />
<img width="534" alt="image" src="https://github.com/user-attachments/assets/bff19071-1d30-4fbe-b026-4bf0adc1435f" />
<img width="533" alt="image" src="https://github.com/user-attachments/assets/c639037d-4897-4eac-8578-1107d8f2d640" />


