### PR TITLE
Templates widgets

### DIFF
--- a/apps/design-system/src/subjects/views/templates/view-only.tsx
+++ b/apps/design-system/src/subjects/views/templates/view-only.tsx
@@ -6,6 +6,7 @@ import {
   StatsPanel,
   StatusBadge,
   Table,
+  Tabs,
   Tag,
   Text,
   Toggle,
@@ -185,6 +186,14 @@ export const ViewOnlyView = () => {
         />
       </Page.Header>
       <Page.Content>
+        <Tabs.NavRoot defaultValue="/dashboard">
+          <Tabs.List variant="overlined" className="mb-10">
+            <Tabs.Trigger value="/dashboard">Сonfiguration</Tabs.Trigger>
+            <Tabs.Trigger value="/analytics">References</Tabs.Trigger>
+            <Tabs.Trigger value="/reports">Activity History</Tabs.Trigger>
+          </Tabs.List>
+        </Tabs.NavRoot>
+
         <Widgets.Root isTwoColumn>
           <Widgets.Item title="Connector details">
             {dataMock.map((props, index) => (
@@ -237,7 +246,7 @@ export const ViewOnlyView = () => {
                   <Table.Cell>
                     <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
                   </Table.Cell>
-                  <Table.Cell>
+                  <Table.Cell align="right" width="40">
                     <Toggle iconOnly>
                       <IconV2 name="pin" />
                     </Toggle>
@@ -259,7 +268,7 @@ export const ViewOnlyView = () => {
                   <Table.Cell>
                     <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
                   </Table.Cell>
-                  <Table.Cell>
+                  <Table.Cell align="right" width="40">
                     <Toggle iconOnly>
                       <IconV2 name="pin" />
                     </Toggle>
@@ -281,7 +290,7 @@ export const ViewOnlyView = () => {
                   <Table.Cell>
                     <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
                   </Table.Cell>
-                  <Table.Cell>
+                  <Table.Cell align="right" width="40">
                     <Toggle iconOnly>
                       <IconV2 name="pin" />
                     </Toggle>
@@ -303,7 +312,7 @@ export const ViewOnlyView = () => {
                   <Table.Cell>
                     <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
                   </Table.Cell>
-                  <Table.Cell>
+                  <Table.Cell align="right" width="40">
                     <Toggle iconOnly>
                       <IconV2 name="pin" />
                     </Toggle>
@@ -325,7 +334,7 @@ export const ViewOnlyView = () => {
                   <Table.Cell>
                     <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
                   </Table.Cell>
-                  <Table.Cell>
+                  <Table.Cell align="right" width="40">
                     <Toggle iconOnly>
                       <IconV2 name="pin" />
                     </Toggle>
@@ -347,7 +356,7 @@ export const ViewOnlyView = () => {
                   <Table.Cell>
                     <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
                   </Table.Cell>
-                  <Table.Cell>
+                  <Table.Cell align="right" width="40">
                     <Toggle iconOnly>
                       <IconV2 name="pin" />
                     </Toggle>

--- a/apps/design-system/src/subjects/views/templates/view-only.tsx
+++ b/apps/design-system/src/subjects/views/templates/view-only.tsx
@@ -7,7 +7,9 @@ import {
   Tag,
   Text,
   ViewOnly,
-  ViewOnlyProps
+  ViewOnlyProps,
+  Widgets,
+  Table, Link
 } from '@harnessio/ui/components'
 import { timeAgo } from '@harnessio/ui/utils'
 import { Page } from '@harnessio/ui/views'
@@ -181,9 +183,59 @@ export const ViewOnlyView = () => {
         />
       </Page.Header>
       <Page.Content>
-        {dataMock.map((props, index) => (
-          <ViewOnly key={index} {...props} />
-        ))}
+        <Widgets.Root isTwoColumn>
+          <Widgets.Item title="Connector details">
+            {dataMock.map((props, index) => (
+              <ViewOnly key={index} {...props} />
+            ))}
+          </Widgets.Item>
+
+          <Widgets.Item
+            title="Activity history"
+            moreLink={{
+              to: '/'
+            }}
+          >
+            {dataMock.slice(0, 2).map((props, index) => (
+              <ViewOnly key={index} {...props} />
+            ))}
+          </Widgets.Item>
+
+          <Widgets.Item
+              title="Secrets"
+              moreLink={{
+                to: '/'
+              }}
+              isWidgetTable
+          >
+            <Table.Root>
+              <Table.Header>
+                <Table.Row>
+                  <Table.Head>Event</Table.Head>
+                  <Table.Head>Type</Table.Head>
+                  <Table.Head>Scope</Table.Head>
+                  <Table.Head>Created</Table.Head>
+                  <Table.Head />
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                <Table.Row>
+                  <Table.Cell>
+                    <Text color="foreground-1" variant="body-strong">secretfile</Text>
+                  </Table.Cell>
+                  <Table.Cell>Pipeline</Table.Cell>
+                  <Table.Cell>
+                    <Link to="/">default_project</Link>
+                  </Table.Cell>
+                  <Table.Cell>
+                    {timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}
+                  </Table.Cell>
+                  <Table.Cell></Table.Cell>
+                </Table.Row>
+              </Table.Body>
+            </Table.Root>
+          </Widgets.Item>
+        </Widgets.Root>
       </Page.Content>
     </Page.Root>
   )

--- a/apps/design-system/src/subjects/views/templates/view-only.tsx
+++ b/apps/design-system/src/subjects/views/templates/view-only.tsx
@@ -1,15 +1,17 @@
 import {
   IconV2,
   Layout,
+  Link,
   LogoV2,
   StatsPanel,
   StatusBadge,
+  Table,
   Tag,
   Text,
+  Toggle,
   ViewOnly,
   ViewOnlyProps,
-  Widgets,
-  Table, Link
+  Widgets
 } from '@harnessio/ui/components'
 import { timeAgo } from '@harnessio/ui/utils'
 import { Page } from '@harnessio/ui/views'
@@ -202,11 +204,11 @@ export const ViewOnlyView = () => {
           </Widgets.Item>
 
           <Widgets.Item
-              title="Secrets"
-              moreLink={{
-                to: '/'
-              }}
-              isWidgetTable
+            title="Secrets"
+            moreLink={{
+              to: '/'
+            }}
+            isWidgetTable
           >
             <Table.Root>
               <Table.Header>
@@ -221,16 +223,135 @@ export const ViewOnlyView = () => {
               <Table.Body>
                 <Table.Row>
                   <Table.Cell>
-                    <Text color="foreground-1" variant="body-strong">secretfile</Text>
+                    <Layout.Flex direction="row" gap="xs" align="center">
+                      <LogoV2 name="servicenow" />
+                      <Text color="foreground-1" variant="body-strong">
+                        secretfile
+                      </Text>
+                    </Layout.Flex>
                   </Table.Cell>
                   <Table.Cell>Pipeline</Table.Cell>
                   <Table.Cell>
                     <Link to="/">default_project</Link>
                   </Table.Cell>
                   <Table.Cell>
-                    {timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}
+                    <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
                   </Table.Cell>
-                  <Table.Cell></Table.Cell>
+                  <Table.Cell>
+                    <Toggle iconOnly>
+                      <IconV2 name="pin" />
+                    </Toggle>
+                  </Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Layout.Flex direction="row" gap="xs" align="center">
+                      <LogoV2 name="android" />
+                      <Text color="foreground-1" variant="body-strong">
+                        testsecret
+                      </Text>
+                    </Layout.Flex>
+                  </Table.Cell>
+                  <Table.Cell>Secret</Table.Cell>
+                  <Table.Cell>
+                    <Link to="/">default_project</Link>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Toggle iconOnly>
+                      <IconV2 name="pin" />
+                    </Toggle>
+                  </Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Layout.Flex direction="row" gap="xs" align="center">
+                      <LogoV2 name="argo" />
+                      <Text color="foreground-1" variant="body-strong">
+                        jamiegit
+                      </Text>
+                    </Layout.Flex>
+                  </Table.Cell>
+                  <Table.Cell>Service</Table.Cell>
+                  <Table.Cell>
+                    <Link to="/">default_project</Link>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Toggle iconOnly>
+                      <IconV2 name="pin" />
+                    </Toggle>
+                  </Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Layout.Flex direction="row" gap="xs" align="center">
+                      <LogoV2 name="artifactory" />
+                      <Text color="foreground-1" variant="body-strong">
+                        nofar123
+                      </Text>
+                    </Layout.Flex>
+                  </Table.Cell>
+                  <Table.Cell>Template</Table.Cell>
+                  <Table.Cell>
+                    <Link to="/">default_project</Link>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Toggle iconOnly>
+                      <IconV2 name="pin" />
+                    </Toggle>
+                  </Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Layout.Flex direction="row" gap="xs" align="center">
+                      <LogoV2 name="android" />
+                      <Text color="foreground-1" variant="body-strong">
+                        nofarb
+                      </Text>
+                    </Layout.Flex>
+                  </Table.Cell>
+                  <Table.Cell>Secret</Table.Cell>
+                  <Table.Cell>
+                    <Link to="/">default_project</Link>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Toggle iconOnly>
+                      <IconV2 name="pin" />
+                    </Toggle>
+                  </Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Layout.Flex direction="row" gap="xs" align="center">
+                      <LogoV2 name="servicenow" />
+                      <Text color="foreground-1" variant="body-strong">
+                        githubtoken
+                      </Text>
+                    </Layout.Flex>
+                  </Table.Cell>
+                  <Table.Cell>Pipeline</Table.Cell>
+                  <Table.Cell>
+                    <Link to="/">default_project</Link>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text wrap="nowrap">{timeAgo('Dec 6, 2024', { dateStyle: 'medium' })}</Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Toggle iconOnly>
+                      <IconV2 name="pin" />
+                    </Toggle>
+                  </Table.Cell>
                 </Table.Row>
               </Table.Body>
             </Table.Root>

--- a/packages/ui/locales/en/component.json
+++ b/packages/ui/locales/en/component.json
@@ -133,6 +133,9 @@
     "input": "Search files...",
     "noFile": "No file found."
   },
+  "widgets": {
+    "viewMore": "View more"
+  },
   "sort": {
     "defaultLabel": "Sort",
     "resetSort": "Reset sort",

--- a/packages/ui/locales/fr/component.json
+++ b/packages/ui/locales/fr/component.json
@@ -133,6 +133,9 @@
     "input": "Rechercher des fichiers...",
     "noFile": "Aucun fichier trouvé."
   },
+  "widgets": {
+    "viewMore": "View more"
+  },
   "sort": {
     "defaultLabel": "Trier",
     "resetSort": "Reset sort",

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -25,7 +25,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog.Root {...props}>
       <Dialog.Content className="overflow-hidden p-0">
-        <CommandRoot className="[&_[cmdk-group-heading]]:text-cn-foreground-3 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:size-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:size-5">
+        <CommandRoot className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-cn-foreground-3 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:size-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:size-5">
           {children}
         </CommandRoot>
       </Dialog.Content>
@@ -69,7 +69,7 @@ CommandList.displayName = CommandPrimitive.List.displayName
 const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => <CommandPrimitive.Empty ref={ref} className="text-cn-foreground-3 px-2 py-4 text-sm" {...props} />)
+>((props, ref) => <CommandPrimitive.Empty ref={ref} className="px-2 py-4 text-sm text-cn-foreground-3" {...props} />)
 
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName
 

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -85,6 +85,7 @@ export * from './draggable-card'
 export * from './button-group'
 export * from './view-only'
 export * from './stats-panel'
+export * from './widgets'
 
 export * as NodeGroup from './node-group'
 export * as ListActions from './list-actions'

--- a/packages/ui/src/components/node-group.tsx
+++ b/packages/ui/src/components/node-group.tsx
@@ -30,7 +30,7 @@ function Icon({
   className?: string
 }) {
   return (
-    <div className="col-start-1 row-start-1 self-start w-full h-full flex items-center justify-center">
+    <div className="col-start-1 row-start-1 flex size-full items-center justify-center self-start">
       <div
         className={cn(
           'border-cn-borders-4 bg-cn-background-2 text-icons-8 relative flex h-6 w-6 place-content-center place-items-center rounded-full border p-1 layer-medium',

--- a/packages/ui/src/components/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/sidebar/sidebar.tsx
@@ -185,7 +185,7 @@ const SidebarRoot = forwardRef<
         <Sheet.Content
           data-sidebar="sidebar"
           data-mobile="true"
-          className="bg-cn-background-0 w-[--cn-sidebar-width] p-0 [&>button]:hidden"
+          className="w-[--cn-sidebar-width] bg-cn-background-0 p-0 [&>button]:hidden"
           style={{ '--cn-sidebar-width': SIDEBAR_WIDTH_MOBILE } as CSSProperties}
           side={side}
         >
@@ -422,7 +422,7 @@ const SidebarMenuItem = forwardRef<HTMLLIElement, ComponentProps<'li'>>(({ class
 SidebarMenuItem.displayName = 'SidebarMenuItem'
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button group-hover/menu-item:bg-sidebar-background-3 data-[active=true]:bg-sidebar-background-3 data-[state=open]:hover:bg-sidebar-background-3 flex w-full cursor-pointer items-center overflow-hidden rounded px-2.5 py-2 text-left text-sm outline-none transition-[width,height,padding] disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-7 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:shrink-0',
+  'peer/menu-button flex w-full cursor-pointer items-center overflow-hidden rounded px-2.5 py-2 text-left text-sm outline-none transition-[width,height,padding] disabled:pointer-events-none disabled:opacity-50 group-hover/menu-item:bg-sidebar-background-3 group-has-[[data-sidebar=menu-action]]/menu-item:pr-7 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-background-3 data-[active=true]:font-medium data-[state=open]:hover:bg-sidebar-background-3 group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -432,7 +432,7 @@ const sidebarMenuButtonVariants = cva(
       },
       size: {
         default: 'h-8 text-sm',
-        sm: 'text-2 h-7',
+        sm: 'h-7 text-2',
         lg: 'h-12 text-sm group-data-[collapsible=icon]:!p-0'
       }
     },

--- a/packages/ui/src/components/widgets.tsx
+++ b/packages/ui/src/components/widgets.tsx
@@ -1,0 +1,74 @@
+import {Children, createContext, FC, ReactNode, useContext} from 'react'
+import type { LinkProps } from 'react-router-dom'
+
+import {Layout, Link, ScrollArea, Text} from '@/components'
+import { useTranslation } from '@/context'
+import { cn } from '@/utils'
+
+interface WidgetsContextProps {
+    isTwoColumn: boolean
+}
+
+const WidgetsContext = createContext<WidgetsContextProps>({
+    isTwoColumn: false
+})
+
+export interface WidgetsRootProps extends Partial<WidgetsContextProps>{
+  children: ReactNode
+}
+
+const Root: FC<WidgetsRootProps> = ({ children, isTwoColumn: isTwoColumnProp = false }) => {
+  const isTwoColumn = isTwoColumnProp && Children.count(children) > 1
+
+  return (
+      <WidgetsContext.Provider value={{ isTwoColumn }}>
+          <div className={cn('gap-[var(--cn-spacing-10)]', isTwoColumn ? 'columns-2' : 'flex flex-col')}>{children}</div>
+      </WidgetsContext.Provider>
+  )
+}
+
+export interface WidgetsItemProps {
+  children: ReactNode
+  title: string
+  moreLink?: LinkProps
+  isWidgetTable?: boolean
+  className?: string
+}
+
+const Item: FC<WidgetsItemProps> = ({ children, title, moreLink, isWidgetTable = false, className }) => {
+    const { isTwoColumn } = useContext(WidgetsContext)
+  const { t } = useTranslation()
+
+  return (
+    <Layout.Vertical className={cn('overflow-hidden',
+        { 'break-inside-avoid mt-[var(--cn-spacing-10)] first:mt-0': isTwoColumn }
+    )}>
+      <Layout.Flex justify="between" gap="md" align="start">
+        <Text as="h2" variant="heading-subsection" color="foreground-1">
+          {title}
+        </Text>
+        {!!moreLink && (
+          <Link className="shrink-0" {...moreLink} suffixIcon="nav-arrow-right">
+            {t('component:widgets.viewMore', 'View more')}
+          </Link>
+        )}
+      </Layout.Flex>
+      <div
+        className={cn(
+            '[contain:inline-size]',
+            { 'border border-cn-borders-3 rounded-3 p-[var(--cn-spacing-5)]': !isWidgetTable },
+            className
+        )}
+      >
+        <ScrollArea classNameContent="w-full">
+          {children}
+        </ScrollArea>
+      </div>
+    </Layout.Vertical>
+  )
+}
+
+export const Widgets = {
+  Root,
+  Item
+}

--- a/packages/ui/src/components/widgets.tsx
+++ b/packages/ui/src/components/widgets.tsx
@@ -1,19 +1,19 @@
-import {Children, createContext, FC, ReactNode, useContext} from 'react'
+import { Children, createContext, FC, ReactNode, useContext } from 'react'
 import type { LinkProps } from 'react-router-dom'
 
-import {Layout, Link, ScrollArea, Text} from '@/components'
+import { Layout, Link, ScrollArea, Text } from '@/components'
 import { useTranslation } from '@/context'
 import { cn } from '@/utils'
 
 interface WidgetsContextProps {
-    isTwoColumn: boolean
+  isTwoColumn: boolean
 }
 
 const WidgetsContext = createContext<WidgetsContextProps>({
-    isTwoColumn: false
+  isTwoColumn: false
 })
 
-export interface WidgetsRootProps extends Partial<WidgetsContextProps>{
+export interface WidgetsRootProps extends Partial<WidgetsContextProps> {
   children: ReactNode
 }
 
@@ -21,9 +21,9 @@ const Root: FC<WidgetsRootProps> = ({ children, isTwoColumn: isTwoColumnProp = f
   const isTwoColumn = isTwoColumnProp && Children.count(children) > 1
 
   return (
-      <WidgetsContext.Provider value={{ isTwoColumn }}>
-          <div className={cn('gap-[var(--cn-spacing-10)]', isTwoColumn ? 'columns-2' : 'flex flex-col')}>{children}</div>
-      </WidgetsContext.Provider>
+    <WidgetsContext.Provider value={{ isTwoColumn }}>
+      <div className={cn('gap-[var(--cn-spacing-10)]', isTwoColumn ? 'columns-2' : 'flex flex-col')}>{children}</div>
+    </WidgetsContext.Provider>
   )
 }
 
@@ -36,13 +36,13 @@ export interface WidgetsItemProps {
 }
 
 const Item: FC<WidgetsItemProps> = ({ children, title, moreLink, isWidgetTable = false, className }) => {
-    const { isTwoColumn } = useContext(WidgetsContext)
+  const { isTwoColumn } = useContext(WidgetsContext)
   const { t } = useTranslation()
 
   return (
-    <Layout.Vertical className={cn('overflow-hidden',
-        { 'break-inside-avoid mt-[var(--cn-spacing-10)] first:mt-0': isTwoColumn }
-    )}>
+    <Layout.Vertical
+      className={cn('overflow-hidden', { 'break-inside-avoid pb-[var(--cn-spacing-10)] last:pb-0': isTwoColumn })}
+    >
       <Layout.Flex justify="between" gap="md" align="start">
         <Text as="h2" variant="heading-subsection" color="foreground-1">
           {title}
@@ -55,14 +55,12 @@ const Item: FC<WidgetsItemProps> = ({ children, title, moreLink, isWidgetTable =
       </Layout.Flex>
       <div
         className={cn(
-            '[contain:inline-size]',
-            { 'border border-cn-borders-3 rounded-3 p-[var(--cn-spacing-5)]': !isWidgetTable },
-            className
+          '[contain:inline-size]',
+          { 'border border-cn-borders-3 rounded-3 p-[var(--cn-spacing-5)]': !isWidgetTable },
+          className
         )}
       >
-        <ScrollArea classNameContent="w-full">
-          {children}
-        </ScrollArea>
+        <ScrollArea classNameContent="w-full">{children}</ScrollArea>
       </div>
     </Layout.Vertical>
   )

--- a/packages/ui/src/views/execution/step-execution.tsx
+++ b/packages/ui/src/views/execution/step-execution.tsx
@@ -25,7 +25,7 @@ const StepExecutionToolbar: FC<
         handleChange={handleInputChange}
         value={query}
       >
-        <div className="border-cn-borders-2 bg-cn-background-3 absolute inset-y-0 right-1.5 my-auto flex h-5 w-8 items-center justify-center gap-1 rounded border">
+        <div className="absolute inset-y-0 right-1.5 my-auto flex h-5 w-8 items-center justify-center gap-1 rounded border border-cn-borders-2 bg-cn-background-3">
           <IconV2 className="text-icons-3" name="apple-shortcut" size="2xs" />
           <span className="text-1 leading-none">F</span>
         </div>
@@ -38,7 +38,7 @@ const StepExecutionToolbar: FC<
           className="rounded-r-none border-r-0 border-cn-borders-2"
           onClick={onCopy}
         >
-          <IconV2 name="copy" className="text-icons-3 size-4" />
+          <IconV2 name="copy" className="size-4 text-icons-3" />
         </Button>
         <Button variant="outline" size="sm" className="rounded-none border-cn-borders-2" onClick={onEdit}>
           <IconV2 name="edit-pencil" className="text-icons-3" size="sm" />

--- a/packages/ui/src/views/repo/pull-request/components/pull-request-diff-viewer.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/pull-request-diff-viewer.tsx
@@ -352,7 +352,7 @@ const PullRequestDiffViewer = ({
       const commentText = newComments[commentKey] ?? ''
 
       return (
-        <div className="border-cn-borders-2 bg-cn-background-1 flex w-full flex-col border-l p-4">
+        <div className="flex w-full flex-col border-l border-cn-borders-2 bg-cn-background-1 p-4">
           <PullRequestCommentBox
             handleUpload={handleUpload}
             isEditMode
@@ -392,7 +392,7 @@ const PullRequestDiffViewer = ({
       if (!threads) return <></>
 
       return (
-        <div className="border-cn-borders-2 bg-cn-background-1 border-l">
+        <div className="border-l border-cn-borders-2 bg-cn-background-1">
           {threads.map(thread => {
             const parent = thread.parent
             const componentId = `activity-code-${parent?.id}`
@@ -421,7 +421,7 @@ const PullRequestDiffViewer = ({
                 contentHeader={
                   !!parent.payload?.resolved && (
                     <div className="flex items-center gap-x-1">
-                      <span className="text-cn-foreground-1 font-medium">{parent.payload?.resolver?.display_name}</span>
+                      <span className="font-medium text-cn-foreground-1">{parent.payload?.resolver?.display_name}</span>
                       <span className="text-cn-foreground-2">marked this conversation as resolved</span>
                     </div>
                   )
@@ -463,7 +463,7 @@ const PullRequestDiffViewer = ({
                       ]}
                       content={
                         parent?.deleted ? (
-                          <div className="bg-cn-background-1 rounded-md border p-1">
+                          <div className="rounded-md border bg-cn-background-1 p-1">
                             {t('views:pullRequests.deletedComment')}
                           </div>
                         ) : editModes[componentId] ? (
@@ -542,7 +542,7 @@ const PullRequestDiffViewer = ({
                               ]}
                               content={
                                 reply?.deleted ? (
-                                  <div className="bg-cn-background-1 rounded-md border p-1">
+                                  <div className="rounded-md border bg-cn-background-1 p-1">
                                     {t('views:pullRequests.deletedComment')}
                                   </div>
                                 ) : editModes[replyComponentId] ? (
@@ -622,7 +622,7 @@ const PullRequestDiffViewer = ({
           {/* @ts-ignore */}
           <DiffView<Thread[]>
             ref={ref}
-            className="bg-tr text-cn-foreground-3 w-full"
+            className="bg-tr w-full text-cn-foreground-3"
             renderWidgetLine={renderWidgetLine}
             renderExtendLine={renderExtendLine}
             diffFile={diffFileInstance}

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-comment-box.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-comment-box.tsx
@@ -351,7 +351,7 @@ export const PullRequestCommentBox = ({
             >
               <Textarea
                 ref={textAreaRef}
-                className="bg-cn-background-2 text-cn-foreground-1 min-h-36 p-3 pb-10"
+                className="min-h-36 bg-cn-background-2 p-3 pb-10 text-cn-foreground-1"
                 autoFocus={!!inReplyMode}
                 placeholder="Add your comment here"
                 value={comment}
@@ -366,10 +366,10 @@ export const PullRequestCommentBox = ({
                 resizable
               />
               {isDragging && (
-                <div className="border-cn-borders-2 absolute inset-1 cursor-copy rounded-sm border border-dashed" />
+                <div className="absolute inset-1 cursor-copy rounded-sm border border-dashed border-cn-borders-2" />
               )}
 
-              <div className="bg-cn-background-2 absolute bottom-px left-1/2 -ml-0.5 flex w-[calc(100%-16px)] -translate-x-1/2 items-center pb-2 pt-1">
+              <div className="absolute bottom-px left-1/2 -ml-0.5 flex w-[calc(100%-16px)] -translate-x-1/2 items-center bg-cn-background-2 pb-2 pt-1">
                 {toolbar.map((item, index) => {
                   const isFirst = index === 0
                   return (
@@ -382,7 +382,7 @@ export const PullRequestCommentBox = ({
                       >
                         <IconV2 className="text-icons-9" name={item.icon} />
                       </Button>
-                      {isFirst && <div className="bg-cn-background-3 h-4 w-px" />}
+                      {isFirst && <div className="h-4 w-px bg-cn-background-3" />}
                     </Fragment>
                   )
                 })}

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-timeline-item.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-timeline-item.tsx
@@ -68,10 +68,10 @@ const ItemHeader: FC<ItemHeaderProps> = memo(
       <div className="inline-flex w-full items-center justify-between gap-1.5">
         <div className="inline-flex items-baseline gap-1.5">
           {!!avatar && <div className="mr-0.5">{avatar}</div>}
-          {!!name && <span className="text-2 text-cn-foreground-1 font-medium">{name}</span>}
+          {!!name && <span className="text-2 font-medium text-cn-foreground-1">{name}</span>}
           {!!description && <span className="text-2 text-cn-foreground-2">{description}</span>}
         </div>
-        {!!selectStatus && <span className="text-2 text-cn-foreground-3 justify-end">{selectStatus}</span>}
+        {!!selectStatus && <span className="justify-end text-2 text-cn-foreground-3">{selectStatus}</span>}
         {isComment && !isDeleted && (
           <MoreActionsTooltip
             className="w-[200px]"
@@ -316,7 +316,7 @@ const PullRequestTimelineItem: FC<TimelineItemProps> = ({
                     {isResolved && (
                       <span className="text-2 text-cn-foreground-2">
                         {/* TODO: need to identify the author who resolved the conversation */}
-                        <span className="text-cn-foreground-1 font-medium">{currentUser}</span> marked this conversation
+                        <span className="font-medium text-cn-foreground-1">{currentUser}</span> marked this conversation
                         as resolved.
                       </span>
                     )}

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/regular-and-code-comment.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/regular-and-code-comment.tsx
@@ -235,7 +235,7 @@ const PullRequestRegularAndCodeCommentInternal: FC<PullRequestRegularAndCodeComm
               contentClassName: 'border-0 pb-0 rounded-none',
               icon: avatar,
               content: commentItem?.deleted ? (
-                <div className="bg-cn-background-1 rounded-md border p-1">{t('views:pullRequests.deletedComment')}</div>
+                <div className="rounded-md border bg-cn-background-1 p-1">{t('views:pullRequests.deletedComment')}</div>
               ) : editModes[componentId] ? (
                 <PullRequestCommentBox
                   handleUpload={handleUpload}
@@ -291,7 +291,7 @@ const PullRequestRegularAndCodeCommentInternal: FC<PullRequestRegularAndCodeComm
         isLast,
         handleSaveComment,
         isNotCodeComment: true,
-        contentHeader: <span className="text-cn-foreground-1 font-medium">{payload?.code_comment?.path}</span>,
+        contentHeader: <span className="font-medium text-cn-foreground-1">{payload?.code_comment?.path}</span>,
         content: (
           <div className="flex flex-col">
             {!!startingLine && (

--- a/packages/ui/tailwind-utils-config/components/table-v2.ts
+++ b/packages/ui/tailwind-utils-config/components/table-v2.ts
@@ -4,7 +4,7 @@ export default {
 
     // Table container
     '&-container': {
-      '@apply relative w-full overflow-hidden border-cn-borders-3': '',
+      '@apply relative w-full overflow-auto border-cn-borders-3': '',
       borderWidth: 'var(--cn-table-border)',
       borderRadius: 'var(--cn-table-radius)',
       borderColor: 'var(--cn-border-3)'


### PR DESCRIPTION
- new `Page` component (for quickly creating a page) – contains atoms: `Page.Root`, `Page.Header`, `Page.Content`
- `Page.Header` – a template component for page headers of any type, includes many settings for building any kind of header
- `Widgets` component – a list of widgets for displaying entity data
- `ViewOnly` component – a component for displaying entity data in read-only mode
- made a fix in the Table so that horizontal scrolling works when needed

[Loom with an overview](https://www.loom.com/share/b8e4a742256e4f58b4dc82b642925006?sid=52cd6b26-3b7c-46d3-8a69-fa2144d46542)

<img width="1917" alt="image" src="https://github.com/user-attachments/assets/8aba6ec2-5990-41d5-9060-1a8dd07ce069" />
