### PR TITLE
feat: [UUI-1927]: add app shell and pipeline studio shadow component tokens

### DIFF
--- a/apps/portal/src/components/CSSVariables.astro
+++ b/apps/portal/src/components/CSSVariables.astro
@@ -146,6 +146,12 @@ function getTwClasses(n: string): string[] {
   if ((m = n.match(/^--cn-comp-shadow-data-viz-\d+-(.+)$/)))
     return [`shadow-cn-${m[1]}`, `drop-shadow-cn-${m[1]}`];
 
+  // comp: app shell rail shadows
+  if (n === "--cn-comp-shadow-nav-rail") return ["shadow-cn-nav-rail"];
+  if (n === "--cn-comp-shadow-chat-rail") return ["shadow-cn-chat-rail"];
+  if (n === "--cn-comp-shadow-chat-rail-mirror")
+    return ["shadow-cn-chat-rail-mirror"];
+
   return [];
 }
 

--- a/apps/portal/src/components/CSSVariables.astro
+++ b/apps/portal/src/components/CSSVariables.astro
@@ -151,6 +151,8 @@ function getTwClasses(n: string): string[] {
   if (n === "--cn-comp-shadow-chat-rail") return ["shadow-cn-chat-rail"];
   if (n === "--cn-comp-shadow-chat-rail-mirror")
     return ["shadow-cn-chat-rail-mirror"];
+  if (n === "--cn-comp-shadow-pipeline-studio-page-header")
+    return ["shadow-cn-pipeline-studio-page-header"];
 
   return [];
 }

--- a/apps/portal/src/content/docs/foundations/shadows.mdx
+++ b/apps/portal/src/content/docs/foundations/shadows.mdx
@@ -85,6 +85,14 @@ The design system maps specific shadow levels to component categories:
             App shell chat panel (right of main content)
           </td>
         </tr>
+        <tr className="cn-table-v2-row">
+          <td className="cn-table-v2-cell">
+            `shadow-cn-pipeline-studio-page-header`
+          </td>
+          <td className="cn-table-v2-cell">
+            Pipelines Studio page header chrome
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>
@@ -109,6 +117,7 @@ var(--cn-shadow-inner)  /* inset */
 var(--cn-comp-shadow-nav-rail)
 var(--cn-comp-shadow-chat-rail)
 var(--cn-comp-shadow-chat-rail-mirror)
+var(--cn-comp-shadow-pipeline-studio-page-header)
 
 /* Shadow colors (for custom shadows) */
 var(--cn-shadow-color-0)
@@ -297,6 +306,29 @@ Use `shadow-cn-nav-rail` on the nav column shell and `shadow-cn-chat-rail` / `sh
     <Text variant="caption-normal" color="foreground-3">Main</Text>
   </Layout.Vertical>
 </Layout.Horizontal>`}
+/>
+
+## Pipelines Studio page header shadow
+
+Component shadow for the Pipelines Studio top header bar (breadcrumb + Studio / Executions tabs). Sourced from the 3dot0Vision prototype (`--ds-shadow-2`).
+
+Use `shadow-cn-pipeline-studio-page-header` on the header shell. Do not apply on the Pipelines list view (header is flat there).
+
+| Mode  | Value                                                                 |
+| ----- | --------------------------------------------------------------------- |
+| Light | `0 1px 2px rgba(15, 23, 42, 0.06), 0 4px 14px rgba(15, 23, 42, 0.08)` |
+| Dark  | `0 1px 2px rgba(0, 0, 0, 0.45), 0 4px 14px rgba(0, 0, 0, 0.5)`        |
+
+<DocsPage.ComponentExample
+  hideCode
+  client:only
+  code={`<Layout.Horizontal
+    className="bg-cn-1 w-full min-w-[320px] p-cn-md shadow-cn-pipeline-studio-page-header"
+    justify="center"
+    align="center"
+  >
+    <Text variant="caption-normal" color="foreground-3">Studio page header</Text>
+  </Layout.Horizontal>`}
 />
 
 ## Shadow Geometry

--- a/apps/portal/src/content/docs/foundations/shadows.mdx
+++ b/apps/portal/src/content/docs/foundations/shadows.mdx
@@ -71,9 +71,7 @@ The design system maps specific shadow levels to component categories:
         </tr>
         <tr className="cn-table-v2-row">
           <td className="cn-table-v2-cell">`shadow-cn-nav-rail`</td>
-          <td className="cn-table-v2-cell">
-            App shell navigation rail panel
-          </td>
+          <td className="cn-table-v2-cell">App shell navigation rail panel</td>
         </tr>
         <tr className="cn-table-v2-row">
           <td className="cn-table-v2-cell">`shadow-cn-chat-rail`</td>

--- a/apps/portal/src/content/docs/foundations/shadows.mdx
+++ b/apps/portal/src/content/docs/foundations/shadows.mdx
@@ -69,6 +69,24 @@ The design system maps specific shadow levels to component categories:
             Inset containers, recessed surfaces
           </td>
         </tr>
+        <tr className="cn-table-v2-row">
+          <td className="cn-table-v2-cell">`shadow-cn-nav-rail`</td>
+          <td className="cn-table-v2-cell">
+            App shell navigation rail panel
+          </td>
+        </tr>
+        <tr className="cn-table-v2-row">
+          <td className="cn-table-v2-cell">`shadow-cn-chat-rail`</td>
+          <td className="cn-table-v2-cell">
+            App shell chat panel (left of main content)
+          </td>
+        </tr>
+        <tr className="cn-table-v2-row">
+          <td className="cn-table-v2-cell">`shadow-cn-chat-rail-mirror`</td>
+          <td className="cn-table-v2-cell">
+            App shell chat panel (right of main content)
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>
@@ -88,6 +106,11 @@ var(--cn-shadow-4)      /* prominent */
 var(--cn-shadow-5)      /* strong */
 var(--cn-shadow-6)      /* maximum */
 var(--cn-shadow-inner)  /* inset */
+
+/* App shell rail shadows (component tokens) */
+var(--cn-comp-shadow-nav-rail)
+var(--cn-comp-shadow-chat-rail)
+var(--cn-comp-shadow-chat-rail-mirror)
 
 /* Shadow colors (for custom shadows) */
 var(--cn-shadow-color-0)
@@ -239,6 +262,43 @@ Seven levels (0–6) plus an inner shadow provide a complete elevation vocabular
     </Layout.Vertical>
   </Layout.Horizontal>
 </Layout.Vertical>`}
+/>
+
+## App shell rail shadows
+
+Component shadows for the unified app shell navigation and chat panels. Values are theme-aware (light: subtle lift; dark: `0 7px 8px` on `#08090d` at 80% alpha).
+
+Use `shadow-cn-nav-rail` on the nav column shell and `shadow-cn-chat-rail` / `shadow-cn-chat-rail-mirror` on the chat panel shell based on chat position. Do not apply to seam overlays or resize handles.
+
+<DocsPage.ComponentExample
+  hideCode
+  client:only
+  code={`<Layout.Horizontal gap="lg" className="min-w-[560px] p-cn-xl bg-cn-0">
+  <Layout.Vertical
+    gap="xs"
+    className="bg-cn-1 h-48 w-16 shrink-0 shadow-cn-nav-rail"
+    justify="center"
+    align="center"
+  >
+    <Text variant="caption-normal" color="foreground-3">Nav</Text>
+  </Layout.Vertical>
+  <Layout.Vertical
+    gap="xs"
+    className="bg-cn-1 h-48 w-40 shrink-0 shadow-cn-chat-rail"
+    justify="center"
+    align="center"
+  >
+    <Text variant="caption-normal" color="foreground-3">Chat</Text>
+  </Layout.Vertical>
+  <Layout.Vertical
+    gap="xs"
+    className="bg-cn-1 h-48 flex-1"
+    justify="center"
+    align="center"
+  >
+    <Text variant="caption-normal" color="foreground-3">Main</Text>
+  </Layout.Vertical>
+</Layout.Horizontal>`}
 />
 
 ## Shadow Geometry

--- a/packages/core-design-system/design-tokens/mode/dark/default.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default.json
@@ -1244,6 +1244,22 @@
         }
       }
     },
+    "app-shell": {
+      "rail-shadow": {
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": "0.8",
+              "space": "lch"
+            }
+          }
+        },
+        "$type": "color",
+        "$value": "{pure.black}",
+        "$description": "Shadow color for app shell nav and chat rail elevation in dark mode (#08090d / bg.0)."
+      }
+    },
     "avatar": {
       "shadow": {
         "$extensions": {
@@ -2694,6 +2710,42 @@
           },
           "$description": "Inner shadow for AI-themed components. Adds depth to AI elements."
         }
+      },
+      "nav-rail": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "7",
+          "blur": "8",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell navigation rail. Casts toward main content."
+      },
+      "chat-rail": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "7",
+          "blur": "8",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell chat panel when chat is left of main content."
+      },
+      "chat-rail-mirror": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "7",
+          "blur": "8",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell chat panel when chat is right of main content."
       },
       "data-viz": {
         "01-blue": {

--- a/packages/core-design-system/design-tokens/mode/dark/default.json
+++ b/packages/core-design-system/design-tokens/mode/dark/default.json
@@ -2747,6 +2747,28 @@
         },
         "$description": "Drop shadow for app shell chat panel when chat is right of main content."
       },
+      "pipeline-studio-page-header": {
+        "$type": "boxShadow",
+        "$value": [
+          {
+            "x": "0",
+            "y": "1",
+            "blur": "2",
+            "spread": "0",
+            "color": "rgba(0, 0, 0, 0.45)",
+            "type": "dropShadow"
+          },
+          {
+            "x": "0",
+            "y": "4",
+            "blur": "14",
+            "spread": "0",
+            "color": "rgba(0, 0, 0, 0.5)",
+            "type": "dropShadow"
+          }
+        ],
+        "$description": "Drop shadow for Pipelines Studio page header chrome. Sourced from 3dot0Vision prototype (--ds-shadow-2 dark)."
+      },
       "data-viz": {
         "01-blue": {
           "$type": "boxShadow",

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -2588,6 +2588,28 @@
         },
         "$description": "Drop shadow for app shell chat panel when chat is right of main content."
       },
+      "pipeline-studio-page-header": {
+        "$type": "boxShadow",
+        "$value": [
+          {
+            "x": "0",
+            "y": "1",
+            "blur": "2",
+            "spread": "0",
+            "color": "rgba(15, 23, 42, 0.06)",
+            "type": "dropShadow"
+          },
+          {
+            "x": "0",
+            "y": "4",
+            "blur": "14",
+            "spread": "0",
+            "color": "rgba(15, 23, 42, 0.08)",
+            "type": "dropShadow"
+          }
+        ],
+        "$description": "Drop shadow for Pipelines Studio page header chrome. Sourced from 3dot0Vision prototype (--ds-shadow-2 light)."
+      },
       "data-viz": {
         "01-blue": {
           "$type": "boxShadow",

--- a/packages/core-design-system/design-tokens/mode/light/default.json
+++ b/packages/core-design-system/design-tokens/mode/light/default.json
@@ -1235,6 +1235,22 @@
         }
       }
     },
+    "app-shell": {
+      "rail-shadow": {
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": "0.08",
+              "space": "lch"
+            }
+          }
+        },
+        "$type": "color",
+        "$value": "{pure.black}",
+        "$description": "Shadow color for app shell nav and chat rail elevation."
+      }
+    },
     "avatar": {
       "shadow": {
         "$extensions": {
@@ -2535,6 +2551,42 @@
           },
           "$description": "Inner shadow for AI-themed components. Adds depth to AI elements."
         }
+      },
+      "nav-rail": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "2",
+          "blur": "12",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell navigation rail. Casts toward main content."
+      },
+      "chat-rail": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "2",
+          "blur": "12",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell chat panel when chat is left of main content."
+      },
+      "chat-rail-mirror": {
+        "$type": "boxShadow",
+        "$value": {
+          "x": "0",
+          "y": "2",
+          "blur": "12",
+          "spread": "0",
+          "color": "{comp.app-shell.rail-shadow}",
+          "type": "dropShadow"
+        },
+        "$description": "Drop shadow for app shell chat panel when chat is right of main content."
       },
       "data-viz": {
         "01-blue": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harnessio/ui",
   "description": "Harness Canary UI component library",
-  "version": "0.5.55",
+  "version": "0.5.56",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/tailwind-design-system.ts
+++ b/packages/ui/tailwind-design-system.ts
@@ -412,7 +412,11 @@ const tailwindDesignSystem: TailwindConfig = {
       'cn-forest': 'var(--cn-comp-shadow-data-viz-09-forest)',
       'cn-red': 'var(--cn-comp-shadow-data-viz-10-red)',
       'cn-yellow': 'var(--cn-comp-shadow-data-viz-11-yellow)',
-      'cn-gray': 'var(--cn-comp-shadow-data-viz-12-gray)'
+      'cn-gray': 'var(--cn-comp-shadow-data-viz-12-gray)',
+
+      'cn-nav-rail': 'var(--cn-comp-shadow-nav-rail)',
+      'cn-chat-rail': 'var(--cn-comp-shadow-chat-rail)',
+      'cn-chat-rail-mirror': 'var(--cn-comp-shadow-chat-rail-mirror)'
     },
     spacing: {
       0: 'var(--cn-spacing-0)',

--- a/packages/ui/tailwind-design-system.ts
+++ b/packages/ui/tailwind-design-system.ts
@@ -416,7 +416,8 @@ const tailwindDesignSystem: TailwindConfig = {
 
       'cn-nav-rail': 'var(--cn-comp-shadow-nav-rail)',
       'cn-chat-rail': 'var(--cn-comp-shadow-chat-rail)',
-      'cn-chat-rail-mirror': 'var(--cn-comp-shadow-chat-rail-mirror)'
+      'cn-chat-rail-mirror': 'var(--cn-comp-shadow-chat-rail-mirror)',
+      'cn-pipeline-studio-page-header': 'var(--cn-comp-shadow-pipeline-studio-page-header)'
     },
     spacing: {
       0: 'var(--cn-spacing-0)',


### PR DESCRIPTION
## Summary

Adds component-level drop shadow tokens for the unified app shell (nav + chat rails) and the Pipelines Studio page header, sourced from the 3dot0Vision prototype / platformUI app shell work.

Jira: [UUI-1927](https://harness.atlassian.net/browse/UUI-1927) (epic: [UUI-1915](https://harness.atlassian.net/browse/UUI-1915))

### App shell rail shadows

- Color token `comp.app-shell.rail-shadow` (light: `pure.black` @ 8%; dark: `pure.black` / `bg.0` @ 80%)
- Box-shadow tokens: `comp.shadow.nav-rail`, `comp.shadow.chat-rail`, `comp.shadow.chat-rail-mirror`
- Tailwind utilities: `shadow-cn-nav-rail`, `shadow-cn-chat-rail`, `shadow-cn-chat-rail-mirror`

| Mode | Rail shadow |
|------|-------------|
| Light | `0 2px 12px` @ 8% `pure.black` |
| Dark | `0 7px 8px` @ 80% `pure.black` |

### Pipelines Studio page header shadow

- Box-shadow token: `comp.shadow.pipeline-studio-page-header`
- Tailwind utility: `shadow-cn-pipeline-studio-page-header`
- CSS variable: `--cn-comp-shadow-pipeline-studio-page-header`
- Shadow colors use raw `rgba()` for now (semantic token refactor planned)

| Mode | Header shadow |
|------|---------------|
| Light | `0 1px 2px rgba(15, 23, 42, 0.06), 0 4px 14px rgba(15, 23, 42, 0.08)` |
| Dark | `0 1px 2px rgba(0, 0, 0, 0.45), 0 4px 14px rgba(0, 0, 0, 0.5)` |

### Docs

- Portal shadows foundation page updated with rail + studio header examples and CSS variable mapping

## Test plan

- [ ] `pnpm --filter @harnessio/core-design-system build:styles` passes
- [ ] `pnpm --filter @harnessio/ui build` passes
- [ ] Portal shadows page shows nav + chat rail example (light + dark)
- [ ] Portal shadows page shows pipeline studio page header example
- [ ] Generated CSS includes `--cn-comp-shadow-nav-rail` and `--cn-comp-shadow-pipeline-studio-page-header` in light/dark theme files

## Follow-up

- **platformUI Step 3:** wire nav/chat rail shadows in `App.css` + `sidebar-layout.tsx` after `@harnessio/ui` publish
- **platformUI:** wire `shadow-cn-pipeline-studio-page-header` on Pipelines Studio page header (not Pipelines list view)

[UUI-1927]: https://harness.atlassian.net/browse/UUI-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UUI-1915]: https://harness.atlassian.net/browse/UUI-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ