### PR TITLE
feat: Integrate "favorite" filter on Repo listing page, few other miscellaneous changes

### DIFF
--- a/apps/design-system/src/subjects/views/repo-list/repo-list.tsx
+++ b/apps/design-system/src/subjects/views/repo-list/repo-list.tsx
@@ -35,6 +35,7 @@ const RepoListWrapper: FC<Partial<RepoListProps>> = props => {
         setSearchQuery={noop}
         setQueryPage={noop}
         onFavoriteToggle={noop}
+        onFilterChange={noop}
         {...props}
       />
     </>

--- a/apps/gitness/src/pages-v2/repo/repo-list.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-list.tsx
@@ -8,7 +8,7 @@ import {
   useListReposQuery
 } from '@harnessio/code-service-client'
 import { Toast, useToast } from '@harnessio/ui/components'
-import { RepositoryType, SandboxRepoListPage } from '@harnessio/ui/views'
+import { RepoListFilters, RepositoryType, SandboxRepoListPage } from '@harnessio/ui/views'
 
 import { useRoutes } from '../../framework/context/NavigationContext'
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'
@@ -37,6 +37,7 @@ export default function ReposListPage() {
 
   const [query, setQuery] = useQueryState('query')
   const { queryPage, setQueryPage } = usePaginationQueryStateWithStore({ page, setPage })
+  const [favorite, setFavorite] = useQueryState<boolean>('favorite')
 
   const {
     data: { body: repoData, headers } = {},
@@ -48,7 +49,8 @@ export default function ReposListPage() {
     {
       queryParams: {
         page: queryPage,
-        query: query ?? ''
+        query: query ?? '',
+        only_favorites: favorite
       },
       space_ref: `${spaceURL}/+`
     },
@@ -143,6 +145,7 @@ export default function ReposListPage() {
       toImportRepo={() => routes.toImportRepo({ spaceId })}
       toImportMultipleRepos={() => routes.toImportMultipleRepos({ spaceId })}
       onFavoriteToggle={onFavoriteToggle}
+      onFilterChange={filters => setFavorite(!!filters?.favorite)}
     />
   )
 }

--- a/apps/gitness/src/pages-v2/repo/repo-list.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-list.tsx
@@ -8,7 +8,7 @@ import {
   useListReposQuery
 } from '@harnessio/code-service-client'
 import { Toast, useToast } from '@harnessio/ui/components'
-import { RepoListFilters, RepositoryType, SandboxRepoListPage } from '@harnessio/ui/views'
+import { RepositoryType, SandboxRepoListPage } from '@harnessio/ui/views'
 
 import { useRoutes } from '../../framework/context/NavigationContext'
 import { useGetSpaceURLParam } from '../../framework/hooks/useGetSpaceParam'

--- a/apps/gitness/src/pages-v2/repo/repo-list.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-list.tsx
@@ -145,7 +145,7 @@ export default function ReposListPage() {
       toImportRepo={() => routes.toImportRepo({ spaceId })}
       toImportMultipleRepos={() => routes.toImportMultipleRepos({ spaceId })}
       onFavoriteToggle={onFavoriteToggle}
-      onFilterChange={filters => setFavorite(!!filters?.favorite)}
+      onFilterChange={({ favorite }) => setFavorite(favorite ?? null)}
     />
   )
 }

--- a/packages/ui/locales/en/views.json
+++ b/packages/ui/locales/en/views.json
@@ -35,6 +35,7 @@
     "findTag": "Find a tag",
     "allCommits": "All commits",
     "noFile": "No files available",
+    "create-file": "Create File",
     "private": "Private",
     "public": "Public",
     "name": "Name",

--- a/packages/ui/locales/en/views.json
+++ b/packages/ui/locales/en/views.json
@@ -1,6 +1,6 @@
 {
   "repos": {
-    "create-new-file-no-plus": "Create New File",
+    "create-file": "Create File",
     "upload-files": "Upload files",
     "summary": "Summary",
     "files": "Files",
@@ -230,6 +230,7 @@
     "creatingWebhook": "Creating webhook...",
     "updateWebhook": "Update webhook",
     "createWebhook": "Create webhook",
+    "create-new-file-no-plus": "Create File",
     "newRule": "New branch rule",
     "deleteConnector": "Delete Connector",
     "deleteSecret": "Delete Secret",

--- a/packages/ui/locales/en/views.json
+++ b/packages/ui/locales/en/views.json
@@ -1,6 +1,6 @@
 {
   "repos": {
-    "new-file": "New File",
+    "create-file": "Create File",
     "upload-files": "Upload files",
     "summary": "Summary",
     "files": "Files",
@@ -35,7 +35,6 @@
     "findTag": "Find a tag",
     "allCommits": "All commits",
     "noFile": "No files available",
-    "create-file": "Create File",
     "private": "Private",
     "public": "Public",
     "name": "Name",

--- a/packages/ui/locales/en/views.json
+++ b/packages/ui/locales/en/views.json
@@ -1,6 +1,6 @@
 {
   "repos": {
-    "create-file": "Create File",
+    "new-file": "New File",
     "upload-files": "Upload files",
     "summary": "Summary",
     "files": "Files",

--- a/packages/ui/locales/en/views.json
+++ b/packages/ui/locales/en/views.json
@@ -230,7 +230,6 @@
     "creatingWebhook": "Creating webhook...",
     "updateWebhook": "Update webhook",
     "createWebhook": "Create webhook",
-    "create-new-file-no-plus": "Create File",
     "newRule": "New branch rule",
     "deleteConnector": "Delete Connector",
     "deleteSecret": "Delete Secret",

--- a/packages/ui/locales/fr/views.json
+++ b/packages/ui/locales/fr/views.json
@@ -35,6 +35,7 @@
     "findTag": "Trouver une étiquette",
     "allCommits": "Tous les commits",
     "noFile": "Aucun fichier disponible",
+    "create-file": "Create File",
     "private": "Privé",
     "public": "Public",
     "name": "Nom",

--- a/packages/ui/locales/fr/views.json
+++ b/packages/ui/locales/fr/views.json
@@ -1,6 +1,6 @@
 {
   "repos": {
-    "new-file": "New File",
+    "create-file": "Create File",
     "upload-files": "Télécharger des fichiers",
     "summary": "Résumé",
     "files": "Fichiers",
@@ -35,7 +35,6 @@
     "findTag": "Trouver une étiquette",
     "allCommits": "Tous les commits",
     "noFile": "Aucun fichier disponible",
-    "create-file": "Create File",
     "private": "Privé",
     "public": "Public",
     "name": "Nom",

--- a/packages/ui/locales/fr/views.json
+++ b/packages/ui/locales/fr/views.json
@@ -1,6 +1,6 @@
 {
   "repos": {
-    "create-file": "Créer fichier",
+    "new-file": "New File",
     "upload-files": "Télécharger des fichiers",
     "summary": "Résumé",
     "files": "Fichiers",

--- a/packages/ui/locales/fr/views.json
+++ b/packages/ui/locales/fr/views.json
@@ -224,7 +224,6 @@
     "creatingWebhook": "Creating webhook...",
     "updateWebhook": "Update webhook",
     "createWebhook": "Create webhook",
-    "create-new-file-no-plus": "Create File",
     "newRule": "Nouvelle règle de branche",
     "branchCreated": "Branche créée",
     "branchCreatedDescription": "La branche {{name}} a été créée avec succès",

--- a/packages/ui/locales/fr/views.json
+++ b/packages/ui/locales/fr/views.json
@@ -1,6 +1,6 @@
 {
   "repos": {
-    "create-new-file-no-plus": "Créer un nouveau fichier",
+    "create-file": "Créer fichier",
     "upload-files": "Télécharger des fichiers",
     "summary": "Résumé",
     "files": "Fichiers",
@@ -224,6 +224,7 @@
     "creatingWebhook": "Creating webhook...",
     "updateWebhook": "Update webhook",
     "createWebhook": "Create webhook",
+    "create-new-file-no-plus": "Create File",
     "newRule": "Nouvelle règle de branche",
     "branchCreated": "Branche créée",
     "branchCreatedDescription": "La branche {{name}} a été créée avec succès",

--- a/packages/ui/src/components/file-additions-trigger.tsx
+++ b/packages/ui/src/components/file-additions-trigger.tsx
@@ -16,7 +16,7 @@ export const FileAdditionsTrigger: FC<FileAdditionsTriggerProps> = ({ pathNewFil
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild ref={triggerRef}>
         <Button className="relative overflow-hidden pl-4 pr-8" variant="outline">
-          <span className="border-r pr-2.5">{t('views:repos.create-new-file-no-plus', 'Create File')}</span>
+          <span className="border-r pr-2.5">{t('views:repos.create-file', 'Create File')}</span>
           <span className="absolute right-0 top-0 flex h-full w-8 items-center justify-center text-icons-7 transition-colors group-data-[state=open]:bg-cn-background-3 group-data-[state=open]:text-icons-9">
             <IconV2 name="nav-arrow-down" size="2xs" />
           </span>
@@ -26,7 +26,7 @@ export const FileAdditionsTrigger: FC<FileAdditionsTriggerProps> = ({ pathNewFil
         <DropdownMenu.Item
           title={
             <Link variant="secondary" to={pathNewFile} prefixIcon="check">
-              <span className="truncate">{t('views:repos.create-new-file-no-plus', 'Create file')}</span>
+              <span className="truncate">{t('views:repos.create-file', 'Create file')}</span>
             </Link>
           }
         />

--- a/packages/ui/src/components/file-additions-trigger.tsx
+++ b/packages/ui/src/components/file-additions-trigger.tsx
@@ -16,7 +16,7 @@ export const FileAdditionsTrigger: FC<FileAdditionsTriggerProps> = ({ pathNewFil
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild ref={triggerRef}>
         <Button className="relative overflow-hidden pl-4 pr-8" variant="outline">
-          <span className="border-r pr-2.5">{t('views:repos.new-file', 'New File')}</span>
+          <span className="border-r pr-2.5">{t('views:repos.create-file', 'Create File')}</span>
           <span className="absolute right-0 top-0 flex h-full w-8 items-center justify-center text-icons-7 transition-colors group-data-[state=open]:bg-cn-background-3 group-data-[state=open]:text-icons-9">
             <IconV2 name="nav-arrow-down" size="2xs" />
           </span>
@@ -26,7 +26,7 @@ export const FileAdditionsTrigger: FC<FileAdditionsTriggerProps> = ({ pathNewFil
         <DropdownMenu.Item
           title={
             <Link variant="secondary" to={pathNewFile} prefixIcon="check">
-              <span className="truncate">{t('views:repos.new-file', 'New file')}</span>
+              <span className="truncate">{t('views:repos.create-file', 'Create File')}</span>
             </Link>
           }
         />

--- a/packages/ui/src/components/file-additions-trigger.tsx
+++ b/packages/ui/src/components/file-additions-trigger.tsx
@@ -16,7 +16,7 @@ export const FileAdditionsTrigger: FC<FileAdditionsTriggerProps> = ({ pathNewFil
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild ref={triggerRef}>
         <Button className="relative overflow-hidden pl-4 pr-8" variant="outline">
-          <span className="border-r pr-2.5">{t('views:repos.create-file', 'Create File')}</span>
+          <span className="border-r pr-2.5">{t('views:repos.new-file', 'New File')}</span>
           <span className="absolute right-0 top-0 flex h-full w-8 items-center justify-center text-icons-7 transition-colors group-data-[state=open]:bg-cn-background-3 group-data-[state=open]:text-icons-9">
             <IconV2 name="nav-arrow-down" size="2xs" />
           </span>
@@ -26,7 +26,7 @@ export const FileAdditionsTrigger: FC<FileAdditionsTriggerProps> = ({ pathNewFil
         <DropdownMenu.Item
           title={
             <Link variant="secondary" to={pathNewFile} prefixIcon="check">
-              <span className="truncate">{t('views:repos.create-file', 'Create file')}</span>
+              <span className="truncate">{t('views:repos.new-file', 'New file')}</span>
             </Link>
           }
         />

--- a/packages/ui/src/views/components/FilterGroup.tsx
+++ b/packages/ui/src/views/components/FilterGroup.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps, ReactNode, useMemo, useRef, useState } from 'react'
 
-import { ListActions, SearchBox } from '@/components'
+import { ListActions, SearchInput } from '@/components'
 import { useTranslation } from '@/context'
 import { renderFilterSelectLabel } from '@components/filters/filter-select'
 import { FilterOptionConfig } from '@components/filters/types'
@@ -20,7 +20,7 @@ interface FilterGroupProps<
   handleFilterOpen?: (filter: V, isOpen: boolean) => void
   searchInput: string
   sortConfig: Omit<ComponentProps<typeof Sort.Root>, 'children'>
-  handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  handleInputChange: (value: string) => void
   filterOptions: FilterOptionConfig<V, CustomValue>[]
   headerAction?: ReactNode
 }
@@ -73,13 +73,11 @@ const FilterGroup = <
       <Sort.Root {...sortConfig} onSortChange={onSortValueChange}>
         <ListActions.Root>
           <ListActions.Left>
-            <SearchBox.Root
-              width="full"
+            <SearchInput
               className="max-w-80"
               value={searchInput}
-              handleChange={handleInputChange}
+              onChange={handleInputChange}
               placeholder={t('views:search', 'Search')}
-              // inputClassName="bg-cn-background-1"
             />
           </ListActions.Left>
           <ListActions.Right>

--- a/packages/ui/src/views/components/FilterGroup.tsx
+++ b/packages/ui/src/views/components/FilterGroup.tsx
@@ -79,7 +79,7 @@ const FilterGroup = <
               value={searchInput}
               handleChange={handleInputChange}
               placeholder={t('views:search', 'Search')}
-              inputClassName="bg-cn-background-1"
+              // inputClassName="bg-cn-background-1"
             />
           </ListActions.Left>
           <ListActions.Right>

--- a/packages/ui/src/views/components/FilterGroup.tsx
+++ b/packages/ui/src/views/components/FilterGroup.tsx
@@ -74,7 +74,7 @@ const FilterGroup = <
         <ListActions.Root>
           <ListActions.Left>
             <SearchInput
-              className="max-w-80"
+              inputContainerClassName="max-w-80"
               value={searchInput}
               onChange={handleInputChange}
               placeholder={t('views:search', 'Search')}

--- a/packages/ui/src/views/components/FilterGroup.tsx
+++ b/packages/ui/src/views/components/FilterGroup.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps, ReactNode, useMemo, useRef, useState } from 'react'
 
-import { ListActions, SearchInput } from '@/components'
+import { ListActions, SearchBox, SearchInput } from '@/components'
 import { useTranslation } from '@/context'
 import { renderFilterSelectLabel } from '@components/filters/filter-select'
 import { FilterOptionConfig } from '@components/filters/types'
@@ -20,7 +20,7 @@ interface FilterGroupProps<
   handleFilterOpen?: (filter: V, isOpen: boolean) => void
   searchInput: string
   sortConfig: Omit<ComponentProps<typeof Sort.Root>, 'children'>
-  handleInputChange: (value: string) => void
+  handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   filterOptions: FilterOptionConfig<V, CustomValue>[]
   headerAction?: ReactNode
 }
@@ -73,11 +73,13 @@ const FilterGroup = <
       <Sort.Root {...sortConfig} onSortChange={onSortValueChange}>
         <ListActions.Root>
           <ListActions.Left>
-            <SearchInput
-              inputContainerClassName="max-w-80"
+            <SearchBox.Root
+              width="full"
+              className="max-w-80"
               value={searchInput}
-              onChange={handleInputChange}
+              handleChange={handleInputChange}
               placeholder={t('views:search', 'Search')}
+              inputClassName="bg-cn-background-1"
             />
           </ListActions.Left>
           <ListActions.Right>

--- a/packages/ui/src/views/components/FilterGroup.tsx
+++ b/packages/ui/src/views/components/FilterGroup.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps, ReactNode, useMemo, useRef, useState } from 'react'
 
-import { ListActions, SearchBox, SearchInput } from '@/components'
+import { ListActions, SearchBox } from '@/components'
 import { useTranslation } from '@/context'
 import { renderFilterSelectLabel } from '@components/filters/filter-select'
 import { FilterOptionConfig } from '@components/filters/types'

--- a/packages/ui/src/views/repo/components/path-action-bar.tsx
+++ b/packages/ui/src/views/repo/components/path-action-bar.tsx
@@ -60,7 +60,7 @@ export const PathActionBar: FC<PathActionBarProps> = ({
         selectedRefType === BranchSelectorTab.BRANCHES && (
           <Button variant="outline" asChild>
             <Link className="relative grid grid-cols-[auto_1fr] items-center gap-1.5" to={pathNewFile}>
-              <span className="truncate">{t('views:repos.create-file', 'Create File')}</span>
+              <span className="truncate">{t('views:repos.new-file', 'New File')}</span>
             </Link>
           </Button>
         )}

--- a/packages/ui/src/views/repo/components/path-action-bar.tsx
+++ b/packages/ui/src/views/repo/components/path-action-bar.tsx
@@ -60,8 +60,7 @@ export const PathActionBar: FC<PathActionBarProps> = ({
         selectedRefType === BranchSelectorTab.BRANCHES && (
           <Button variant="outline" asChild>
             <Link className="relative grid grid-cols-[auto_1fr] items-center gap-1.5" to={pathNewFile}>
-              <IconV2 name="plus" size="2xs" />
-              <span className="truncate">{t('views:repos.create-new-file-no-plus', 'Create File')}</span>
+              <span className="truncate">{t('views:repos.create-file', 'Create File')}</span>
             </Link>
           </Button>
         )}

--- a/packages/ui/src/views/repo/components/path-action-bar.tsx
+++ b/packages/ui/src/views/repo/components/path-action-bar.tsx
@@ -58,7 +58,7 @@ export const PathActionBar: FC<PathActionBarProps> = ({
         pathNewFile &&
         pathUploadFiles &&
         selectedRefType === BranchSelectorTab.BRANCHES && (
-          <Button variant="outline" asChild>
+          <Button asChild>
             <Link className="relative grid grid-cols-[auto_1fr] items-center gap-1.5" to={pathNewFile}>
               <span className="truncate">{t('views:repos.new-file', 'New File')}</span>
             </Link>

--- a/packages/ui/src/views/repo/components/path-action-bar.tsx
+++ b/packages/ui/src/views/repo/components/path-action-bar.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 
-import { Button, IconV2, PathBreadcrumbs, PathParts } from '@/components'
+import { Button, PathBreadcrumbs, PathParts } from '@/components'
 import { useRouterContext, useTranslation } from '@/context'
 import { BranchSelectorTab, CodeModes } from '@/views'
 

--- a/packages/ui/src/views/repo/components/path-action-bar.tsx
+++ b/packages/ui/src/views/repo/components/path-action-bar.tsx
@@ -60,7 +60,7 @@ export const PathActionBar: FC<PathActionBarProps> = ({
         selectedRefType === BranchSelectorTab.BRANCHES && (
           <Button asChild>
             <Link className="relative grid grid-cols-[auto_1fr] items-center gap-1.5" to={pathNewFile}>
-              <span className="truncate">{t('views:repos.new-file', 'New File')}</span>
+              <span className="truncate">{t('views:repos.create-file', 'Create File')}</span>
             </Link>
           </Button>
         )}

--- a/packages/ui/src/views/repo/repo-branch/repo-branch-list-view.tsx
+++ b/packages/ui/src/views/repo/repo-branch/repo-branch-list-view.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback, useMemo } from 'react'
 
-import { Button, ListActions, Pagination, SearchInput, Spacer } from '@/components'
+import { Button, ListActions, Pagination, SearchInput, Spacer, Text } from '@/components'
 import { useTranslation } from '@/context'
 import { SandboxLayout } from '@/views'
 import { cn } from '@utils/cn'
@@ -48,10 +48,11 @@ export const RepoBranchListView: FC<RepoBranchListViewProps> = ({
   return (
     <SandboxLayout.Main>
       <SandboxLayout.Content className={cn({ 'h-full': !isLoading && !branchList.length && !searchQuery })}>
-        <Spacer size={2} />
         {(isLoading || !!branchList.length || isDirtyList) && (
           <>
-            <span className="text-24 font-medium text-cn-foreground-1">{t('views:repos.branches', 'Branches')}</span>
+            <Text as="h1" variant="heading-section">
+              {t('views:repos.branches', 'Branches')}
+            </Text>
             <Spacer size={6} />
             <ListActions.Root>
               <ListActions.Left>

--- a/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
@@ -1,11 +1,16 @@
 import { FC, useCallback, useMemo } from 'react'
 
-import { ListActions, NoData, Pagination, SearchInput, Spacer, SplitButton, Text } from '@/components'
+import { IconV2, NoData, Pagination, Spacer, SplitButton, Text } from '@/components'
 import { useRouterContext, useTranslation } from '@/context'
 import { SandboxLayout } from '@/views'
+import { FilterFieldTypes } from '@components/filters/types'
+import FilterGroup from '@views/components/FilterGroup'
+import { noop } from 'lodash-es'
+
+import { booleanParser } from '@harnessio/filters'
 
 import { RepoList } from './repo-list'
-import { RepoListProps } from './types'
+import { RepoListFilters, RepoListFiltersKeys, RepoListProps } from './types'
 
 const SandboxRepoListPage: FC<RepoListProps> = ({
   useRepoStore,
@@ -19,6 +24,7 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
   toImportRepo,
   toImportMultipleRepos,
   onFavoriteToggle,
+  onFilterChange,
   ...routingProps
 }) => {
   const { t } = useTranslation()
@@ -73,7 +79,9 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
     setPage(1)
   }
 
-  // return null
+  const onFilterSelectionChange = (filterValues: RepoListFiltersKeys[]) => {}
+
+  const onFilterValueChange = (filterValues: RepoListFilters) => onFilterChange(filterValues)
 
   return (
     <SandboxLayout.Main>
@@ -87,17 +95,16 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
               </Text>
             </div>
             <Spacer size={6} />
-            <ListActions.Root>
-              <ListActions.Left>
-                <SearchInput
-                  inputContainerClassName="max-w-96"
-                  defaultValue={searchQuery || ''}
-                  placeholder={t('views:repos.search', 'Search')}
-                  size="sm"
-                  onChange={handleSearch}
-                />
-              </ListActions.Left>
-              <ListActions.Right>
+            <FilterGroup<RepoListFilters, keyof RepoListFilters>
+              sortConfig={{
+                sortOptions: [],
+                onSortChange: noop
+              }}
+              onFilterSelectionChange={onFilterSelectionChange}
+              onFilterValueChange={onFilterValueChange}
+              searchInput={searchQuery || ''}
+              handleInputChange={handleSearch}
+              headerAction={
                 <SplitButton<string>
                   dropdownContentClassName="mt-0 min-w-[170px]"
                   handleButtonClick={() => navigate(toCreateRepo?.() || '')}
@@ -121,8 +128,19 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
                 >
                   {t('views:repos.create-repository', 'Create Repository')}
                 </SplitButton>
-              </ListActions.Right>
-            </ListActions.Root>
+              }
+              filterOptions={[
+                {
+                  label: t('views:connectors.filterOptions.statusOption.favorite', 'Favorites'),
+                  value: 'favorite',
+                  type: FilterFieldTypes.Checkbox,
+                  filterFieldConfig: {
+                    label: <IconV2 name="star-solid" size="md" className="text-cn-icon-yellow" />
+                  },
+                  parser: booleanParser
+                }
+              ]}
+            />
           </>
         )}
         <Spacer size={5} />

--- a/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
@@ -71,9 +71,6 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
     )
   }
 
-  const noData = !(repositories && !!repositories.length)
-  const showTopBar = !noData || !!searchQuery?.length || page !== 1
-
   const handleResetFiltersQueryAndPages = () => {
     handleSearch('')
     setPage(1)
@@ -84,62 +81,60 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
   return (
     <SandboxLayout.Main>
       <SandboxLayout.Content>
-        {showTopBar && (
-          <>
-            <Spacer size={8} />
-            <div className="flex items-end">
-              <Text variant="heading-section" as="h1">
-                {t('views:repos.repositories', 'Repositories')}
-              </Text>
-            </div>
-            <Spacer size={6} />
-            <FilterGroup<RepoListFilters, keyof RepoListFilters>
-              sortConfig={{
-                sortOptions: [],
-                onSortChange: noop
-              }}
-              onFilterValueChange={onFilterValueChange}
-              searchInput={searchQuery || ''}
-              handleInputChange={(e: React.ChangeEvent<HTMLInputElement>) => handleSearch(e.target.value)}
-              headerAction={
-                <SplitButton<string>
-                  dropdownContentClassName="mt-0 min-w-[170px]"
-                  handleButtonClick={() => navigate(toCreateRepo?.() || '')}
-                  handleOptionChange={option => {
-                    if (option === 'import') {
-                      navigate(toImportRepo?.() || '')
-                    } else if (option === 'import-multiple') {
-                      navigate(toImportMultipleRepos?.() || '')
-                    }
-                  }}
-                  options={[
-                    {
-                      value: 'import',
-                      label: t('views:repos.import-repository', 'Import Repository')
-                    },
-                    {
-                      value: 'import-multiple',
-                      label: t('views:repos.import-repositories', 'Import Repositories')
-                    }
-                  ]}
-                >
-                  {t('views:repos.create-repository', 'Create Repository')}
-                </SplitButton>
-              }
-              filterOptions={[
-                {
-                  label: t('views:connectors.filterOptions.statusOption.favorite', 'Favorites'),
-                  value: 'favorite',
-                  type: FilterFieldTypes.Checkbox,
-                  filterFieldConfig: {
-                    label: <IconV2 name="star-solid" size="md" className="text-cn-icon-yellow" />
+        <>
+          <Spacer size={8} />
+          <div className="flex items-end">
+            <Text variant="heading-section" as="h1">
+              {t('views:repos.repositories', 'Repositories')}
+            </Text>
+          </div>
+          <Spacer size={6} />
+          <FilterGroup<RepoListFilters, keyof RepoListFilters>
+            sortConfig={{
+              sortOptions: [],
+              onSortChange: noop
+            }}
+            onFilterValueChange={onFilterValueChange}
+            searchInput={searchQuery || ''}
+            handleInputChange={(e: React.ChangeEvent<HTMLInputElement>) => handleSearch(e.target.value)}
+            headerAction={
+              <SplitButton<string>
+                dropdownContentClassName="mt-0 min-w-[170px]"
+                handleButtonClick={() => navigate(toCreateRepo?.() || '')}
+                handleOptionChange={option => {
+                  if (option === 'import') {
+                    navigate(toImportRepo?.() || '')
+                  } else if (option === 'import-multiple') {
+                    navigate(toImportMultipleRepos?.() || '')
+                  }
+                }}
+                options={[
+                  {
+                    value: 'import',
+                    label: t('views:repos.import-repository', 'Import Repository')
                   },
-                  parser: booleanParser
-                }
-              ]}
-            />
-          </>
-        )}
+                  {
+                    value: 'import-multiple',
+                    label: t('views:repos.import-repositories', 'Import Repositories')
+                  }
+                ]}
+              >
+                {t('views:repos.create-repository', 'Create Repository')}
+              </SplitButton>
+            }
+            filterOptions={[
+              {
+                label: t('views:connectors.filterOptions.statusOption.favorite', 'Favorites'),
+                value: 'favorite',
+                type: FilterFieldTypes.Checkbox,
+                filterFieldConfig: {
+                  label: <IconV2 name="star-solid" size="md" className="text-cn-icon-yellow" />
+                },
+                parser: booleanParser
+              }
+            ]}
+          />
+        </>
         <Spacer size={5} />
         <RepoList
           repos={repositories || []}

--- a/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-list/repo-list-page.tsx
@@ -10,7 +10,7 @@ import { noop } from 'lodash-es'
 import { booleanParser } from '@harnessio/filters'
 
 import { RepoList } from './repo-list'
-import { RepoListFilters, RepoListFiltersKeys, RepoListProps } from './types'
+import { RepoListFilters, RepoListProps } from './types'
 
 const SandboxRepoListPage: FC<RepoListProps> = ({
   useRepoStore,
@@ -79,8 +79,6 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
     setPage(1)
   }
 
-  const onFilterSelectionChange = (filterValues: RepoListFiltersKeys[]) => {}
-
   const onFilterValueChange = (filterValues: RepoListFilters) => onFilterChange(filterValues)
 
   return (
@@ -100,10 +98,9 @@ const SandboxRepoListPage: FC<RepoListProps> = ({
                 sortOptions: [],
                 onSortChange: noop
               }}
-              onFilterSelectionChange={onFilterSelectionChange}
               onFilterValueChange={onFilterValueChange}
               searchInput={searchQuery || ''}
-              handleInputChange={handleSearch}
+              handleInputChange={(e: React.ChangeEvent<HTMLInputElement>) => handleSearch(e.target.value)}
               headerAction={
                 <SplitButton<string>
                   dropdownContentClassName="mt-0 min-w-[170px]"

--- a/packages/ui/src/views/repo/repo-list/types.ts
+++ b/packages/ui/src/views/repo/repo-list/types.ts
@@ -27,10 +27,20 @@ export interface FavoriteProps {
   onFavoriteToggle: ({ repoId, isFavorite }: { repoId: number; isFavorite: boolean }) => void
 }
 
+export type RepoListFiltersKeys = keyof RepoListFilters
+
+export type RepoListFilters = {
+  favorite?: boolean
+}
+
+export interface FilterProps {
+  onFilterChange: (filters: RepoListFilters) => void
+}
+
 /**
  * RoutingProps made optional for usage in apps/design-system
  */
-export interface RepoListProps extends Partial<RoutingProps>, FavoriteProps {
+export interface RepoListProps extends Partial<RoutingProps>, FavoriteProps, FilterProps {
   useRepoStore: () => RepoStore
   isLoading: boolean
   isError: boolean

--- a/packages/ui/src/views/repo/repo-list/types.ts
+++ b/packages/ui/src/views/repo/repo-list/types.ts
@@ -27,8 +27,6 @@ export interface FavoriteProps {
   onFavoriteToggle: ({ repoId, isFavorite }: { repoId: number; isFavorite: boolean }) => void
 }
 
-export type RepoListFiltersKeys = keyof RepoListFilters
-
 export type RepoListFilters = {
   favorite?: boolean
 }

--- a/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
@@ -68,7 +68,7 @@ git push -u origin main
           title="This repository is empty"
           description={['We recommend every repository include a', 'README, LICENSE, and .gitignore.']}
           primaryButton={{
-            label: t('views:repos.new-file', 'New File'),
+            label: t('views:repos.create-file', 'Create File'),
             to: `${projName ? `/${projName}` : ''}/repos/${repoName}/code/new/${gitRef}/~/`
           }}
           className="min-h-[40vh] py-0"

--- a/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-empty-view.tsx
@@ -11,6 +11,7 @@ import {
   Spacer,
   Text
 } from '@/components'
+import { useTranslation } from '@/context'
 import { SandboxLayout } from '@/views'
 
 interface RepoEmptyViewProps {
@@ -32,6 +33,7 @@ export const RepoEmptyView: React.FC<RepoEmptyViewProps> = ({
   handleCreateToken,
   navigateToProfileKeys
 }) => {
+  const { t } = useTranslation()
   const getInitialCommitMarkdown = () => {
     return `
 \`\`\`shell
@@ -66,7 +68,7 @@ git push -u origin main
           title="This repository is empty"
           description={['We recommend every repository include a', 'README, LICENSE, and .gitignore.']}
           primaryButton={{
-            label: 'New file',
+            label: t('views:repos.new-file', 'New File'),
             to: `${projName ? `/${projName}` : ''}/repos/${repoName}/code/new/${gitRef}/~/`
           }}
           className="min-h-[40vh] py-0"

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -191,7 +191,7 @@ export function RepoSummaryView({
                         className="relative grid grid-cols-[auto_1fr] items-center gap-1.5"
                         to={`${spaceId ? `/${spaceId}` : ''}/repos/${repoId}/code/new/${gitRef || selectedBranchOrTag?.name || ''}/~/`}
                       >
-                        <span className="truncate">{t('views:repos.new-file', 'New File')}</span>
+                        <span className="truncate">{t('views:repos.create-file', 'Create File')}</span>
                       </Link>
                     </Button>
                   ) : null}

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -191,7 +191,7 @@ export function RepoSummaryView({
                         className="relative grid grid-cols-[auto_1fr] items-center gap-1.5"
                         to={`${spaceId ? `/${spaceId}` : ''}/repos/${repoId}/code/new/${gitRef || selectedBranchOrTag?.name || ''}/~/`}
                       >
-                        <span className="truncate">{t('views:repos.create-file', 'Create File')}</span>
+                        <span className="truncate">{t('views:repos.new-file', 'New File')}</span>
                       </Link>
                     </Button>
                   ) : null}

--- a/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
+++ b/packages/ui/src/views/repo/repo-summary/repo-summary.tsx
@@ -191,8 +191,7 @@ export function RepoSummaryView({
                         className="relative grid grid-cols-[auto_1fr] items-center gap-1.5"
                         to={`${spaceId ? `/${spaceId}` : ''}/repos/${repoId}/code/new/${gitRef || selectedBranchOrTag?.name || ''}/~/`}
                       >
-                        <IconV2 name="plus" size="2xs" />
-                        <span className="truncate">{t('views:repos.create-new-file-no-plus', 'Create File')}</span>
+                        <span className="truncate">{t('views:repos.create-file', 'Create File')}</span>
                       </Link>
                     </Button>
                   ) : null}

--- a/packages/ui/src/views/repo/repo-tags/repo-tags-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-tags/repo-tags-list-page.tsx
@@ -55,7 +55,6 @@ export const RepoTagsListView: FC<RepoTagsListViewProps> = ({
       >
         {!isLoading && (!!tagsList.length || isDirtyList) && (
           <>
-            <Spacer size={2} />
             <Text as="h1" variant="heading-section">
               {t('views:repos.tags', 'Tags')}
             </Text>

--- a/packages/ui/src/views/search/search-page.tsx
+++ b/packages/ui/src/views/search/search-page.tsx
@@ -64,8 +64,9 @@ export const SearchPageView: FC<SearchPageViewProps> = ({
           'h-full': !isLoading && !results.length && !searchQuery
         })}
       >
-        <Spacer size={2} />
-        <Text variant="heading-section">{t('views:search.title', 'Search')}</Text>
+        <Text as="h1" variant="heading-section">
+          {t('views:search.title', 'Search')}
+        </Text>
         <Spacer size={6} />
 
         <SearchInput


### PR DESCRIPTION
Integrate "favorite" filter on Repo listing page

https://github.com/user-attachments/assets/ab2a3ef3-8190-45b4-83bc-88575247be19

---

- Renames button labels from `+ Create New File` to just `Create File`.

<img width="1728" height="960" alt="image" src="https://github.com/user-attachments/assets/f598960b-4511-4cfa-ab7e-9f6cb76362d4" />

- Fixes button variant.

<img width="1728" height="958" alt="image" src="https://github.com/user-attachments/assets/d1f15748-764e-4ad6-9eff-75b2b5469a05" />

- Fixes headers for pages under Repository to same equal top spacing.