### PR TITLE
Icon colors for multi-type input

### DIFF
--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -338,10 +338,13 @@ DropdownMenuLogoItem.displayName = displayNames.logoItem
 
 interface DropdownMenuIconItemProps extends Omit<DropdownMenuItemProps, 'prefix'> {
   icon: IconPropsV2['name']
+  iconClassName?: string
 }
 
 const DropdownMenuIconItem = forwardRef<ElementRef<typeof DropdownMenuPrimitive.Item>, DropdownMenuIconItemProps>(
-  ({ icon, ...props }, ref) => <DropdownMenuItem ref={ref} {...props} prefix={<IconV2 size="2xs" name={icon} />} />
+  ({ icon, iconClassName, ...props }, ref) => (
+    <DropdownMenuItem ref={ref} {...props} prefix={<IconV2 size="2xs" name={icon} className={iconClassName} />} />
+  )
 )
 DropdownMenuIconItem.displayName = displayNames.iconItem
 

--- a/packages/ui/tailwind-design-system.ts
+++ b/packages/ui/tailwind-design-system.ts
@@ -33,8 +33,8 @@ import {
   tableV2Styles,
   tagStyles,
   textareaStyles,
-  tooltipStyles,
-  toggleGroupStyles
+  toggleGroupStyles,
+  tooltipStyles
 } from './tailwind-utils-config/components'
 import { typography as typographyStyles } from './tailwind-utils-config/utilities'
 
@@ -66,6 +66,11 @@ export default {
           warning: 'var(--cn-text-warning)',
           accent: 'var(--cn-text-accent)',
           disabled: 'var(--cn-state-disabled-text)',
+          multitype: {
+            codebrackets: 'var(--cn-set-blue-surface-text)',
+            code: 'var(--cn-set-purple-surface-text)',
+            variables: 'var(--cn-set-orange-surface-text)'
+          },
 
           // Remove
           solidred: 'lch(from var(--cn-set-red-solid-text) l c h / <alpha-value>)',


### PR DESCRIPTION
Add icon colors for multi-type input icons and support setting icon color in dropdown menu.

https://github.com/user-attachments/assets/8a77a98d-ea5f-4b41-b831-e7123a31d569
