### PR TITLE
feat: Conditional handling of `deploy/template` key

### DIFF
--- a/packages/ui/src/views/unified-pipeline-studio/components/entity-form/unified-pipeline-studio-entity-form.tsx
+++ b/packages/ui/src/views/unified-pipeline-studio/components/entity-form/unified-pipeline-studio-entity-form.tsx
@@ -180,11 +180,15 @@ export const UnifiedPipelineStudioEntityForm = (props: UnifiedPipelineStudioEnti
         if (formEntity?.source === 'external') {
           // remove "with" if its a empty object
           const cleanWith = omitBy(stepValue.template?.with, isUndefined)
-          const modules: string[] = get(formDefinition.metadata, 'modules', [])
+          const alias = String(get(formDefinition.metadata, 'alias', ''))
+          /**
+           * "alias" will be used directly as the "templateKey" once TEMPLATE_CI_STEP_IDENTIFIER changes from "template" to "build"
+           */
+          const templateKey = alias === 'deploy' ? alias : TEMPLATE_CI_STEP_IDENTIFIER
 
           stepValue = {
-            ...omit(stepValue, 'template'),
-            [modules.includes('cd') ? 'deploy' : 'template']: {
+            ...omit(stepValue, templateKey),
+            [templateKey]: {
               uses: `${formEntity.data.identifier}@${formEntity.data.version}`,
               ...(isEmpty(cleanWith) ? {} : { with: cleanWith })
             }

--- a/packages/ui/src/views/unified-pipeline-studio/components/steps/types.ts
+++ b/packages/ui/src/views/unified-pipeline-studio/components/steps/types.ts
@@ -14,7 +14,7 @@ export const APPROVAL_STEP_IDENTIFIER = 'approval'
 export const BARRIER_STEP_IDENTIFIER = 'barrier'
 export const ACTION_STEP_IDENTIFIER = 'action'
 
-export const TEMPLATE_CI_STEP_IDENTIFIER = 'template'
+export const TEMPLATE_CI_STEP_IDENTIFIER = 'template' // This would change to "build" once Backend support for the same gets added.
 export const TEMPLATE_CD_STEP_IDENTIFIER = 'deploy'
 
 export const GROUP_IDENTIFIER = 'group'


### PR DESCRIPTION
Introduces support for CD templates that need to be added to yaml as follows:
```
- deploy:
    uses: "K8sRollingDeploy@1.0.0"
```

For CI templates:
```
- template:
    uses: "DLCDockerBuildPush@1.0.0"
```