### PR TITLE
fix: Handle "undefined" error while adding a template with no inputs

### DIFF
--- a/packages/ui/src/views/unified-pipeline-studio/components/entity-form/unified-pipeline-studio-entity-form.tsx
+++ b/packages/ui/src/views/unified-pipeline-studio/components/entity-form/unified-pipeline-studio-entity-form.tsx
@@ -172,7 +172,7 @@ export const UnifiedPipelineStudioEntityForm = (props: UnifiedPipelineStudioEnti
         // TODO:move transform logic outside for "external"
         if (formEntity?.source === 'external') {
           // remove "with" if its a empty object
-          const cleanWith = omitBy(stepValue.template.with, isUndefined)
+          const cleanWith = omitBy(stepValue.template?.with, isUndefined)
 
           // add 'uses' for template step
           stepValue = {


### PR DESCRIPTION
Currently, we get this error while trying to add a template with no inputs. Adding the missing null check.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/bd5fd5c3-5043-41b5-b6a9-09465d90883c" />
