### PR TITLE
prevent commit suggestion button from rerender

### DIFF
--- a/packages/ui/locales/en/views.json
+++ b/packages/ui/locales/en/views.json
@@ -641,11 +641,11 @@
     "split": "Split",
     "unified": "Unified",
     "comments": {
-      "suggestionApplied": "Suggestion applied",
-      "codeSuggestion": "Code suggestion",
       "commitSuggestion": "Commit suggestion",
       "removeSuggestion": "Remove suggestion from batch",
-      "addSuggestion": "Add suggestion to batch"
+      "addSuggestion": "Add suggestion to batch",
+      "suggestionApplied": "Suggestion applied",
+      "codeSuggestion": "Code suggestion"
     },
     "deleted": "Deleted",
     "searchUsers": "Search users",

--- a/packages/ui/locales/fr/views.json
+++ b/packages/ui/locales/fr/views.json
@@ -632,11 +632,11 @@
     "split": "Diviser",
     "unified": "Unifié",
     "comments": {
-      "suggestionApplied": "Suggestion applied",
-      "codeSuggestion": "Code suggestion",
       "commitSuggestion": "Commit suggestion",
       "removeSuggestion": "Remove suggestion from batch",
-      "addSuggestion": "Add suggestion to batch"
+      "addSuggestion": "Add suggestion to batch",
+      "suggestionApplied": "Suggestion applied",
+      "codeSuggestion": "Code suggestion"
     },
     "deleted": "Supprimé",
     "searchUsers": "Rechercher des utilisateurs",

--- a/packages/ui/src/components/markdown-viewer/index.tsx
+++ b/packages/ui/src/components/markdown-viewer/index.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode, useCallback, useEffect, useMemo, useRef } from 'react'
+import { CSSProperties, memo, ReactNode, useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { CopyButton, Text } from '@/components'
 import MarkdownPreview from '@uiw/react-markdown-preview'
@@ -36,7 +36,7 @@ type MarkdownViewerProps = {
   isLoading?: boolean
 }
 
-export function MarkdownViewer({
+const MarkdownViewerLocal = ({
   source,
   maxHeight,
   withBorder = false,
@@ -48,7 +48,7 @@ export function MarkdownViewer({
   suggestionTitle,
   suggestionFooter,
   isLoading = false
-}: MarkdownViewerProps) {
+}: MarkdownViewerProps) => {
   const { navigate } = useRouterContext()
   const refRootHref = useMemo(() => document.getElementById('repository-ref-root')?.getAttribute('href'), [])
   const ref = useRef<HTMLDivElement>(null)
@@ -323,3 +323,9 @@ export function MarkdownViewer({
     </div>
   )
 }
+
+MarkdownViewerLocal.displayName = 'MarkdownViewer'
+
+const MarkdownViewer = memo(MarkdownViewerLocal)
+
+export { MarkdownViewer }


### PR DESCRIPTION
#### Preventing commit suggestion button from re-render

- after closing a dialog, the focus returns to its trigger now

<img width="447" height="314" alt="image" src="https://github.com/user-attachments/assets/0eac0ce3-b6c9-4643-bb6f-202e0752f839" />
