### PR TITLE
fix: minor enhancements on PR page and commit listing

### DIFF
--- a/apps/gitness/src/pages-v2/repo/repo-tags-list-container.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-tags-list-container.tsx
@@ -14,6 +14,7 @@ import {
   CommitTagType,
   CreateTagDialog,
   CreateTagFormFields,
+  orderSortDate,
   RepoTagsListView
 } from '@harnessio/ui/views'
 
@@ -58,7 +59,9 @@ export const RepoTagsListContainer = () => {
       query: query ?? '',
       page: queryPage,
       limit: 10,
-      include_commit: true
+      include_commit: true,
+      sort: 'date',
+      order: orderSortDate.DESC
     }
   })
 

--- a/packages/forms/playground/src/examples/validation-example/validation-example.tsx
+++ b/packages/forms/playground/src/examples/validation-example/validation-example.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { RenderForm, RootForm, useZodValidationResolver } from '../../../../src'
 import inputComponentFactory from '../../implementation/factory/factory'
 import { formDefinition } from './form-definition'

--- a/packages/ui/src/views/repo/pull-request/components/pull-request-header.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/pull-request-header.tsx
@@ -79,9 +79,6 @@ export const PullRequestHeader: React.FC<PullRequestTitleProps> = ({
             <IconV2 name="edit-pencil" className="text-icons-1 group-hover:text-icons-3" />
           </Button>
           <Separator orientation="vertical" className="mx-1 h-4 bg-cn-background-0" />
-          <Button variant="link" onClick={() => setIsEditing(true)}>
-            {description ? 'Edit description' : 'Add a description'}
-          </Button>
         </div>
 
         <div className="flex items-center gap-x-3">


### PR DESCRIPTION
## Summary

- removed the redundant `edit and add description button` to match the mocks

<img width="669" height="91" alt="Screenshot 2025-07-18 at 3 28 58 PM" src="https://github.com/user-attachments/assets/1b7fc03a-e511-46fe-ae01-11ec6778190d" />

From mocks - 
<img width="1142" height="616" alt="Screenshot 2025-07-21 at 12 05 03 PM" src="https://github.com/user-attachments/assets/ac4363ab-ac49-4e68-a302-e2d8835c63a3" />

Both the edit icon and the button beside it were opening the same modal. 

- added query params for sorting tags listing 

Before - 

<img width="600" height="593" alt="Screenshot 2025-07-21 at 12 14 07 PM" src="https://github.com/user-attachments/assets/61b5791d-0839-4a1b-bb47-42aed4296ff8" />

After - 

<img width="705" height="621" alt="Screenshot 2025-07-21 at 12 13 32 PM" src="https://github.com/user-attachments/assets/e734cea8-3769-46d1-8604-d4407026e2ff" />
