### PR TITLE
Enhance branch info display with pluralized commit counts

### DIFF
--- a/packages/ui/src/views/repo/components/branch-info-bar.tsx
+++ b/packages/ui/src/views/repo/components/branch-info-bar.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 
 import { Button, DropdownMenu, IconV2, StatusBadge, Link as StyledLink } from '@/components'
 import { useRouterContext, useTranslation } from '@/context'
-import { BranchSelectorListItem, BranchSelectorTab } from '@/views'
+import { BranchSelectorListItem, BranchSelectorTab, easyPluralize } from '@/views'
 
 interface BranchInfoBarProps {
   defaultBranchName?: string
@@ -38,14 +38,14 @@ export const BranchInfoBar: FC<BranchInfoBarProps> = ({
           {hasAhead && (
             <>
               <StyledLink to={`${spaceId ? `/${spaceId}` : ''}/repos/${repoId}/pulls/compare/`}>
-                {ahead} commits ahead of
+                {ahead} {easyPluralize(ahead, 'commit', 'commits')} ahead of
               </StyledLink>
               {hasBehind && ', '}
             </>
           )}
           {hasBehind && (
             <StyledLink to={`${spaceId ? `/${spaceId}` : ''}/repos/${repoId}/pulls/compare/`}>
-              {behind} commits behind
+              {behind} {easyPluralize(behind, 'commit', 'commits')} behind
             </StyledLink>
           )}
           {!hasAhead && !hasBehind && 'up to date with'}
@@ -79,7 +79,7 @@ export const BranchInfoBar: FC<BranchInfoBarProps> = ({
               </div>
               <div>
                 <span className="text-2 leading-snug text-cn-foreground-1">
-                  This branch is {ahead} commits ahead of{' '}
+                  This branch is {ahead} {easyPluralize(ahead, 'commit', 'commits')} ahead of{' '}
                 </span>
                 <StatusBadge className="mt-1" variant="secondary" theme="muted" size="sm">
                   <IconV2 name="git-branch" size="xs" />


### PR DESCRIPTION
<img width="959" height="327" alt="Screenshot 2025-07-21 at 17 05 24" src="https://github.com/user-attachments/assets/fc43a877-0302-4e90-8589-6cba86115777" />
<img width="959" height="327" alt="Screenshot 2025-07-21 at 17 07 20" src="https://github.com/user-attachments/assets/7a9bc9db-00e9-4a97-a46e-d5535d30b0e1" />
