### PR TITLE
Add minimum height for Monaco editor and diff editor

### DIFF
--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -509,6 +509,11 @@ mark {
 }
 
 /*  MONACO EDITOR  */
+.monaco-editor,
+.monaco-diff-editor {
+  min-height: 100px;
+}
+
 .monaco-scrollable-element > .scrollbar > .slider {
   border-radius: var(--cn-rounded-full, 0.25rem);
   --vscode-scrollbarSlider-background: var(--cn-comp-scrollbar-thumb, lch(20.5% 2.62 285.74));


### PR DESCRIPTION
Before if we have empty content auto-height = 5px
<img width="841" height="190" alt="Screenshot 2025-07-25 at 11 34 40" src="https://github.com/user-attachments/assets/ee77b7b0-2dcd-42f6-825e-6ede06c593ff" />
After:
<img width="841" height="273" alt="Screenshot 2025-07-25 at 16 51 03" src="https://github.com/user-attachments/assets/6323def6-598d-4905-afbd-6a8e23d5645f" />
