### PR TITLE
fix: search page states, error handling, semantic search visbility

### DIFF
--- a/packages/ui/src/views/search/components/search-results-list.tsx
+++ b/packages/ui/src/views/search/components/search-results-list.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from 'react'
 
-import { Card, Layout, Link, SkeletonList, Spacer, Tag, Text } from '@/components'
+import { Alert, Card, Layout, Link, SkeletonList, Spacer, Tag, Text } from '@/components'
 import { useTranslation } from '@/context'
 import { cn } from '@utils/cn'
 
@@ -11,6 +11,7 @@ interface SearchResultsListProps {
     results?: SearchResultItem[]
   }
   toRepoFileDetails: (params: { repoPath: string; filePath: string; branch: string }) => string
+  searchError?: string
 }
 
 export interface SearchResultItem {
@@ -34,7 +35,8 @@ export const SearchResultsList: FC<SearchResultsListProps> = ({
   isLoading,
   isDirtyList,
   useSearchResultsStore,
-  toRepoFileDetails
+  toRepoFileDetails,
+  searchError
 }) => {
   const { t } = useTranslation()
   const { results } = useSearchResultsStore()
@@ -45,6 +47,15 @@ export const SearchResultsList: FC<SearchResultsListProps> = ({
   }
 
   if (!results?.length) {
+    // Display error message if there's a search error
+    if (searchError) {
+      return (
+        <Alert.Root theme="danger">
+          <Alert.Title>{searchError}</Alert.Title>
+        </Alert.Root>
+      )
+    }
+    
     return (
       <div className={cn('flex flex-col items-center justify-center py-12')}>
         <Text variant="heading-section">

--- a/packages/ui/src/views/search/components/semantic-search-results-list.tsx
+++ b/packages/ui/src/views/search/components/semantic-search-results-list.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from 'react'
 
-import { Card, Layout, Link, SkeletonList, Spacer, Text } from '@/components'
+import { Alert, Card, Layout, Link, SkeletonList, Spacer, Text } from '@/components'
 import { useTranslation } from '@/context'
 import { cn } from '@utils/cn'
 
@@ -22,13 +22,15 @@ interface SemanticSearchResultsListProps {
     semanticResults?: SemanticSearchResultItem[]
   }
   toRepoFileDetails: (params: { filePath: string }) => string
+  semanticSearchError?: string
 }
 
 export const SemanticSearchResultsList: FC<SemanticSearchResultsListProps> = ({
   isLoading,
   isDirtyList,
   useSearchResultsStore,
-  toRepoFileDetails
+  toRepoFileDetails,
+  semanticSearchError
 }) => {
   const { t } = useTranslation()
   const { semanticResults } = useSearchResultsStore()
@@ -39,6 +41,13 @@ export const SemanticSearchResultsList: FC<SemanticSearchResultsListProps> = ({
   }
 
   if (!semanticResults?.length) {
+    if (semanticSearchError) {
+      return (
+        <Alert.Root theme="danger">
+          <Alert.Title>{semanticSearchError}</Alert.Title>
+        </Alert.Root>
+      )
+    }
     return (
       <div className={cn('flex flex-col items-center justify-center py-12')}>
         <Text variant="heading-section">

--- a/packages/ui/src/views/search/search-page.tsx
+++ b/packages/ui/src/views/search/search-page.tsx
@@ -39,6 +39,9 @@ export interface SearchPageViewProps {
   setRegexEnabled: (selected: boolean) => void
   semanticEnabled: boolean
   setSemanticEnabled: (selected: boolean) => void
+  isProjectScope: boolean
+  semanticSearchError?: string
+  searchError?: string
   useSearchResultsStore: () => {
     results?: SearchResultItem[]
     semanticResults?: SemanticSearchResultItem[]
@@ -68,6 +71,9 @@ export const SearchPageView: FC<SearchPageViewProps> = ({
   setRegexEnabled,
   semanticEnabled,
   setSemanticEnabled,
+  isProjectScope,
+  semanticSearchError,
+  searchError,
   useSearchResultsStore,
   stats,
   toRepoFileDetails,
@@ -121,16 +127,18 @@ export const SearchPageView: FC<SearchPageViewProps> = ({
           placeholder={t('views:search.searchPlaceholder', 'Search anything...')}
           suffix={
             <>
-              <Toggle
-                selected={semanticEnabled}
-                onChange={setSemanticEnabled}
-                iconOnly
-                prefixIcon="sparks"
-                prefixIconProps={{
-                  size: 'md'
-                }}
-                tooltipProps={{ content: 'Enable AI Semantic Search' }}
-              />
+              {isProjectScope ? (
+                <Toggle
+                  selected={semanticEnabled}
+                  onChange={setSemanticEnabled}
+                  iconOnly
+                  prefixIcon="sparks"
+                  prefixIconProps={{
+                    size: 'md'
+                  }}
+                  tooltipProps={{ content: 'Enable AI Semantic Search' }}
+                />
+              ) : null}
               {!semanticEnabled ? (
                 <Toggle
                   selected={regexEnabled}
@@ -200,6 +208,7 @@ export const SearchPageView: FC<SearchPageViewProps> = ({
             isDirtyList={isDirtyList}
             useSearchResultsStore={useSearchResultsStore}
             toRepoFileDetails={toRepoFileDetails}
+            semanticSearchError={semanticSearchError}
           />
         ) : (
           <SearchResultsList
@@ -207,6 +216,7 @@ export const SearchPageView: FC<SearchPageViewProps> = ({
             isDirtyList={isDirtyList}
             useSearchResultsStore={useSearchResultsStore}
             toRepoFileDetails={toRepoFileDetails}
+            searchError={searchError}
           />
         )}
 


### PR DESCRIPTION
1. Fix error, and search states on search page
2. Make semantic search button visible only in `project-scoped-repos`


https://github.com/user-attachments/assets/cac9453e-65a7-48f1-9dea-a9d7370ea8ab

