### PR TITLE
fix: blame editor time ago format

### DIFF
--- a/packages/yaml-editor/package.json
+++ b/packages/yaml-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/yaml-editor",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "private": false,
   "author": "Harness Inc.",
   "license": "Apache-2.0",

--- a/packages/yaml-editor/src/utils/blame-editor-utils.ts
+++ b/packages/yaml-editor/src/utils/blame-editor-utils.ts
@@ -1,5 +1,5 @@
 import { BlameItem } from '../types/blame'
-import { escapeSingleQuote } from './utils'
+import { escapeSingleQuote, timeAgoFromISOTime } from './utils'
 
 export function getMonacoEditorCss({
   instanceId,
@@ -68,7 +68,7 @@ export function getMonacoEditorCommitCss({
       if (lineNo === blameItem.fromLineNumber) {
         css += `
           .monaco-editor-${instanceId} .view-line .blame-editor-commit-${lineNo}:before {
-            content: '${escapeSingleQuote(blameItem?.commitInfo?.author?.when || '')}';
+            content: '${escapeSingleQuote(timeAgoFromISOTime(blameItem?.commitInfo?.author?.when || ''))}';
             position: absolute;
             left: 10px;
             top: 0px;

--- a/packages/yaml-editor/src/utils/utils.ts
+++ b/packages/yaml-editor/src/utils/utils.ts
@@ -10,3 +10,50 @@ export function createRandomString(length: number) {
 export function escapeSingleQuote(str: string) {
   return str.replace(`'`, `&#39;`)
 }
+
+const formatRelativeTime = (diffInSeconds: number): string => {
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
+
+  if (diffInSeconds < 60) {
+    return rtf.format(-diffInSeconds, 'second')
+  }
+
+  const diffInMinutes = Math.floor(diffInSeconds / 60)
+  if (diffInMinutes < 60) {
+    return rtf.format(-diffInMinutes, 'minute')
+  }
+
+  const diffInHours = Math.floor(diffInMinutes / 60)
+  if (diffInHours < 24) {
+    return rtf.format(-diffInHours, 'hour')
+  }
+
+  const diffInDays = Math.floor(diffInHours / 24)
+  if (diffInDays < 30) {
+    return rtf.format(-diffInDays, 'day')
+  }
+
+  const diffInMonths = Math.floor(diffInDays / 30)
+  if (diffInMonths < 12) {
+    return rtf.format(-diffInMonths, 'month')
+  }
+
+  const diffInYears = Math.floor(diffInMonths / 12)
+  return rtf.format(-diffInYears, 'year')
+}
+
+/**
+ * Formats ISO format date string to human-readable duration format.
+ * For e.g., "2024-09-10T13:38:55-07:00" is formatted as "1 hour ago".
+ * @param timestamp
+ * @returns formatted duration string
+ */
+export const timeAgoFromISOTime = (timestamp: string): string => {
+  const date = new Date(timestamp)
+  const now = new Date()
+
+  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000)
+  // Always treat time differences as past events
+  const absDiffInSeconds = Math.abs(diffInSeconds)
+  return formatRelativeTime(absDiffInSeconds)
+}


### PR DESCRIPTION
fix: blame editor time ago format

**After**
<img width="1607" alt="Screenshot 2025-07-01 at 8 35 55 PM" src="https://github.com/user-attachments/assets/cba543f2-b467-4f92-82d1-b4d52eac165b" />


**Before**
<img width="1607" alt="Screenshot 2025-07-01 at 8 36 10 PM" src="https://github.com/user-attachments/assets/647b0843-1f54-4686-8672-7aaecbbbde36" />
