### PR TITLE
fix: add size support for Select and Textarea components

### DIFF
--- a/apps/portal/src/content/docs/components/select.mdx
+++ b/apps/portal/src/content/docs/components/select.mdx
@@ -555,6 +555,54 @@ Customize how individual options are rendered using the `optionRenderer` prop. T
 }`}
 />
 
+## Sizes
+
+The `Select` component supports two sizes: `default` and `sm`. The default size is suitable for most use cases, while the `sm` size is useful for compact layouts.
+
+<DocsPage.ComponentExample
+  client:only
+  code={`() => {
+    const [value, setValue] = React.useState('banana');
+    
+    return (
+      <div className="grid gap-4">
+        <div>
+          <Text>Size sm:</Text>
+          <Select
+            options={[
+              { label: 'Apple', value: 'apple' },
+              { label: 'Banana', value: 'banana' },
+              { label: 'Orange', value: 'orange' },
+              { label: 'Strawberry', value: 'strawberry' },
+            ]}
+            value={value}
+            onChange={setValue}
+            placeholder="Select a fruit"
+            size="sm"
+          />
+        </div>
+
+        <div>
+          <Text>Size default:</Text>
+          <Select
+            options={[
+              { label: 'Apple', value: 'apple' },
+              { label: 'Banana', value: 'banana' },
+              { label: 'Orange', value: 'orange' },
+              { label: 'Strawberry', value: 'strawberry' },
+            ]}
+            value={value}
+            onChange={setValue}
+            placeholder="Select a fruit"
+            size="default"
+          />
+        </div>
+      </div>
+    );
+
+}`}
+/>
+
 ## API Reference
 
 ### `Select`
@@ -634,6 +682,13 @@ The `Select` component is the main component for creating dropdown selections.
         "Callback fired when user scrolls near the bottom of options list",
       required: false,
       value: "() => void",
+    },
+    {
+      name: "size",
+      description: "Size of the select input",
+      required: false,
+      value: "'sm' | 'default'",
+      defaultValue: "'default'",
     },
     {
       name: "placeholder",

--- a/apps/portal/src/content/docs/components/textarea.mdx
+++ b/apps/portal/src/content/docs/components/textarea.mdx
@@ -74,6 +74,32 @@ return (
 )
 ```
 
+## Sizes
+
+The `Textarea` component supports the following sizes: `sm` and `default`. The default size is `default`.
+
+<DocsPage.ComponentExample
+  client:only
+  code={`<div className="grid gap-4 max-w-96 w-full">
+    <Textarea
+      id="1"
+      name="sm"
+      label="Size small:"
+      placeholder="Placeholder"
+      rows={4}
+      size="sm"
+    />
+    
+    <Textarea
+      id="2"
+      name="default"
+      label="Size default:"
+      placeholder="Placeholder"
+      rows={4}
+    />
+  </div>`}
+/>
+
 ## API Reference
 
 The `Textarea` can be used either controlled or uncontrolled. When controlled, the
@@ -146,6 +172,13 @@ all attributes of the `textarea` HTML element.
       required: false,
       value: "boolean",
       defaultValue: "false",
+    },
+    {
+      name: "size",
+      description: "Size of the textarea",
+      required: false,
+      value: "'sm' | 'default'",
+      defaultValue: "default",
     },
   ]}
 />

--- a/packages/ui/src/components/form-primitives/select.tsx
+++ b/packages/ui/src/components/form-primitives/select.tsx
@@ -26,10 +26,15 @@ const selectVariants = cva('cn-select', {
       default: '',
       danger: 'cn-select-danger',
       warning: 'cn-select-warning'
+    },
+    size: {
+      default: '',
+      sm: 'cn-select-sm'
     }
   },
   defaultVariants: {
-    theme: 'default'
+    theme: 'default',
+    size: 'default'
   }
 })
 
@@ -65,6 +70,7 @@ interface SelectProps<T = string>
   isLoading?: boolean
   label?: string
   theme?: VariantProps<typeof selectVariants>['theme']
+  size?: VariantProps<typeof selectVariants>['size']
   caption?: string
   error?: string
   warning?: string
@@ -142,6 +148,7 @@ function SelectInner<T = string>(
     suffix,
     triggerClassName,
     rootClassName,
+    size,
     ...props
   }: SelectProps<T>,
   ref: ForwardedRef<HTMLButtonElement>
@@ -373,7 +380,7 @@ function SelectInner<T = string>(
           id={id}
           ref={ref}
           disabled={disabled}
-          className={cn(selectVariants({ theme }), triggerClassName)}
+          className={cn(selectVariants({ theme, size }), triggerClassName)}
         >
           <div className="cn-select-trigger">
             <Text color={disabled ? 'disabled' : selectedOption ? 'foreground-1' : 'foreground-2'} truncate>

--- a/packages/ui/src/components/form-primitives/textarea.tsx
+++ b/packages/ui/src/components/form-primitives/textarea.tsx
@@ -11,10 +11,15 @@ const textareaVariants = cva('cn-textarea', {
       default: '',
       danger: 'cn-textarea-danger',
       warning: 'cn-textarea-warning'
+    },
+    size: {
+      default: '',
+      sm: 'cn-textarea-sm'
     }
   },
   defaultVariants: {
-    theme: 'default'
+    theme: 'default',
+    size: 'default'
   }
 })
 
@@ -22,6 +27,7 @@ export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
   label?: string
   labelSuffix?: ReactNode
   theme?: VariantProps<typeof textareaVariants>['theme']
+  size?: VariantProps<typeof textareaVariants>['size']
   caption?: string
   error?: string
   warning?: string
@@ -50,6 +56,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       maxCharacters,
       resizable = false,
       labelSuffix,
+      size,
       ...props
     },
     ref
@@ -104,7 +111,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         <textarea
           id={id}
           ref={mergedRef}
-          className={cn(textareaVariants({ theme }), { 'cn-textarea-resizable': resizable }, className)}
+          className={cn(textareaVariants({ theme, size }), { 'cn-textarea-resizable': resizable }, className)}
           disabled={disabled}
           onChange={handleChange}
           {...props}

--- a/packages/ui/tailwind-utils-config/components/select.ts
+++ b/packages/ui/tailwind-utils-config/components/select.ts
@@ -1,6 +1,7 @@
 import { CSSRuleObject } from 'tailwindcss/types/config'
 
 const themes = ['danger', 'warning'] as const
+const sizes = ['sm'] as const
 
 function createSelectThemeStyles() {
   const styles: CSSRuleObject = {}
@@ -14,6 +15,16 @@ function createSelectThemeStyles() {
         borderColor: `var(--cn-border-${theme})`,
         boxShadow: `var(--cn-ring-${theme}-hover)`
       }
+    }
+  })
+
+  sizes.forEach(size => {
+    styles[`&.cn-select-${size}`] = {
+      height: `var(--cn-input-size-${size})`
+    }
+
+    styles[`&.cn-select-${size} .cn-select-trigger`] = {
+      padding: `var(--cn-input-${size}-py) var(--cn-input-${size}-pr) var(--cn-input-${size}-py) var(--cn-input-${size}-pl)`
     }
   })
 

--- a/packages/ui/tailwind-utils-config/components/textarea.ts
+++ b/packages/ui/tailwind-utils-config/components/textarea.ts
@@ -1,6 +1,7 @@
 import { CSSRuleObject } from 'tailwindcss/types/config'
 
 const themes = ['danger', 'warning'] as const
+const sizes = ['sm'] as const
 
 function createInputThemeStyles() {
   const styles: CSSRuleObject = {}
@@ -19,6 +20,12 @@ function createInputThemeStyles() {
         borderColor: `var(--cn-border-${theme})`,
         boxShadow: `var(--cn-ring-${theme})`
       }
+    }
+  })
+
+  sizes.forEach(size => {
+    styles[`&.cn-textarea-${size}`] = {
+      padding: `var(--cn-input-${size}-py) var(--cn-input-${size}-pr) var(--cn-input-${size}-py) var(--cn-input-${size}-pl)`
     }
   })
 


### PR DESCRIPTION
Add prop `size` for Select and Textarea with values `sm` and `default`