### PR TITLE
Update styles for new diff line widgets and adjust layout in pull request diff viewer

### DIFF
--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -169,6 +169,9 @@
 }
 
 .diff-tailwindcss-wrapper {
+  .diff-line-widget-new-content,
+  .diff-line-widget-new-placeholder,
+  .diff-line-new-placeholder,
   .diff-line-new-num {
     @apply border-l;
   }

--- a/packages/ui/src/views/repo/pull-request/components/pull-request-diff-viewer.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/pull-request-diff-viewer.tsx
@@ -351,7 +351,7 @@ const PullRequestDiffViewer = ({
       const commentText = newComments[commentKey] ?? ''
 
       return (
-        <div className="flex w-full flex-col border-l border-cn-borders-2 bg-cn-background-1 p-4">
+        <div className="flex w-full flex-col bg-cn-background-1 p-4">
           <PullRequestCommentBox
             handleUpload={handleUpload}
             isEditMode


### PR DESCRIPTION
before:
<img width="881" height="236" alt="Screenshot 2025-07-16 at 17 55 11" src="https://github.com/user-attachments/assets/04bb2eac-2c32-4fc0-b708-256c4eb5261c" />

after:
<img width="1198" height="691" alt="Screenshot 2025-07-18 at 16 49 26" src="https://github.com/user-attachments/assets/7e18dde7-1cf1-4c85-ba20-19cb657b4c01" />
