### PR TITLE
feat: [UUI-1927]: add app shell nav and chat rail shadow component tokens

### DIFF
--- a/apps/portal/src/components/CSSVariables.astro
+++ b/apps/portal/src/components/CSSVariables.astro
@@ -146,6 +146,12 @@ function getTwClasses(n: string): string[] {
   if ((m = n.match(/^--cn-comp-shadow-data-viz-\d+-(.+)$/)))
     return [`shadow-cn-${m[1]}`, `drop-shadow-cn-${m[1]}`];
 
+  // comp: app shell rail shadows
+  if (n === "--cn-comp-shadow-nav-rail") return ["shadow-cn-nav-rail"];
+  if (n === "--cn-comp-shadow-chat-rail") return ["shadow-cn-chat-rail"];
+  if (n === "--cn-comp-shadow-chat-rail-mirror")
+    return ["shadow-cn-chat-rail-mirror"];
+
   return [];
 }
 

--- a/apps/portal/src/content/docs/foundations/shadows.mdx
+++ b/apps/portal/src/content/docs/foundations/shadows.mdx
@@ -69,6 +69,24 @@ The design system maps specific shadow levels to component categories:
             Inset containers, recessed surfaces
           </td>
         </tr>
+        <tr className="cn-table-v2-row">
+          <td className="cn-table-v2-cell">`shadow-cn-nav-rail`</td>
+          <td className="cn-table-v2-cell">
+            App shell navigation rail panel
+          </td>
+        </tr>
+        <tr className="cn-table-v2-row">
+          <td className="cn-table-v2-cell">`shadow-cn-chat-rail`</td>
+          <td className="cn-table-v2-cell">
+            App shell chat panel (left of main content)
+          </td>
+        </tr>
+        <tr className="cn-table-v2-row">
+          <td className="cn-table-v2-cell">`shadow-cn-chat-rail-mirror`</td>
+          <td className="cn-table-v2-cell">
+            App shell chat panel (right of main content)
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>
@@ -88,6 +106,11 @@ var(--cn-shadow-4)      /* prominent */
 var(--cn-shadow-5)      /* strong */
 var(--cn-shadow-6)      /* maximum */
 var(--cn-shadow-inner)  /* inset */
+
+/* App shell rail shadows (component tokens) */
+var(--cn-comp-shadow-nav-rail)
+var(--cn-comp-shadow-chat-rail)
+var(--cn-comp-shadow-chat-rail-mirror)
 
 /* Shadow colors (for custom shadows) */
 var(--cn-shadow-color-0)
@@ -239,6 +262,43 @@ Seven levels (0–6) plus an inner shadow provide a complete elevation vocabular
     </Layout.Vertical>
   </Layout.Horizontal>
 </Layout.Vertical>`}
+/>
+
+## App shell rail shadows
+
+Component shadows for the unified app shell navigation and chat panels. Values are theme-aware (light: subtle lift; dark: `0 7px 8px` on `#08090d` at 80% alpha).
+
+Use `shadow-cn-nav-rail` on the nav column shell and `shadow-cn-chat-rail` / `shadow-cn-chat-rail-mirror` on the chat panel shell based on chat position. Do not apply to seam overlays or resize handles.
+
+<DocsPage.ComponentExample
+  hideCode
+  client:only
+  code={`<Layout.Horizontal gap="lg" className="min-w-[560px] p-cn-xl bg-cn-0">
+  <Layout.Vertical
+    gap="xs"
+    className="bg-cn-1 h-48 w-16 shrink-0 shadow-cn-nav-rail"
+    justify="center"
+    align="center"
+  >
+    <Text variant="caption-normal" color="foreground-3">Nav</Text>
+  </Layout.Vertical>
+  <Layout.Vertical
+    gap="xs"
+    className="bg-cn-1 h-48 w-40 shrink-0 shadow-cn-chat-rail"
+    justify="center"
+    align="center"
+  >
+    <Text variant="caption-normal" color="foreground-3">Chat</Text>
+  </Layout.Vertical>
+  <Layout.Vertical
+    gap="xs"
+    className="bg-cn-1 h-48 flex-1"
+    justify="center"
+    align="center"
+  >
+    <Text variant="caption-normal" color="foreground-3">Main</Text>
+  </Layout.Vertical>
+</Layout.Horizontal>`}
 />
 
 ## Shadow Geometry

--- a/packages/core-design-system/design-tokens/mode/dark/default.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default.json
@@ -1244,6 +1244,22 @@
         }
       }
     },
+    "app-shell": {
+      "rail-shadow": {
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": "0.8",
+              "space": "lch"
+            }
+          }
+        },
+        "$type": "color",
+        "$value": "{pure.black}",
+        "$description": "Shadow color for app shell nav and chat rail elevation in dark mode (#08090d / bg.0)."
+      }
+    },
     "avatar": {
       "shadow": {
         "$extensions": {
@@ -2694,6 +2710,42 @@
           },
           "$description": "Inner shadow for AI-themed components. Adds depth to AI elements."
         }
+      },
+      "nav-rail": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "7",
+          "blur": "8",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell navigation rail. Casts toward main content."
+      },
+      "chat-rail": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "7",
+          "blur": "8",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell chat panel when chat is left of main content."
+      },
+      "chat-rail-mirror": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "7",
+          "blur": "8",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell chat panel when chat is right of main content."
       },
       "data-viz": {
         "01-blue": {

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -1235,6 +1235,22 @@
         }
       }
     },
+    "app-shell": {
+      "rail-shadow": {
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": "0.08",
+              "space": "lch"
+            }
+          }
+        },
+        "$type": "color",
+        "$value": "{pure.black}",
+        "$description": "Shadow color for app shell nav and chat rail elevation."
+      }
+    },
     "avatar": {
       "shadow": {
         "$extensions": {
@@ -2535,6 +2551,42 @@
           },
           "$description": "Inner shadow for AI-themed components. Adds depth to AI elements."
         }
+      },
+      "nav-rail": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "2",
+          "blur": "12",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell navigation rail. Casts toward main content."
+      },
+      "chat-rail": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "2",
+          "blur": "12",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell chat panel when chat is left of main content."
+      },
+      "chat-rail-mirror": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "2",
+          "blur": "12",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell chat panel when chat is right of main content."
       },
       "data-viz": {
         "01-blue": {

--- a/packages/ui/tailwind-design-system.ts
+++ b/packages/ui/tailwind-design-system.ts
@@ -412,7 +412,11 @@ const tailwindDesignSystem: TailwindConfig = {
       'cn-forest': 'var(--cn-comp-shadow-data-viz-09-forest)',
       'cn-red': 'var(--cn-comp-shadow-data-viz-10-red)',
       'cn-yellow': 'var(--cn-comp-shadow-data-viz-11-yellow)',
-      'cn-gray': 'var(--cn-comp-shadow-data-viz-12-gray)'
+      'cn-gray': 'var(--cn-comp-shadow-data-viz-12-gray)',
+
+      'cn-nav-rail': 'var(--cn-comp-shadow-nav-rail)',
+      'cn-chat-rail': 'var(--cn-comp-shadow-chat-rail)',
+      'cn-chat-rail-mirror': 'var(--cn-comp-shadow-chat-rail-mirror)'
     },
     spacing: {
       0: 'var(--cn-spacing-0)',


### PR DESCRIPTION
## Summary

Adds component-level drop shadow tokens for the unified app shell navigation and chat rails (3dot0Vision / platformUI app shell work).

Jira: [UUI-1927](https://harness.atlassian.net/browse/UUI-1927) (epic: [UUI-1915](https://harness.atlassian.net/browse/UUI-1915))

- New color token `comp.app-shell.rail-shadow` (light: `pure.black` @ 8%; dark: `pure.black` / `bg.0` @ 80%)
- New box-shadow tokens: `comp.shadow.nav-rail`, `comp.shadow.chat-rail`, `comp.shadow.chat-rail-mirror`
- Tailwind utilities: `shadow-cn-nav-rail`, `shadow-cn-chat-rail`, `shadow-cn-chat-rail-mirror`
- Portal docs: shadows foundation page + CSS variable mapping

## Token values

| Token | Light | Dark |
|-------|-------|------|
| `--cn-comp-shadow-nav-rail` | `0 2px 12px` | `0 7px 8px` |
| `--cn-comp-shadow-chat-rail` | same | same |
| `--cn-comp-shadow-chat-rail-mirror` | same | same |

Shadow color resolves via `--cn-comp-app-shell-rail-shadow` → `lch(from var(--cn-pure-black) …)`.

## Test plan

- [ ] `pnpm --filter @harnessio/core-design-system build:styles` passes
- [ ] `pnpm --filter @harnessio/ui build` passes
- [ ] Portal shadows page shows nav + chat rail example (light + dark)
- [ ] Generated CSS includes `--cn-comp-shadow-nav-rail` in light/dark theme files

## Follow-up

- platformUI: wire tokens in `App.css` + `sidebar-layout.tsx` after `@harnessio/ui` publish

[UUI-1927]: https://harness.atlassian.net/browse/UUI-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UUI-1915]: https://harness.atlassian.net/browse/UUI-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ