### PR TITLE
Refactor dialog trigger on other repo page

### DIFF
--- a/apps/gitness/src/pages-v2/repo/repo-sidebar.tsx
+++ b/apps/gitness/src/pages-v2/repo/repo-sidebar.tsx
@@ -9,7 +9,7 @@ import {
   useListPathsQuery,
   useListTagsQuery
 } from '@harnessio/code-service-client'
-import { Layout, SkeletonFileExplorer } from '@harnessio/ui/components'
+import { Layout, SkeletonFileExplorer, useCustomDialogTrigger } from '@harnessio/ui/components'
 import {
   BranchSelectorListItem,
   BranchSelectorTab,
@@ -43,6 +43,12 @@ export const RepoSidebar = () => {
   const [branchQueryForNewBranch, setBranchQueryForNewBranch] = useState<string>('')
   const [sidebarWidth, setSidebarWidth] = useLocalStorage<number>('sidebarWidth', SIDEBAR_MIN_WIDTH)
   const containerRef = useRef<HTMLDivElement>(null)
+
+  const { triggerRef, registerTrigger } = useCustomDialogTrigger()
+  const toggleCreateBranchDialogOpen = (open: boolean) => {
+    registerTrigger()
+    setCreateBranchDialogOpen(open)
+  }
 
   const {
     fullGitRef,
@@ -212,10 +218,11 @@ export const RepoSidebar = () => {
             repoRef={repoRef}
             branchSelectorRenderer={
               <BranchSelectorContainer
+                ref={triggerRef}
                 onSelectBranchorTag={selectBranchOrTag}
                 selectedBranch={{ name: gitRefName, sha: repoDetails?.body?.latest_commit?.sha || '' }}
                 preSelectedTab={preSelectedTab}
-                setCreateBranchDialogOpen={setCreateBranchDialogOpen}
+                setCreateBranchDialogOpen={toggleCreateBranchDialogOpen}
                 onBranchQueryChange={setBranchQueryForNewBranch}
               />
             }

--- a/packages/ui/src/components/no-data.tsx
+++ b/packages/ui/src/components/no-data.tsx
@@ -63,8 +63,8 @@ export const NoData: FC<NoDataProps> = ({
 }) => {
   const { NavLink } = useRouterContext()
 
-  const PrimaryWrapper = primaryButton?.isDialogTrigger ? Dialog.Trigger : Fragment
-  const SecondaryWrapper = secondaryButton?.isDialogTrigger ? Dialog.Trigger : Fragment
+  const PrimaryDialogTrigger = primaryButton?.isDialogTrigger ? Dialog.Trigger : Fragment
+  const SecondaryDialogTrigger = secondaryButton?.isDialogTrigger ? Dialog.Trigger : Fragment
 
   return (
     <Layout.Vertical
@@ -99,12 +99,12 @@ export const NoData: FC<NoDataProps> = ({
                   </NavLink>
                 </Button>
               ) : (
-                <PrimaryWrapper>
+                <PrimaryDialogTrigger>
                   <Button {...toButtonProps(omit(primaryButton, ['label', 'icon']) as ButtonProps)}>
                     {primaryButton.icon && <IconV2 name={primaryButton.icon} size="sm" />}
                     {primaryButton.label}
                   </Button>
-                </PrimaryWrapper>
+                </PrimaryDialogTrigger>
               ))}
             {secondaryButton &&
               (secondaryButton.to ? (
@@ -119,12 +119,12 @@ export const NoData: FC<NoDataProps> = ({
                   </NavLink>
                 </Button>
               ) : (
-                <SecondaryWrapper>
+                <SecondaryDialogTrigger>
                   <Button variant="outline" {...toButtonProps(omit(secondaryButton, ['label', 'icon']) as ButtonProps)}>
                     {secondaryButton.icon && <IconV2 name={secondaryButton.icon} size="sm" />}
                     {secondaryButton.label}
                   </Button>
-                </SecondaryWrapper>
+                </SecondaryDialogTrigger>
               ))}
             {splitButton && (
               <SplitButton<string>

--- a/packages/ui/src/components/no-data.tsx
+++ b/packages/ui/src/components/no-data.tsx
@@ -1,8 +1,9 @@
-import { Dispatch, FC, ReactNode, SetStateAction } from 'react'
+import { Dispatch, FC, Fragment, ReactNode, SetStateAction } from 'react'
 
 import {
   Button,
   ButtonProps,
+  Dialog,
   IconPropsV2,
   IconV2,
   Illustration,
@@ -25,11 +26,13 @@ export interface NoDataProps {
     icon?: IconPropsV2['name']
     label: ReactNode | string
     to?: string
+    isDialogTrigger?: boolean
   }
   secondaryButton?: ButtonProps & {
     icon?: IconPropsV2['name']
     label: ReactNode | string
     to?: string
+    isDialogTrigger?: boolean
   }
   withBorder?: boolean
   loadState?: string
@@ -59,6 +62,9 @@ export const NoData: FC<NoDataProps> = ({
   splitButton
 }) => {
   const { NavLink } = useRouterContext()
+
+  const PrimaryWrapper = primaryButton?.isDialogTrigger ? Dialog.Trigger : Fragment
+  const SecondaryWrapper = secondaryButton?.isDialogTrigger ? Dialog.Trigger : Fragment
 
   return (
     <Layout.Vertical
@@ -93,10 +99,12 @@ export const NoData: FC<NoDataProps> = ({
                   </NavLink>
                 </Button>
               ) : (
-                <Button {...toButtonProps(omit(primaryButton, ['label', 'icon']) as ButtonProps)}>
-                  {primaryButton.icon && <IconV2 name={primaryButton.icon} size="sm" />}
-                  {primaryButton.label}
-                </Button>
+                <PrimaryWrapper>
+                  <Button {...toButtonProps(omit(primaryButton, ['label', 'icon']) as ButtonProps)}>
+                    {primaryButton.icon && <IconV2 name={primaryButton.icon} size="sm" />}
+                    {primaryButton.label}
+                  </Button>
+                </PrimaryWrapper>
               ))}
             {secondaryButton &&
               (secondaryButton.to ? (
@@ -111,10 +119,12 @@ export const NoData: FC<NoDataProps> = ({
                   </NavLink>
                 </Button>
               ) : (
-                <Button variant="outline" {...toButtonProps(omit(secondaryButton, ['label', 'icon']) as ButtonProps)}>
-                  {secondaryButton.icon && <IconV2 name={secondaryButton.icon} size="sm" />}
-                  {secondaryButton.label}
-                </Button>
+                <SecondaryWrapper>
+                  <Button variant="outline" {...toButtonProps(omit(secondaryButton, ['label', 'icon']) as ButtonProps)}>
+                    {secondaryButton.icon && <IconV2 name={secondaryButton.icon} size="sm" />}
+                    {secondaryButton.label}
+                  </Button>
+                </SecondaryWrapper>
               ))}
             {splitButton && (
               <SplitButton<string>

--- a/packages/ui/src/views/labels/components/labels-list-view.tsx
+++ b/packages/ui/src/views/labels/components/labels-list-view.tsx
@@ -1,6 +1,17 @@
-import { FC, useState } from 'react'
+import { FC, useCallback, useState } from 'react'
 
-import { Button, getScopeType, IconV2, Layout, MoreActionsTooltip, NoData, ScopeTag, Table, Text } from '@/components'
+import {
+  Button,
+  getScopeType,
+  IconV2,
+  Layout,
+  MoreActionsTooltip,
+  NoData,
+  ScopeTag,
+  Table,
+  Text,
+  useCustomDialogTrigger
+} from '@/components'
 import { useTranslation } from '@/context'
 import { cn } from '@/utils'
 import { ILabelType, LabelTag, LabelType, LabelValuesType } from '@/views'
@@ -43,6 +54,15 @@ export const LabelsListView: FC<LabelsListViewProps> = ({
       [key]: !prev[key]
     }))
   }
+
+  const { triggerRef, registerTrigger } = useCustomDialogTrigger()
+  const handleDeleteLabelWithTrigger = useCallback(
+    (labelKey: string) => {
+      registerTrigger()
+      handleDeleteLabel(labelKey)
+    },
+    [handleDeleteLabel, registerTrigger]
+  )
 
   if (!labels.length) {
     if (searchQuery) {
@@ -169,6 +189,7 @@ export const LabelsListView: FC<LabelsListViewProps> = ({
               </Table.Cell>
               <Table.Cell className="align-top">
                 <MoreActionsTooltip
+                  ref={triggerRef}
                   isInTable
                   iconName="more-horizontal"
                   actions={[
@@ -181,7 +202,7 @@ export const LabelsListView: FC<LabelsListViewProps> = ({
                       isDanger: true,
                       title: t('views:labelData.delete', 'Delete label'),
                       iconName: 'trash',
-                      onClick: () => handleDeleteLabel(label.key)
+                      onClick: () => handleDeleteLabelWithTrigger(label.key)
                     }
                   ]}
                 />

--- a/packages/ui/src/views/profile-settings/components/profile-settings-keys-list.tsx
+++ b/packages/ui/src/views/profile-settings/components/profile-settings-keys-list.tsx
@@ -1,6 +1,6 @@
-import { FC } from 'react'
+import { FC, useCallback } from 'react'
 
-import { IconV2, MoreActionsTooltip, Skeleton, Table, TimeAgoCard } from '@/components'
+import { IconV2, MoreActionsTooltip, Skeleton, Table, TimeAgoCard, useCustomDialogTrigger } from '@/components'
 import { useTranslation } from '@/context'
 
 import { KeysList } from '../types'
@@ -13,6 +13,15 @@ interface ProfileKeysListProps {
 
 export const ProfileKeysList: FC<ProfileKeysListProps> = ({ publicKeys, isLoading, openAlertDeleteDialog }) => {
   const { t } = useTranslation()
+
+  const { triggerRef, registerTrigger } = useCustomDialogTrigger()
+  const handleDeleteKey = useCallback(
+    (keyId: string) => {
+      registerTrigger()
+      openAlertDeleteDialog({ identifier: keyId, type: 'key' })
+    },
+    [openAlertDeleteDialog, registerTrigger]
+  )
 
   return (
     <Table.Root
@@ -55,12 +64,13 @@ export const ProfileKeysList: FC<ProfileKeysListProps> = ({ publicKeys, isLoadin
                 </Table.Cell>
                 <Table.Cell className="content-center text-right">
                   <MoreActionsTooltip
+                    ref={triggerRef}
                     isInTable
                     actions={[
                       {
                         isDanger: true,
                         title: t('views:profileSettings.deleteSshKey', 'Delete SSH key'),
-                        onClick: () => openAlertDeleteDialog({ identifier: key.identifier!, type: 'key' })
+                        onClick: () => handleDeleteKey(key.identifier!)
                       }
                     ]}
                   />

--- a/packages/ui/src/views/profile-settings/components/profile-settings-tokens-list.tsx
+++ b/packages/ui/src/views/profile-settings/components/profile-settings-tokens-list.tsx
@@ -1,6 +1,6 @@
-import { FC } from 'react'
+import { FC, useCallback } from 'react'
 
-import { IconV2, MoreActionsTooltip, Skeleton, Table, TimeAgoCard } from '@/components'
+import { IconV2, MoreActionsTooltip, Skeleton, Table, TimeAgoCard, useCustomDialogTrigger } from '@/components'
 import { useTranslation } from '@/context'
 
 import { TokensList } from '../types'
@@ -13,6 +13,15 @@ interface ProfileTokensListProps {
 
 export const ProfileTokensList: FC<ProfileTokensListProps> = ({ tokens, isLoading, openAlertDeleteDialog }) => {
   const { t } = useTranslation()
+
+  const { triggerRef, registerTrigger } = useCustomDialogTrigger()
+  const handleDeleteToken = useCallback(
+    (tokenId: string) => {
+      registerTrigger()
+      openAlertDeleteDialog({ identifier: tokenId, type: 'token' })
+    },
+    [openAlertDeleteDialog, registerTrigger]
+  )
 
   return (
     <Table.Root
@@ -56,13 +65,14 @@ export const ProfileTokensList: FC<ProfileTokensListProps> = ({ tokens, isLoadin
                 </Table.Cell>
                 <Table.Cell className="content-center text-right">
                   <MoreActionsTooltip
+                    ref={triggerRef}
                     isInTable
                     actions={[
                       {
                         isDanger: true,
                         title: t('views:profileSettings.deleteToken', 'Delete token'),
                         onClick: () => {
-                          openAlertDeleteDialog({ identifier: token.identifier!, type: 'token' })
+                          handleDeleteToken(token.identifier!)
                         }
                       }
                     ]}

--- a/packages/ui/src/views/profile-settings/profile-settings-keys-page.tsx
+++ b/packages/ui/src/views/profile-settings/profile-settings-keys-page.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 
-import { Alert, Button, Fieldset, FormSeparator, Layout, Legend, Text } from '@/components'
+import { Alert, Button, Dialog, Fieldset, FormSeparator, Layout, Legend, Text } from '@/components'
 import { useTranslation } from '@/context'
 import { ApiErrorType } from '@/views'
 
@@ -61,9 +61,11 @@ const SettingsAccountKeysPage: FC<SettingsAccountKeysPageProps> = ({
                 'Personal access tokens allow you to authenticate with the API.'
               )}
             />
-            <Button type="button" variant="outline" onClick={openTokenDialog}>
-              {t('views:profileSettings.addToken', 'Add new token')}
-            </Button>
+            <Dialog.Trigger>
+              <Button type="button" variant="outline" onClick={openTokenDialog}>
+                {t('views:profileSettings.addToken', 'Add new token')}
+              </Button>
+            </Dialog.Trigger>
           </div>
           {error?.type === ApiErrorType.TokenFetch ? (
             <ErrorMessage message={error.message} />
@@ -88,9 +90,11 @@ const SettingsAccountKeysPage: FC<SettingsAccountKeysPageProps> = ({
                 'SSH keys allow you to establish a secure connection to your code repository.'
               )}
             />
-            <Button variant="outline" type="button" onClick={openSshKeyDialog}>
-              {t('views:profileSettings.addSshKey', 'Add new SSH key')}
-            </Button>
+            <Dialog.Trigger>
+              <Button variant="outline" type="button" onClick={openSshKeyDialog}>
+                {t('views:profileSettings.addSshKey', 'Add new SSH key')}
+              </Button>
+            </Dialog.Trigger>
           </div>
           {error?.type === ApiErrorType.KeyFetch ? (
             <ErrorMessage message={error.message} />

--- a/packages/ui/src/views/project/project-general/project-general-page.tsx
+++ b/packages/ui/src/views/project/project-general/project-general-page.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   ButtonLayout,
   ControlGroup,
+  Dialog,
   Fieldset,
   FormInput,
   FormSeparator,
@@ -172,9 +173,11 @@ export const ProjectSettingsGeneralPage = ({
                 'This will permanently delete this project, and everything contained in it. All repositories in it will also be deleted.'
               )}
             >
-              <Button theme="danger" variant="secondary" className="mt-3.5 w-fit" onClick={setOpenDeleteDialog}>
-                {t('views:projectSettings.general.deleteProjectButton', 'Delete project')}
-              </Button>
+              <Dialog.Trigger>
+                <Button theme="danger" variant="secondary" className="mt-3.5 w-fit" onClick={setOpenDeleteDialog}>
+                  {t('views:projectSettings.general.deleteProjectButton', 'Delete project')}
+                </Button>
+              </Dialog.Trigger>
             </Legend>
           </>
         )}

--- a/packages/ui/src/views/project/project-members/components/member-list.tsx
+++ b/packages/ui/src/views/project/project-members/components/member-list.tsx
@@ -46,17 +46,17 @@ export const MembersList = ({ members, onDelete, onEdit }: MembersListProps) => 
             <Table.Cell className="content-center">
               <div className="flex items-center gap-2">
                 <Avatar name={member.display_name} src={member.avatarUrl} rounded />
-                <span className="text-cn-1 font-medium">{member.display_name}</span>
+                <span className="font-medium text-cn-1">{member.display_name}</span>
               </div>
             </Table.Cell>
 
             {/* EMAIL */}
-            <Table.Cell className="text-cn-2 content-center">{member.email}</Table.Cell>
+            <Table.Cell className="content-center text-cn-2">{member.email}</Table.Cell>
 
             {/* ROLE */}
             <Table.Cell className="w-1/5 content-center">
               <DropdownMenu.Root>
-                <DropdownMenu.Trigger className="text-cn-2 hover:text-cn-1 flex items-center gap-x-1.5">
+                <DropdownMenu.Trigger className="flex items-center gap-x-1.5 text-cn-2 hover:text-cn-1">
                   {getRoleLabel(member.role)}
                   <IconV2 className="chevron-down text-cn-2" name="nav-solid-arrow-down" size="2xs" />
                 </DropdownMenu.Trigger>

--- a/packages/ui/src/views/project/project-members/components/member-list.tsx
+++ b/packages/ui/src/views/project/project-members/components/member-list.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
-import { Avatar, DropdownMenu, IconV2, MoreActionsTooltip, Table } from '@/components'
+import { Avatar, DropdownMenu, IconV2, MoreActionsTooltip, Table, useCustomDialogTrigger } from '@/components'
 import { useTranslation } from '@/context'
 import { MembersProps } from '@/views'
 import { getRolesData } from '@views/project/project-members/constants'
@@ -20,6 +20,15 @@ export const MembersList = ({ members, onDelete, onEdit }: MembersListProps) => 
     return roleOptions.find(it => it.uid === role)?.label || ''
   }
 
+  const { triggerRef, registerTrigger } = useCustomDialogTrigger()
+  const handleDeleteMember = useCallback(
+    (memberId: string) => {
+      registerTrigger()
+      onDelete(memberId)
+    },
+    [onDelete, registerTrigger]
+  )
+
   return (
     <Table.Root>
       <Table.Header>
@@ -37,17 +46,17 @@ export const MembersList = ({ members, onDelete, onEdit }: MembersListProps) => 
             <Table.Cell className="content-center">
               <div className="flex items-center gap-2">
                 <Avatar name={member.display_name} src={member.avatarUrl} rounded />
-                <span className="font-medium text-cn-1">{member.display_name}</span>
+                <span className="text-cn-1 font-medium">{member.display_name}</span>
               </div>
             </Table.Cell>
 
             {/* EMAIL */}
-            <Table.Cell className="content-center text-cn-2">{member.email}</Table.Cell>
+            <Table.Cell className="text-cn-2 content-center">{member.email}</Table.Cell>
 
             {/* ROLE */}
             <Table.Cell className="w-1/5 content-center">
               <DropdownMenu.Root>
-                <DropdownMenu.Trigger className="flex items-center gap-x-1.5 text-cn-2 hover:text-cn-1">
+                <DropdownMenu.Trigger className="text-cn-2 hover:text-cn-1 flex items-center gap-x-1.5">
                   {getRoleLabel(member.role)}
                   <IconV2 className="chevron-down text-cn-2" name="nav-solid-arrow-down" size="2xs" />
                 </DropdownMenu.Trigger>
@@ -66,12 +75,13 @@ export const MembersList = ({ members, onDelete, onEdit }: MembersListProps) => 
 
             <Table.Cell className="text-right">
               <MoreActionsTooltip
+                ref={triggerRef}
                 isInTable
                 actions={[
                   {
                     isDanger: true,
                     title: t('views:projectSettings.removeMember', 'Remove member'),
-                    onClick: () => onDelete(member.uid)
+                    onClick: () => handleDeleteMember(member.uid)
                   }
                 ]}
               />

--- a/packages/ui/src/views/project/project-members/projects-member-page.tsx
+++ b/packages/ui/src/views/project/project-members/projects-member-page.tsx
@@ -1,6 +1,6 @@
 import { FC, useMemo } from 'react'
 
-import { Button, ListActions, NoData, SearchBox, Spacer, Text } from '@/components'
+import { Button, Dialog, ListActions, NoData, SearchBox, Spacer, Text } from '@/components'
 import { useTranslation } from '@/context'
 import { useDebounceSearch } from '@/hooks'
 import { SandboxLayout } from '@/views'
@@ -83,13 +83,15 @@ export const ProjectMemberListView: FC<ProjectMemberListViewProps> = ({
                     />
                   </ListActions.Left>
                   <ListActions.Right>
-                    <Button
-                      onClick={() => {
-                        setIsInviteMemberDialogOpen(true)
-                      }}
-                    >
-                      {t('views:projectSettings.newMember', 'New member')}
-                    </Button>
+                    <Dialog.Trigger>
+                      <Button
+                        onClick={() => {
+                          setIsInviteMemberDialogOpen(true)
+                        }}
+                      >
+                        {t('views:projectSettings.newMember', 'New member')}
+                      </Button>
+                    </Dialog.Trigger>
                   </ListActions.Right>
                 </ListActions.Root>
 

--- a/packages/ui/src/views/repo/pull-request/components/pull-request-header.tsx
+++ b/packages/ui/src/views/repo/pull-request/components/pull-request-header.tsx
@@ -1,6 +1,17 @@
 import { useCallback, useState } from 'react'
 
-import { Avatar, BranchTag, Button, IconV2, Layout, Separator, StatusBadge, Text, TimeAgoCard } from '@/components'
+import {
+  Avatar,
+  BranchTag,
+  Button,
+  Dialog,
+  IconV2,
+  Layout,
+  Separator,
+  StatusBadge,
+  Text,
+  TimeAgoCard
+} from '@/components'
 import { cn } from '@utils/cn'
 import { BranchSelectorContainerProps } from '@views/repo'
 
@@ -69,20 +80,22 @@ export const PullRequestHeader: React.FC<PullRequestTitleProps> = ({
           <Text as="span" variant="heading-section" color="foreground-3" className="ml-cn-xs inline-block">
             #{number}
           </Text>
-          <Button
-            className="ml-cn-xs group inline-flex"
-            variant="ghost"
-            iconOnly
-            aria-label="Edit"
-            onClick={() => {
-              setIsEditing(true)
-            }}
-            tooltipProps={{
-              content: 'Edit'
-            }}
-          >
-            <IconV2 name="edit-pencil" />
-          </Button>
+          <Dialog.Trigger>
+            <Button
+              className="ml-cn-xs group inline-flex"
+              variant="ghost"
+              iconOnly
+              aria-label="Edit"
+              onClick={() => {
+                setIsEditing(true)
+              }}
+              tooltipProps={{
+                content: 'Edit'
+              }}
+            >
+              <IconV2 name="edit-pencil" />
+            </Button>
+          </Dialog.Trigger>
         </Text>
 
         <Layout.Horizontal gap="sm" align="center">

--- a/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-timeline-item.tsx
+++ b/packages/ui/src/views/repo/pull-request/details/components/conversation/pull-request-timeline-item.tsx
@@ -10,7 +10,8 @@ import {
   MoreActionsTooltip,
   NodeGroup,
   Text,
-  TextInput
+  TextInput,
+  useCustomDialogTrigger
 } from '@/components'
 import {
   HandleUploadType,
@@ -80,6 +81,12 @@ const ItemHeader: FC<ItemHeaderProps> = memo(
     isReply = false,
     isResolved = false
   }) => {
+    const { triggerRef, registerTrigger } = useCustomDialogTrigger()
+    const handleDeleteCommentWithTrigger = useCallback(() => {
+      registerTrigger()
+      handleDeleteComment?.()
+    }, [handleDeleteComment, registerTrigger])
+
     const actions: Array<{
       title: string
       onClick: () => void
@@ -109,7 +116,7 @@ const ItemHeader: FC<ItemHeaderProps> = memo(
         ? [
             {
               title: `Delete ${isReply ? 'reply' : 'comment'}`,
-              onClick: () => handleDeleteComment?.(),
+              onClick: handleDeleteCommentWithTrigger,
               isDanger: true,
               iconName: 'trash' as const
             }
@@ -147,7 +154,13 @@ const ItemHeader: FC<ItemHeaderProps> = memo(
           </Layout.Horizontal>
         </Text>
         {isComment && !isDeleted && !isResolved && (
-          <MoreActionsTooltip iconName="more-horizontal" sideOffset={4} alignOffset={0} actions={actions} />
+          <MoreActionsTooltip
+            ref={triggerRef}
+            iconName="more-horizontal"
+            sideOffset={4}
+            alignOffset={0}
+            actions={actions}
+          />
         )}
       </Layout.Horizontal>
     )

--- a/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-delete.tsx
+++ b/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-delete.tsx
@@ -1,6 +1,15 @@
 import { FC } from 'react'
 
-import { Button, ButtonLayout, FormSeparator, Layout, PermissionIdentifier, ResourceType, Text } from '@/components'
+import {
+  Button,
+  ButtonLayout,
+  Dialog,
+  FormSeparator,
+  Layout,
+  PermissionIdentifier,
+  ResourceType,
+  Text
+} from '@/components'
 import { useComponents, useTranslation } from '@/context'
 import { ErrorTypes } from '@/views'
 
@@ -34,22 +43,24 @@ export const RepoSettingsGeneralDelete: FC<{
         </Layout.Vertical>
 
         <ButtonLayout horizontalAlign="start">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={() => {
-              openRepoArchiveDialog()
-            }}
-            disabled={isUpdatingArchive}
-          >
-            {isUpdatingArchive
-              ? archived
-                ? t('views:repos.unarchiving', 'Unarchiving...')
-                : t('views:repos.archiving', 'Archiving...')
-              : archived
-                ? t('views:repos.unarchiveRepoButton', 'Unarchive Repository')
-                : t('views:repos.archiveRepoButton', 'Archive Repository')}
-          </Button>
+          <Dialog.Trigger>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                openRepoArchiveDialog()
+              }}
+              disabled={isUpdatingArchive}
+            >
+              {isUpdatingArchive
+                ? archived
+                  ? t('views:repos.unarchiving', 'Unarchiving...')
+                  : t('views:repos.archiving', 'Archiving...')
+                : archived
+                  ? t('views:repos.unarchiveRepoButton', 'Unarchive Repository')
+                  : t('views:repos.archiveRepoButton', 'Archive Repository')}
+            </Button>
+          </Dialog.Trigger>
         </ButtonLayout>
 
         {apiError && apiError.type === ErrorTypes.ARCHIVE_REPO && <Text color="danger">{apiError.message}</Text>}
@@ -69,18 +80,20 @@ export const RepoSettingsGeneralDelete: FC<{
         </Layout.Vertical>
 
         <ButtonLayout horizontalAlign="start">
-          <RbacButton
-            type="button"
-            variant="primary"
-            theme="danger"
-            onClick={openRepoAlertDeleteDialog}
-            rbac={{
-              resource: { resourceType: ResourceType.CODE_REPOSITORY },
-              permissions: [PermissionIdentifier.CODE_REPO_DELETE]
-            }}
-          >
-            {t('views:repos.deleteRepoButton', 'Delete Repository')}
-          </RbacButton>
+          <Dialog.Trigger>
+            <RbacButton
+              type="button"
+              variant="primary"
+              theme="danger"
+              onClick={openRepoAlertDeleteDialog}
+              rbac={{
+                resource: { resourceType: ResourceType.CODE_REPOSITORY },
+                permissions: [PermissionIdentifier.CODE_REPO_DELETE]
+              }}
+            >
+              {t('views:repos.deleteRepoButton', 'Delete Repository')}
+            </RbacButton>
+          </Dialog.Trigger>
         </ButtonLayout>
 
         {apiError && apiError.type === ErrorTypes.DELETE_REPO && <Text color="danger">{apiError.message}</Text>}

--- a/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-form.tsx
+++ b/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-form.tsx
@@ -11,7 +11,8 @@ import {
   Label,
   Radio,
   Skeleton,
-  Text
+  Text,
+  useCustomDialogTrigger
 } from '@/components'
 import { useTranslation } from '@/context'
 import { AccessLevel, ErrorTypes, errorTypes, generalSettingsFormSchema, RepoData, RepoUpdateData } from '@/views'
@@ -25,7 +26,7 @@ export const RepoSettingsGeneralForm: FC<{
   isLoadingRepoData: boolean
   isUpdatingRepoData: boolean
   isRepoUpdateSuccess: boolean
-  branchSelectorRenderer: React.ComponentType<BranchSelectorContainerProps>
+  branchSelectorRenderer: React.ComponentType<BranchSelectorContainerProps & React.RefAttributes<HTMLButtonElement>>
   setCreateBranchDialogOpen: (open: boolean) => void
   onBranchQueryChange: (query: string) => void
 }> = ({
@@ -42,6 +43,12 @@ export const RepoSettingsGeneralForm: FC<{
   const { t } = useTranslation()
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false)
   const BranchSelector = branchSelectorRenderer
+
+  const { triggerRef, registerTrigger } = useCustomDialogTrigger()
+  const toggleCreateBranchDialogOpen = (open: boolean) => {
+    registerTrigger()
+    setCreateBranchDialogOpen(open)
+  }
 
   const formMethods = useForm<RepoUpdateData>({
     resolver: zodResolver(generalSettingsFormSchema),
@@ -140,6 +147,7 @@ export const RepoSettingsGeneralForm: FC<{
       <ControlGroup>
         <Label>{t('views:repos.defaultBranch', 'Default Branch')}</Label>
         <BranchSelector
+          ref={triggerRef}
           onSelectBranchorTag={value => {
             handleSelectChange('branch', value.name)
           }}
@@ -147,7 +155,7 @@ export const RepoSettingsGeneralForm: FC<{
           selectedBranch={{ name: branchValue, sha: '' }}
           isUpdating={isUpdatingRepoData}
           disabled={isUpdatingRepoData}
-          setCreateBranchDialogOpen={setCreateBranchDialogOpen}
+          setCreateBranchDialogOpen={toggleCreateBranchDialogOpen}
           onBranchQueryChange={onBranchQueryChange}
           className="w-fit max-w-full"
         />

--- a/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-rules.tsx
+++ b/packages/ui/src/views/repo/repo-settings/components/repo-settings-general-rules.tsx
@@ -15,7 +15,8 @@ import {
   SplitButton,
   StackedList,
   Tag,
-  Text
+  Text,
+  useCustomDialogTrigger
 } from '@/components'
 import { Select } from '@/components/form-primitives/select'
 import { useRouterContext, useTranslation } from '@/context'
@@ -112,6 +113,15 @@ export const RepoSettingsGeneralRules: FC<RepoSettingsGeneralRulesProps> = ({
       setRulesSearchQuery?.(val)
     },
     [setRulesSearchQuery]
+  )
+
+  const { triggerRef, registerTrigger } = useCustomDialogTrigger()
+  const handleDeleteRule = useCallback(
+    (ruleId: string, scope: number) => {
+      registerTrigger()
+      openRulesAlertDeleteDialog(ruleId, scope)
+    },
+    [openRulesAlertDeleteDialog, registerTrigger]
   )
 
   const resetSearch = () => {
@@ -218,6 +228,7 @@ export const RepoSettingsGeneralRules: FC<RepoSettingsGeneralRulesProps> = ({
                 }}
                 actions={
                   <MoreActionsTooltip
+                    ref={triggerRef}
                     actions={[
                       {
                         title: t('views:rules.edit', 'Edit Rule'),
@@ -228,7 +239,7 @@ export const RepoSettingsGeneralRules: FC<RepoSettingsGeneralRulesProps> = ({
                         isDanger: true,
                         title: t('views:rules.delete', 'Delete Rule'),
                         iconName: 'trash',
-                        onClick: () => openRulesAlertDeleteDialog(rule.identifier!, rule?.scope ?? 0)
+                        onClick: () => handleDeleteRule(rule.identifier!, rule?.scope ?? 0)
                       }
                     ]}
                   />

--- a/packages/ui/src/views/repo/repo-tags/components/repo-tags-list.tsx
+++ b/packages/ui/src/views/repo/repo-tags/components/repo-tags-list.tsx
@@ -123,7 +123,8 @@ export const RepoTagsList: FC<RepoTagsListProps> = ({
                     {t('views:noData.createNewTag', 'Create Tag')}
                   </>
                 ),
-                onClick: onOpenCreateTagDialog
+                onClick: onOpenCreateTagDialog,
+                isDialogTrigger: true
               }
         }
       />

--- a/packages/ui/src/views/repo/repo-tags/components/repo-tags-list.tsx
+++ b/packages/ui/src/views/repo/repo-tags/components/repo-tags-list.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useCallback } from 'react'
 
 import {
   ActionData,
@@ -12,7 +12,8 @@ import {
   Skeleton,
   Table,
   Text,
-  TimeAgoCard
+  TimeAgoCard,
+  useCustomDialogTrigger
 } from '@/components'
 import { useTranslation } from '@/context'
 import { BranchSelectorListItem, CommitTagType, RepoTagsStore } from '@/views'
@@ -41,11 +42,29 @@ export const RepoTagsList: FC<RepoTagsListProps> = ({
   const { t } = useTranslation()
   const { tags: tagsList } = useRepoTagsStore()
 
+  const { triggerRef, registerTrigger } = useCustomDialogTrigger()
+
+  const handleDeleteTag = useCallback(
+    (tagName: string) => {
+      registerTrigger()
+      onDeleteTag(tagName)
+    },
+    [onDeleteTag, registerTrigger]
+  )
+
+  const handleOpenCreateBranchDialog = useCallback(
+    (tag: CommitTagType) => {
+      registerTrigger()
+      onOpenCreateBranchDialog(tag)
+    },
+    [onOpenCreateBranchDialog, registerTrigger]
+  )
+
   const getTableActions = (tag: CommitTagType): ActionData[] => [
     {
       iconName: 'git-branch',
       title: t('views:repos.tags.createBranch', 'Create Branch'),
-      onClick: () => onOpenCreateBranchDialog(tag)
+      onClick: () => handleOpenCreateBranchDialog(tag)
     },
     {
       iconName: 'folder',
@@ -56,7 +75,7 @@ export const RepoTagsList: FC<RepoTagsListProps> = ({
       iconName: 'trash',
       isDanger: true,
       title: t('views:repos.deleteTag', 'Delete Tag'),
-      onClick: () => onDeleteTag(tag.name)
+      onClick: () => handleDeleteTag(tag.name)
     }
   ]
 
@@ -166,6 +185,7 @@ export const RepoTagsList: FC<RepoTagsListProps> = ({
             </Table.Cell>
             <Table.Cell className="text-right">
               <MoreActionsTooltip
+                ref={triggerRef}
                 actions={getTableActions(tag).map(action => ({
                   ...action,
                   to: action?.to?.replace('${tag.name}', tag.name)

--- a/packages/ui/src/views/repo/repo-tags/repo-tags-list-page.tsx
+++ b/packages/ui/src/views/repo/repo-tags/repo-tags-list-page.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback, useMemo } from 'react'
 
-import { Button, IconV2, Layout, ListActions, Pagination, SearchInput, Text } from '@/components'
+import { Button, Dialog, IconV2, Layout, ListActions, Pagination, SearchInput, Text } from '@/components'
 import { useTranslation } from '@/context'
 import { RepoTagsListViewProps, SandboxLayout } from '@/views'
 import { cn } from '@utils/cn'
@@ -74,10 +74,12 @@ export const RepoTagsListView: FC<RepoTagsListViewProps> = ({
                   />
                 </ListActions.Left>
                 <ListActions.Right>
-                  <Button onClick={openCreateTagDialog}>
-                    <IconV2 name="plus" />
-                    <span>{t('views:repos.createTag', 'Create Tag')}</span>
-                  </Button>
+                  <Dialog.Trigger>
+                    <Button onClick={openCreateTagDialog}>
+                      <IconV2 name="plus" />
+                      <span>{t('views:repos.createTag', 'Create Tag')}</span>
+                    </Button>
+                  </Dialog.Trigger>
                 </ListActions.Right>
               </ListActions.Root>
             )}

--- a/packages/ui/src/views/repo/webhooks/webhook-list/components/repo-webhook-list.tsx
+++ b/packages/ui/src/views/repo/webhooks/webhook-list/components/repo-webhook-list.tsx
@@ -1,4 +1,6 @@
-import { Layout, MoreActionsTooltip, StatusBadge, Switch, Table, Text } from '@/components'
+import { useCallback } from 'react'
+
+import { Layout, MoreActionsTooltip, StatusBadge, Switch, Table, Text, useCustomDialogTrigger } from '@/components'
 import { useRouterContext, useTranslation } from '@/context'
 import { WebhookType } from '@/views'
 
@@ -19,6 +21,15 @@ export function RepoWebhookList({
 }: RepoWebhookListProps) {
   const { t } = useTranslation()
   const { navigate } = useRouterContext()
+
+  const { triggerRef, registerTrigger } = useCustomDialogTrigger()
+  const handleDeleteWebhook = useCallback(
+    (webhookId: number) => {
+      registerTrigger()
+      openDeleteWebhookDialog(webhookId)
+    },
+    [openDeleteWebhookDialog, registerTrigger]
+  )
 
   return (
     <>
@@ -59,6 +70,7 @@ export function RepoWebhookList({
 
                 <Table.Cell>
                   <MoreActionsTooltip
+                    ref={triggerRef}
                     iconName="more-horizontal"
                     actions={[
                       {
@@ -70,7 +82,7 @@ export function RepoWebhookList({
                         isDanger: true,
                         iconName: 'trash',
                         title: t('views:webhookData.delete', 'Delete Webhook'),
-                        onClick: () => openDeleteWebhookDialog(webhook.id)
+                        onClick: () => handleDeleteWebhook(webhook.id)
                       }
                     ]}
                   />

--- a/packages/ui/src/views/user-management/components/page-components/actions/actions.tsx
+++ b/packages/ui/src/views/user-management/components/page-components/actions/actions.tsx
@@ -1,4 +1,4 @@
-import { Button, IconV2, ListActions, SearchBox } from '@/components'
+import { Button, Dialog, IconV2, ListActions, SearchBox } from '@/components'
 import { useTranslation } from '@/context'
 import { DialogLabels } from '@/views/user-management/components/dialogs'
 import { useDialogData } from '@/views/user-management/components/dialogs/hooks/use-dialog-data'
@@ -22,10 +22,12 @@ export const Actions = () => {
         />
       </ListActions.Left>
       <ListActions.Right>
-        <Button onClick={() => handleDialogOpen(null, DialogLabels.CREATE_USER)}>
-          <IconV2 name="plus" />
-          {t('views:userManagement.newUserButton', 'Create User')}
-        </Button>
+        <Dialog.Trigger>
+          <Button onClick={() => handleDialogOpen(null, DialogLabels.CREATE_USER)}>
+            <IconV2 name="plus" />
+            {t('views:userManagement.newUserButton', 'Create User')}
+          </Button>
+        </Dialog.Trigger>
       </ListActions.Right>
     </ListActions.Root>
   )

--- a/packages/ui/src/views/user-management/components/page-components/content/components/users-list/users-list.tsx
+++ b/packages/ui/src/views/user-management/components/page-components/content/components/users-list/users-list.tsx
@@ -1,4 +1,6 @@
-import { Avatar, MoreActionsTooltip, Skeleton, StatusBadge, Table } from '@/components'
+import { useCallback } from 'react'
+
+import { Avatar, MoreActionsTooltip, Skeleton, StatusBadge, Table, useCustomDialogTrigger } from '@/components'
 import { DialogLabels } from '@/views/user-management/components/dialogs'
 import { useDialogData } from '@/views/user-management/components/dialogs/hooks/use-dialog-data'
 import { ErrorState } from '@/views/user-management/components/page-components/content/components/users-list/components/error-state'
@@ -18,6 +20,15 @@ export const UsersList = () => {
   const { loadingStates, errorStates } = useStates()
   const { isFetchingUsers } = loadingStates
   const { fetchUsersError } = errorStates
+
+  const { triggerRef, registerTrigger } = useCustomDialogTrigger()
+  const handleToggleDialog = useCallback(
+    (user: UsersProps | null, dialogType: DialogLabels) => {
+      registerTrigger()
+      handleDialogOpen(user, dialogType)
+    },
+    [handleDialogOpen, registerTrigger]
+  )
 
   if (isFetchingUsers) {
     return <Skeleton.List />
@@ -75,24 +86,25 @@ export const UsersList = () => {
 
                 <Table.Cell className="text-right">
                   <MoreActionsTooltip
+                    ref={triggerRef}
                     isInTable
                     actions={[
                       {
                         title: user.admin ? 'Remove admin' : 'Set as Admin',
-                        onClick: () => handleDialogOpen(user, DialogLabels.TOGGLE_ADMIN)
+                        onClick: () => handleToggleDialog(user, DialogLabels.TOGGLE_ADMIN)
                       },
                       {
                         title: 'Reset password',
-                        onClick: () => handleDialogOpen(user, DialogLabels.RESET_PASSWORD)
+                        onClick: () => handleToggleDialog(user, DialogLabels.RESET_PASSWORD)
                       },
                       {
                         title: 'Edit user',
-                        onClick: () => handleDialogOpen(user, DialogLabels.EDIT_USER)
+                        onClick: () => handleToggleDialog(user, DialogLabels.EDIT_USER)
                       },
                       {
                         isDanger: true,
                         title: 'Delete user',
-                        onClick: () => handleDialogOpen(user, DialogLabels.DELETE_USER)
+                        onClick: () => handleToggleDialog(user, DialogLabels.DELETE_USER)
                       }
                     ]}
                   />


### PR DESCRIPTION
Refactoring of the dialog trigger on other repo page:
- files
- pull request page
- tags
- repo settings
- general settings
- users list page

After modals closed, a focus returns to triggers, but not the page body.