### PR TITLE
Update styles for horizontal control groups to improve layout and alignment

### DIFF
--- a/packages/ui/tailwind-utils-config/components/form-shared-styles.ts
+++ b/packages/ui/tailwind-utils-config/components/form-shared-styles.ts
@@ -15,7 +15,7 @@ export default {
       },
 
       '.cn-control-group-label': {
-        maxWidth: 'var(--cn-input-horizontal-label-max-width)',
+        width: 'var(--cn-input-horizontal-label-max-width)',
         '@apply justify-center': ''
       },
 


### PR DESCRIPTION
before:
<img width="422" height="111" alt="Screenshot 2025-07-28 at 15 37 34" src="https://github.com/user-attachments/assets/8a1454d4-b031-42a4-b6c0-5739a62de216" />

after:
<img width="422" height="111" alt="Screenshot 2025-07-28 at 15 37 58" src="https://github.com/user-attachments/assets/97042a11-0795-4b17-af86-fe6752f6e8ec" />