### PR TITLE
fix tabs content focus issue

### DIFF
--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -342,7 +342,7 @@ const TabsContent = forwardRef<ElementRef<typeof TabsPrimitive.Content>, TabsCon
       return <div ref={ref} className={cn('cn-tabs-content', className)} {...props} />
     }
 
-    return <TabsPrimitive.Content ref={ref} className={cn('cn-tabs-content', className)} {...props} />
+    return <TabsPrimitive.Content ref={ref} className={cn('cn-tabs-content', className)} {...props} tabIndex={-1} />
   }
 )
 TabsContent.displayName = TabsPrimitive.Content.displayName


### PR DESCRIPTION
#### Fix for tabs content focus issue

For some reason a tab content is focusable by default. Now the focus goes directly to the inner components