### PR TITLE
first round of mock alignment and bug fixes for v2 repo list screen

### DIFF
--- a/packages/ui/src/components/stacked-list.tsx
+++ b/packages/ui/src/components/stacked-list.tsx
@@ -22,7 +22,7 @@ const listItemVariants = cva(
   }
 )
 
-const listFieldVariants = cva('flex flex-1 flex-col items-stretch justify-center gap-[0.3125rem] text-sm', {
+const listFieldVariants = cva('flex flex-1 flex-col items-stretch justify-center gap-[2px] text-sm', {
   variants: {
     right: {
       true: 'items-end'
@@ -135,7 +135,7 @@ const ListField = ({ className, title, description, label, primary, secondary, r
     {description && (
       <div
         className={cn(
-          'text-cn-foreground-2 flex gap-2 text-ellipsis whitespace-nowrap',
+          'text-cn-foreground-2 flex gap-2 text-ellipsis whitespace-nowrap leading-none',
           primary ? 'text-sm' : 'text-2',
           className
         )}

--- a/packages/ui/src/components/time-ago-card.tsx
+++ b/packages/ui/src/components/time-ago-card.tsx
@@ -163,7 +163,7 @@ export const TimeAgoCard = memo(
       return (
         <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
           <Popover.Trigger className="cn-time-ago-card-trigger" onClick={handleClick} ref={ref}>
-            <Text<'time'> as="time" {...textProps} ref={textProps?.ref as Ref<HTMLTimeElement>}>
+            <Text<'time'> as="time" color="foreground-1" {...textProps} ref={textProps?.ref as Ref<HTMLTimeElement>}>
               {formattedShort}
             </Text>
           </Popover.Trigger>

--- a/packages/ui/src/views/layouts/SandboxLayout.tsx
+++ b/packages/ui/src/views/layouts/SandboxLayout.tsx
@@ -87,7 +87,7 @@ function Content({ children, maxWidth, className }: ContentProps) {
   return (
     <div
       className={cn(
-        'px-5 pt-7 pb-11 flex flex-col grow w-full',
+        'px-6 pt-7 pb-11 flex flex-col grow w-full',
         { [`max-w-${maxWidth} mx-auto`]: !!maxWidth },
         className
       )}

--- a/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback, useMemo } from 'react'
 
-import { ListActions, NoData, Pagination, SearchInput, Spacer, SplitButton, Text } from '@/components'
+import { IconV2, ListActions, NoData, Pagination, SearchInput, Spacer, SplitButton, Text } from '@/components'
 import { useRouterContext, useTranslation } from '@/context'
 import { SandboxLayout } from '@/views'
 
@@ -76,11 +76,11 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
 
   return (
     <SandboxLayout.Main>
-      <SandboxLayout.Content>
+      <SandboxLayout.Content className="pt-0">
         {showTopBar && (
           <>
-            <Spacer size={8} />
-            <div className="flex items-end">
+            <Spacer size={7} className="mt-[30px]" />
+            <div className="flex items-end tracking-[-0.8px]">
               <Text variant="heading-section" as="h1" color="foreground-1">
                 {t('views:repos.repositories', 'Repositories')}
               </Text>
@@ -89,10 +89,10 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
             <ListActions.Root>
               <ListActions.Left>
                 <SearchInput
-                  inputContainerClassName="max-w-96"
+                  inputContainerClassName="max-w-[22.5rem]"
                   defaultValue={searchQuery || ''}
                   placeholder={t('views:repos.search', 'Search')}
-                  size="sm"
+                  size="md"
                   onChange={handleSearch}
                 />
               </ListActions.Left>
@@ -118,13 +118,14 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
                     }
                   ]}
                 >
+                  <IconV2 name="plus" />
                   {t('views:repos.create-repository', 'Create Repository')}
                 </SplitButton>
               </ListActions.Right>
             </ListActions.Root>
           </>
         )}
-        <Spacer size={5} />
+        <Spacer size={4.5} />
         <RepoList
           repos={repositories || []}
           handleResetFiltersQueryAndPages={handleResetFiltersQueryAndPages}

--- a/packages/ui/src/views/repo/repo-list/repo-list.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list.tsx
@@ -26,7 +26,7 @@ const Title = ({ title, isPrivate }: { title: string; isPrivate: boolean }) => {
   return (
     <div className="inline-flex items-center gap-2.5">
       <span className="max-w-full truncate font-medium">{title}</span>
-      <StatusBadge variant="outline" size="sm" theme={isPrivate ? 'muted' : 'success'}>
+      <StatusBadge variant="outline" size="sm" theme={isPrivate ? 'muted' : 'success'} className="rounded-4">
         {isPrivate ? t('views:repos.private', 'Private') : t('views:repos.public', 'Public')}
       </StatusBadge>
     </div>
@@ -92,18 +92,18 @@ export function RepoList({
             'pointer-events-none': repo.importing
           })}
         >
-          <StackedList.Item key={repo.name} className="pb-2.5 pt-3" isLast={repos.length - 1 === repo_idx}>
+          <StackedList.Item key={repo.name} className="h-[68.8px] pb-2.5 pt-3" isLast={repos.length - 1 === repo_idx}>
             <StackedList.Field
               primary
+              title={<Title title={repo.name} isPrivate={repo.private} />}
               description={
                 repo.importing ? (
                   t('views:repos.importing', 'Importing…')
-                ) : (
+                ) : repo.description ? (
                   <span className="max-w-full truncate">{repo.description}</span>
-                )
+                ) : undefined
               }
-              title={<Title title={repo.name} isPrivate={repo.private} />}
-              className="flex max-w-[80%] gap-1.5 text-wrap"
+              className="flex max-w-[80%] text-wrap"
             />
             {!repo.importing && (
               <StackedList.Field


### PR DESCRIPTION
Several style changes and bug fixes to align with reference designs.

Issues:
- Adjusted styling to align (close to) pixel perfect with mock
- In repository table if repository doesn’t have a description, the title isn’t vertically aligned
- Time text at row should be text-1 color
- The badge next to a repository name should be rounded
- The height of the search field is only 32px when it should be 36px