### PR TITLE
Card Select grid layout and other minor updates

### DIFF
--- a/apps/portal/src/content/docs/components/card-select.mdx
+++ b/apps/portal/src/content/docs/components/card-select.mdx
@@ -306,7 +306,7 @@ The `CardSelect.Root` is the top-level wrapper that controls selection state.
     },
     {
       name: "layout",
-      description: "Layout direction of the cards.",
+      description: "Layout of the cards.",
       required: false,
       value: "'horizontal' | 'vertical' | 'grid'",
       defaultValue: "'vertical'",

--- a/apps/portal/src/content/docs/components/card-select.mdx
+++ b/apps/portal/src/content/docs/components/card-select.mdx
@@ -30,21 +30,6 @@ import { DocsPage } from "@/components/docs-page";
       </CardSelect.Item>
     </CardSelect.Root>
 
-    <CardSelect.Root type="single" layout="grid" cols={2} rows={2} gap="md">
-      <CardSelect.Item value="grid-1">
-        <CardSelect.Title>Grid Item 1</CardSelect.Title>
-      </CardSelect.Item>
-      <CardSelect.Item value="grid-2">
-        <CardSelect.Title>Grid Item 2</CardSelect.Title>
-      </CardSelect.Item>
-      <CardSelect.Item value="grid-3">
-        <CardSelect.Title>Grid Item 3</CardSelect.Title>
-      </CardSelect.Item>
-      <CardSelect.Item value="grid-4">
-        <CardSelect.Title>Grid Item 4</CardSelect.Title>
-      </CardSelect.Item>
-    </CardSelect.Root>
-
   </div>`}
 />
 
@@ -109,7 +94,7 @@ The `CardSelect` supports two selection types:
 
 ### Layout
 
-Cards can be arranged horizontally or vertically:
+Cards can be arranged horizontally, vertically, or in a grid:
 
 <DocsPage.ComponentExample
   client:only
@@ -138,6 +123,24 @@ Cards can be arranged horizontally or vertically:
         <CardSelect.Item value="h2">
           <CardSelect.Title>Second Card</CardSelect.Title>
           <CardSelect.Description>In the same row</CardSelect.Description>
+        </CardSelect.Item>
+      </CardSelect.Root>
+    </div>
+
+    <div className="flex flex-col space-y-2">
+      <h1 className="text-lg font-semibold">Grid Layout</h1>
+      <CardSelect.Root type="single" layout="grid" cols={2} rows={2} gap="md">
+        <CardSelect.Item value="grid-1">
+          <CardSelect.Title>Grid Item 1</CardSelect.Title>
+        </CardSelect.Item>
+        <CardSelect.Item value="grid-2">
+          <CardSelect.Title>Grid Item 2</CardSelect.Title>
+        </CardSelect.Item>
+        <CardSelect.Item value="grid-3">
+          <CardSelect.Title>Grid Item 3</CardSelect.Title>
+        </CardSelect.Item>
+        <CardSelect.Item value="grid-4">
+          <CardSelect.Title>Grid Item 4</CardSelect.Title>
         </CardSelect.Item>
       </CardSelect.Root>
     </div>

--- a/apps/portal/src/content/docs/components/card-select.mdx
+++ b/apps/portal/src/content/docs/components/card-select.mdx
@@ -1,10 +1,10 @@
 ---
 title: CardSelect
-description: A card-based selection interface for single and multiple selections
+description: A card-based selection interface for single and multiple selections with flexible layouts
 beta: true
 ---
 
-The `CardSelect` component provides an accessible and customizable card-based selection interface. It supports both single and multiple selection modes, making it suitable for forms, settings, and decision workflows.
+The `CardSelect` component provides an accessible and customizable card-based selection interface. It supports both single and multiple selection modes with flexible layouts (horizontal, vertical, or grid), making it suitable for forms, settings, and decision workflows.
 
 import { DocsPage } from "@/components/docs-page";
 
@@ -29,6 +29,22 @@ import { DocsPage } from "@/components/docs-page";
         <CardSelect.Title>Option B</CardSelect.Title>
       </CardSelect.Item>
     </CardSelect.Root>
+
+    <CardSelect.Root type="single" layout="grid" cols={2} rows={2} gap="md">
+      <CardSelect.Item value="grid-1">
+        <CardSelect.Title>Grid Item 1</CardSelect.Title>
+      </CardSelect.Item>
+      <CardSelect.Item value="grid-2">
+        <CardSelect.Title>Grid Item 2</CardSelect.Title>
+      </CardSelect.Item>
+      <CardSelect.Item value="grid-3">
+        <CardSelect.Title>Grid Item 3</CardSelect.Title>
+      </CardSelect.Item>
+      <CardSelect.Item value="grid-4">
+        <CardSelect.Title>Grid Item 4</CardSelect.Title>
+      </CardSelect.Item>
+    </CardSelect.Root>
+
   </div>`}
 />
 
@@ -248,7 +264,7 @@ The `CardSelect.Root` is the top-level wrapper that controls selection state.
   value={selectedValue}             // [OPTIONAL] For controlled usage
   defaultValue={defaultValue}       // [OPTIONAL] For selecting item initially
   onValueChange={handleChange}      // [OPTIONAL] Selection change handler
-  layout="horizontal"               // [OPTIONAL] Card layout: 'horizontal' or 'vertical'
+  layout="horizontal"               // [OPTIONAL] Card layout: 'horizontal', 'vertical', or 'grid'
   gap="md"                          // [OPTIONAL] Space between cards
   disabled={false}                  // [OPTIONAL] Disable all selections
 >
@@ -289,7 +305,7 @@ The `CardSelect.Root` is the top-level wrapper that controls selection state.
       name: "layout",
       description: "Layout direction of the cards.",
       required: false,
-      value: "'horizontal' | 'vertical'",
+      value: "'horizontal' | 'vertical' | 'grid'",
       defaultValue: "'vertical'",
     },
     {
@@ -298,6 +314,20 @@ The `CardSelect.Root` is the top-level wrapper that controls selection state.
       required: false,
       value: "'sm' | 'md' | 'lg'",
       defaultValue: "'md'",
+    },
+    {
+      name: "rows",
+      description: "Number of rows for grid layout.",
+      required: false,
+      value: "number",
+      defaultValue: "undefined",
+    },
+    {
+      name: "cols",
+      description: "Number of columns for grid layout.",
+      required: false,
+      value: "number",
+      defaultValue: "undefined",
     },
     {
       name: "disabled",

--- a/apps/portal/src/content/docs/components/card-select.mdx
+++ b/apps/portal/src/content/docs/components/card-select.mdx
@@ -12,7 +12,7 @@ import { DocsPage } from "@/components/docs-page";
   client:only
   code={`
   <div className="flex flex-col space-y-8">
-    <CardSelect.Root type="single" orientation="horizontal" onValueChange={console.log}>
+    <CardSelect.Root type="single" layout="horizontal" onValueChange={console.log}>
       <CardSelect.Item value="option-1">
         <CardSelect.Title>Option 1</CardSelect.Title>
       </CardSelect.Item>
@@ -91,7 +91,7 @@ The `CardSelect` supports two selection types:
 </div>`}
 />
 
-### Orientation
+### Layout
 
 Cards can be arranged horizontally or vertically:
 
@@ -100,7 +100,7 @@ Cards can be arranged horizontally or vertically:
   code={`<div className="flex flex-col space-y-8">
     <div className="flex flex-col space-y-2">
       <h1 className="text-lg font-semibold">Vertical Layout (Default)</h1>
-      <CardSelect.Root type="single" orientation="vertical">
+      <CardSelect.Root type="single" layout="vertical">
         <CardSelect.Item value="v1">
           <CardSelect.Title>First Card</CardSelect.Title>
           <CardSelect.Description>Cards stacked vertically</CardSelect.Description>
@@ -114,7 +114,7 @@ Cards can be arranged horizontally or vertically:
 
     <div className="flex flex-col space-y-2">
       <h1 className="text-lg font-semibold">Horizontal Layout</h1>
-      <CardSelect.Root type="single" orientation="horizontal">
+      <CardSelect.Root type="single" layout="horizontal">
         <CardSelect.Item value="h1">
           <CardSelect.Title>First Card</CardSelect.Title>
           <CardSelect.Description>Cards arranged side by side</CardSelect.Description>
@@ -138,7 +138,7 @@ Control the gap between cards using the `gap` prop:
   code={`<div className="flex flex-col space-y-8">
     <div className="flex flex-col space-y-2">
       <h1 className="text-lg font-semibold">Small Gap</h1>
-      <CardSelect.Root type="single" gap="sm" orientation="horizontal">
+      <CardSelect.Root type="single" gap="sm" layout="horizontal">
         <CardSelect.Item value="small-1">
           <CardSelect.Title>Small 1</CardSelect.Title>
         </CardSelect.Item>
@@ -153,7 +153,7 @@ Control the gap between cards using the `gap` prop:
 
     <div className="flex flex-col space-y-2">
       <h1 className="text-lg font-semibold">Medium Gap (Default)</h1>
-      <CardSelect.Root type="single" gap="md" orientation="horizontal">
+      <CardSelect.Root type="single" gap="md" layout="horizontal">
         <CardSelect.Item value="medium-1">
           <CardSelect.Title>Medium 1</CardSelect.Title>
         </CardSelect.Item>
@@ -168,7 +168,7 @@ Control the gap between cards using the `gap` prop:
 
     <div className="flex flex-col space-y-2">
       <h1 className="text-lg font-semibold">Large Gap</h1>
-      <CardSelect.Root type="single" gap="lg" orientation="horizontal">
+      <CardSelect.Root type="single" gap="lg" layout="horizontal">
         <CardSelect.Item value="large-1">
           <CardSelect.Title>Large 1</CardSelect.Title>
         </CardSelect.Item>
@@ -248,7 +248,7 @@ The `CardSelect.Root` is the top-level wrapper that controls selection state.
   value={selectedValue}             // [OPTIONAL] For controlled usage
   defaultValue={defaultValue}       // [OPTIONAL] For selecting item initially
   onValueChange={handleChange}      // [OPTIONAL] Selection change handler
-  orientation="horizontal"           // [OPTIONAL] Card layout direction
+  layout="horizontal"               // [OPTIONAL] Card layout: 'horizontal' or 'vertical'
   gap="md"                          // [OPTIONAL] Space between cards
   disabled={false}                  // [OPTIONAL] Disable all selections
 >
@@ -286,7 +286,7 @@ The `CardSelect.Root` is the top-level wrapper that controls selection state.
       defaultValue: "undefined",
     },
     {
-      name: "orientation",
+      name: "layout",
       description: "Layout direction of the cards.",
       required: false,
       value: "'horizontal' | 'vertical'",

--- a/packages/ui/src/components/card-select.tsx
+++ b/packages/ui/src/components/card-select.tsx
@@ -15,8 +15,10 @@ interface CardSelectRootProps<T> {
   defaultValue?: T extends 'single' ? unknown : unknown[]
   onValueChange?: T extends 'single' ? (val: unknown) => void : (val: unknown[]) => void
   disabled?: boolean
-  layout?: 'horizontal' | 'vertical'
+  layout?: 'horizontal' | 'vertical' | 'grid'
   gap?: 'sm' | 'md' | 'lg'
+  rows?: number
+  cols?: number
   children: ReactNode
 }
 
@@ -54,7 +56,8 @@ const cardSelectVariants = cva('cn-card-select-root', {
   variants: {
     layout: {
       vertical: 'cn-card-select-vertical',
-      horizontal: 'cn-card-select-horizontal'
+      horizontal: 'cn-card-select-horizontal',
+      grid: 'cn-card-select-grid'
     },
     gap: {
       sm: 'cn-card-select-gap-sm',
@@ -77,7 +80,9 @@ function CardSelectRoot<T extends CardSelectType>({
   defaultValue,
   onValueChange,
   disabled = false,
-  children
+  children,
+  rows,
+  cols
 }: CardSelectRootProps<T>) {
   const [internalValue, setInternalValue] = useState<unknown | unknown[]>(
     defaultValue ?? (type === 'multiple' ? [] : undefined)
@@ -114,7 +119,16 @@ function CardSelectRoot<T extends CardSelectType>({
         onValueChange: handleValueChange
       }}
     >
-      <div className={cardSelectVariants({ layout, gap })} role={type === 'single' ? 'radiogroup' : 'group'}>
+      <div
+        className={cardSelectVariants({ layout, gap })}
+        role={type === 'single' ? 'radiogroup' : 'group'}
+        style={
+          {
+            '--cols': cols,
+            '--rows': rows
+          } as React.CSSProperties
+        }
+      >
         {children}
       </div>
     </CardSelectContext.Provider>

--- a/packages/ui/src/components/card-select.tsx
+++ b/packages/ui/src/components/card-select.tsx
@@ -15,8 +15,7 @@ interface CardSelectRootProps<T> {
   defaultValue?: T extends 'single' ? unknown : unknown[]
   onValueChange?: T extends 'single' ? (val: unknown) => void : (val: unknown[]) => void
   disabled?: boolean
-  orientation?: 'horizontal' | 'vertical'
-  wrap?: boolean
+  layout?: 'horizontal' | 'vertical'
   gap?: 'sm' | 'md' | 'lg'
   children: ReactNode
 }
@@ -53,7 +52,7 @@ function isChecked(value: unknown, current: unknown | unknown[]) {
 
 const cardSelectVariants = cva('cn-card-select-root', {
   variants: {
-    orientation: {
+    layout: {
       vertical: 'cn-card-select-vertical',
       horizontal: 'cn-card-select-horizontal'
     },
@@ -64,14 +63,14 @@ const cardSelectVariants = cva('cn-card-select-root', {
     }
   },
   defaultVariants: {
-    orientation: 'vertical',
+    layout: 'vertical',
     gap: 'md'
   }
 })
 
 function CardSelectRoot<T extends CardSelectType>({
   type,
-  orientation = 'vertical',
+  layout = 'vertical',
   gap = 'md',
   name = `card-select-${Math.random().toString(36).slice(2)}`,
   value,
@@ -115,7 +114,7 @@ function CardSelectRoot<T extends CardSelectType>({
         onValueChange: handleValueChange
       }}
     >
-      <div className={cardSelectVariants({ orientation, gap })} role={type === 'single' ? 'radiogroup' : 'group'}>
+      <div className={cardSelectVariants({ layout, gap })} role={type === 'single' ? 'radiogroup' : 'group'}>
         {children}
       </div>
     </CardSelectContext.Provider>

--- a/packages/ui/src/components/card-select.tsx
+++ b/packages/ui/src/components/card-select.tsx
@@ -16,6 +16,7 @@ interface CardSelectRootProps<T> {
   onValueChange?: T extends 'single' ? (val: unknown) => void : (val: unknown[]) => void
   disabled?: boolean
   orientation?: 'horizontal' | 'vertical'
+  wrap?: boolean
   gap?: 'sm' | 'md' | 'lg'
   children: ReactNode
 }
@@ -53,7 +54,7 @@ function isChecked(value: unknown, current: unknown | unknown[]) {
 const cardSelectVariants = cva('cn-card-select-root', {
   variants: {
     orientation: {
-      vertical: '',
+      vertical: 'cn-card-select-vertical',
       horizontal: 'cn-card-select-horizontal'
     },
     gap: {

--- a/packages/ui/tailwind-utils-config/components/card-select.ts
+++ b/packages/ui/tailwind-utils-config/components/card-select.ts
@@ -18,6 +18,12 @@ export default {
 
     '&:where(.cn-card-select-vertical)': {
       '@apply h-full overflow-y-auto': ''
+    },
+
+    '&:where(.cn-card-select-grid)': {
+      '@apply w-full': '',
+      gridTemplateColumns: 'repeat(var(--cols, 1), minmax(0, 1fr))',
+      gridTemplateRows: 'repeat(var(--rows, 1), minmax(0, 1fr))'
     }
   },
 

--- a/packages/ui/tailwind-utils-config/components/card-select.ts
+++ b/packages/ui/tailwind-utils-config/components/card-select.ts
@@ -13,7 +13,11 @@ export default {
     },
 
     '&:where(.cn-card-select-horizontal)': {
-      '@apply auto-cols-max grid-flow-col': ''
+      '@apply w-full auto-cols-max grid-flow-col overflow-x-auto': ''
+    },
+
+    '&:where(.cn-card-select-vertical)': {
+      '@apply h-full overflow-y-auto': ''
     }
   },
 


### PR DESCRIPTION
This PR takes care of the following:
- Changes `orientation` prop to `layout`
- Adds an option for `grid` layout where the user can pass `rows` and `cols` to structure the grid
- Adds `overflow` to the the horizontal and vertical layouts
- Modifies the docs to reflect all these changes

https://github.com/user-attachments/assets/26a5af85-f008-4bc9-877e-ca55225aaa7e
