### PR TITLE
Light mode colors update

### DIFF
--- a/packages/core-design-system/design-tokens/$themes.json
+++ b/packages/core-design-system/design-tokens/$themes.json
@@ -1597,7 +1597,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -1931,7 +1930,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "$figmaCollectionId": "VariableCollectionId:1340:156918",
     "$figmaModeId": "1340:3",
@@ -2559,7 +2559,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -2893,7 +2892,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -3520,7 +3520,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -3854,7 +3853,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -4480,7 +4480,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -4814,7 +4813,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -5441,7 +5441,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -5775,7 +5774,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -6402,7 +6402,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -6736,7 +6735,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -7363,7 +7363,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -7697,7 +7696,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -8324,7 +8324,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -8658,7 +8657,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -9285,7 +9285,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -9619,7 +9618,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -10246,7 +10246,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -10580,7 +10579,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -11207,7 +11207,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -11541,7 +11540,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -12168,7 +12168,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -12502,7 +12501,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -13129,7 +13129,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -13463,7 +13462,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -14089,7 +14089,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -14423,7 +14422,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -15049,7 +15049,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -15383,7 +15382,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -16009,7 +16009,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -16343,7 +16342,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -16969,7 +16969,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -17303,7 +17302,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -17929,7 +17929,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -18263,7 +18262,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -18889,7 +18889,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -19223,7 +19222,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -19873,7 +19873,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -20207,7 +20206,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -20833,7 +20833,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -21167,7 +21166,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -21793,7 +21793,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -22127,7 +22126,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -22753,7 +22753,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -23087,7 +23086,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },
@@ -23713,7 +23713,6 @@
       "border.1": "5ad2231a611605964ba70f80e7aabb48f04bc704",
       "border.2": "9084bef359e38136e0dddac25a464896456a9b1a",
       "border.3": "5ff5d5233f7cb0233ce7634bc480026668c818f6",
-      "border.accent": "8db219e896acc4d828aaaf4add646d96540a84ea",
       "border.success": "b13758973865eab0b4d79028a48e457eae8bec47",
       "border.danger": "33d53c1486021bb3c9edce4123b484a2aabc8de0",
       "border.warning": "027e57e08a1edcaaa7fbe033902bb3f65497abb4",
@@ -24047,7 +24046,8 @@
       "flow.onboard.ellipse-t-2.default": "dcf39668c229dd78326b87e66f3187c3575f2376",
       "flow.onboard.ellipse-t-2.danger": "5c480adf9a3351f8f66fe42722729fca8a4ec0da",
       "flow.onboard.ellipse-b.default": "d527a05727ae29b8d86af64efc7f7a26b01f22ea",
-      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01"
+      "flow.onboard.ellipse-b.danger": "18261f1dee39801e11bab7001f53775aa48f8e01",
+      "border.brand": "8db219e896acc4d828aaaf4add646d96540a84ea"
     },
     "group": "mode"
   },

--- a/packages/core-design-system/design-tokens/mode/dark/default-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default-deuteranopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.850}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/dark/default-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default-deuteranopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/default-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default-protanopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.850}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/dark/default-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default-protanopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/default-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default-tritanopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.850}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/dark/default-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default-tritanopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/default.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default.json
@@ -69,7 +69,7 @@
       "$value": "{chrome.900}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{blue.600}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1466,7 +1466,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1900,7 +1900,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/dark/default.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default.json
@@ -1314,6 +1314,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/default.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default.json
@@ -56,7 +56,7 @@
   "border": {
     "1": {
       "$type": "color",
-      "$value": "{blue.600}",
+      "$value": "{chrome.800}",
       "$description": "Enhanced border color for interactive states. Creates strong visual definition for important boundaries.\n\nCommon uses: Focus states, hover states, active elements, primary containers."
     },
     "2": {
@@ -71,7 +71,7 @@
     },
     "accent": {
       "$type": "color",
-      "$value": "{blue.400}",
+      "$value": "{blue.600}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
     },
     "success": {
@@ -1455,7 +1455,7 @@
         },
         "border": {
           "$type": "color",
-          "$value": "{chrome.800}",
+          "$value": "{border.1}",
           "$description": "Border color for unselected elements in selection controls. Defines the clickable area with a visible boundary."
         },
         "border-hover": {

--- a/packages/core-design-system/design-tokens/mode/dark/default.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default.json
@@ -1317,7 +1317,7 @@
     "link": {
       "text": {
         "$type": "color",
-        "$value": "{blue.400}",
+        "$value": "{blue.300}",
         "$description": "Default color for text links. Creates distinct visual identification of interactive text elements."
       },
       "text-hover": {

--- a/packages/core-design-system/design-tokens/mode/dark/default.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default.json
@@ -1455,7 +1455,7 @@
         },
         "border": {
           "$type": "color",
-          "$value": "{border.2}",
+          "$value": "{chrome.800}",
           "$description": "Border color for unselected elements in selection controls. Defines the clickable area with a visible boundary."
         },
         "border-hover": {

--- a/packages/core-design-system/design-tokens/mode/dark/dimmer-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/dimmer-deuteranopia.json
@@ -1314,6 +1314,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/dimmer-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/dimmer-deuteranopia.json
@@ -69,7 +69,7 @@
       "$value": "{chrome.900}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1475,7 +1475,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1909,7 +1909,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/dark/dimmer-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/dimmer-protanopia.json
@@ -1314,6 +1314,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/dimmer-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/dimmer-protanopia.json
@@ -69,7 +69,7 @@
       "$value": "{chrome.900}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1475,7 +1475,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1909,7 +1909,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/dark/dimmer-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/dimmer-tritanopia.json
@@ -1314,6 +1314,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/dimmer-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/dimmer-tritanopia.json
@@ -69,7 +69,7 @@
       "$value": "{chrome.900}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1475,7 +1475,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1909,7 +1909,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/dark/dimmer.json
+++ b/packages/core-design-system/design-tokens/mode/dark/dimmer.json
@@ -1314,6 +1314,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/dimmer.json
+++ b/packages/core-design-system/design-tokens/mode/dark/dimmer.json
@@ -69,7 +69,7 @@
       "$value": "{chrome.900}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1475,7 +1475,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1909,7 +1909,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/dark/high-contrast-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/high-contrast-deuteranopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/high-contrast-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/high-contrast-deuteranopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.800}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/dark/high-contrast-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/high-contrast-protanopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/high-contrast-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/high-contrast-protanopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.800}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/dark/high-contrast-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/high-contrast-tritanopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/high-contrast-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/dark/high-contrast-tritanopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.800}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/dark/high-contrast.json
+++ b/packages/core-design-system/design-tokens/mode/dark/high-contrast.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.2}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/dark/high-contrast.json
+++ b/packages/core-design-system/design-tokens/mode/dark/high-contrast.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.800}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/default-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/default-deuteranopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.100}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/default-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/default-deuteranopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/light/default-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/default-protanopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.100}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/default-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/default-protanopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/light/default-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/default-tritanopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.100}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/default-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/default-tritanopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -69,7 +69,7 @@
       "$value": "{chrome.100}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{blue.600}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1475,7 +1475,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1909,7 +1909,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -1317,7 +1317,7 @@
     "link": {
       "text": {
         "$type": "color",
-        "$value": "{blue.600}",
+        "$value": "{blue.700}",
         "$description": "Default color for text links. Creates distinct visual identification of interactive text elements."
       },
       "text-hover": {

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -56,7 +56,7 @@
   "border": {
     "1": {
       "$type": "color",
-      "$value": "{blue.600}",
+      "$value": "{chrome.200}",
       "$description": "Enhanced border color for interactive states. Creates strong visual definition for important boundaries.\n\nCommon uses: Focus states, hover states, active elements, primary containers."
     },
     "2": {
@@ -71,7 +71,7 @@
     },
     "accent": {
       "$type": "color",
-      "$value": "{blue.700}",
+      "$value": "{blue.600}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
     },
     "success": {
@@ -1464,7 +1464,7 @@
         },
         "border": {
           "$type": "color",
-          "$value": "{chrome.200}",
+          "$value": "{border.1}",
           "$description": "Border color for unselected elements in selection controls. Defines the clickable area with a visible boundary."
         },
         "border-hover": {

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -96,13 +96,13 @@
         "studio.tokens": {
           "modify": {
             "type": "alpha",
-            "value": "0.36",
+            "value": "0.16",
             "space": "lch"
           }
         }
       },
       "$type": "color",
-      "$value": "{chrome.150}",
+      "$value": "{chrome.300}",
       "$description": "Light overlay for gentle interactive effects. Creates subtle visual feedback during user interaction.\n\nCommon uses: Button hover states, link hover states, soft interactions, menu items."
     },
     "selected": {
@@ -110,13 +110,13 @@
         "studio.tokens": {
           "modify": {
             "type": "alpha",
-            "value": "0.45",
+            "value": "0.22",
             "space": "lch"
           }
         }
       },
       "$type": "color",
-      "$value": "{chrome.150}",
+      "$value": "{chrome.300}",
       "$description": "Strong overlay for emphasized selection states. Creates distinct visual indication of active or selected elements.\n\nCommon uses: Selected list items, active tabs, chosen options, current navigation item."
     },
     "disabled": {

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -1314,6 +1314,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -1464,7 +1464,7 @@
         },
         "border": {
           "$type": "color",
-          "$value": "{border.2}",
+          "$value": "{chrome.200}",
           "$description": "Border color for unselected elements in selection controls. Defines the clickable area with a visible boundary."
         },
         "border-hover": {

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -96,13 +96,13 @@
         "studio.tokens": {
           "modify": {
             "type": "alpha",
-            "value": "0.05",
+            "value": "0.36",
             "space": "lch"
           }
         }
       },
       "$type": "color",
-      "$value": "{pure.black}",
+      "$value": "{chrome.150}",
       "$description": "Light overlay for gentle interactive effects. Creates subtle visual feedback during user interaction.\n\nCommon uses: Button hover states, link hover states, soft interactions, menu items."
     },
     "selected": {
@@ -110,13 +110,13 @@
         "studio.tokens": {
           "modify": {
             "type": "alpha",
-            "value": "0.07",
+            "value": "0.45",
             "space": "lch"
           }
         }
       },
       "$type": "color",
-      "$value": "{pure.black}",
+      "$value": "{chrome.150}",
       "$description": "Strong overlay for emphasized selection states. Creates distinct visual indication of active or selected elements.\n\nCommon uses: Selected list items, active tabs, chosen options, current navigation item."
     },
     "disabled": {

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -1323,12 +1323,12 @@
     "link": {
       "text": {
         "$type": "color",
-        "$value": "{blue.700}",
+        "$value": "{blue.600}",
         "$description": "Default color for text links. Creates distinct visual identification of interactive text elements."
       },
       "text-hover": {
         "$type": "color",
-        "$value": "{blue.800}",
+        "$value": "{blue.700}",
         "$description": "Hover color for text links."
       }
     },

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -122,7 +122,7 @@
     "disabled": {
       "text": {
         "$type": "color",
-        "$value": "{chrome.400}",
+        "$value": "{chrome.500}",
         "$description": "Lowest emphasis text color for unavailable options. Creates visual differentiation between interactive and non-interactive elements.\n\nCommon uses: Disabled buttons, inactive form elements, unavailable options, placeholders."
       },
       "bg": {

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -56,7 +56,7 @@
   "border": {
     "1": {
       "$type": "color",
-      "$value": "{chrome.200}",
+      "$value": "{chrome.300}",
       "$description": "Enhanced border color for interactive states. Creates strong visual definition for important boundaries.\n\nCommon uses: Focus states, hover states, active elements, primary containers."
     },
     "2": {

--- a/packages/core-design-system/design-tokens/mode/light/dimmer-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/dimmer-deuteranopia.json
@@ -1332,6 +1332,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/light/dimmer-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/dimmer-deuteranopia.json
@@ -87,7 +87,7 @@
       "$value": "{chrome.100}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1493,7 +1493,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1927,7 +1927,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/dimmer-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/dimmer-protanopia.json
@@ -1332,6 +1332,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/light/dimmer-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/dimmer-protanopia.json
@@ -87,7 +87,7 @@
       "$value": "{chrome.100}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1493,7 +1493,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1927,7 +1927,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/dimmer-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/dimmer-tritanopia.json
@@ -1332,6 +1332,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/light/dimmer-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/dimmer-tritanopia.json
@@ -87,7 +87,7 @@
       "$value": "{chrome.100}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1493,7 +1493,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1927,7 +1927,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/dimmer.json
+++ b/packages/core-design-system/design-tokens/mode/light/dimmer.json
@@ -69,7 +69,7 @@
       "$value": "{chrome.100}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{chrome.700}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1475,7 +1475,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1909,7 +1909,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/dimmer.json
+++ b/packages/core-design-system/design-tokens/mode/light/dimmer.json
@@ -1314,6 +1314,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/light/high-contrast-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/high-contrast-deuteranopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.200}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/high-contrast-deuteranopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/high-contrast-deuteranopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/light/high-contrast-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/high-contrast-protanopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.200}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/high-contrast-protanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/high-contrast-protanopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/light/high-contrast-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/high-contrast-tritanopia.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.200}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/high-contrast-tritanopia.json
+++ b/packages/core-design-system/design-tokens/mode/light/high-contrast-tritanopia.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/core-design-system/design-tokens/mode/light/high-contrast.json
+++ b/packages/core-design-system/design-tokens/mode/light/high-contrast.json
@@ -78,7 +78,7 @@
       "$value": "{chrome.200}",
       "$description": "Softer border color for minimal separation. Creates subtle visual boundaries that don't dominate the UI.\n\nCommon uses: Subtle dividers, grouped content, secondary containers, table rows."
     },
-    "accent": {
+    "brand": {
       "$type": "color",
       "$value": "{set.brand.solid.bg}",
       "$description": "Focus state indicator color. Provides clear visual feedback for keyboard navigation and accessibility.\n\nCommon uses: Focus rings, keyboard navigation highlights, selection indicators."
@@ -1484,7 +1484,7 @@
         },
         "border-hover": {
           "$type": "color",
-          "$value": "{border.accent}"
+          "$value": "{border.brand}"
         }
       },
       "selected": {
@@ -1918,7 +1918,7 @@
           "y": "0",
           "blur": "0",
           "spread": "2",
-          "color": "{border.accent}",
+          "color": "{border.brand}",
           "type": "dropShadow"
         }
       ],

--- a/packages/core-design-system/design-tokens/mode/light/high-contrast.json
+++ b/packages/core-design-system/design-tokens/mode/light/high-contrast.json
@@ -1323,6 +1323,12 @@
         "$description": "Background for controls that expand/collapse code sections to show additional context."
       }
     },
+    "input": {
+      "bg": {
+        "$type": "color",
+        "$value": "{bg.3}"
+      }
+    },
     "link": {
       "text": {
         "$type": "color",

--- a/packages/ui/src/components/inputs/number-input.tsx
+++ b/packages/ui/src/components/inputs/number-input.tsx
@@ -124,6 +124,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
             ref={setRefs}
             id={inputId}
             disabled={disabled}
+            readOnly={readOnly}
             inputMode={integerOnly ? 'numeric' : 'decimal'}
             theme={effectiveTheme}
             onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {

--- a/packages/ui/tailwind-utils-config/components/input.ts
+++ b/packages/ui/tailwind-utils-config/components/input.ts
@@ -41,7 +41,7 @@ export default {
       },
 
       '&::placeholder': {
-        color: 'var(--cn-text-3)'
+        color: 'var(--cn-state-disabled-text)'
       },
 
       '&:where([disabled])': {
@@ -67,11 +67,11 @@ export default {
       height: 'var(--cn-input-size-md)',
       border: 'var(--cn-input-border) solid var(--cn-border-2)',
       borderRadius: 'var(--cn-input-radius)',
-      backgroundColor: 'var(--cn-bg-2)',
+      backgroundColor: 'var(--cn-comp-input-bg)',
       '@apply w-full font-body-normal p-0 flex items-center transition-[color,box-shadow,border-color]': '',
 
       '&:where(:focus-within)': {
-        borderColor: 'var(--cn-border-1)',
+        borderColor: 'var(--cn-border-brand)',
         boxShadow: 'var(--cn-ring-selected)',
         outline: 'none'
       },
@@ -97,7 +97,7 @@ export default {
       },
 
       '&:where(:hover):not(:has(input[disabled])):not(.cn-input-success, .cn-input-warning, .cn-input-danger)': {
-        borderColor: 'var(--cn-border-1)'
+        borderColor: 'var(--cn-border-brand)'
       },
 
       '&:where(.cn-input-sm)': {

--- a/packages/ui/tailwind-utils-config/components/multi-select.ts
+++ b/packages/ui/tailwind-utils-config/components/multi-select.ts
@@ -35,17 +35,17 @@ export default {
       minHeight: 'var(--cn-input-size-md)',
       border: 'var(--cn-input-border) solid var(--cn-border-2)',
       borderRadius: 'var(--cn-input-radius)',
-      backgroundColor: 'var(--cn-bg-2)',
+      backgroundColor: 'var(--cn-comp-input-bg)',
       '@apply w-full font-body-normal transition-[color,box-shadow,border-color] px-3 py-2': '',
 
       '&:where(:focus-within):not(.cn-multi-select-danger)': {
-        borderColor: 'var(--cn-border-1)',
+        borderColor: 'var(--cn-border-brand)',
         boxShadow: 'var(--cn-ring-selected)',
         outline: 'none'
       },
 
       '&:where(:hover):not(:has(input[disabled]))': {
-        borderColor: 'var(--cn-border-1)'
+        borderColor: 'var(--cn-border-brand)'
       },
 
       ...createMultiSelectThemeStyles()
@@ -70,7 +70,7 @@ export default {
     },
 
     '&-dropdown': {
-      backgroundColor: 'var(--cn-bg-2)',
+      backgroundColor: 'var(--cn-bg-3)',
       borderColor: 'var(--cn-border-2)',
       '@apply border rounded-md shadow-md mt-1 overflow-hidden animate-in absolute top-1 z-[55] w-full outline-none':
         '',

--- a/packages/ui/tailwind-utils-config/components/select.ts
+++ b/packages/ui/tailwind-utils-config/components/select.ts
@@ -38,7 +38,7 @@ export default {
     borderRadius: 'var(--cn-input-radius)',
     height: 'var(--cn-input-size-md)',
     border: 'var(--cn-input-border) solid var(--cn-border-2)',
-    backgroundColor: 'var(--cn-bg-2)',
+    backgroundColor: 'var(--cn-comp-input-bg)',
     color: 'var(--cn-text-1)',
     textAlign: 'start',
     '@apply transition-[box-shadow,border-color]': '',
@@ -48,7 +48,7 @@ export default {
     },
 
     '&:focus-visible, &:where([data-state="open"])': {
-      borderColor: 'var(--cn-border-1)',
+      borderColor: 'var(--cn-border-brand)',
       boxShadow: 'var(--cn-ring-selected)',
       outline: 'none'
     },
@@ -65,7 +65,7 @@ export default {
     },
 
     '&:where(:hover):not(:disabled)': {
-      borderColor: 'var(--cn-border-1)'
+      borderColor: 'var(--cn-border-brand)'
     },
 
     '&-content': {

--- a/packages/ui/tailwind-utils-config/components/tabs.ts
+++ b/packages/ui/tailwind-utils-config/components/tabs.ts
@@ -112,7 +112,7 @@ export default {
       '@apply font-body-normal': '',
 
       '&:where(:not([disabled]).cn-tabs-trigger-active)': {
-        borderColor: 'var(--cn-border-accent)',
+        borderColor: 'var(--cn-border-brand)',
         color: 'var(--cn-text-1)'
       },
 

--- a/packages/ui/tailwind-utils-config/components/tabs.ts
+++ b/packages/ui/tailwind-utils-config/components/tabs.ts
@@ -112,7 +112,7 @@ export default {
       '@apply font-body-normal': '',
 
       '&:where(:not([disabled]).cn-tabs-trigger-active)': {
-        borderColor: 'var(--cn-border-1)',
+        borderColor: 'var(--cn-border-accent)',
         color: 'var(--cn-text-1)'
       },
 

--- a/packages/ui/tailwind-utils-config/components/textarea.ts
+++ b/packages/ui/tailwind-utils-config/components/textarea.ts
@@ -38,7 +38,7 @@ export default {
     padding: 'var(--cn-input-md-py) var(--cn-input-md-pr) var(--cn-input-md-py) var(--cn-input-md-pl)',
     minHeight: 'var(--cn-input-text-area-min-height)',
     border: 'var(--cn-input-border) solid var(--cn-border-2)',
-    backgroundColor: 'var(--cn-bg-2)',
+    backgroundColor: 'var(--cn-comp-input-bg)',
     '@apply font-body-normal': '',
     color: 'var(--cn-text-1)',
     whiteSpace: 'pre-wrap',
@@ -50,11 +50,11 @@ export default {
     },
 
     '&::placeholder': {
-      color: 'var(--cn-text-3)'
+      color: 'var(--cn-state-disabled-text)'
     },
 
     '&:where(:focus)': {
-      borderColor: 'var(--cn-border-1)',
+      borderColor: 'var(--cn-border-brand)',
       boxShadow: 'var(--cn-ring-selected)',
       outline: 'none'
     },
@@ -75,8 +75,8 @@ export default {
       borderColor: 'var(--cn-state-disabled-border)'
     },
 
-    '&:where(:hover):not(:disabled):not(.cn-textarea-danger)': {
-      borderColor: 'var(--cn-border-1)'
+    '&:where(:hover):not(:disabled):not(.cn-textarea-danger):not(.cn-textarea-warning)': {
+      borderColor: 'var(--cn-border-brand)'
     },
 
     '&-resizable': {


### PR DESCRIPTION
Light mode colors update

Tabs before / after

(in current implementation it also shows blue, because I updated "border.1" to blue color on friday quickly, but token should be "accent", I remapped it in this PR)

<img width="370" height="135" alt="Screen Shot 2025-07-21 at 11 27 14 AM" src="https://github.com/user-attachments/assets/aa05ade0-3870-4083-853e-ada000a6e679" />

<img width="842" height="516" alt="Screen Shot 2025-07-21 at 11 24 55 AM" src="https://github.com/user-attachments/assets/8c75f78d-5e04-40f1-bf1c-ef386c974160" />


