### PR TITLE
add input to create repo form for default branch

### DIFF
--- a/apps/design-system/src/subjects/views/repo-create/index.tsx
+++ b/apps/design-system/src/subjects/views/repo-create/index.tsx
@@ -5,7 +5,7 @@ import { RepoCreatePage } from '@harnessio/ui/views'
 import { useRepoCreateStore } from './repo-create-store'
 
 export const CreateRepoView = () => {
-  const { defaultBranchOptions, gitIgnoreOptions, licenseOptions } = useRepoCreateStore()
+  const { gitIgnoreOptions, licenseOptions } = useRepoCreateStore()
 
   return (
     <RepoCreatePage
@@ -13,7 +13,6 @@ export const CreateRepoView = () => {
       onFormCancel={noop}
       isLoading={false}
       isSuccess={false}
-      defaultBranchOptions={defaultBranchOptions}
       gitIgnoreOptions={gitIgnoreOptions}
       licenseOptions={licenseOptions}
     />

--- a/apps/design-system/src/subjects/views/repo-create/repo-create-store.tsx
+++ b/apps/design-system/src/subjects/views/repo-create/repo-create-store.tsx
@@ -1,6 +1,4 @@
 export const useRepoCreateStore = () => {
-  const defaultBranchOptions = ['main', 'master']
-
   const gitIgnoreOptions = [
     'AL',
     'Actionscript',
@@ -257,7 +255,6 @@ export const useRepoCreateStore = () => {
   ]
 
   return {
-    defaultBranchOptions,
     gitIgnoreOptions,
     licenseOptions
   }

--- a/apps/gitness/src/pages-v2/repo/repo-create-page.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-create-page.tsx
@@ -18,7 +18,6 @@ export const CreateRepo = () => {
   const { spaceId } = useParams<PathParams>()
   const spaceURL = useGetSpaceURLParam()
   const navigate = useNavigate()
-  const defaultBranchOptions = ['main', 'master']
 
   const onSubmit = (data: FormFields) => {
     const repositoryRequest: OpenapiCreateRepositoryRequest = {
@@ -62,7 +61,6 @@ export const CreateRepo = () => {
         onFormCancel={onCancel}
         isLoading={isLoading}
         isSuccess={isSuccess}
-        defaultBranchOptions={defaultBranchOptions}
         gitIgnoreOptions={gitIgnoreOptions}
         licenseOptions={licenseOptions}
         apiError={error?.message?.toString()}

--- a/packages/ui/src/views/repo/repo-create/index.tsx
+++ b/packages/ui/src/views/repo/repo-create/index.tsx
@@ -32,7 +32,7 @@ const formSchema = z.object({
     .min(1, { message: 'Please provide a name' })
     .regex(/^[a-z0-9-_.]+$/i, { message: 'Name can only contain letters, numbers, dash, dot, or underscore' }),
   description: z.string(),
-  defaultBranch: z.string(),
+  defaultBranch: z.string().min(1, { message: 'Please provide a name to initialize the default branch' }),
   gitignore: z.string().optional(),
   license: z.string().optional(),
   access: z.enum(['1', '2'], { errorMap: () => ({ message: 'Please select who has access' }) }),
@@ -46,7 +46,6 @@ interface RepoCreatePageProps {
   onFormCancel: () => void
   isLoading: boolean
   isSuccess: boolean
-  defaultBranchOptions?: string[]
   gitIgnoreOptions?: string[]
   licenseOptions?: { value?: string; label?: string }[]
   apiError?: string
@@ -57,7 +56,6 @@ export function RepoCreatePage({
   onFormCancel,
   isLoading,
   isSuccess,
-  defaultBranchOptions: _defaultBranchOptions,
   gitIgnoreOptions: _gitIgnoreOptions,
   licenseOptions: _licenseOptions,
   apiError
@@ -70,7 +68,7 @@ export function RepoCreatePage({
     defaultValues: {
       name: '',
       description: '',
-      defaultBranch: _defaultBranchOptions?.at(0) ?? 'main',
+      defaultBranch: 'main',
       gitignore: '',
       license: '',
       access: '2',
@@ -87,15 +85,9 @@ export function RepoCreatePage({
     formState: { errors }
   } = formMethods
 
-  const defaultBranchValue = watch('defaultBranch')
   const gitignoreValue = watch('gitignore')
   const licenseValue = watch('license')
   const readmeValue = watch('readme')
-
-  const defaultBranchOptions: SelectValueOption[] = useMemo(
-    () => _defaultBranchOptions?.map(option => ({ value: option, label: option })) ?? [],
-    [_defaultBranchOptions]
-  )
 
   const gitIgnoreOptions: SelectValueOption[] = useMemo(
     () => _gitIgnoreOptions?.map(option => ({ value: option, label: option })) ?? [],
@@ -155,20 +147,15 @@ export function RepoCreatePage({
               label="Description"
               optional
             />
-          </Fieldset>
-
-          {/* DEFAULT BRANCH */}
-          {defaultBranchOptions.length ? (
-            <Select
-              value={defaultBranchValue}
-              options={defaultBranchOptions}
-              onChange={value => handleSelectChange('defaultBranch', value)}
-              placeholder="Select"
-              label="Select a default branch"
-              error={errors.defaultBranch?.message?.toString()}
-              caption="Choose the name to initialize the default branch of your repository."
+            {/* DEFAULT BRANCH */}
+            <FormInput.Text
+              id="default-branch"
+              label="Default branch"
+              {...register('defaultBranch')}
+              placeholder="Enter name to initialize default branch"
+              // error={errors.defaultBranch?.message?.toString()}
             />
-          ) : undefined}
+          </Fieldset>
 
           {/* GITIGNORE */}
           <Select


### PR DESCRIPTION
Removes dropdown and uses input (defaulted to `main`) that allows entry of custom name.