### PR TITLE
feat: add search filters support

### DIFF
--- a/apps/design-system/src/subjects/views/search-page/search-page-preview.tsx
+++ b/apps/design-system/src/subjects/views/search-page/search-page-preview.tsx
@@ -18,6 +18,9 @@ export const SearchPagePreview = () => {
       setSearchQuery={setSearchQuery}
       useSearchResultsStore={useSearchResultsStore}
       toRepoFileDetails={() => '#'}
+      onRepoSelect={() => {}}
+      onLanguageSelect={() => {}}
+      onClearFilters={() => {}}
     />
   )
 }

--- a/packages/ui/src/views/search/components/search-results-list.tsx
+++ b/packages/ui/src/views/search/components/search-results-list.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from 'react'
 
-import { Button, Card, Layout, Link, SkeletonList, Spacer, Tag, Text } from '@/components'
+import { Card, Layout, Link, SkeletonList, Spacer, Tag, Text } from '@/components'
 import { useTranslation } from '@/context'
 import { cn } from '@utils/cn'
 
@@ -10,7 +10,6 @@ interface SearchResultsListProps {
   useSearchResultsStore: () => {
     results: SearchResultItem[]
   }
-  clearSearch: () => void
   toRepoFileDetails: (params: { repoPath: string; filePath: string; branch: string }) => string
 }
 
@@ -35,8 +34,7 @@ export const SearchResultsList: FC<SearchResultsListProps> = ({
   isLoading,
   isDirtyList,
   useSearchResultsStore,
-  toRepoFileDetails,
-  clearSearch
+  toRepoFileDetails
 }) => {
   const { t } = useTranslation()
   const { results } = useSearchResultsStore()
@@ -61,7 +59,6 @@ export const SearchResultsList: FC<SearchResultsListProps> = ({
             : t('views:search.enterSearchTerms', 'Enter search terms to find relevant results')}
         </Text>
         <Spacer size={4} />
-        {isDirtyList && <Button onClick={clearSearch}>{t('views:search.clearSearch', 'Clear search')}</Button>}
       </div>
     )
   }
@@ -85,8 +82,10 @@ export const SearchResultsList: FC<SearchResultsListProps> = ({
                 {item.matches
                   .slice(0, expandedItems[`${item.repo_path}/${item.file_name}`] ? undefined : 3)
                   .map(match => (
-                    <div key={`${match.before}-${match.fragments.join('')}-${match.after}`}>
-                      <pre className={cn('bg-cn-background-1 p-1 mt-1 overflow-x-scroll rounded')}>
+                    <div
+                      key={`${match.before}-${match.fragments.map(frag => frag.pre + frag.match + frag.post).join('')}-${match.after}`}
+                    >
+                      <pre className={cn('bg-cn-background-1 p-1 mt-1 rounded')}>
                         <code className="monospace">
                           {match.before.trim().length > 0 && (
                             <>

--- a/packages/ui/src/views/search/search-page.tsx
+++ b/packages/ui/src/views/search/search-page.tsx
@@ -1,11 +1,28 @@
 import { FC, useCallback, useMemo } from 'react'
 
-import { Pagination, SearchInput, Spacer, Text, Toggle } from '@/components'
+import { Button, Layout, Pagination, SearchInput, Select, Spacer, Text, Toggle } from '@/components'
 import { useTranslation } from '@/context'
-import { SandboxLayout } from '@/views'
+import { RepositoryType, SandboxLayout } from '@/views'
 import { cn } from '@utils/cn'
 
 import { SearchResultItem, SearchResultsList } from './components/search-results-list'
+
+const languageOptions = [
+  { label: 'JavaScript', value: 'javascript' },
+  { label: 'Python', value: 'python' },
+  { label: 'Java', value: 'java' },
+  { label: 'C#', value: 'csharp' },
+  { label: 'PHP', value: 'php' },
+  { label: 'TypeScript', value: 'typescript' },
+  { label: 'C++', value: 'cpp' },
+  { label: 'C', value: 'c' },
+  { label: 'Ruby', value: 'ruby' },
+  { label: 'Go', value: 'go' },
+  { label: 'Swift', value: 'swift' },
+  { label: 'Kotlin', value: 'kotlin' },
+  { label: 'Rust', value: 'rust' },
+  { label: 'Scala', value: 'scala' }
+]
 
 // Define the props interface for the SearchPageView
 export interface SearchPageViewProps {
@@ -21,6 +38,19 @@ export interface SearchPageViewProps {
     xPrevPage: number
     setPage: (page: number) => void
   }
+  stats?: {
+    total_files: number
+    total_matches: number
+  }
+  // repo filter props
+  repos?: RepositoryType[]
+  selectedRepoId?: string
+  isReposListLoading?: boolean
+  onRepoSelect: (repoName: string) => void
+  // language filter props
+  selectedLanguage?: string
+  onLanguageSelect: (language: string) => void
+  onClearFilters: () => void
   toRepoFileDetails: (params: { repoPath: string; filePath: string; branch: string }) => string
 }
 
@@ -31,7 +61,15 @@ export const SearchPageView: FC<SearchPageViewProps> = ({
   regex,
   setRegex,
   useSearchResultsStore,
-  toRepoFileDetails
+  stats,
+  toRepoFileDetails,
+  repos,
+  selectedRepoId,
+  isReposListLoading,
+  selectedLanguage,
+  onLanguageSelect,
+  onRepoSelect,
+  onClearFilters
 }) => {
   const { t } = useTranslation()
   const { results, page, xNextPage, xPrevPage, setPage } = useSearchResultsStore()
@@ -86,18 +124,52 @@ export const SearchPageView: FC<SearchPageViewProps> = ({
           }
           autoFocus
         />
+        <Spacer size={5} />
+        {results.length > 0 || selectedLanguage || selectedRepoId ? (
+          <Layout.Horizontal gap="sm">
+            {repos ? (
+              <Select
+                isLoading={isReposListLoading}
+                label={t('views:search.repository', 'Repository')}
+                onChange={value => onRepoSelect?.(value)}
+                value={selectedRepoId}
+                options={repos.map(repo => ({ label: repo.name, value: repo.name }))}
+                placeholder={t('views:search.repositoryPlaceholder', 'Select a repository')}
+                orientation="horizontal"
+              />
+            ) : null}
+            <Select
+              label={t('views:search.language', 'Language')}
+              onChange={value => onLanguageSelect?.(value)}
+              options={languageOptions}
+              value={selectedLanguage}
+              placeholder={'Select a language'}
+              orientation="horizontal"
+            />
+            <Button variant={'secondary'} onClick={onClearFilters}>
+              Clear Filters
+            </Button>
+          </Layout.Horizontal>
+        ) : null}
 
-        <Spacer size={4.5} />
+        <Spacer size={5} />
+
+        {!isLoading && stats && results.length > 0 && (
+          <Text variant={'caption-normal'}>
+            {t('views:search.statsText', '{{matchCount}} matches found across {{fileCount}} files', {
+              matchCount: stats.total_matches,
+              fileCount: stats.total_files
+            })}
+          </Text>
+        )}
+
+        <Spacer size={5} />
 
         <SearchResultsList
           isLoading={isLoading}
           isDirtyList={isDirtyList}
           useSearchResultsStore={useSearchResultsStore}
           toRepoFileDetails={toRepoFileDetails}
-          clearSearch={() => {
-            setSearchQuery('')
-            setPage(1)
-          }}
         />
 
         <Spacer size={5} />


### PR DESCRIPTION
Adds missing parity items on search page:
- Repo filter (if you're NOT in repo scope_
- Language filter
- Clear filter
- query syncing to maintain state

<img width="1447" height="609" alt="Screenshot 2025-07-23 at 4 52 22 PM" src="https://github.com/user-attachments/assets/0385ebfd-bd66-41fb-8a58-d7bfc6eaa438" />

Note: design looks broken right now due to the `horizontal` variant of the Select not working correctly. Reported that issue separately to the PP team.