### PR TITLE
Added mandatory tooltip support for the iconOnly button

### DIFF
--- a/apps/design-system/src/App.tsx
+++ b/apps/design-system/src/App.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 import ViewPreview from '@/pages/view-preview/view-preview'
 import { useThemeStore } from '@utils/theme-utils'
 
+import { TooltipProvider } from '@harnessio/ui/components'
 import { ThemeProvider, TranslationProvider } from '@harnessio/ui/context'
 
 import AppRouterProvider from './AppRouterProvider'
@@ -24,7 +25,9 @@ const App: FC = () => {
   return (
     <ThemeProvider {...themeStore}>
       <TranslationProvider>
-        <RouterProvider router={router} />
+        <TooltipProvider>
+          <RouterProvider router={router} />
+        </TooltipProvider>
       </TranslationProvider>
     </ThemeProvider>
   )

--- a/apps/design-system/src/AppRouterProvider.tsx
+++ b/apps/design-system/src/AppRouterProvider.tsx
@@ -10,8 +10,30 @@ import {
   useSearchParams
 } from 'react-router-dom'
 
-import { Button, SplitButton } from '@harnessio/ui/components'
+import { Button, RbacButtonProps, SplitButton, toButtonProps, Tooltip } from '@harnessio/ui/components'
 import { ComponentProvider, RouterContextProvider } from '@harnessio/ui/context'
+
+const RbacButton = ({ rbac: _, tooltip, ...rest }: RbacButtonProps) => {
+  const hasPermission = true
+
+  const button = (
+    <Button
+      {...toButtonProps({
+        ...rest,
+        ignoreIconOnlyTooltip: true
+      })}
+      disabled={!hasPermission}
+    />
+  )
+
+  return !hasPermission ? (
+    <Tooltip title={tooltip?.title ?? 'You are missing the permission for this action.'} content={tooltip?.content}>
+      {button}
+    </Tooltip>
+  ) : (
+    button
+  )
+}
 
 const AppRouterProvider: FC = () => {
   const navigate = useNavigate()
@@ -28,7 +50,7 @@ const AppRouterProvider: FC = () => {
       useMatches={useMatches}
       useParams={useParams}
     >
-      <ComponentProvider components={{ RbacButton: Button, RbacSplitButton: SplitButton }}>
+      <ComponentProvider components={{ RbacButton, RbacSplitButton: SplitButton }}>
         <Outlet />
       </ComponentProvider>
     </RouterContextProvider>

--- a/apps/design-system/src/pages/view-preview/view-preview.tsx
+++ b/apps/design-system/src/pages/view-preview/view-preview.tsx
@@ -59,7 +59,7 @@ import TableV2Demo from '@subjects/views/table-v2-demo'
 import { ViewOnlyView } from '@subjects/views/templates/view-only'
 import UnifiedPipelineStudioWrapper from '@subjects/views/unified-pipeline-studio/unified-pipeline-studio'
 
-import { ChatEmptyPreviewWrapper, ChatPreviewWrapper, TooltipProvider } from '@harnessio/ui/components'
+import { ChatEmptyPreviewWrapper, ChatPreviewWrapper } from '@harnessio/ui/components'
 import { NotFoundPage } from '@harnessio/ui/views'
 
 import { AppViewWrapper } from './app-view-wrapper'
@@ -606,7 +606,7 @@ export const viewPreviews: Record<string, ViewPreviewGroup> = {
 
 const ViewPreview: FC = () => {
   return (
-    <TooltipProvider>
+    <>
       <Routes>
         {Object.entries(viewPreviews).map(([_, group]) =>
           Object.entries(group.items).map(([route, { element }]) => (
@@ -616,7 +616,7 @@ const ViewPreview: FC = () => {
         <Route path="/" element={<Navigate to={Object.keys(viewPreviews)[0]} />} />
       </Routes>
       <ViewSettings routes={Object.keys(viewPreviews)} />
-    </TooltipProvider>
+    </>
   )
 }
 

--- a/apps/design-system/src/pages/view-preview/view-settings.tsx
+++ b/apps/design-system/src/pages/view-preview/view-settings.tsx
@@ -56,6 +56,9 @@ const ViewSettings: FC<ViewSettingsProps> = ({ routes }) => {
         onClick={() => setShowSettings(current => !current)}
         className={css.showHideButton}
         title={showSettings ? 'Hide view settings' : 'Show view settings'}
+        tooltipProps={{
+          content: showSettings ? 'Hide view settings' : 'Show view settings'
+        }}
       >
         <IconV2 name={showSettings ? 'xmark' : 'settings'} />
       </Button>

--- a/apps/design-system/src/subjects/views/templates/view-only.tsx
+++ b/apps/design-system/src/subjects/views/templates/view-only.tsx
@@ -257,7 +257,7 @@ export const ViewOnlyView = () => {
                     />
                   </Table.Cell>
                   <Table.Cell align="right" width="40">
-                    <Toggle prefixIcon="pin" iconOnly />
+                    <Toggle prefixIcon="pin" iconOnly tooltipProps={{ content: 'Toggle Pin' }} />
                   </Table.Cell>
                 </Table.Row>
                 <Table.Row>
@@ -281,7 +281,7 @@ export const ViewOnlyView = () => {
                     />
                   </Table.Cell>
                   <Table.Cell align="right" width="40">
-                    <Toggle prefixIcon="pin" iconOnly />
+                    <Toggle prefixIcon="pin" iconOnly tooltipProps={{ content: 'Toggle Pin' }} />
                   </Table.Cell>
                 </Table.Row>
                 <Table.Row>
@@ -305,7 +305,7 @@ export const ViewOnlyView = () => {
                     />
                   </Table.Cell>
                   <Table.Cell align="right" width="40">
-                    <Toggle prefixIcon="pin" iconOnly />
+                    <Toggle prefixIcon="pin" iconOnly tooltipProps={{ content: 'Toggle Pin' }} />
                   </Table.Cell>
                 </Table.Row>
                 <Table.Row>
@@ -329,7 +329,7 @@ export const ViewOnlyView = () => {
                     />
                   </Table.Cell>
                   <Table.Cell align="right" width="40">
-                    <Toggle prefixIcon="pin" iconOnly />
+                    <Toggle prefixIcon="pin" iconOnly tooltipProps={{ content: 'Toggle Pin' }} />
                   </Table.Cell>
                 </Table.Row>
                 <Table.Row>
@@ -353,7 +353,7 @@ export const ViewOnlyView = () => {
                     />
                   </Table.Cell>
                   <Table.Cell align="right" width="40">
-                    <Toggle prefixIcon="pin" iconOnly />
+                    <Toggle prefixIcon="pin" iconOnly tooltipProps={{ content: 'Toggle Pin' }} />
                   </Table.Cell>
                 </Table.Row>
                 <Table.Row>
@@ -377,7 +377,7 @@ export const ViewOnlyView = () => {
                     />
                   </Table.Cell>
                   <Table.Cell align="right" width="40">
-                    <Toggle prefixIcon="pin" iconOnly />
+                    <Toggle prefixIcon="pin" iconOnly tooltipProps={{ content: 'Toggle Pin' }} />
                   </Table.Cell>
                 </Table.Row>
               </Table.Body>

--- a/apps/gitness/src/framework/rbac/rbac-button.tsx
+++ b/apps/gitness/src/framework/rbac/rbac-button.tsx
@@ -1,4 +1,4 @@
-import { Button, RbacButtonProps, Resource, Tooltip } from '@harnessio/ui/components'
+import { Button, RbacButtonProps, Resource, toButtonProps, Tooltip } from '@harnessio/ui/components'
 
 import { useMFEContext } from '../hooks/useMFEContext'
 
@@ -16,7 +16,15 @@ export const RbacButton = ({ rbac, tooltip, ...rest }: RbacButtonProps) => {
       })
       ?.some(Boolean) ?? true
 
-  const button = <Button {...rest} disabled={!hasPermission} />
+  const button = (
+    <Button
+      {...toButtonProps({
+        ...rest,
+        ignoreIconOnlyTooltip: true
+      })}
+      disabled={!hasPermission}
+    />
+  )
 
   return !hasPermission ? (
     <Tooltip title={tooltip?.title ?? 'You are missing the permission for this action.'} content={tooltip?.content}>

--- a/apps/portal/src/components/docs-page/example.tsx
+++ b/apps/portal/src/components/docs-page/example.tsx
@@ -75,9 +75,7 @@ const Example: FC<ExampleProps> = ({
       element: (
         <RouterContextProvider Link={Link} NavLink={NavLink} Outlet={Outlet}>
           <TranslationProvider>
-            <TooltipProvider>
-              <LivePreview />
-            </TooltipProvider>
+            <LivePreview />
           </TranslationProvider>
         </RouterContextProvider>
       ),
@@ -85,6 +83,7 @@ const Example: FC<ExampleProps> = ({
   ]);
 
   return (
+      <TooltipProvider>
     <div className="bg-cn-1 not-content my-12 overflow-hidden rounded-md border">
       <LiveProvider code={currentCode} scope={scopeWithLayout} enableTypeScript>
         <div className={cn("grid place-items-center p-12", contentClassName)}>
@@ -110,6 +109,7 @@ const Example: FC<ExampleProps> = ({
         )}
       </LiveProvider>
     </div>
+      </TooltipProvider>
   );
 };
 

--- a/apps/portal/src/components/docs-page/example.tsx
+++ b/apps/portal/src/components/docs-page/example.tsx
@@ -83,33 +83,37 @@ const Example: FC<ExampleProps> = ({
   ]);
 
   return (
-      <TooltipProvider>
-    <div className="bg-cn-1 not-content my-12 overflow-hidden rounded-md border">
-      <LiveProvider code={currentCode} scope={scopeWithLayout} enableTypeScript>
-        <div className={cn("grid place-items-center p-12", contentClassName)}>
-          <RouterProvider router={router} />
-        </div>
-        {!hideCode && (
-          <details className="relative example-expand bg-cn-2 border-t p-3">
-            <CopyButton
-              buttonVariant="transparent"
-              className="absolute top-3 right-3"
-              name={currentCode}
-            />
-            <summary className="flex cursor-pointer select-none items-center gap-1 text-sm">
-              <IconV2 name="nav-arrow-right" className="disclosure-icon" />
-              Show code
-            </summary>
-            <LiveEditor
-              theme={isLightTheme ? themes.vsLight : themes.vsDark}
-              className="font-body-code line-numbers p-1 text-sm leading-6"
-              onChange={setCurrentCode}
-            />
-          </details>
-        )}
-      </LiveProvider>
-    </div>
-      </TooltipProvider>
+    <TooltipProvider>
+      <div className="bg-cn-1 not-content my-12 overflow-hidden rounded-md border">
+        <LiveProvider
+          code={currentCode}
+          scope={scopeWithLayout}
+          enableTypeScript
+        >
+          <div className={cn("grid place-items-center p-12", contentClassName)}>
+            <RouterProvider router={router} />
+          </div>
+          {!hideCode && (
+            <details className="relative example-expand bg-cn-2 border-t p-3">
+              <CopyButton
+                buttonVariant="transparent"
+                className="absolute top-3 right-3"
+                name={currentCode}
+              />
+              <summary className="flex cursor-pointer select-none items-center gap-1 text-sm">
+                <IconV2 name="nav-arrow-right" className="disclosure-icon" />
+                Show code
+              </summary>
+              <LiveEditor
+                theme={isLightTheme ? themes.vsLight : themes.vsDark}
+                className="font-body-code line-numbers p-1 text-sm leading-6"
+                onChange={setCurrentCode}
+              />
+            </details>
+          )}
+        </LiveProvider>
+      </div>
+    </TooltipProvider>
   );
 };
 

--- a/apps/portal/src/components/layout/ThemeSelector.tsx
+++ b/apps/portal/src/components/layout/ThemeSelector.tsx
@@ -3,6 +3,7 @@ import {
   IconV2,
   ThemeDialog,
   type ThemeDialogProps,
+  TooltipProvider,
 } from "@harnessio/ui/components";
 import { useEffect, useState } from "react";
 
@@ -25,16 +26,22 @@ export function ThemeSelector() {
   }, [theme]);
 
   return (
-    <ThemeDialog
-      open={open}
-      onOpenChange={setOpen}
-      setTheme={setTheme}
-      theme={theme}
-    >
-      <Button iconOnly onClick={() => setOpen(true)}>
-        <IconV2 name="theme" />
-      </Button>
-    </ThemeDialog>
+    <TooltipProvider>
+      <ThemeDialog
+        open={open}
+        onOpenChange={setOpen}
+        setTheme={setTheme}
+        theme={theme}
+      >
+        <Button
+          iconOnly
+          onClick={() => setOpen(true)}
+          tooltipProps={{ content: "Appearance settings" }}
+        >
+          <IconV2 name="theme" />
+        </Button>
+      </ThemeDialog>
+    </TooltipProvider>
   );
 }
 
@@ -44,8 +51,10 @@ export default function ThemeSelectorWrapper() {
   }
 
   return (
-    <Button iconOnly>
-      <IconV2 name="theme" />
-    </Button>
+    <TooltipProvider>
+      <Button iconOnly ignoreIconOnlyTooltip>
+        <IconV2 name="theme" />
+      </Button>
+    </TooltipProvider>
   );
 }

--- a/apps/portal/src/content/docs/components/button.mdx
+++ b/apps/portal/src/content/docs/components/button.mdx
@@ -179,7 +179,7 @@ Secondary buttons can be styled with different themes for various contexts.
       Success Loading
     </Button>
   </div>
-  
+
   <div className="flex gap-3">
     <Button variant="secondary" theme="danger" disabled>
       Danger Disabled
@@ -428,34 +428,38 @@ Transparent buttons have no background or border and don't accept theme props.
 
 ## Additional Features
 
+When the `iconOnly` prop is used, you must also provide `tooltipProps` to display content in the tooltip.
+
+If you need to skip showing the tooltip, you should set `ignoreIconOnlyTooltip`.
+
 <DocsPage.ComponentExample
   client:only
   code={`<div className="flex flex-col items-start min-w-[600px] gap-8">
 <h4>Icon Only Buttons</h4>
 
 <div className="flex gap-3">
-  <Button iconOnly>
+  <Button iconOnly tooltipProps={{ content: "Add" }}>
     <IconV2 name="plus" skipSize />
   </Button>
-  <Button variant="secondary" size="sm" iconOnly>
+  <Button variant="secondary" size="sm" iconOnly ignoreIconOnlyTooltip>
     <IconV2 name="git-branch" skipSize />
   </Button>
-  <Button variant="transparent" size="sm" iconOnly>
+  <Button variant="transparent" size="sm" iconOnly ignoreIconOnlyTooltip>
     <IconV2 name="xmark" skipSize />
   </Button>
-  <Button variant="outline" size="xs" iconOnly>
+  <Button variant="outline" size="xs" iconOnly ignoreIconOnlyTooltip>
     <IconV2 name="check" skipSize />
   </Button>
-  <Button variant="outline" size="2xs" iconOnly>
+  <Button variant="outline" size="2xs" iconOnly ignoreIconOnlyTooltip>
     <IconV2 name="check" skipSize />
   </Button>
-  <Button variant="outline" size="3xs" iconOnly>
+  <Button variant="outline" size="3xs" iconOnly ignoreIconOnlyTooltip>
     <IconV2 name="check" skipSize />
   </Button>
-  <Button variant="outline" size="2xs" iconOnly>
+  <Button variant="outline" size="2xs" iconOnly ignoreIconOnlyTooltip>
     <IconV2 name="xmark" skipSize />
   </Button>
-  <Button variant="outline" size="3xs" iconOnly>
+  <Button variant="outline" size="3xs" iconOnly ignoreIconOnlyTooltip>
     <IconV2 name="xmark" skipSize />
   </Button>
 </div>
@@ -515,7 +519,7 @@ import { Button } from '@harnessio/ui/components'
 <Button rounded>Rounded Button</Button>
 
 // Icon only button
-<Button iconOnly>
+<Button iconOnly tooltipProps={{ content: 'Add' }}>
   <IconV2 name="plus" />
 </Button>
 
@@ -617,6 +621,22 @@ This ensures type safety and provides proper development-time feedback on invali
       description: "Content to display inside the button.",
       required: true,
       value: "ReactNode",
+    },
+    {
+      name: "tooltipProps",
+      description:
+        "If provided, wraps the Button in a tooltip with the specified properties.",
+      required: false,
+      defaultValue: "undefined",
+      value: "Pick<TooltipProps, 'title' | 'content' | 'side'>",
+    },
+    {
+      name: "ignoreIconOnlyTooltip",
+      description:
+        "Allows skipping the required tooltipProps when using iconOnly.",
+      required: false,
+      value: "boolean",
+      defaultValue: "undefined",
     },
   ]}
 />

--- a/apps/portal/src/content/docs/components/toggle-group.mdx
+++ b/apps/portal/src/content/docs/components/toggle-group.mdx
@@ -429,7 +429,7 @@ The `Item` component is used to define each toggle button within the group.
     {
       name: "tooltipProps",
       description:
-        "If provided, wraps the ToggleItem in a tooltip with the specified properties.",
+        "If provided, wraps the Button in a tooltip with the specified properties.",
       required: false,
       defaultValue: "undefined",
       value: "Pick<TooltipProps, 'title' | 'content' | 'side' | 'align'>",

--- a/apps/portal/src/content/docs/components/toggle.mdx
+++ b/apps/portal/src/content/docs/components/toggle.mdx
@@ -273,10 +273,10 @@ The `Toggle` component is a button that can be toggled on and off.
     {
       name: "tooltipProps",
       description:
-        "If provided, wraps the toggle in a tooltip with the specified properties.",
+        "If provided, wraps the Button in a tooltip with the specified properties.",
       required: false,
       defaultValue: "undefined",
-      value: "Pick<TooltipProps, 'title' | 'content' | 'side' | 'align'>",
+      value: "Pick<TooltipProps, 'title' | 'content' | 'side'>",
     },
   ]}
 />

--- a/packages/ui/src/components/alert/AlertRoot.tsx
+++ b/packages/ui/src/components/alert/AlertRoot.tsx
@@ -90,6 +90,7 @@ export const AlertRoot = forwardRef<HTMLDivElement, AlertRootProps>(
             size="sm"
             iconOnly
             aria-label={t('component:alert.close', 'Close alert')}
+            ignoreIconOnlyTooltip
           >
             <IconV2 className="cn-alert-close-button-icon" name="xmark" skipSize />
           </Button>

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,5 +1,6 @@
-import { ButtonHTMLAttributes, forwardRef } from 'react'
+import { ButtonHTMLAttributes, forwardRef, Fragment } from 'react'
 
+import { Tooltip, TooltipProps } from '@/components'
 import { Slot } from '@radix-ui/react-slot'
 import { cn } from '@utils/cn'
 import { filterChildrenByDisplayNames } from '@utils/utils'
@@ -90,16 +91,38 @@ const buttonVariants = cva('cn-button', {
   }
 })
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
-  asChild?: boolean
-  loading?: boolean
-  rounded?: boolean
-  iconOnly?: boolean
+type ButtonTooltipProps = Pick<TooltipProps, 'title' | 'content' | 'side'>
+
+type CommonButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+    loading?: boolean
+    rounded?: boolean
+  }
+
+type ButtonPropsIconOnlyRequired = {
+  iconOnly: true
+  ignoreIconOnlyTooltip?: false
+  tooltipProps: ButtonTooltipProps
 }
 
-export type ButtonThemes = VariantProps<typeof buttonVariants>['theme']
-export type ButtonVariants = VariantProps<typeof buttonVariants>['variant']
-export type ButtonSizes = VariantProps<typeof buttonVariants>['size']
+type ButtonPropsIconOnlyIgnored = {
+  iconOnly: true
+  ignoreIconOnlyTooltip: true
+  tooltipProps?: ButtonTooltipProps
+}
+
+type ButtonPropsRegular = {
+  iconOnly?: false
+  tooltipProps?: ButtonTooltipProps
+  ignoreIconOnlyTooltip?: boolean
+}
+
+type ButtonProps = CommonButtonProps & (ButtonPropsIconOnlyRequired | ButtonPropsIconOnlyIgnored | ButtonPropsRegular)
+
+type ButtonThemes = VariantProps<typeof buttonVariants>['theme']
+type ButtonVariants = VariantProps<typeof buttonVariants>['variant']
+type ButtonSizes = VariantProps<typeof buttonVariants>['size']
 
 // add icon only aria attr if iconOnly is true
 
@@ -111,19 +134,21 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       size = 'md',
       theme = 'default',
       rounded,
-      iconOnly: _iconOnly = false,
+      iconOnly: iconOnlyProp = false,
       asChild = false,
       loading,
       disabled,
       children: _children,
       type = 'button',
+      tooltipProps,
+      ignoreIconOnlyTooltip: _,
       ...props
     },
     ref
   ) => {
     const Comp = asChild ? Slot : 'button'
     const microSize = size === '2xs' || size === '3xs'
-    const iconOnly = _iconOnly || microSize
+    const iconOnly = iconOnlyProp || microSize
 
     const filteredChildren = iconOnly ? filterChildrenByDisplayNames(_children, [IconV2DisplayName])[0] : _children
 
@@ -137,7 +162,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       filteredChildren
     )
 
-    return (
+    const ButtonComp = (
       <Comp
         className={cn(buttonVariants({ variant, size, theme, rounded, iconOnly, className }))}
         ref={ref}
@@ -148,8 +173,54 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {children}
       </Comp>
     )
+
+    if (tooltipProps) {
+      return (
+        <Tooltip hideArrow {...tooltipProps}>
+          {ButtonComp}
+        </Tooltip>
+      )
+    }
+
+    return ButtonComp
   }
 )
 Button.displayName = 'Button'
 
-export { Button, buttonVariants, type ButtonProps }
+/**
+ * Converts iconOnly into a literal and returns props ready to be spread into <Button />
+ * @param p
+ */
+type BtnIconOnly = Extract<ButtonProps, { iconOnly: true }>
+type BtnRegular = Extract<ButtonProps, { iconOnly?: false }>
+type ButtonLike = Omit<Partial<ButtonProps>, 'iconOnly' | 'ignoreIconOnlyTooltip'> & {
+  iconOnly?: boolean
+  ignoreIconOnlyTooltip?: boolean
+}
+
+const toButtonProps = (p: ButtonLike) => {
+  if (p?.iconOnly) {
+    return {
+      ...p,
+      iconOnly: true,
+      ignoreIconOnlyTooltip: (p as any)?.ignoreIconOnlyTooltip ?? false
+    } as BtnIconOnly
+  }
+
+  const { ignoreIconOnlyTooltip: _drop, ...rest } = p as any
+  return {
+    ...rest,
+    iconOnly: false
+  } as BtnRegular
+}
+
+export { Button, buttonVariants, toButtonProps }
+export type {
+  ButtonProps,
+  ButtonThemes,
+  ButtonVariants,
+  ButtonSizes,
+  ButtonTooltipProps,
+  ButtonPropsIconOnlyRequired,
+  ButtonPropsRegular
+}

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -109,7 +109,7 @@ type ButtonPropsIconOnlyRequired = {
 type ButtonPropsIconOnlyIgnored = {
   iconOnly: true
   ignoreIconOnlyTooltip: true
-  tooltipProps?: ButtonTooltipProps
+  tooltipProps?: never
 }
 
 type ButtonPropsRegular = {
@@ -141,7 +141,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       children: _children,
       type = 'button',
       tooltipProps,
-      ignoreIconOnlyTooltip: _,
+      ignoreIconOnlyTooltip,
       ...props
     },
     ref
@@ -174,7 +174,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       </Comp>
     )
 
-    if (tooltipProps) {
+    if (tooltipProps && !ignoreIconOnlyTooltip) {
       return (
         <Tooltip hideArrow {...tooltipProps}>
           {ButtonComp}

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,6 +1,6 @@
 import { ButtonHTMLAttributes, forwardRef, Fragment } from 'react'
 
-import { Tooltip, TooltipProps } from '@/components'
+import { Tooltip, TooltipProps } from '@components/tooltip'
 import { Slot } from '@radix-ui/react-slot'
 import { cn } from '@utils/cn'
 import { filterChildrenByDisplayNames } from '@utils/utils'

--- a/packages/ui/src/components/carousel.tsx
+++ b/packages/ui/src/components/carousel.tsx
@@ -218,6 +218,9 @@ const CarouselPrevious = forwardRef<HTMLButtonElement, ComponentProps<typeof But
         )}
         disabled={!canScrollPrev}
         onClick={scrollPrev}
+        tooltipProps={{
+          content: 'Previous'
+        }}
         {...props}
       >
         <ArrowLeftIcon className="size-4" />
@@ -248,6 +251,9 @@ const CarouselNext = forwardRef<HTMLButtonElement, ComponentProps<typeof Button>
         )}
         disabled={!canScrollNext}
         onClick={scrollNext}
+        tooltipProps={{
+          content: 'Next'
+        }}
         {...props}
       >
         <ArrowRightIcon className="size-4" />

--- a/packages/ui/src/components/carousel.tsx
+++ b/packages/ui/src/components/carousel.tsx
@@ -198,7 +198,9 @@ const CarouselItem = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
 })
 CarouselItem.displayName = 'CarouselItem'
 
-const CarouselPrevious = forwardRef<HTMLButtonElement, ComponentProps<typeof Button>>(
+type CarouselButtonProp = Omit<ComponentProps<typeof Button>, 'iconOnly' | 'tooltipProps' | 'ignoreIconOnlyTooltip'>
+
+const CarouselPrevious = forwardRef<HTMLButtonElement, CarouselButtonProp>(
   ({ className, variant = 'outline', theme = 'default', size = 'sm', ...props }, ref) => {
     const { orientation, scrollPrev, canScrollPrev } = useCarousel()
 
@@ -231,7 +233,7 @@ const CarouselPrevious = forwardRef<HTMLButtonElement, ComponentProps<typeof But
 )
 CarouselPrevious.displayName = 'CarouselPrevious'
 
-const CarouselNext = forwardRef<HTMLButtonElement, ComponentProps<typeof Button>>(
+const CarouselNext = forwardRef<HTMLButtonElement, CarouselButtonProp>(
   ({ className, variant = 'outline', theme = 'default', size = 'sm', ...props }, ref) => {
     const { orientation, scrollNext, canScrollNext } = useCarousel()
 

--- a/packages/ui/src/components/chat/chat.tsx
+++ b/packages/ui/src/components/chat/chat.tsx
@@ -11,7 +11,7 @@ const Header: FC<{ onClose: () => void }> = ({ onClose }) => {
   return (
     <div className="sticky top-0 flex items-center justify-between bg-cn-1 px-6 py-4">
       <p className="text-16 font-medium text-cn-1">Harness AI</p>
-      <Button size="sm" iconOnly variant="ghost" onClick={onClose}>
+      <Button size="sm" iconOnly variant="ghost" onClick={onClose} ignoreIconOnlyTooltip>
         <IconV2 name="xmark" />
         <span className="sr-only">Close</span>
       </Button>

--- a/packages/ui/src/components/copy-button/copy-button.tsx
+++ b/packages/ui/src/components/copy-button/copy-button.tsx
@@ -7,26 +7,14 @@ export interface CopyButtonProps extends Omit<UseCopyButtonProps, 'copyData'> {
   className?: string
   buttonVariant?: ButtonVariants
   size?: ButtonSizes
-  iconOnly?: boolean
 }
 
 export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
-  (
-    { name, className, buttonVariant = 'outline', iconSize = 'sm', size = 'sm', onClick, color, iconOnly = false },
-    ref
-  ) => {
+  ({ name, className, buttonVariant = 'outline', iconSize = 'sm', size = 'sm', onClick, color }, ref) => {
     const { copyButtonProps, CopyIcon } = useCopyButton({ onClick, copyData: name, iconSize, color })
 
     return (
-      <Button
-        className={className}
-        type="button"
-        variant={buttonVariant}
-        size={size}
-        iconOnly={iconOnly}
-        {...copyButtonProps}
-        ref={ref}
-      >
+      <Button ref={ref} className={className} type="button" variant={buttonVariant} size={size} {...copyButtonProps}>
         {CopyIcon}
       </Button>
     )

--- a/packages/ui/src/components/copy-button/use-copy-button.tsx
+++ b/packages/ui/src/components/copy-button/use-copy-button.tsx
@@ -56,7 +56,10 @@ export const useCopyButton = ({ onClick, copyData, color, iconSize }: UseCopyBut
   const copyButtonProps: ButtonProps = {
     iconOnly: true,
     'aria-label': 'Copy',
-    onClick: handleClick
+    onClick: handleClick,
+    tooltipProps: {
+      content: 'Copy'
+    }
   }
 
   return {

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -157,6 +157,9 @@ export function DataTable<TData>({
                 size="xs"
                 iconOnly
                 role="button"
+                tooltipProps={{
+                  content: 'Toggle Row Expanded'
+                }}
               >
                 <IconV2 name={row.getIsExpanded() ? 'nav-arrow-down' : 'nav-arrow-up'} size="2xs" />
               </Button>

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -62,7 +62,7 @@ const Content = forwardRef<HTMLDivElement, ContentProps>(
           <DialogPrimitive.Content ref={ref} className={cn(contentVariants({ size }), className)} {...props}>
             {!hideClose && (
               <DialogPrimitive.Close asChild>
-                <Button variant="transparent" className="cn-modal-dialog-close" iconOnly>
+                <Button className="cn-modal-dialog-close" variant="transparent" iconOnly ignoreIconOnlyTooltip>
                   <IconV2 name="xmark" />
                 </Button>
               </DialogPrimitive.Close>

--- a/packages/ui/src/components/drawer/DrawerContent.tsx
+++ b/packages/ui/src/components/drawer/DrawerContent.tsx
@@ -61,7 +61,7 @@ export const DrawerContent = forwardRef<ElementRef<typeof DrawerPrimitive.Conten
       >
         {!hideClose && (
           <DrawerPrimitive.Close asChild>
-            <Button className="cn-drawer-close-button" variant="transparent" iconOnly>
+            <Button className="cn-drawer-close-button" variant="transparent" iconOnly ignoreIconOnlyTooltip>
               <IconV2 className="cn-drawer-close-button-icon" name="xmark" skipSize />
             </Button>
           </DrawerPrimitive.Close>

--- a/packages/ui/src/components/favorite.tsx
+++ b/packages/ui/src/components/favorite.tsx
@@ -20,6 +20,9 @@ const Favorite: FC<FavoriteIconProps> = ({ isFavorite = false, onFavoriteToggle 
       size: '2xs'
     }}
     onChange={(selected: boolean) => onFavoriteToggle(selected)}
+    tooltipProps={{
+      content: isFavorite ? 'Remove from favorite' : 'Add to favorite'
+    }}
   />
 )
 

--- a/packages/ui/src/components/file-toolbar-actions.tsx
+++ b/packages/ui/src/components/file-toolbar-actions.tsx
@@ -32,14 +32,20 @@ export const FileToolbarActions: FC<FileToolbarActionsProps> = ({
               {
                 children: <IconV2 name="edit-pencil" />,
                 'aria-label': 'Edit',
-                onClick: onEditClick
+                onClick: onEditClick,
+                tooltipProps: {
+                  content: 'Edit'
+                }
               }
             ]
           : []),
         {
           children: <IconV2 name="download" />,
           'aria-label': 'Download',
-          onClick: onDownloadClick
+          onClick: onDownloadClick,
+          tooltipProps: {
+            content: 'Download'
+          }
         },
         ...additionalButtonsProps
       ]}

--- a/packages/ui/src/components/filters/filter-box-wrapper.tsx
+++ b/packages/ui/src/components/filters/filter-box-wrapper.tsx
@@ -75,6 +75,9 @@ const FilterBoxWrapper = ({
               size="2xs"
               onClick={handleRemoveFilter}
               aria-label={t('component:filter.delete', 'Delete filter')}
+              tooltipProps={{
+                content: t('component:filter.delete', 'Delete filter')
+              }}
             >
               <IconV2 name="trash" skipSize />
             </Button>

--- a/packages/ui/src/components/filters/filter-select.tsx
+++ b/packages/ui/src/components/filters/filter-select.tsx
@@ -51,6 +51,7 @@ const FilterSelect = <FilterKey extends string, CustomValue = Record<string, unk
                 onClick={() => {
                   setSearchQuery('')
                 }}
+                ignoreIconOnlyTooltip
               >
                 <IconV2 name="xmark" size="2xs" />
               </Button>

--- a/packages/ui/src/components/filters/filters-bar/actions/variants/text-field.tsx
+++ b/packages/ui/src/components/filters/filters-bar/actions/variants/text-field.tsx
@@ -26,7 +26,7 @@ const Text = ({ filter, onUpdateFilter }: TextFilterProps) => {
       onChange={handleInputChange}
       prefix={false}
       suffix={
-        <Button iconOnly size="sm" variant="transparent" onClick={handleClear}>
+        <Button iconOnly size="sm" variant="transparent" onClick={handleClear} ignoreIconOnlyTooltip>
           <IconV2 name="xmark" size="2xs" />
         </Button>
       }

--- a/packages/ui/src/components/image-carousel.tsx
+++ b/packages/ui/src/components/image-carousel.tsx
@@ -57,6 +57,9 @@ export const ImageCarousel: FC<ImageCarouselProps> = ({ isOpen, setIsOpen, imgEv
               }
             }}
             title="Zoom out"
+            tooltipProps={{
+              content: 'Zoom out'
+            }}
           >
             <IconV2 name="minus" />
           </Button>
@@ -71,6 +74,9 @@ export const ImageCarousel: FC<ImageCarouselProps> = ({ isOpen, setIsOpen, imgEv
               }
             }}
             title="Zoom in"
+            tooltipProps={{
+              content: 'Zoom in'
+            }}
           >
             <IconV2 name="plus" />
           </Button>

--- a/packages/ui/src/components/inputs/number-input.tsx
+++ b/packages/ui/src/components/inputs/number-input.tsx
@@ -147,6 +147,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
                         onClick={handleIncrement}
                         disabled={disabled}
                         size="sm"
+                        ignoreIconOnlyTooltip
                       >
                         <IconV2 name="nav-arrow-up" size="xs" />
                       </Button>
@@ -160,6 +161,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
                         onClick={handleDecrement}
                         disabled={disabled}
                         size="sm"
+                        ignoreIconOnlyTooltip
                       >
                         <IconV2 name="nav-arrow-down" size="xs" />
                       </Button>

--- a/packages/ui/src/components/manage-navigation/index.tsx
+++ b/packages/ui/src/components/manage-navigation/index.tsx
@@ -179,6 +179,9 @@ export const ManageNavigation = ({
                                 onClick={() => {
                                   removeFromPinnedItems(item)
                                 }}
+                                tooltipProps={{
+                                  content: 'Unpin'
+                                }}
                               >
                                 <IconV2 name="xmark" size="xs" />
                               </Button>
@@ -217,7 +220,15 @@ export const ManageNavigation = ({
                       <Text color="foreground-1">{item.title}</Text>
                     </Layout.Flex>
 
-                    <Button iconOnly size="sm" variant="transparent" onClick={() => addToPinnedItems(item)}>
+                    <Button
+                      iconOnly
+                      size="sm"
+                      variant="transparent"
+                      onClick={() => addToPinnedItems(item)}
+                      tooltipProps={{
+                        content: 'Toggle pin'
+                      }}
+                    >
                       <IconV2 name="pin" size="xs" />
                     </Button>
                   </Layout.Flex>

--- a/packages/ui/src/components/more-actions-tooltip.tsx
+++ b/packages/ui/src/components/more-actions-tooltip.tsx
@@ -48,6 +48,8 @@ export const MoreActionsTooltip: FC<MoreActionsTooltipProps> = ({
           variant={buttonVariant}
           iconOnly
           size="md"
+          aria-label="Show more actions"
+          ignoreIconOnlyTooltip
         >
           <IconV2 name={iconName} />
         </Button>

--- a/packages/ui/src/components/no-data.tsx
+++ b/packages/ui/src/components/no-data.tsx
@@ -86,14 +86,14 @@ export const NoData: FC<NoDataProps> = ({
           <Layout.Horizontal gap="sm">
             {primaryButton &&
               (primaryButton.to ? (
-                <Button asChild {...toButtonProps(omit(secondaryButton, ['to', 'label', 'icon']) as ButtonProps)}>
+                <Button asChild {...toButtonProps(omit(primaryButton, ['to', 'label', 'icon']) as ButtonProps)}>
                   <NavLink to={primaryButton.to}>
                     {primaryButton.icon && <IconV2 name={primaryButton.icon} size="sm" />}
                     {primaryButton.label}
                   </NavLink>
                 </Button>
               ) : (
-                <Button {...toButtonProps(omit(secondaryButton, ['label', 'icon']) as ButtonProps)}>
+                <Button {...toButtonProps(omit(primaryButton, ['label', 'icon']) as ButtonProps)}>
                   {primaryButton.icon && <IconV2 name={primaryButton.icon} size="sm" />}
                   {primaryButton.label}
                 </Button>

--- a/packages/ui/src/components/no-data.tsx
+++ b/packages/ui/src/components/no-data.tsx
@@ -9,7 +9,8 @@ import {
   IllustrationsNameType,
   Layout,
   SplitButton,
-  Text
+  Text,
+  toButtonProps
 } from '@/components'
 import { useRouterContext } from '@/context'
 import { cn } from '@utils/cn'
@@ -85,28 +86,32 @@ export const NoData: FC<NoDataProps> = ({
           <Layout.Horizontal gap="sm">
             {primaryButton &&
               (primaryButton.to ? (
-                <Button asChild {...omit(primaryButton, ['to', 'label', 'icon'])}>
+                <Button asChild {...toButtonProps(omit(secondaryButton, ['to', 'label', 'icon']) as ButtonProps)}>
                   <NavLink to={primaryButton.to}>
                     {primaryButton.icon && <IconV2 name={primaryButton.icon} size="sm" />}
                     {primaryButton.label}
                   </NavLink>
                 </Button>
               ) : (
-                <Button {...omit(primaryButton, ['label', 'icon'])}>
+                <Button {...toButtonProps(omit(secondaryButton, ['label', 'icon']) as ButtonProps)}>
                   {primaryButton.icon && <IconV2 name={primaryButton.icon} size="sm" />}
                   {primaryButton.label}
                 </Button>
               ))}
             {secondaryButton &&
               (secondaryButton.to ? (
-                <Button variant="outline" asChild {...omit(secondaryButton, ['to', 'label', 'icon'])}>
+                <Button
+                  asChild
+                  variant="outline"
+                  {...toButtonProps(omit(secondaryButton, ['to', 'label', 'icon']) as ButtonProps)}
+                >
                   <NavLink to={secondaryButton.to}>
                     {secondaryButton.icon && <IconV2 name={secondaryButton.icon} size="sm" />}
                     {secondaryButton.label}
                   </NavLink>
                 </Button>
               ) : (
-                <Button variant="outline" {...omit(secondaryButton, ['label', 'icon'])}>
+                <Button variant="outline" {...toButtonProps(omit(secondaryButton, ['label', 'icon']) as ButtonProps)}>
                   {secondaryButton.icon && <IconV2 name={secondaryButton.icon} size="sm" />}
                   {secondaryButton.label}
                 </Button>

--- a/packages/ui/src/components/pipeline-nodes/components/collapse-button.tsx
+++ b/packages/ui/src/components/pipeline-nodes/components/collapse-button.tsx
@@ -5,7 +5,16 @@ import { CollapseButtonProps } from '@harnessio/pipeline-graph'
 
 export const CollapseButton = ({ collapsed, onToggle }: CollapseButtonProps) => {
   return (
-    <Button size="sm" variant="secondary" iconOnly onMouseDown={e => e.stopPropagation()} onClick={onToggle}>
+    <Button
+      size="sm"
+      variant="secondary"
+      iconOnly
+      onMouseDown={e => e.stopPropagation()}
+      onClick={onToggle}
+      tooltipProps={{
+        content: collapsed ? 'Expand' : 'Collapse'
+      }}
+    >
       <IconV2 size="md" name={collapsed ? 'enlarge' : 'reduce'} />
     </Button>
   )

--- a/packages/ui/src/components/pipeline-nodes/components/floating-add-button.tsx
+++ b/packages/ui/src/components/pipeline-nodes/components/floating-add-button.tsx
@@ -69,6 +69,9 @@ export function FloatingAddButton(props: FloatingAddButtonProp) {
           e.stopPropagation()
           onClick(e)
         }}
+        tooltipProps={{
+          content: 'Add'
+        }}
       >
         <IconV2 className="text-icons-3" name="plus" size="2xs" />
       </Button>

--- a/packages/ui/src/components/pipeline-nodes/components/node-menu-trigger.tsx
+++ b/packages/ui/src/components/pipeline-nodes/components/node-menu-trigger.tsx
@@ -21,6 +21,7 @@ export const NodeMenuTrigger: FC<NodeMenuTriggerProps> = ({ onEllipsisClick }) =
       iconOnly
       onMouseDown={e => e.stopPropagation()}
       onClick={onEllipsisClick}
+      ignoreIconOnlyTooltip
     >
       <IconV2 className="text-icons-2" name="more-horizontal" size="2xs" />
     </Button>

--- a/packages/ui/src/components/rbac/types.ts
+++ b/packages/ui/src/components/rbac/types.ts
@@ -32,7 +32,7 @@ interface RBACProps {
  * Types for RBAC-enabled components.
  * These components will automatically handle RBAC checks based on the provided `rbac` prop.
  */
-export interface RbacButtonProps extends Omit<ButtonProps, 'resource'>, RBACProps {
+export interface RbacButtonProps extends Omit<ButtonProps, 'resource' | 'tooltipProps'>, RBACProps {
   tooltip?: Pick<TooltipProps, 'title' | 'content'>
 }
 

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -101,7 +101,7 @@ const SheetContent = forwardRef<ElementRef<typeof SheetPrimitive.Content>, Sheet
             className="absolute right-1 top-2 flex items-center justify-center transition-colors disabled:pointer-events-none"
             asChild
           >
-            <Button className={closeClassName} variant="ghost" size="sm" iconOnly>
+            <Button className={closeClassName} variant="ghost" size="sm" iconOnly ignoreIconOnlyTooltip>
               <IconV2 name="xmark" />
               <span className="sr-only">Close</span>
             </Button>

--- a/packages/ui/src/components/sidebar/sidebar-units.tsx
+++ b/packages/ui/src/components/sidebar/sidebar-units.tsx
@@ -60,7 +60,17 @@ export const SidebarTrigger = forwardRef<ElementRef<typeof Button>, ComponentPro
     )
 
     return (
-      <Button ref={ref} size="xs" variant="ghost" iconOnly onClick={onClickHandler} {...props}>
+      <Button
+        ref={ref}
+        size="xs"
+        variant="ghost"
+        iconOnly
+        onClick={onClickHandler}
+        tooltipProps={{
+          content: t('component:sidebar.toggle', 'Toggle sidebar')
+        }}
+        {...props}
+      >
         <IconV2 name="sidebar" />
         <span className="sr-only">{t('component:sidebar.toggle', 'Toggle sidebar')}</span>
       </Button>

--- a/packages/ui/src/components/sidebar/sidebar-units.tsx
+++ b/packages/ui/src/components/sidebar/sidebar-units.tsx
@@ -46,7 +46,9 @@ export const SidebarRoot = forwardRef<HTMLDivElement, ComponentProps<'div'> & { 
 )
 SidebarRoot.displayName = 'SidebarRoot'
 
-export const SidebarTrigger = forwardRef<ElementRef<typeof Button>, ComponentProps<typeof Button>>(
+type SidebarTriggerProp = Omit<ComponentProps<typeof Button>, 'iconOnly' | 'tooltipProps' | 'ignoreIconOnlyTooltip'>
+
+export const SidebarTrigger = forwardRef<ElementRef<typeof Button>, SidebarTriggerProp>(
   ({ onClick, ...props }, ref) => {
     const { toggleSidebar } = useSidebar()
     const { t } = useTranslation()

--- a/packages/ui/src/components/sorts/multi-sort.tsx
+++ b/packages/ui/src/components/sorts/multi-sort.tsx
@@ -103,7 +103,14 @@ const SortableItem = ({
         </DropdownMenu.Content>
       </DropdownMenu.Root>
 
-      <Button variant="transparent" size="sm" iconOnly className="ml-auto" onClick={() => onRemoveSort(index)}>
+      <Button
+        variant="transparent"
+        size="sm"
+        iconOnly
+        className="ml-auto"
+        onClick={() => onRemoveSort(index)}
+        ignoreIconOnlyTooltip
+      >
         <IconV2 name="xmark" size="2xs" />
       </Button>
     </div>

--- a/packages/ui/src/components/tag.tsx
+++ b/packages/ui/src/components/tag.tsx
@@ -149,6 +149,7 @@ const Tag = forwardRef<HTMLDivElement, TagProps>(
               e.preventDefault()
               onActionClick?.()
             }}
+            ignoreIconOnlyTooltip
           >
             <IconV2 skipSize name={actionIcon} className={cn('cn-tag-icon', { 'text-cn-disabled': disabled })} />
           </Button>

--- a/packages/ui/src/components/toggle-group.tsx
+++ b/packages/ui/src/components/toggle-group.tsx
@@ -2,10 +2,8 @@ import {
   ComponentPropsWithoutRef,
   createContext,
   ElementRef,
-  FC,
   forwardRef,
   PropsWithoutRef,
-  ReactNode,
   useCallback,
   useContext,
   useEffect,
@@ -13,14 +11,22 @@ import {
   useState
 } from 'react'
 
-import { Button, IconPropsV2, IconV2, IconV2NamesType, toggleVariants, Tooltip, TooltipProps } from '@/components'
+import {
+  Button,
+  IconPropsV2,
+  IconV2,
+  IconV2NamesType,
+  toButtonProps,
+  TogglePropsIconOnly,
+  TogglePropsNotIconOnly,
+  toggleVariants
+} from '@/components'
 import { cn } from '@/utils'
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group'
 import { VariantProps } from 'class-variance-authority'
 
 type ToggleGroupVariant = VariantProps<typeof toggleVariants>['variant']
 type ToggleGroupSelectedVariant = 'primary' | 'secondary'
-type ToggleTooltipProps = Pick<TooltipProps, 'title' | 'content' | 'side' | 'align'>
 type SelectedValuesProp = Map<string, boolean>
 
 interface ToggleGroupContextValue {
@@ -54,31 +60,13 @@ export interface ToggleGroupProps
 
 export type ToggleGroupItemPropsBase = {
   value: string
-  tooltipProps?: ToggleTooltipProps
   disabled?: boolean
   suffixIcon?: IconV2NamesType
   suffixIconProps?: PropsWithoutRef<IconPropsV2>
   text?: string
 }
 
-type TogglePropsIconOnly = ToggleGroupItemPropsBase & {
-  iconOnly: true
-  prefixIcon: IconV2NamesType
-  prefixIconProps: PropsWithoutRef<IconPropsV2>
-  suffixIcon: never
-  suffixIconProps: never
-}
-
-type TogglePropsNotIconOnly = ToggleGroupItemPropsBase & {
-  iconOnly?: false
-  prefixIcon?: IconV2NamesType
-  prefixIconProps?: PropsWithoutRef<IconPropsV2>
-}
-
-export type ToggleGroupItemProps = TogglePropsIconOnly | TogglePropsNotIconOnly
-
-const TooltipWrapper: FC<{ children: ReactNode; tooltipProps?: ToggleTooltipProps }> = ({ children, tooltipProps }) =>
-  tooltipProps ? <Tooltip {...tooltipProps}>{children}</Tooltip> : <>{children}</>
+export type ToggleGroupItemProps = ToggleGroupItemPropsBase & (TogglePropsIconOnly | TogglePropsNotIconOnly)
 
 const ToggleGroupRoot = forwardRef<ElementRef<typeof ToggleGroupPrimitive.Root>, ToggleGroupProps>(
   (
@@ -204,14 +192,18 @@ const ToggleGroupItem = forwardRef<
 
     const renderContent = () => {
       if (iconOnly) {
-        return <IconV2 {...prefixIconProps} name={prefixIcon} />
+        return <IconV2 {...prefixIconProps} name={prefixIcon} fallback={prefixIconProps?.fallback ?? 'stop'} />
       }
 
       return (
         <>
-          {prefixIcon && <IconV2 {...prefixIconProps} name={prefixIcon} />}
+          {prefixIcon && (
+            <IconV2 {...prefixIconProps} name={prefixIcon} fallback={prefixIconProps?.fallback ?? 'stop'} />
+          )}
           {text}
-          {suffixIcon && <IconV2 {...suffixIconProps} name={suffixIcon} />}
+          {suffixIcon && (
+            <IconV2 {...suffixIconProps} name={suffixIcon} fallback={suffixIconProps?.fallback ?? 'stop'} />
+          )}
         </>
       )
     }
@@ -219,20 +211,18 @@ const ToggleGroupItem = forwardRef<
     const accessibilityProps = iconOnly && text ? { 'aria-label': text } : {}
 
     return (
-      <TooltipWrapper tooltipProps={tooltipProps}>
-        <ToggleGroupPrimitive.Item ref={ref} asChild value={value} disabled={finalDisabled} {...props}>
-          <Button
-            className={toggleVariants({ size, variant, iconOnly })}
-            variant={buttonVariant}
-            size={size}
-            disabled={finalDisabled}
-            iconOnly={iconOnly}
-            {...accessibilityProps}
-          >
-            {renderContent()}
-          </Button>
-        </ToggleGroupPrimitive.Item>
-      </TooltipWrapper>
+      <ToggleGroupPrimitive.Item ref={ref} asChild value={value} disabled={finalDisabled} {...props}>
+        <Button
+          className={toggleVariants({ size, variant, iconOnly })}
+          variant={buttonVariant}
+          size={size}
+          disabled={finalDisabled}
+          {...accessibilityProps}
+          {...toButtonProps({ iconOnly, tooltipProps })}
+        >
+          {renderContent()}
+        </Button>
+      </ToggleGroupPrimitive.Item>
     )
   }
 )

--- a/packages/ui/src/components/toggle.tsx
+++ b/packages/ui/src/components/toggle.tsx
@@ -1,6 +1,15 @@
-import { ElementRef, FC, forwardRef, PropsWithoutRef, ReactNode, useCallback, useState } from 'react'
+import { ElementRef, forwardRef, MouseEvent, PropsWithoutRef, useCallback, useState } from 'react'
 
-import { Button, ButtonProps, IconPropsV2, IconV2, IconV2NamesType, Tooltip, TooltipProps } from '@/components'
+import {
+  Button,
+  ButtonProps,
+  ButtonPropsIconOnlyRequired,
+  ButtonPropsRegular,
+  IconPropsV2,
+  IconV2,
+  IconV2NamesType,
+  toButtonProps
+} from '@/components'
 import * as TogglePrimitive from '@radix-ui/react-toggle'
 import { cn } from '@utils/cn'
 import { cva, type VariantProps } from 'class-variance-authority'
@@ -31,9 +40,8 @@ export const toggleVariants = cva('cn-toggle', {
 
 type ToggleVariant = VariantProps<typeof toggleVariants>['variant']
 type TypeSelectedVariant = 'primary' | 'secondary'
-type ToggleTooltipProps = Pick<TooltipProps, 'title' | 'content' | 'side' | 'align'>
 
-type TogglePropsBase = Pick<ButtonProps, 'rounded' | 'iconOnly' | 'disabled'> & {
+type TogglePropsBase = Pick<ButtonProps, 'rounded' | 'disabled' | 'className'> & {
   variant?: ToggleVariant
   selectedVariant?: TypeSelectedVariant
   onChange?: (selected: boolean) => void
@@ -43,28 +51,21 @@ type TogglePropsBase = Pick<ButtonProps, 'rounded' | 'iconOnly' | 'disabled'> & 
   suffixIconProps?: PropsWithoutRef<Omit<IconPropsV2, 'name'>>
   selected?: boolean
   defaultValue?: boolean
-  tooltipProps?: ToggleTooltipProps
-  className?: string
 }
 
-type TogglePropsIconOnly = TogglePropsBase & {
-  iconOnly: true
+type TogglePropsIconOnly = ButtonPropsIconOnlyRequired & {
   prefixIcon: IconV2NamesType
   prefixIconProps?: PropsWithoutRef<Omit<IconPropsV2, 'name'>>
   suffixIcon?: never
   suffixIconProps?: never
 }
 
-type TogglePropsNotIconOnly = TogglePropsBase & {
-  iconOnly?: false
+type TogglePropsNotIconOnly = ButtonPropsRegular & {
   prefixIcon?: IconV2NamesType
   prefixIconProps?: PropsWithoutRef<Omit<IconPropsV2, 'name'>>
 }
 
-export type ToggleProps = TogglePropsIconOnly | TogglePropsNotIconOnly
-
-const TooltipWrapper: FC<{ children: ReactNode; tooltipProps?: ToggleTooltipProps }> = ({ children, tooltipProps }) =>
-  tooltipProps ? <Tooltip {...tooltipProps}>{children}</Tooltip> : <>{children}</>
+export type ToggleProps = TogglePropsBase & (TogglePropsIconOnly | TogglePropsNotIconOnly)
 
 const Toggle = forwardRef<ElementRef<typeof TogglePrimitive.Root>, ToggleProps>(
   (
@@ -103,7 +104,7 @@ const Toggle = forwardRef<ElementRef<typeof TogglePrimitive.Root>, ToggleProps>(
       [isControlled, onChange]
     )
 
-    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
       e.preventDefault()
       e.stopPropagation()
       handleChange(!selected)
@@ -130,24 +131,24 @@ const Toggle = forwardRef<ElementRef<typeof TogglePrimitive.Root>, ToggleProps>(
     }
 
     return (
-      <TooltipWrapper tooltipProps={tooltipProps}>
-        <TogglePrimitive.Root ref={ref} asChild pressed={selected} onClick={handleClick} disabled={disabled}>
-          <Button
-            className={cn(className, toggleVariants({ size, variant, iconOnly }))}
-            variant={selected ? selectedVariant : variant}
-            disabled={disabled}
-            size={size}
-            rounded={rounded}
-            iconOnly={iconOnly}
-            {...accessibilityProps}
-          >
-            {renderContent()}
-          </Button>
-        </TogglePrimitive.Root>
-      </TooltipWrapper>
+      <TogglePrimitive.Root ref={ref} asChild pressed={selected} onClick={handleClick} disabled={disabled}>
+        <Button
+          className={cn(className, toggleVariants({ size, variant, iconOnly }))}
+          variant={selected ? selectedVariant : variant}
+          disabled={disabled}
+          size={size}
+          rounded={rounded}
+          {...accessibilityProps}
+          {...toButtonProps({ iconOnly, tooltipProps })}
+        >
+          {renderContent()}
+        </Button>
+      </TogglePrimitive.Root>
     )
   }
 )
 Toggle.displayName = TogglePrimitive.Root.displayName
 
 export { Toggle }
+
+export type { TogglePropsIconOnly, TogglePropsNotIconOnly }

--- a/packages/ui/src/views/components/page.tsx
+++ b/packages/ui/src/views/components/page.tsx
@@ -62,7 +62,7 @@ const Header: FC<PageHeaderProps> = ({ backLink, logoName, title, description, c
           {!!moreActions && (
             <DropdownMenu.Root>
               <DropdownMenu.Trigger aria-label="More actions" asChild>
-                <Button variant="outline" iconOnly>
+                <Button variant="outline" iconOnly tooltipProps={{ content: 'More actions' }}>
                   <IconV2 name="more-vert" />
                 </Button>
               </DropdownMenu.Trigger>

--- a/packages/ui/src/views/execution/step-execution.tsx
+++ b/packages/ui/src/views/execution/step-execution.tsx
@@ -31,7 +31,16 @@ const StepExecutionToolbar: FC<
         </div>
       </SearchBox.Root>
       <div className="flex">
-        <Button variant="outline" size="sm" iconOnly className="rounded-r-none border-r-0 border-cn-2" onClick={onCopy}>
+        <Button
+          className="rounded-r-none border-r-0 border-cn-2"
+          variant="outline"
+          size="sm"
+          iconOnly
+          onClick={onCopy}
+          tooltipProps={{
+            content: 'Copy'
+          }}
+        >
           <IconV2 name="copy" className="size-4 text-icons-3" />
         </Button>
         <Button variant="outline" size="sm" className="rounded-none border-cn-2" onClick={onEdit}>

--- a/packages/ui/src/views/labels/components/label-form-color-and-name-group.tsx
+++ b/packages/ui/src/views/labels/components/label-form-color-and-name-group.tsx
@@ -60,6 +60,9 @@ export const LabelFormColorAndNameGroup: FC<LabelFormColorAndNameGroupProps> = (
           onClick={handleDeleteValue}
           size="sm"
           aria-label={t('views:labelData.form.removeValue', 'Remove a value')}
+          tooltipProps={{
+            content: t('views:labelData.form.removeValue', 'Remove a value')
+          }}
         >
           <IconV2 name="xmark" />
         </Button>

--- a/packages/ui/src/views/labels/components/labels-list-view.tsx
+++ b/packages/ui/src/views/labels/components/labels-list-view.tsx
@@ -124,6 +124,9 @@ export const LabelsListView: FC<LabelsListViewProps> = ({
                     iconOnly
                     onClick={e => toggleRow(label.key, e)}
                     className="mt-cn-2xs"
+                    tooltipProps={{
+                      content: 'Toggle details'
+                    }}
                   >
                     <IconV2 name={isExpanded ? 'nav-arrow-up' : 'nav-arrow-down'} />
                   </Button>

--- a/packages/ui/src/views/platform/input-reference-component.tsx
+++ b/packages/ui/src/views/platform/input-reference-component.tsx
@@ -159,10 +159,10 @@ export const InputReference = <T,>({
           <div className="flex-1 truncate">{displayContent}</div>
           {hasValue && !disabled && (
             <div className="ml-3 flex items-center">
-              <Button onClick={handleEdit} size="sm" variant="ghost" iconOnly>
+              <Button onClick={handleEdit} size="sm" variant="ghost" iconOnly tooltipProps={{ content: 'Edit' }}>
                 <IconV2 name="edit-pencil" />
               </Button>
-              <Button onClick={handleClear} size="sm" variant="ghost" iconOnly>
+              <Button onClick={handleClear} size="sm" variant="ghost" iconOnly ignoreIconOnlyTooltip>
                 <IconV2 name="xmark" className="text-cn-danger" />
               </Button>
             </div>

--- a/packages/ui/src/views/repo/components/branch-banner/branch-compare-banner.tsx
+++ b/packages/ui/src/views/repo/components/branch-banner/branch-compare-banner.tsx
@@ -67,6 +67,9 @@ const BranchCompareBanner: FC<BranchCompareBannerProps> = ({
           onClick={handleDismiss}
           aria-label={t('views:repos.dismiss', 'Dismiss')}
           title={t('views:repos.dismiss', 'Dismiss')}
+          tooltipProps={{
+            content: t('views:repos.dismiss', 'Dismiss')
+          }}
         >
           <IconV2 name="xmark" size="xs" />
         </Button>

--- a/packages/ui/src/views/repo/components/commits-list.tsx
+++ b/packages/ui/src/views/repo/components/commits-list.tsx
@@ -103,6 +103,9 @@ export const CommitsList: FC<CommitProps> = ({ data, toCommitDetails, toPullRequ
                               size="sm"
                               asChild
                               iconOnly
+                              tooltipProps={{
+                                content: 'View repository at this point of history'
+                              }}
                             >
                               <Link to={toCode?.({ sha: commit?.sha || '' }) || ''}>
                                 <IconV2 name="code" />

--- a/packages/ui/src/views/repo/pull-request/components/labels/label-value-selector.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/labels/label-value-selector.tsx
@@ -107,7 +107,7 @@ export const LabelValueSelector: FC<LabelValueSelectorProps> = ({ label, handleA
           placeholder={getSearchBoxPlaceholder()}
           onKeyDown={handleSearchKeyDown}
           suffix={
-            <Button iconOnly size="xs" variant="transparent" onClick={onSearchClean}>
+            <Button iconOnly size="xs" variant="transparent" onClick={onSearchClean} ignoreIconOnlyTooltip>
               <IconV2 name="xmark" size="2xs" />
             </Button>
           }

--- a/packages/ui/src/views/repo/pull-request/components/labels/pull-request-labels-header.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/labels/pull-request-labels-header.tsx
@@ -127,7 +127,7 @@ export const LabelsHeader = ({
 
       <DropdownMenu.Root onOpenChange={isOpen => !isOpen && handleCloseValuesView()}>
         <DropdownMenu.Trigger asChild>
-          <Button iconOnly variant="ghost" size="sm">
+          <Button iconOnly variant="ghost" size="sm" tooltipProps={{ content: 'Manage labels' }}>
             <IconV2 name="more-vert" size="2xs" />
           </Button>
         </DropdownMenu.Trigger>

--- a/packages/ui/src/views/repo/pull-request/components/pull-request-header.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/pull-request-header.tsx
@@ -77,6 +77,9 @@ export const PullRequestHeader: React.FC<PullRequestTitleProps> = ({
             onClick={() => {
               setIsEditing(true)
             }}
+            tooltipProps={{
+              content: 'Edit'
+            }}
           >
             <IconV2 name="edit-pencil" className="text-icons-1 group-hover:text-icons-3" />
           </Button>

--- a/packages/ui/src/views/repo/pull-request/components/reviewers/pull-request-reviewers-header.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/reviewers/pull-request-reviewers-header.tsx
@@ -53,7 +53,7 @@ const ReviewersHeader = ({
 
       <DropdownMenu.Root onOpenChange={isOpen => !isOpen && handleCloseValuesView()}>
         <DropdownMenu.Trigger asChild>
-          <Button iconOnly variant="ghost" size="sm">
+          <Button iconOnly variant="ghost" size="sm" tooltipProps={{ content: 'Manage reviewers' }}>
             <IconV2 name="more-vert" size="2xs" />
           </Button>
         </DropdownMenu.Trigger>

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-comment-box.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-comment-box.tsx
@@ -78,7 +78,7 @@ interface ToolbarItem {
   icon: IconV2NamesType
   variant?: ButtonVariants
   action: ToolbarAction
-  title?: string
+  title: string
   size?: number
 }
 
@@ -456,25 +456,25 @@ export const PullRequestCommentBox = ({
 
   const toolbar: ToolbarItem[] = useMemo(() => {
     const aiButton: ToolbarItem[] = handleAiPullRequestSummary
-      ? [{ icon: 'ai-solid' as IconV2NamesType, variant: 'ai', action: ToolbarAction.AI_SUMMARY }]
+      ? [{ icon: 'ai-solid' as IconV2NamesType, variant: 'ai', action: ToolbarAction.AI_SUMMARY, title: 'AI Summary' }]
       : []
 
     const suggestionButton: ToolbarItem[] =
       diff !== '' && lineNumber !== undefined && lineFromNumber !== undefined
-        ? [{ icon: 'suggestion', action: ToolbarAction.SUGGESTION }]
+        ? [{ icon: 'suggestion', action: ToolbarAction.SUGGESTION, title: 'Add a suggestion' }]
         : []
 
     // TODO: Design system: Update icons once they are available in IconV2
     return [
       ...aiButton,
       ...suggestionButton,
-      { icon: 'header', action: ToolbarAction.HEADER },
-      { icon: 'bold', action: ToolbarAction.BOLD },
-      { icon: 'italic', action: ToolbarAction.ITALIC },
-      { icon: 'attachment', action: ToolbarAction.UPLOAD },
-      { icon: 'list', action: ToolbarAction.UNORDERED_LIST },
-      { icon: 'list-select', action: ToolbarAction.CHECK_LIST },
-      { icon: 'code', action: ToolbarAction.CODE_BLOCK }
+      { icon: 'header', action: ToolbarAction.HEADER, title: 'Heading' },
+      { icon: 'bold', action: ToolbarAction.BOLD, title: 'Bold' },
+      { icon: 'italic', action: ToolbarAction.ITALIC, title: 'Italic' },
+      { icon: 'attachment', action: ToolbarAction.UPLOAD, title: 'Attach files' },
+      { icon: 'list', action: ToolbarAction.UNORDERED_LIST, title: 'Unordered list' },
+      { icon: 'list-select', action: ToolbarAction.CHECK_LIST, title: 'Task list' },
+      { icon: 'code', action: ToolbarAction.CODE_BLOCK, title: 'Code' }
     ]
   }, [diff, lineNumber, lineFromNumber, handleAiPullRequestSummary])
 
@@ -728,6 +728,9 @@ export const PullRequestCommentBox = ({
                         iconOnly
                         disabled={showAiLoader}
                         onClick={() => handleActionClick(item.action, textComment, textSelection)}
+                        tooltipProps={{
+                          content: item.title
+                        }}
                       >
                         <IconV2 name={item.icon} />
                       </Button>

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-description-box.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-description-box.tsx
@@ -155,6 +155,9 @@ const PullRequestDescBox: FC<PullRequestDescBoxProps> = ({
                 iconOnly
                 size="sm"
                 variant="outline"
+                tooltipProps={{
+                  content: 'Edit'
+                }}
               >
                 <IconV2 name="edit-pencil" size="xs" />
               </Button>

--- a/packages/ui/src/views/repo/repo-sidebar/index.tsx
+++ b/packages/ui/src/views/repo/repo-sidebar/index.tsx
@@ -28,7 +28,15 @@ export const RepoSidebar = ({
           <Layout.Grid columns="1fr auto" flow="column" align="center" gapX="xs">
             {branchSelectorRenderer}
             {!isRepoEmpty && (
-              <Button iconOnly variant="outline" aria-label="Create file" onClick={navigateToNewFile}>
+              <Button
+                iconOnly
+                variant="outline"
+                tooltipProps={{
+                  content: 'Create file'
+                }}
+                aria-label="Create file"
+                onClick={navigateToNewFile}
+              >
                 <IconV2 name="plus" className="text-icons-3" />
               </Button>
             )}

--- a/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
+++ b/packages/ui/src/views/repo/repo-summary/components/summary-panel.tsx
@@ -72,7 +72,13 @@ const SummaryPanel: FC<SummaryPanelProps> = ({
 
           <DropdownMenu.Root>
             <DropdownMenu.Trigger asChild>
-              <Button variant="ghost" size="xs" aria-label="More options" iconOnly>
+              <Button
+                variant="ghost"
+                size="xs"
+                aria-label="More options"
+                iconOnly
+                tooltipProps={{ content: 'More options' }}
+              >
                 <IconV2 name="more-horizontal" size="2xs" className="text-icons-3" />
               </Button>
             </DropdownMenu.Trigger>

--- a/packages/ui/src/views/unified-pipeline-studio/components/entity-form/unified-pipeline-studio-entity-form.tsx
+++ b/packages/ui/src/views/unified-pipeline-studio/components/entity-form/unified-pipeline-studio-entity-form.tsx
@@ -282,6 +282,7 @@ export const UnifiedPipelineStudioEntityForm = (props: UnifiedPipelineStudioEnti
                         requestClose()
                       }}
                       aria-label="Remove Step"
+                      tooltipProps={{ content: 'Remove Step' }}
                     >
                       <IconV2 name="trash" />
                     </Button>

--- a/packages/ui/src/views/unified-pipeline-studio/components/form-inputs/array-input.tsx
+++ b/packages/ui/src/views/unified-pipeline-studio/components/form-inputs/array-input.tsx
@@ -78,6 +78,7 @@ function ArrayFormInputInternal(props: ArrayFormInputProps): JSX.Element {
                         remove(idx)
                       }}
                       disabled={readonly}
+                      tooltipProps={{ content: 'Remove' }}
                     >
                       <IconV2 name="trash" />
                     </Button>

--- a/packages/ui/src/views/unified-pipeline-studio/components/form-inputs/list-form-input.tsx
+++ b/packages/ui/src/views/unified-pipeline-studio/components/form-inputs/list-form-input.tsx
@@ -105,6 +105,7 @@ function ListFormInputInternal(props: ListFormInputProps): JSX.Element {
                             remove(idx)
                           }}
                           disabled={readonly}
+                          tooltipProps={{ content: 'Remove' }}
                         >
                           <IconV2 name="trash" />
                         </Button>

--- a/packages/ui/src/views/unified-pipeline-studio/components/stage-config/unified-pipeline-studio-stage-config-form.tsx
+++ b/packages/ui/src/views/unified-pipeline-studio/components/stage-config/unified-pipeline-studio-stage-config-form.tsx
@@ -147,6 +147,7 @@ export const UnifiedPipelineStudioStageConfigForm = (props: UnifiedPipelineStudi
                         requestClose()
                       }}
                       aria-label="Remove Stage"
+                      tooltipProps={{ content: 'Remove Stage' }}
                     >
                       <IconV2 name="trash" />
                     </Button>

--- a/packages/ui/src/views/unified-pipeline-studio/unified-pipeline-studio-internal.tsx
+++ b/packages/ui/src/views/unified-pipeline-studio/unified-pipeline-studio-internal.tsx
@@ -62,6 +62,7 @@ export const PipelineStudioInternal = (): JSX.Element => {
                 setEditPipelineIntention({ path: 'pipeline' })
                 setRightDrawer(RightDrawer.PipelineConfig)
               }}
+              tooltipProps={{ content: 'Edit pipeline' }}
             >
               <IconV2 name="edit-pencil" />
             </Button>


### PR DESCRIPTION
This PR is based on #2124 , which was reverted from main due to an issue with button callbacks.
- Fixed the issue where `secondaryButton` data was mistakenly passed into `primaryButton`.
- Ensured button callbacks are working as expected

<img width="1746" height="816" alt="image" src="https://github.com/user-attachments/assets/bb47496f-5689-41af-9bc5-3e6bef92cd11" />
