### PR TITLE
Wire up title and message edits in PR merge form

### DIFF
--- a/apps/gitness/src/pages-v2/pull-request/pull-request-conversation.tsx
+++ b/apps/gitness/src/pages-v2/pull-request/pull-request-conversation.tsx
@@ -557,6 +557,9 @@ export default function PullRequestConversationPage() {
     refetchActivities()
   }, [refetchCodeOwners, refetchPullReq, refetchActivities])
 
+  const [mergeTitle, setMergeTitle] = useState(pullReqMetadata?.title || '')
+  const [mergeMessage, setMergeMessage] = useState('')
+
   const handleMerge = useCallback(
     (method: EnumMergeMethod) => {
       const payload: OpenapiMergePullReq = {
@@ -564,13 +567,8 @@ export default function PullRequestConversationPage() {
         source_sha: pullReqMetadata?.source_sha,
         bypass_rules: checkboxBypass,
         dry_run: false,
-        message:
-          method === 'squash'
-            ? pullReqCommits?.commits
-                ?.map(commit => `* ${commit?.sha?.substring(0, 6)} ${commit?.title}`)
-                .join('\n\n')
-                ?.slice(0, 1000)
-            : ''
+        title: mergeTitle,
+        message: mergeMessage
       }
       mergePullReqOp({ body: payload, repo_ref: repoRef, pullreq_number: prId })
         .then(_res => {
@@ -589,7 +587,16 @@ export default function PullRequestConversationPage() {
       //todo: add catch to show errors
       // .catch(exception => showError(getErrorMessage(exception)))
     },
-    [pullReqMetadata?.source_sha, checkboxBypass, repoRef, prId, handleRefetchData, setRuleViolationArr, pullReqCommits]
+    [
+      pullReqMetadata?.source_sha,
+      checkboxBypass,
+      repoRef,
+      prId,
+      handleRefetchData,
+      setRuleViolationArr,
+      mergeTitle,
+      mergeMessage
+    ]
   )
 
   const handlePrState = useCallback(
@@ -756,7 +763,11 @@ export default function PullRequestConversationPage() {
       toPRCheck: ({ pipelineId, executionId }: { pipelineId: string; executionId: string }) =>
         routes.toExecution({ spaceId, repoId, pipelineId, executionId }),
       spaceId,
-      repoId
+      repoId,
+      mergeTitle,
+      mergeMessage,
+      setMergeTitle,
+      setMergeMessage
     }
   }, [
     handleRebaseBranch,
@@ -776,7 +787,11 @@ export default function PullRequestConversationPage() {
     onDeleteBranch,
     showDeleteBranchButton,
     showRestoreBranchButton,
-    errorMsg
+    errorMsg,
+    mergeTitle,
+    mergeMessage,
+    setMergeTitle,
+    setMergeMessage
   ])
 
   if (prPanelData?.PRStateLoading || (changesLoading && !!pullReqMetadata?.closed)) {

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-panel.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-panel.tsx
@@ -207,7 +207,11 @@ export interface PullRequestPanelProps
   repoId?: string
   error?: string | null
   defaultReviewersData?: DefaultReviewersDataProps
-  pullReqCommits: TypesListCommitResponse
+  pullReqCommits: TypesListCommitResponse | undefined
+  mergeTitle: string
+  mergeMessage: string
+  setMergeTitle: (title: string) => void
+  setMergeMessage: (message: string) => void
 }
 
 const PullRequestPanel = ({
@@ -238,6 +242,10 @@ const PullRequestPanel = ({
   repoId,
   error,
   defaultReviewersData,
+  mergeTitle,
+  mergeMessage,
+  setMergeTitle,
+  setMergeMessage,
   ...routingProps
 }: PullRequestPanelProps) => {
   const { Link } = useRouterContext()
@@ -245,8 +253,7 @@ const PullRequestPanel = ({
   const [mergeButtonValue, setMergeButtonValue] = useState(actions[0].id)
   const [accordionValues, setAccordionValues] = useState<string[]>([])
   const [showMergeInputs, setShowMergeInputs] = useState(false)
-  const [mergeTitle, setMergeTitle] = useState(pullReqMetadata?.title || '')
-  const [mergeMessage, setMergeMessage] = useState('')
+
   const [selectedMergeOption, setSelectedMergeOption] = useState<string | null>(null)
 
   useEffect(() => {


### PR DESCRIPTION
Currently, the PR merge form, when edited by the user, doesn't actually reflect the edits in the merge commit. This PR fixes the issue.