### PR TITLE
fix: git commit modal, branch selector

### DIFF
--- a/apps/gitness/src/pages-v2/repo/repo-sidebar.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-sidebar.tsx
@@ -92,6 +92,9 @@ export const RepoSidebar = () => {
       } else if (selectedGitRefTag) {
         setSelectedBranchTag({ name: gitRefName, sha: '' })
         setSelectedRefType(BranchSelectorTab.TAGS)
+      } else {
+        setSelectedBranchTag({ name: fullGitRef, sha: fullGitRef })
+        setSelectedRefType(BranchSelectorTab.BRANCHES)
       }
     }
   }, [repository?.default_branch, fullGitRef, branchList, tagList, gitRefName, selectedGitRefBranch])

--- a/packages/ui/src/components/git-commit-dialog/git-commit-dialog.tsx
+++ b/packages/ui/src/components/git-commit-dialog/git-commit-dialog.tsx
@@ -124,7 +124,7 @@ export const GitCommitDialog: FC<GitCommitDialogProps> = ({
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={handleDialogClose}>
-      <Dialog.Content>
+      <Dialog.Content size="md">
         <Dialog.Header>
           <Dialog.Title>Commit Changes</Dialog.Title>
         </Dialog.Header>

--- a/packages/ui/src/views/repo/components/branch-selector-v2/branch-selector.tsx
+++ b/packages/ui/src/views/repo/components/branch-selector-v2/branch-selector.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 
-import { Button, DropdownMenu, IconV2, type ButtonSizes } from '@/components'
+import { Button, DropdownMenu, IconV2, Text, type ButtonSizes } from '@/components'
 import { BranchData, BranchSelectorListItem, BranchSelectorTab } from '@/views'
 
 import { BranchSelectorDropdown } from './branch-selector-dropdown'
@@ -53,11 +53,11 @@ export const BranchSelectorV2: FC<BranchSelectorProps> = ({
           {!branchPrefix && (
             <IconV2 className="shrink-0 fill-transparent" name={isTag ? 'tag' : 'git-branch'} size="xs" />
           )}
-          <span className="text-ellipsis whitespace-nowrap">
+          <Text className="truncate">
             {branchPrefix
               ? `${branchPrefix}: ${selectedBranch?.name || selectedBranchorTag.name}`
               : selectedBranch?.name || selectedBranchorTag.name}
-          </span>
+          </Text>
           <IconV2 name="nav-arrow-down" className="chevron-down ml-auto shrink-0" size="2xs" />
         </Button>
       </DropdownMenu.Trigger>


### PR DESCRIPTION
1. fixes git commit modal text and size
**Before**
<img width="1726" alt="before commit modal" src="https://github.com/user-attachments/assets/e2f4866b-6230-4571-ae73-05b47ba09945" />

**After**
<img width="1726" alt="now commit modal" src="https://github.com/user-attachments/assets/eb9722e1-cf6e-4cb8-b746-b84d21badbf3" />


2.fixes branch selector text overflow on long branch names 
**Before**
<img width="1726" alt="before branch selector" src="https://github.com/user-attachments/assets/b8cb1970-cb0d-4efe-a86f-b72c4f3e880f" />

**After**
<img width="1726" alt="now branch selector" src="https://github.com/user-attachments/assets/9c387a6d-c06c-4301-880e-da1a895dce00" />


3. fixes View repository at this time - commit sha not reflected in branch selector
**Before**
<img width="1726" alt="before commit sha" src="https://github.com/user-attachments/assets/4578555a-e967-409c-a3cc-fa9aa2ad089e" />


**After**
<img width="1726" alt="now commit sha" src="https://github.com/user-attachments/assets/4e702c3e-6b2a-42f9-9a00-e9f5b0a91236" />
