### PR TITLE
Disabled tab access for empty repo

### DIFF
--- a/apps/gitness/src/pages-v2/repo/repo-layout.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-layout.tsx
@@ -50,6 +50,7 @@ const RepoLayout = () => {
           summaryPath={routes.toRepoSummary({ spaceId, repoId, '*': gitRefPath })}
           filesPath={routes.toRepoFiles({ spaceId, repoId, '*': gitRefPath })}
           commitsPath={toRepoCommits({ spaceId, repoId, fullGitRef, gitRefName })}
+          isRepoEmpty={!!repoData?.is_empty}
         />
       </SubHeaderWrapper>
       <Outlet />

--- a/packages/ui/src/components/repo-subheader.tsx
+++ b/packages/ui/src/components/repo-subheader.tsx
@@ -23,6 +23,7 @@ interface RepoSubheaderProps {
   summaryPath?: string
   filesPath?: string
   commitsPath?: string
+  isRepoEmpty?: boolean
 }
 
 export const RepoSubheader = ({
@@ -31,7 +32,8 @@ export const RepoSubheader = ({
   className,
   summaryPath,
   filesPath,
-  commitsPath
+  commitsPath,
+  isRepoEmpty = false
 }: RepoSubheaderProps) => {
   const { t } = useTranslation()
 
@@ -40,16 +42,28 @@ export const RepoSubheader = ({
       <Tabs.NavRoot>
         <Tabs.List className="px-6">
           <Tabs.Trigger value={summaryPath || RepoTabsKeys.SUMMARY}>{t('views:repos.summary', 'Summary')}</Tabs.Trigger>
-          <Tabs.Trigger value={filesPath || RepoTabsKeys.CODE}>{t('views:repos.files', 'Files')}</Tabs.Trigger>
+          <Tabs.Trigger value={filesPath || RepoTabsKeys.CODE} disabled={isRepoEmpty}>
+            {t('views:repos.files', 'Files')}
+          </Tabs.Trigger>
           {showPipelinesTab && (
             <Tabs.Trigger value={RepoTabsKeys.PIPELINES}>{t('views:repos.pipelines', 'Pipelines')}</Tabs.Trigger>
           )}
-          <Tabs.Trigger value={commitsPath || RepoTabsKeys.COMMITS}>{t('views:repos.commits', 'Commits')}</Tabs.Trigger>
-          <Tabs.Trigger value={RepoTabsKeys.TAGS}>{t('views:repos.tags', 'Tags')}</Tabs.Trigger>
-          <Tabs.Trigger value={RepoTabsKeys.PULLS}>{t('views:repos.pull-requests', 'Pull Requests')}</Tabs.Trigger>
-          <Tabs.Trigger value={RepoTabsKeys.BRANCHES}>{t('views:repos.branches', 'Branches')}</Tabs.Trigger>
+          <Tabs.Trigger value={commitsPath || RepoTabsKeys.COMMITS} disabled={isRepoEmpty}>
+            {t('views:repos.commits', 'Commits')}
+          </Tabs.Trigger>
+          <Tabs.Trigger value={RepoTabsKeys.TAGS} disabled={isRepoEmpty}>
+            {t('views:repos.tags', 'Tags')}
+          </Tabs.Trigger>
+          <Tabs.Trigger value={RepoTabsKeys.PULLS} disabled={isRepoEmpty}>
+            {t('views:repos.pull-requests', 'Pull Requests')}
+          </Tabs.Trigger>
+          <Tabs.Trigger value={RepoTabsKeys.BRANCHES} disabled={isRepoEmpty}>
+            {t('views:repos.branches', 'Branches')}
+          </Tabs.Trigger>
           {showSearchTab && (
-            <Tabs.Trigger value={RepoTabsKeys.SEARCH}>{t('views:repos.search', 'Search')}</Tabs.Trigger>
+            <Tabs.Trigger value={RepoTabsKeys.SEARCH} disabled={isRepoEmpty}>
+              {t('views:repos.search', 'Search')}
+            </Tabs.Trigger>
           )}
           <Tabs.Trigger value={RepoTabsKeys.SETTINGS}>{t('views:repos.settings', 'Settings')}</Tabs.Trigger>
         </Tabs.List>

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -161,7 +161,9 @@ interface TabsTriggerBasePropsWithLogo extends TabsTriggerBaseProps {
   logo?: LogoPropsV2['name']
 }
 
-type TabsTriggerExtendedProps = TabsTriggerBasePropsWithIcon | TabsTriggerBasePropsWithLogo
+type TabsTriggerExtendedProps = (TabsTriggerBasePropsWithIcon | TabsTriggerBasePropsWithLogo) & {
+  disabled?: boolean
+}
 
 type TabsTriggerButtonProps = TabsTriggerExtendedProps &
   Omit<ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>, keyof TabsTriggerExtendedProps>
@@ -169,6 +171,7 @@ type TabsTriggerButtonProps = TabsTriggerExtendedProps &
 type TabsTriggerLinkProps = TabsTriggerExtendedProps &
   Omit<ComponentPropsWithoutRef<'a'>, keyof TabsTriggerExtendedProps | 'href'> & {
     linkProps?: Omit<NavLinkProps, 'to'>
+    disabled?: boolean
   }
 
 export type TabsTriggerProps = TabsTriggerButtonProps | TabsTriggerLinkProps
@@ -198,9 +201,14 @@ const TabsTrigger = forwardRef<HTMLButtonElement | HTMLAnchorElement, TabsTrigge
   )
 
   if (type === 'tabsnav') {
-    const { linkProps, ..._restProps } = restProps as TabsTriggerLinkProps
+    const { linkProps, disabled, ..._restProps } = restProps as TabsTriggerLinkProps
 
-    const handleClick = () => {
+    const handleClick = (e: React.MouseEvent) => {
+      if (disabled) {
+        e.preventDefault()
+        e.stopPropagation()
+        return
+      }
       onValueChange?.(value)
     }
 
@@ -209,6 +217,7 @@ const TabsTrigger = forwardRef<HTMLButtonElement | HTMLAnchorElement, TabsTrigge
         role="tab"
         to={value}
         onClick={handleClick}
+        aria-disabled={disabled}
         className={({ isActive }) => {
           return cn(
             tabsTriggerVariants({ variant }),

--- a/packages/ui/tailwind-utils-config/components/tabs.ts
+++ b/packages/ui/tailwind-utils-config/components/tabs.ts
@@ -126,6 +126,11 @@ export default {
     '&:where([disabled])': {
       color: 'var(--cn-state-disabled-text)',
       cursor: 'not-allowed'
+    },
+
+    '&:where([aria-disabled="true"])': {
+      color: 'var(--cn-state-disabled-text)',
+      cursor: 'not-allowed'
     }
   }
 }


### PR DESCRIPTION
**FIX**
1.  ***Empty Repository Behavior*** -  When a repository had `no files`, we `disabled` other tab options like Files, Commits, Tags, Pull Requests, Branches, and Search.



https://github.com/user-attachments/assets/51315cf5-5d5a-473a-b510-4418eb55a76b



