### PR TITLE
fix: support for drawer animation under mfe

### DIFF
--- a/packages/ui/global.d.ts
+++ b/packages/ui/global.d.ts
@@ -17,3 +17,8 @@ declare module 'monaco-editor/esm/vs/editor/standalone/browser/standaloneService
     get: (id: unknown) => { documentSymbolProvider: unknown }
   }
 }
+
+declare module '*.css?raw' {
+  const content: string
+  export default content
+}

--- a/packages/ui/src/components/drawer/DrawerRoot.tsx
+++ b/packages/ui/src/components/drawer/DrawerRoot.tsx
@@ -1,6 +1,8 @@
 import { ComponentProps, useEffect, useRef } from 'react'
 
+import { usePortal } from '@/context'
 import { Drawer as DrawerPrimitive } from 'vaul'
+import styleText from 'vaul/style.css?raw'
 
 import { DrawerContext } from './drawer-context'
 
@@ -14,6 +16,17 @@ export const DrawerRoot = ({
 }: ComponentProps<typeof DrawerPrimitive.Root>) => {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const closeRef = useRef<HTMLButtonElement>(null)
+  const { portalContainer } = usePortal()
+
+  useEffect(() => {
+    if (!portalContainer || portalContainer.querySelector('#vaul-style')) return
+
+    const style = document.createElement('style')
+    style.setAttribute('id', 'vaul-style')
+    style.textContent = styleText
+
+    portalContainer?.appendChild(style)
+  }, [portalContainer])
 
   useEffect(() => {
     if (!nested) return
@@ -49,7 +62,7 @@ export const DrawerRoot = ({
 
   return (
     <DrawerContext.Provider value={{ direction, nested }}>
-      <RootComponent {...rootProps}>
+      <RootComponent {...rootProps} container={portalContainer as HTMLElement}>
         {nested && FakeTriggers}
         {children}
       </RootComponent>

--- a/packages/ui/vite-base.config.ts
+++ b/packages/ui/vite-base.config.ts
@@ -17,6 +17,11 @@ const external = [
 
 export default defineConfig({
   plugins: [react(), svgr({ include: '**/*.svg' }), tsConfigPaths()],
+  resolve: {
+    alias: {
+      'vaul/style.css?raw': resolve(__dirname, 'node_modules/vaul/style.css?raw')
+    }
+  },
   build: {
     lib: {
       cssFileName: 'styles',


### PR DESCRIPTION
Root cause -
vaul pkg seems to have some custom styles, which is getting injected into document head by default,
this would not work for components under shadow-dom

Resolutions
1. We can import the style file directly into ui pkg styles, which would then by imported dynamically under mfe
    - Tried this approach, but some style selector in vaul pkg seems to be broken, due to which our build would fail on import

2. We can duplicate whole styles under vaul pkg into ui pkg
     - Maintenance overhead
     
3. Import the styles from vaul as raw and inject it under portalContainer, while initializing drawer.root
    - Went with this approach

https://github.com/user-attachments/assets/2f633478-2676-4734-887c-02ecd5cf0a59
