### PR TITLE
Search followup 1

### DIFF
--- a/apps/design-system/src/subjects/views/search-page/search-results-store.ts
+++ b/apps/design-system/src/subjects/views/search-page/search-results-store.ts
@@ -24,7 +24,7 @@ export const searchResultsStore: SearchResultsStore = {
           line_num: 42,
           before: 'export const userService = {',
           after: '};',
-          segments: [
+          fragments: [
             {
               pre: '  ',
               match: 'searchUsers',
@@ -36,7 +36,7 @@ export const searchResultsStore: SearchResultsStore = {
           line_num: 124,
           before: 'const searchUsersByName = async (name: string) => {',
           after: '  return results;',
-          segments: [
+          fragments: [
             {
               pre: '  const results = await db.users.find({ name: { $regex: ',
               match: 'searchPattern',
@@ -56,7 +56,7 @@ export const searchResultsStore: SearchResultsStore = {
           line_num: 15,
           before: 'interface SearchProps {',
           after: '}',
-          segments: [
+          fragments: [
             {
               pre: '  ',
               match: 'onSearch',
@@ -68,7 +68,7 @@ export const searchResultsStore: SearchResultsStore = {
           line_num: 57,
           before: 'const handleSearch = useCallback(() => {',
           after: '}, [searchTerm, onSearch]);',
-          segments: [
+          fragments: [
             {
               pre: '  ',
               match: 'onSearch',
@@ -88,7 +88,7 @@ export const searchResultsStore: SearchResultsStore = {
           line_num: 32,
           before: 'describe("Search API", () => {',
           after: '  });',
-          segments: [
+          fragments: [
             {
               pre: '  it("should return results when ',
               match: 'search',
@@ -108,7 +108,7 @@ export const searchResultsStore: SearchResultsStore = {
           line_num: 45,
           before: '@Service',
           after: '}',
-          segments: [
+          fragments: [
             {
               pre: 'public class ',
               match: 'SearchService',
@@ -120,7 +120,7 @@ export const searchResultsStore: SearchResultsStore = {
           line_num: 78,
           before: '  @Override',
           after: '  }',
-          segments: [
+          fragments: [
             {
               pre: '  public List<SearchResult> ',
               match: 'search',

--- a/packages/ui/src/views/search/components/search-results-list.tsx
+++ b/packages/ui/src/views/search/components/search-results-list.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 
 import { Button, Card, Layout, Link, SkeletonList, Spacer, Tag, Text } from '@/components'
 import { useTranslation } from '@/context'
@@ -40,6 +40,7 @@ export const SearchResultsList: FC<SearchResultsListProps> = ({
 }) => {
   const { t } = useTranslation()
   const { results } = useSearchResultsStore()
+  const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>({})
 
   if (isLoading) {
     return <SkeletonList />
@@ -81,35 +82,53 @@ export const SearchResultsList: FC<SearchResultsListProps> = ({
 
             {item.matches && item.matches.length > 1 && (
               <Layout.Vertical gap="sm">
-                {item.matches.slice(0, 3).map(match => (
-                  <div key={`${match.before}-${match.fragments.join('')}-${match.after}`}>
-                    <pre className={cn('bg-cn-background-1 p-1 mt-1 overflow-x-scroll rounded')}>
-                      <code className="monospace">
-                        {match.before.trim().length > 0 && (
-                          <>
-                            {match.line_num - 1} {match.before}
-                            <br />
-                          </>
-                        )}
-                        {match.line_num}{' '}
-                        {match.fragments?.map((segment, segIndex) => (
-                          <span key={`seg-${segIndex}`}>
-                            {segment.pre}
-                            <mark>{segment.match}</mark>
-                            {segment.post}
-                          </span>
-                        ))}
-                        {match.after.trim().length > 0 && (
-                          <>
-                            <br />
-                            {match.line_num + 1} {match.after}
-                          </>
-                        )}
-                      </code>
-                    </pre>
-                  </div>
-                ))}
-                {item.matches?.length > 3 && <Text variant="body-normal">+{item.matches.length - 3} more</Text>}
+                {item.matches
+                  .slice(0, expandedItems[`${item.repo_path}/${item.file_name}`] ? undefined : 3)
+                  .map(match => (
+                    <div key={`${match.before}-${match.fragments.join('')}-${match.after}`}>
+                      <pre className={cn('bg-cn-background-1 p-1 mt-1 overflow-x-scroll rounded')}>
+                        <code className="monospace">
+                          {match.before.trim().length > 0 && (
+                            <>
+                              {match.line_num - 1} {match.before}
+                              <br />
+                            </>
+                          )}
+                          {match.line_num}{' '}
+                          {match.fragments?.map((segment, segIndex) => (
+                            <span key={`seg-${segIndex}`}>
+                              {segment.pre}
+                              <mark>{segment.match}</mark>
+                              {segment.post}
+                            </span>
+                          ))}
+                          {match.after.trim().length > 0 && (
+                            <>
+                              <br />
+                              {match.line_num + 1} {match.after}
+                            </>
+                          )}
+                        </code>
+                      </pre>
+                    </div>
+                  ))}
+                {item.matches?.length > 3 && (
+                  <Text
+                    variant="body-normal"
+                    className="text-cn-primary cursor-pointer hover:underline"
+                    onClick={() => {
+                      const key = `${item.repo_path}/${item.file_name}`
+                      setExpandedItems(prev => ({
+                        ...prev,
+                        [key]: !prev[key]
+                      }))
+                    }}
+                  >
+                    {expandedItems[`${item.repo_path}/${item.file_name}`]
+                      ? t('views:search.showLess', '- Show Less')
+                      : t('views:search.showMore', `+${item.matches.length - 3} more`)}
+                  </Text>
+                )}
               </Layout.Vertical>
             )}
           </Layout.Vertical>

--- a/packages/ui/src/views/search/components/search-results-list.tsx
+++ b/packages/ui/src/views/search/components/search-results-list.tsx
@@ -81,8 +81,8 @@ export const SearchResultsList: FC<SearchResultsListProps> = ({
 
             {item.matches && item.matches.length > 1 && (
               <Layout.Vertical gap="sm">
-                {item.matches.slice(0, 3).map((match, matchIndex) => (
-                  <div key={`match-${matchIndex}`}>
+                {item.matches.slice(0, 3).map(match => (
+                  <div key={`${match.before}-${match.fragments.join('')}-${match.after}`}>
                     <pre className={cn('bg-cn-background-1 p-1 mt-1 overflow-x-scroll rounded')}>
                       <code className="monospace">
                         {match.before.trim().length > 0 && (
@@ -95,7 +95,7 @@ export const SearchResultsList: FC<SearchResultsListProps> = ({
                         {match.fragments?.map((segment, segIndex) => (
                           <span key={`seg-${segIndex}`}>
                             {segment.pre}
-                            <span className={cn('bg-cn-foreground-accent')}>{segment.match}</span>
+                            <mark>{segment.match}</mark>
                             {segment.post}
                           </span>
                         ))}

--- a/packages/ui/src/views/search/components/search-results-list.tsx
+++ b/packages/ui/src/views/search/components/search-results-list.tsx
@@ -23,7 +23,7 @@ export interface SearchResultItem {
     line_num: number
     before: string
     after: string
-    segments: Array<{
+    fragments: Array<{
       pre: string
       match: string
       post: string
@@ -70,8 +70,8 @@ export const SearchResultsList: FC<SearchResultsListProps> = ({
       {results.map(item => (
         <Card.Root key={`${item.repo_path}/${item.file_name}`} tabIndex={0}>
           <Layout.Vertical gap="sm">
-            <Layout.Horizontal gap="sm">
-              <Tag value={item.repo_path} icon="repository" />
+            <Layout.Horizontal gap="xs">
+              <Tag value={item.repo_path} icon="repository" showIcon={true} size={'sm'} />
               <Link
                 to={toRepoFileDetails({ repoPath: item.repo_path, filePath: item.file_name, branch: item.repo_branch })}
               >
@@ -83,18 +83,28 @@ export const SearchResultsList: FC<SearchResultsListProps> = ({
               <Layout.Vertical gap="sm">
                 {item.matches.slice(0, 3).map((match, matchIndex) => (
                   <div key={`match-${matchIndex}`}>
-                    <Text variant="body-normal">Line {match.line_num}</Text>
                     <pre className={cn('bg-cn-background-1 p-1 mt-1 overflow-x-scroll rounded')}>
-                      <code>
-                        {match.before}
-                        {match.segments?.map((segment, segIndex) => (
+                      <code className="monospace">
+                        {match.before.trim().length > 0 && (
+                          <>
+                            {match.line_num - 1} {match.before}
+                            <br />
+                          </>
+                        )}
+                        {match.line_num}{' '}
+                        {match.fragments?.map((segment, segIndex) => (
                           <span key={`seg-${segIndex}`}>
                             {segment.pre}
-                            <span className={cn('bg-yellow-100/30')}>{segment.match}</span>
+                            <span className={cn('bg-cn-foreground-accent')}>{segment.match}</span>
                             {segment.post}
                           </span>
                         ))}
-                        {match.after}
+                        {match.after.trim().length > 0 && (
+                          <>
+                            <br />
+                            {match.line_num + 1} {match.after}
+                          </>
+                        )}
                       </code>
                     </pre>
                   </div>

--- a/packages/ui/src/views/search/search-page.tsx
+++ b/packages/ui/src/views/search/search-page.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback, useMemo } from 'react'
 
-import { ListActions, Pagination, SearchInput, Spacer, Text, Toggle } from '@/components'
+import { Pagination, SearchInput, Spacer, Text, Toggle } from '@/components'
 import { useTranslation } from '@/context'
 import { SandboxLayout } from '@/views'
 import { cn } from '@utils/cn'

--- a/packages/ui/src/views/search/search-page.tsx
+++ b/packages/ui/src/views/search/search-page.tsx
@@ -68,16 +68,11 @@ export const SearchPageView: FC<SearchPageViewProps> = ({
         <Text variant="heading-section">{t('views:search.title', 'Search')}</Text>
         <Spacer size={6} />
 
-        <ListActions.Root>
-          <ListActions.Left>
-            <SearchInput
-              defaultValue={searchQuery || ''}
-              onChange={handleSearchChange}
-              placeholder={t('views:search.searchPlaceholder', 'Search anything...')}
-              autoFocus
-            />
-          </ListActions.Left>
-          <ListActions.Right>
+        <SearchInput
+          defaultValue={searchQuery || ''}
+          onChange={handleSearchChange}
+          placeholder={t('views:search.searchPlaceholder', 'Search anything...')}
+          suffix={
             <Toggle
               defaultValue={regex}
               onChange={setRegex}
@@ -88,8 +83,9 @@ export const SearchPageView: FC<SearchPageViewProps> = ({
               }}
               tooltipProps={{ content: 'Enable Regex' }}
             />
-          </ListActions.Right>
-        </ListActions.Root>
+          }
+          autoFocus
+        />
 
         <Spacer size={4.5} />
 


### PR DESCRIPTION
Adds styling fixes, and also adds a expand/collapse behaviour.

Collapsed:
<img width="1443" height="478" alt="Screenshot 2025-07-21 at 2 14 08 PM" src="https://github.com/user-attachments/assets/2b37b81a-1f57-4167-aeed-465fd3d5787a" />

Expanded:
<img width="1425" height="819" alt="Screenshot 2025-07-21 at 2 14 14 PM" src="https://github.com/user-attachments/assets/7eb67048-01a0-4d54-9885-e422081395fa" />
