### PR TITLE
MFE theme switch

### DIFF
--- a/apps/gitness/src/AppMFE.tsx
+++ b/apps/gitness/src/AppMFE.tsx
@@ -181,6 +181,7 @@ export default function AppMFE({
                   customPromises,
                   routes,
                   hooks,
+                  theme,
                   setMFETheme
                 }}
               >

--- a/apps/gitness/src/framework/context/MFEContext.tsx
+++ b/apps/gitness/src/framework/context/MFEContext.tsx
@@ -47,6 +47,7 @@ interface IMFEContext {
     toProjectSettings: () => string
   }>
   hooks: Hooks
+  theme: string
   setMFETheme: (newTheme: string) => void
 }
 
@@ -58,5 +59,6 @@ export const MFEContext = createContext<IMFEContext>({
   customPromises: {},
   routes: {},
   hooks: {},
+  theme: '',
   setMFETheme: noop
 })

--- a/apps/gitness/src/framework/context/ThemeContext.tsx
+++ b/apps/gitness/src/framework/context/ThemeContext.tsx
@@ -7,6 +7,7 @@ import { getModeColorContrastFromFullTheme } from '@harnessio/ui/components'
 import { FullTheme, IThemeStore, ModeType, ThemeProvider as UIThemeProvider } from '@harnessio/ui/context'
 
 import { useIsMFE } from '../hooks/useIsMFE'
+import { useMFEContext } from '../hooks/useMFEContext'
 
 export const useThemeStore = create<IThemeStore>()(
   persist(
@@ -27,6 +28,7 @@ interface ThemeProviderProps {
 }
 export function ThemeProvider({ children, defaultTheme }: ThemeProviderProps) {
   const { theme, setTheme, isLightTheme } = useThemeStore()
+  const { theme: mfeTheme } = useMFEContext()
   const isMFE = useIsMFE()
 
   const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
@@ -72,6 +74,12 @@ export function ThemeProvider({ children, defaultTheme }: ThemeProviderProps) {
       document.head.appendChild(colorSchemeMeta)
     }
   }, [theme, setTheme, systemMode])
+
+  useEffect(() => {
+    if (isMFE) {
+      setTheme(mfeTheme as any)
+    }
+  }, [mfeTheme])
 
   return (
     <UIThemeProvider theme={theme} setTheme={setTheme} isLightTheme={isLightTheme}>


### PR DESCRIPTION
Ideally, the theme in the ThemeStore should be in sync with the theme from MFEContext. This PR tries to achieve that, but in a hacky way, we need to find the root cause and make sure the theme in the root html element should always be `light` or `dark` and the theme inside the shadow dom should always be `light-std-std` or `dark-std-std`. The same should also reflect in the ThemeStore. Right now, they are all not in sync.

P.S. With this change, the CodeEditor theme started working fine, for both the dark and the light mode.